### PR TITLE
remove unused method

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -17,10 +17,3 @@ bool isMobile() {
 
   return width <= mobileSize || height <= mobileSize;
 }
-
-/**
- * Return the plural of the given word.
- */
-String plural(String word, int count) {
-  return count == 1 ? word : '${word}s';
-}


### PR DESCRIPTION
Remove `plural()` - it's unused. If we need it again, we can look at the `inflection ` library (re: #90).