### PR TITLE
fix a race condition when switching frame content

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -144,6 +144,10 @@ class _CodeMirrorDocument extends Document {
   final List<LineWidget> widgets = [];
   final List<html.DivElement> nodes = [];
 
+  /**
+   * We use `_lastSetValue` here to avoid a change notification when we
+   * programatically change the `value` field.
+   */
   String _lastSetValue;
 
   _CodeMirrorDocument._(_CodeMirrorEditor editor, this.doc) : super(editor);
@@ -248,9 +252,13 @@ class _CodeMirrorDocument extends Document {
 //  }
 
   Stream get onChange => doc.onChange.where((_) {
-    if (value != _lastSetValue) return true;
-    _lastSetValue = null;
-    return false;
+    if (value != _lastSetValue) {
+      _lastSetValue = null;
+      return true;
+    } else {
+      //_lastSetValue = null;
+      return false;
+    }
   });
 }
 

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -9,10 +9,8 @@ import 'dart:async';
 abstract class ExecutionService {
   Future execute(String html, String css, String javaScript);
 
-  void replaceCss(String css);
   void replaceHtml(String html);
-
-  void reset();
+  void replaceCss(String css);
 
   Stream<String> get onStdout;
   Stream<String> get onStderr;

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -81,7 +81,7 @@ class ExecutionServiceIFrame implements ExecutionService {
     return new Future.value();
   }
 
-  /// Destroy and re-load iframe.
+  /// Destroy and re-load the iframe.
   Future _reset() {
     _readyCompleter = new Completer();
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -14,25 +14,39 @@ class ExecutionServiceIFrame implements ExecutionService {
   final StreamController _stdoutController = new StreamController.broadcast();
   final StreamController _stderrController = new StreamController.broadcast();
 
-  final IFrameElement frame;
+  IFrameElement _frame;
+  String _frameSrc;
+  Completer _readyCompleter = new Completer();
 
-  ExecutionServiceIFrame(this.frame) {
+  ExecutionServiceIFrame(this._frame) {
+    _frameSrc = _frame.src;
+
     window.onMessage.listen((MessageEvent event) {
       String message = '${event.data}';
 
       if (message.startsWith('stderr: ')) {
-        _stderrController.add(message.substring('stderr: '.length));
+        // Ignore any exceptions before the iframe has completed initialization.
+        //
+        if (_readyCompleter.isCompleted) {
+          _stderrController.add(message.substring('stderr: '.length));
+        }
+      } else if (message == 'status: ready' && !_readyCompleter.isCompleted) {
+        _readyCompleter.complete();
       } else {
         _stdoutController.add(message);
       }
     });
   }
 
+  IFrameElement get frame => _frame;
+
   Future execute(String html, String css, String javaScript) {
-    return _send('execute', {
-      'html': html,
-      'css': css,
-      'js': _decorateJavaScript(javaScript)
+    return _reset().whenComplete(() {
+      return _send('execute', {
+        'html': html,
+        'css': css,
+        'js': _decorateJavaScript(javaScript)
+      });
     });
   }
 
@@ -44,16 +58,10 @@ class ExecutionServiceIFrame implements ExecutionService {
     _send('setCss', {'css': css});
   }
 
-  void reset() {
-    // TODO: Destroy and re-load iframe.
-
-  }
-
   String _decorateJavaScript(String javaScript) {
     final String postMessagePrint =
         "function dartPrint(message) { parent.postMessage(message, '*'); }";
 
-    // TODO: Use a better encoding than 'stderr: '.
     final String exceptionHandler =
         "window.onerror = function(message, url, lineNumber) { "
         "parent.postMessage('stderr: ' + message.toString(), '*'); };";
@@ -71,5 +79,25 @@ class ExecutionServiceIFrame implements ExecutionService {
     frame.contentWindow.postMessage(m, '*');
 
     return new Future.value();
+  }
+
+  /// Destroy and re-load iframe.
+  Future _reset() {
+    _readyCompleter = new Completer();
+
+    IFrameElement clone = _frame.clone(false);
+    clone.src = _frameSrc;
+
+    List<Element> children = frame.parent.children;
+    int index = children.indexOf(_frame);
+    children.insert(index, clone);
+    frame.parent.children.remove(_frame);
+    _frame = clone;
+
+    return _readyCompleter.future.timeout(
+        new Duration(seconds: 1),
+        onTimeout: () {
+          if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+        });
   }
 }

--- a/web/frame.html
+++ b/web/frame.html
@@ -64,6 +64,8 @@ messageHandler = function(e) {
 }
 
 window.addEventListener('message', messageHandler, false);
+
+parent.postMessage('status: ready', '*');
     </script>
 
     <style id="styleId"></style>


### PR DESCRIPTION
Fix https://github.com/dart-lang/dart-pad/issues/95

- ensure that programmatically changing the codemirror text does not fire a change event. This fixes an issue with inadvertently replacing the html content out from under the javascript code
- move to a mode where we create a new iframe to handle each run execution; we tear down the old one and create a new one for each run

