### PR TITLE
devoncarew_fix_safari_mobile

### DIFF
--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -15,6 +15,7 @@ final _isMac = window.navigator.appVersion.toLowerCase().contains('macintosh');
 class Keys {
   Map<String, Function> _bindings = {};
   StreamSubscription _sub;
+  bool _loggedException = false;
 
   Keys() {
     _sub = document.onKeyDown.listen(_handleKeyEvent);
@@ -29,16 +30,25 @@ class Keys {
   }
 
   void _handleKeyEvent(KeyboardEvent event) {
-    KeyboardEvent k = event;
+    try {
+      KeyboardEvent k = event;
 
-    if (!k.altKey && !k.ctrlKey && !k.metaKey
-        && !(event.keyCode >= KeyCode.F1 && event.keyCode <= KeyCode.F12)) {
-      return;
-    }
+      if (!k.altKey && !k.ctrlKey && !k.metaKey
+          && !(event.keyCode >= KeyCode.F1 && event.keyCode <= KeyCode.F12)) {
+        return;
+      }
 
-    if (_handleKey(printKeyEvent(k))) {
-      k.preventDefault();
-      k.stopPropagation();
+      if (_handleKey(printKeyEvent(k))) {
+        k.preventDefault();
+        k.stopPropagation();
+      }
+    } catch (e) {
+      if (!_loggedException) {
+        _loggedException = true;
+
+        // The polymer polyfills make any event handling code unhappy.
+        print('${e}');
+      }
     }
   }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -66,8 +66,8 @@ class Playground {
     runbutton.onClick.listen((e) {
       _handleRun();
 
-      // On a mobile device, focusing the editing are causes the keyboard to pop
-      // up when the user hits the run button.
+      // On a mobile device, focusing the editing area causes the keyboard to
+      // pop up when the user hits the run button.
       if (!isMobile()) _context.focus();
     });
 

--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -4,27 +4,21 @@
 
 library dart_pad.sample;
 
-// TODO: Better sample code.
-
-final String dartCode = r'''void main() {
-  for (int i = 0; i < 4; i++) {
-    print('hello ${i}');
+final String dartCode = r'''
+void main() {
+  for (int i = 0; i < 5; i++) {
+    print('hello ${i + 1}');
   }
 }
 ''';
 
-final String htmlCode = r'''<h2>Dart Sample</h2>
+final String htmlCode = r'''
+<h2>Dart Sample</h2>
 
 <p id="output">Hello world!<p>
 ''';
 
-final String cssCode = r'''/* my styles */
-
-h2 {
-  font-weight: normal;
-  margin-top: 0;
-}
-
+final String cssCode = r'''
 p {
   color: #888;
 }

--- a/web/frame.html
+++ b/web/frame.html
@@ -65,7 +65,7 @@ messageHandler = function(e) {
 
 window.addEventListener('message', messageHandler, false);
 
-parent.postMessage('status: ready', '*');
+parent.postMessage({'sender': 'frame', 'type': 'ready'}, '*');
     </script>
 
     <style id="styleId"></style>

--- a/web/index.html
+++ b/web/index.html
@@ -134,8 +134,8 @@
         var data = event.data;
 
         if (data.sender == 'frame') {
-          if (dartMessageListener) {
-            dartMessageListener(data);
+          if (window.dartMessageListener) {
+            window.dartMessageListener(data);
           }
         }
       });

--- a/web/index.html
+++ b/web/index.html
@@ -126,5 +126,19 @@
       ga('create', 'UA-26406144-18', 'auto');
       ga('send', 'pageview');
     </script>
+    <script>
+      /* Patch to work around a polymer polyfill issue. */
+
+      // Patch window message listening.
+      window.addEventListener('message', function(event) {
+        var data = event.data;
+
+        if (data.sender == 'frame') {
+          if (dartMessageListener) {
+            dartMessageListener(data);
+          }
+        }
+      });
+    </script>
   </body>
 </html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -63,8 +63,7 @@ header {
 }
 
 section {
-  margin: 0 24px;
-  padding-bottom: 24px;
+  padding: 0 24px 24px 24px;
   position: relative;
 
   box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;


### PR DESCRIPTION
Work around https://github.com/dart-lang/dart-pad/issues/108. We listen to the window.message and document.keydown events in javascript; these then delegate to some registered dart methods.

This will fix the issue of getting console output on safari and firefox (and i.e.?) for the mobile UI.