### PR TITLE
add an about box w/ the privacy statement

### DIFF
--- a/lib/mobile/mobile.dart
+++ b/lib/mobile/mobile.dart
@@ -27,6 +27,7 @@ import 'package:route_hierarchical/client.dart';
 import '../polymer/base.dart';
 import '../polymer/core.dart';
 import '../polymer/paper.dart';
+import '../src/util.dart';
 
 PlaygroundMobile get playground => _playground;
 
@@ -52,7 +53,7 @@ class PlaygroundMobile {
 
   PaperToast _messageToast;
   PaperToast _errorsToast;
-  PaperActionDialog _errorDialog;
+  PaperActionDialog _messageDialog;
   CoreElement _output;
   CoreAnimatedPages _pages;
   PaperProgress _editProgress;
@@ -122,13 +123,13 @@ class PlaygroundMobile {
     document.body.children.add(_errorsToast.element);
 
     // TODO: use a dark theme?
-    _errorDialog = new PaperActionDialog();
+    _messageDialog = new PaperActionDialog();
     PaperButton closeButton = new PaperButton(text: 'Close');
-    _errorDialog.makeAffirmative(closeButton);
-    _errorDialog.add(closeButton);
-    Transition.coreTransitionCenter(_errorDialog);
-    _errorDialog.add(CoreElement.p());
-    document.body.children.add(_errorDialog.element);
+    _messageDialog.makeAffirmative(closeButton);
+    _messageDialog.add(closeButton);
+    Transition.coreTransitionCenter(_messageDialog);
+    _messageDialog.add(CoreElement.p());
+    document.body.children.add(_messageDialog.element);
   }
 
   CoreElement _createEditSection(CoreAnimatedPages pages) {
@@ -160,25 +161,17 @@ class PlaygroundMobile {
     toolbar.add(CoreElement.span()..clazz('sample-titles')..flex());
 
     // Overflow menu.
-//    PaperMenuButton overflowMenuButton = new PaperMenuButton();
-//    overflowMenuButton.add(new PaperIconButton(icon: 'more-vert'));
-//    PaperDropdown dropdown = new PaperDropdown()..halign = 'right';
-//    CoreMenu overflowMenu = new CoreMenu();
-//    overflowMenu.add(new PaperItem(text: 'Share')..onTap.listen((event) {
-//      event.preventDefault();
-//      _showMessage('TODO: share');
-//    }));
-//    overflowMenu.add(new PaperItem(text: 'Settings')..onTap.listen((event) {
-//      event.preventDefault();
-//      _showMessage('TODO: settings');
-//    }));
-//    overflowMenu.add(new PaperItem(text: 'Help')..onTap.listen((event) {
-//      event.preventDefault();
-//      _showMessage('TODO: help');
-//    }));
-//    dropdown.add(overflowMenu);
-//    overflowMenuButton.add(dropdown);
-//    toolbar.add(overflowMenuButton);
+    PaperMenuButton overflowMenuButton = new PaperMenuButton();
+    overflowMenuButton.add(new PaperIconButton(icon: 'more-vert'));
+    PaperDropdown dropdown = new PaperDropdown()..halign = 'right';
+    CoreMenu overflowMenu = new CoreMenu();
+    overflowMenu.add(new PaperItem(text: 'About')..onTap.listen((event) {
+      event.preventDefault();
+      _showAboutDialog();
+    }));
+    dropdown.add(overflowMenu);
+    overflowMenuButton.add(dropdown);
+    toolbar.add(overflowMenuButton);
 
     CoreElement div = CoreElement.div()..clazz('bottom fit')..horizontal()..vertical();
     PaperTabs tabs = new PaperTabs()..flex();
@@ -548,11 +541,17 @@ class PlaygroundMobile {
     _messageToast.show();
   }
 
+  void _showAboutDialog() {
+    _messageDialog.heading = 'About Dart Pad';
+    _messageDialog.element.querySelector('p').setInnerHtml(privacyText,
+        validator: new _NodeValidator());
+    _messageDialog.open();
+  }
+
   void _showError(String title, String message) {
-    _errorDialog.heading = title;
-    _errorDialog.element.querySelector('p').text = message;
-    _errorDialog.open();
-    //_errorDialog.toggle();
+    _messageDialog.heading = title;
+    _messageDialog.element.querySelector('p').text = message;
+    _messageDialog.open();
   }
 
   String _currentGistId() => _gistId;
@@ -702,4 +701,10 @@ class BusyLight {
   }
 
   _reconcile() => element.classes.toggle('busy', _count > 0);
+}
+
+class _NodeValidator implements NodeValidator {
+  bool allowsAttribute(Element element, String attributeName, String value) =>
+      true;
+  bool allowsElement(Element element) => true;
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -17,3 +17,26 @@ bool isMobile() {
 
   return width <= mobileSize || height <= mobileSize;
 }
+
+/**
+ * Text to be displayed to Dart Pad users. The associated title should be
+ * 'About Dart Pad' (or equivalent).
+ */
+final String privacyText = '''
+Dart Pad is a free, open-source service to help developers learn about the Dart
+language and libraries. Source code entered into Dart Pad may be sent to servers
+running in Google Cloud Platform to be analyzed for errors/warnings, compiled to
+JavaScript, and returned to the browser.
+<br><br>
+Source code entered into Dart Pad may be stored, processed, and aggregated in
+order to improve the user experience of Dart Pad and other Dart tools. For
+example, we may use the source code to help offer better code completion
+suggestions. The raw source code is deleted after 6 months.
+<br><br>
+Learn more about Google's
+<a href="http://www.google.com/policies/privacy/" target="policy">privacy policy</a>.
+We look forward to your
+<a href="https://github.com/dart-lang/dart-pad/issues" target="feedback">feedback</a>.
+<br><br>
+Made with &lt;3 by Google.
+''';

--- a/web/index.html
+++ b/web/index.html
@@ -104,14 +104,8 @@
       </div>
       <div flex></div>
       <div>
-        <a href="https://github.com/dart-lang/dart-pad/issues"
-          target="github_issues">
-            Send feedback
-            <svg width="15" height="15" viewBox="0 0 24 24"
-                style="margin-bottom: -4px">
-              <path d="M21.99 4c0-1.1-.89-2-1.99-2h-16c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18zm-3.99 10h-12v-2h12v2zm0-3h-12v-2h12v2zm0-3h-12v-2h12v2z"/>
-            </svg>
-          </a>
+        <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
+          target="privacy">Privacy policy</a>
       </div>
     </footer>
 


### PR DESCRIPTION
Fix https://github.com/dart-lang/dart-pad/issues/103

- add privacy text in `lib/src/util.dart`
- add an about dialog to the mobile UI
- add a link to an online privacy page (`https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy`)
- add the link to the desktop UI

![screen shot 2015-03-02 at 1 21 33 pm](https://cloud.githubusercontent.com/assets/1269969/6451018/96796d00-c0e0-11e4-96e4-c144b66879fd.png)
![screen shot 2015-03-02 at 1 30 18 pm](https://cloud.githubusercontent.com/assets/1269969/6451019/967c4426-c0e0-11e4-9f17-1a8ef6d4e09b.png)

@lukechurch, @sethladd 