### PR TITLE
use Inconsolata for editing area

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: dart
-dart:
-  - stable
-  - dev
 before_install:
   - "export CHROME_ARGS=--no-sandbox"
   - "export DISPLAY=:99.0"

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -8,6 +8,7 @@
 /* CodeMirror tweaks */
 
 #editpanel .CodeMirror {
+  font-family: 'Inconsolata', monospace;
   background: inherit;
   color: inherit;
   box-shadow: none;
@@ -27,10 +28,6 @@
 
 #editpanel .CodeMirror-lines {
   padding: 0;
-}
-
-#editpanel {
-
 }
 
 .squiggle-error {

--- a/web/frame.html
+++ b/web/frame.html
@@ -19,7 +19,7 @@
         margin: 0;
         padding: 0;
         font-family: 'Roboto', sans-serif;
-        font-size: 14px;
+        font-size: 15px;
       }
       h2 {
         margin-top: 0;

--- a/web/mobile.css
+++ b/web/mobile.css
@@ -89,7 +89,7 @@ iframe {
 
 .console {
   font-family: 'Inconsolata', monospace;
-  font-size: 12pt;
+  font-size: 15px;
   line-height: 20px;
   min-height: 50px;
   overflow-y: auto;
@@ -108,7 +108,7 @@ iframe {
 
 .editor {
   font-family: 'Inconsolata', monospace;
-  font-size: 12pt;
+  font-size: 15px;
   line-height: 20px;
   display: block;
   position: relative;

--- a/web/styles.css
+++ b/web/styles.css
@@ -133,7 +133,7 @@ a[selected]:hover {
 
 .header {
   line-height: 24px;
-  font-size: 12pt;
+  font-size: 15px;
 }
 
 button {
@@ -143,7 +143,7 @@ button {
   border: 1px solid #222;
   border-radius: 2px;
   font-family: 'Roboto', sans-serif;
-  font-size: 12pt;
+  font-size: 15px;
   line-height: 18px;
   height: 24px;
   cursor: pointer;
@@ -226,7 +226,7 @@ div.toggle {
 
 .console {
   font-family: 'Inconsolata', monospace;
-  font-size: 12pt;
+  font-size: 15px;
   line-height: 20px;
   min-height: 50px;
   overflow-y: auto;
@@ -243,7 +243,7 @@ div.toggle {
 
 #editpanel {
   font-family: 'Inconsolata', monospace;
-  font-size: 12pt;
+  font-size: 15px;
   line-height: 20px;
   display: block;
   position: relative;


### PR DESCRIPTION
- really use Inconsolata for the editing font (previously it had been used only in the console output area).
- also, shrink the size of the font used by about a px (12pt changed to 15px).

![screen shot 2015-03-16 at 12 27 36 am](https://cloud.githubusercontent.com/assets/1269969/6662097/52ccd3aa-cb74-11e4-9c3e-98d028fd0c81.png)
