### PR TITLE
work on cc UI

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad.completion;
+
+import 'dart:async';
+//import 'dart:convert' show JSON;
+
+import 'package:logging/logging.dart';
+
+import 'dartservices_client/v1.dart';
+import 'editing/editor.dart';
+import 'src/util.dart';
+
+Logger _logger = new Logger('completion');
+
+// TODO: For CodeMirror, we get a request each time the user hits a key when the
+// completion popup is open. We need to cache the results when appropriate.
+
+class DartCompleter extends CodeCompleter {
+  final DartservicesApi servicesApi;
+  final Document document;
+
+  CancellableCompleter _lastCompleter;
+
+  DartCompleter(this.servicesApi, this.document);
+
+  Future<List<Completion>> complete(Editor editor) {
+    // Cancel any open completion request.
+    if (_lastCompleter != null) _lastCompleter.cancel();
+
+    int offset = editor.document.indexFromPos(editor.document.cursor);
+
+    var request = new SourceRequest()
+      ..source = editor.document.value
+      ..offset = offset;
+
+    Stopwatch timer = new Stopwatch()..start();
+
+    CancellableCompleter completer = new CancellableCompleter();
+    _lastCompleter = completer;
+
+    servicesApi.complete(request).then((response) {
+      List<Completion> completions =  response.completions.map((completion) {
+        AnalysisCompletion c = new AnalysisCompletion(completion);
+
+        String displayString = c.isMethod ? '${c.text}()' : c.text;
+
+        if (c.returnType != null) displayString += ': ${c.returnType}';
+
+        return new Completion(c.text, displayString: displayString);
+      }).toList();
+
+      completer.complete(completions);
+
+      if (!completer.isCancelled) {
+        timer.stop();
+        _logger.info('completion request in ${timer.elapsedMilliseconds}ms');
+      }
+    }).catchError((e) {
+      completer.completeError(e);
+    });
+
+    return completer.future;
+  }
+}
+
+//{kind: KEYWORD, relevance: 2000, completion: library, selectionOffset: 7, selectionLength: 0, isDeprecated: false, isPotential: false}
+//{kind: INVOCATION, relevance: 1000, completion: int, selectionOffset: 3, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: CLASS, name: int, flags: 1}}
+//{kind: INVOCATION, relevance: 1059, completion: i, selectionOffset: 1, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: LOCAL_VARIABLE, name: i, flags: 0, returnType: int}, returnType: int}
+//{kind: INVOCATION, relevance: 1056, completion: main, selectionOffset: 4, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: FUNCTION, name: main, flags: 0, parameters: (), returnType: void}, returnType: void, parameterNames: [], parameterTypes: [], requiredParameterCount: 0, hasNamedParameters: false}
+//{kind: INVOCATION, relevance: 1000, completion: proxy, selectionOffset: 5, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: GETTER, name: proxy, flags: 8, returnType: Object}, returnType: Object}
+//{kind: INVOCATION, relevance: 1000, completion: int, selectionOffset: 3, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: CLASS, name: int, flags: 1}}
+//{kind: INVOCATION, relevance: 1000, completion: Cat, selectionOffset: 3, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: CLASS, name: Cat, flags: 0}}
+//{kind: INVOCATION, relevance: 1000, completion: print, selectionOffset: 5, selectionLength: 0, isDeprecated: false, isPotential: false, element: {kind: FUNCTION, name: print, flags: 8, parameters: (Object object), returnType: void}, returnType: void, parameterNames: [object], parameterTypes: [Object], requiredParameterCount: 1, hasNamedParameters: false}
+
+class AnalysisCompletion {
+  final Map _map;
+
+  AnalysisCompletion(this._map) {
+    print(_map);
+
+    // TODO: We need to pass the completion info better.
+    var element = _map['element'];
+    if (element is String) {
+      _map.remove('element'); //['element'] = JSON.decode(element);
+    }
+  }
+
+  // KEYWORD, INVOCATION, ...
+  String get kind => _map['kind'];
+
+  // TODO:
+  bool get isMethod => _map.containsKey('parameterNames');
+
+//  bool get isMethod {
+//    var element = _map['element'];
+//    return element is Map ? element['kind'] == 'FUNCTION' : false;
+//  }
+
+  String get text => _map['completion'];
+
+  String get returnType => _map['returnType'];
+
+  int get relevance => _int(_map['relevance']);
+
+  bool get isDeprecated => _map['isDeprecated'] == 'true';
+
+  bool get isPotential => _map['isPotential'] == 'true';
+
+  int get selectionLength => _int(_map['selectionLength']);
+
+  int get selectionOffset => _int(_map['selectionOffset']);
+
+  String toString() => text;
+
+  int _int(String val) => val == null ? 0 : int.parse(val);
+}

--- a/lib/dartservices_client/v1.dart
+++ b/lib/dartservices_client/v1.dart
@@ -478,6 +478,12 @@ class CompleteResponse {
   /** Not documented yet. */
   core.List<core.Map<core.String, core.String>> completions;
 
+  /** The length of the text to be replaced. */
+  core.int replacementLength;
+
+  /** The offset of the start of the text to be replaced. */
+  core.int replacementOffset;
+
 
   CompleteResponse();
 
@@ -485,12 +491,24 @@ class CompleteResponse {
     if (_json.containsKey("completions")) {
       completions = _json["completions"];
     }
+    if (_json.containsKey("replacementLength")) {
+      replacementLength = _json["replacementLength"];
+    }
+    if (_json.containsKey("replacementOffset")) {
+      replacementOffset = _json["replacementOffset"];
+    }
   }
 
   core.Map toJson() {
     var _json = new core.Map();
     if (completions != null) {
       _json["completions"] = completions;
+    }
+    if (replacementLength != null) {
+      _json["replacementLength"] = replacementLength;
+    }
+    if (replacementOffset != null) {
+      _json["replacementOffset"] = replacementOffset;
     }
     return _json;
   }

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -16,8 +16,6 @@ import 'editor.dart' as ed show Position;
 
 export 'editor.dart';
 
-// TODO: code completion initial hook up for dart
-
 final CodeMirrorFactory codeMirrorFactory = new CodeMirrorFactory._();
 
 final _gutterId = 'CodeMirror-lint-markers';

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -10,6 +10,7 @@ import 'dart:html' hide Document;
 import 'package:logging/logging.dart';
 import 'package:route_hierarchical/client.dart';
 
+import 'completion.dart';
 import 'context.dart';
 import 'core/dependencies.dart';
 import 'core/modules.dart';
@@ -184,14 +185,15 @@ class Playground {
     _editpanel.children.first.attributes['flex'] = '';
     editor.resize();
 
-    editorFactory.registerCompleter('dart', new DartCompleter());
-
     keys.bind('ctrl-s', _handleSave);
     keys.bind('ctrl-enter', _handleRun);
     keys.bind('f1', _handleHelp);
 
     _context = new PlaygroundContext(editor);
     deps[Context] = _context;
+
+    editorFactory.registerCompleter(
+        'dart', new DartCompleter(dartServices, _context._dartDoc));
 
     _context.onHtmlDirty.listen((_) => htmlBusyLight.on());
     _context.onHtmlReconcile.listen((_) {
@@ -325,7 +327,7 @@ class Playground {
               // TODO: Tell the user there were no results.
             } else {
               // TODO: Display this info
-              print(result.info['description']);
+              print(result.info); //['description']);
             }
           });
     }
@@ -521,32 +523,6 @@ class PlaygroundContext extends Context {
       timer = new Timer(new Duration(milliseconds: delay), () {
         controller.add(null);
       });
-    });
-  }
-}
-
-// TODO: For CodeMirror, we get a request each time the user hits a key when the
-// completion popup is open. We need to cache the results when appropriate.
-
-// TODO: We need to cancel completion requests if one is open when we get
-// another.
-
-class DartCompleter extends CodeCompleter {
-  Future<List<Completion>> complete(Editor editor) {
-
-    int offset = editor.document.indexFromPos(editor.document.cursor);
-
-    var request =
-        new SourceRequest()..source = editor.document.value
-        ..offset = offset;
-
-    return dartServices.complete(request).then((response) {
-
-      List<Completion> cpls = new List<Completion>();
-      response.completions.forEach((mp)
-          => cpls.add(new Completion(mp['completion'])));
-
-      return cpls;
     });
   }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,6 +4,7 @@
 
 library dart_pad.util;
 
+import 'dart:async';
 import 'dart:html';
 
 /**
@@ -50,3 +51,31 @@ We look forward to your
 <br><br>
 Made with &lt;3 by Google.
 ''';
+
+class CancellableCompleter<T> implements Completer {
+  Completer _completer = new Completer();
+  bool _cancelled = false;
+
+  CancellableCompleter();
+
+  void complete([value]) {
+    if (!_cancelled) _completer.complete(value);
+  }
+
+  void completeError(Object error, [StackTrace stackTrace]) {
+    if (!_cancelled) _completer.completeError(error, stackTrace);
+  }
+
+  Future<T> get future => _completer.future;
+
+  bool get isCompleted => _completer.isCompleted;
+
+  void cancel() {
+    if (!_cancelled) {
+      if (!isCompleted) completeError(new TimeoutException('cancelled'));
+      _cancelled = true;
+    }
+  }
+
+  bool get isCancelled => _cancelled;
+}


### PR DESCRIPTION
- move all the completion related code to its own library
- cancel old cc requests when sending a new request
- in-progress changes to move our cc to parity with what's offered by codemirror out of the box

@lukechurch, this is in-progress and not ready to be merged yet. Can you land the companion services one? I'll need that to make progress here.