### PR TITLE
Filter completions for only items that match the prefix

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -58,7 +58,7 @@ class DartCompleter extends CodeCompleter {
       int replacementOffset = response.replacementOffset;
       int delta = offset - replacementOffset;
       String prefix = editor.document.value.substring(
-          replacementOffset, replacementOffset + delta);
+          replacementOffset, replacementOffset + delta).toLowerCase();
 
 
       List<Completion> completions =  analysisCompletions.map((completion) {
@@ -69,7 +69,7 @@ class DartCompleter extends CodeCompleter {
 
         // Filter unmatching completions.
         if (delta > 0) {
-          if (!completion.text.startsWith(prefix)) {
+          if (!completion.text.toLowerCase().startsWith(prefix)) {
             return null;
           }
         }

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -55,13 +55,24 @@ class DartCompleter extends CodeCompleter {
             response.replacementOffset, response.replacementLength, completion);
       }).toList();
 
-      int delta = offset - response.replacementOffset;
+      int replacementOffset = response.replacementOffset;
+      int delta = offset - replacementOffset;
+      String prefix = editor.document.value.substring(
+          replacementOffset, replacementOffset + delta);
+
 
       List<Completion> completions =  analysisCompletions.map((completion) {
         // TODO: Move to using a LabelProvider; decouple the data from the
         // rendering.
         String displayString = completion.isMethod ? '${completion.text}()' : completion.text;
         if (completion.returnType != null) displayString += ': ${completion.returnType}';
+
+        // Filter unmatching completions.
+        if (delta > 0) {
+          if (!completion.text.startsWith(prefix)) {
+            return null;
+          }
+        }
 
         // TODO: We need to be more precise about the text we're inserting and
         // replacing.
@@ -72,7 +83,7 @@ class DartCompleter extends CodeCompleter {
 
         // TODO: Use classes to decorate the completion UI ('cm-builtin').
         return new Completion(text, displayString: displayString);
-      }).toList();
+      }).where((x) => x != null).toList();
 
       completer.complete(completions);
     }).catchError((e) {

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -57,7 +57,7 @@ class DartCompleter extends CodeCompleter {
 
       int replacementOffset = response.replacementOffset;
       int delta = offset - replacementOffset;
-      String prefix = editor.document.value.substring(
+      String lowerPrefix = editor.document.value.substring(
           replacementOffset, replacementOffset + delta).toLowerCase();
 
 
@@ -69,7 +69,7 @@ class DartCompleter extends CodeCompleter {
 
         // Filter unmatching completions.
         if (delta > 0) {
-          if (!completion.text.toLowerCase().startsWith(prefix)) {
+          if (!completion.text.toLowerCase().startsWith(lowerPrefix)) {
             return null;
           }
         }


### PR DESCRIPTION
@devoncarew PTAL - This filters the list for matching prefixes.

There may be a better iterator manipulation method that wouldn't result in needing to post-filter for nulls. 