### PR TITLE
Improve cancellation notification

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -28,7 +28,7 @@ class DartCompleter extends CodeCompleter {
 
   Future<List<Completion>> complete(Editor editor) {
     // Cancel any open completion request.
-    if (_lastCompleter != null) _lastCompleter.cancel();
+    if (_lastCompleter != null) _lastCompleter.cancel(reason: "new request");
 
     int offset = editor.document.indexFromPos(editor.document.cursor);
 

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -55,13 +55,24 @@ class DartCompleter extends CodeCompleter {
             response.replacementOffset, response.replacementLength, completion);
       }).toList();
 
-      int delta = offset - response.replacementOffset;
+      int replacementOffset = response.replacementOffset;
+      int delta = offset - replacementOffset;
+      String prefix = editor.document.value.substring(
+          replacementOffset, replacementOffset + delta);
+
 
       List<Completion> completions =  analysisCompletions.map((completion) {
         // TODO: Move to using a LabelProvider; decouple the data from the
         // rendering.
         String displayString = completion.isMethod ? '${completion.text}()' : completion.text;
         if (completion.returnType != null) displayString += ': ${completion.returnType}';
+
+        // Filter unmatching completions.
+        if (delta > 0) {
+          if (!completion.text.startsWith(prefix)) {
+            return null;
+          }
+        }
 
         // TODO: We need to be more precise about the text we're inserting and
         // replacing.
@@ -72,7 +83,7 @@ class DartCompleter extends CodeCompleter {
 
         // TODO: Use classes to decorate the completion UI ('cm-builtin').
         return new Completion(text, displayString: displayString);
-      }).toList();
+      }).where((x) => x != null).toList();
 
       completer.complete(completions);
     }).catchError((e) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -52,6 +52,21 @@ We look forward to your
 Made with &lt;3 by Google.
 ''';
 
+/**
+ * Thrown when a cancellation occurs whilst waiting for a result.
+ */
+class CancellationException implements Exception {
+  final String reason;
+
+  CancellationException(this.reason);
+
+  String toString() {
+    String result = "Request cancelled";
+    if (reason != null) result = "$result due to: $reason";
+    return result;
+  }
+}
+
 class CancellableCompleter<T> implements Completer {
   Completer _completer = new Completer();
   bool _cancelled = false;
@@ -70,9 +85,9 @@ class CancellableCompleter<T> implements Completer {
 
   bool get isCompleted => _completer.isCompleted;
 
-  void cancel() {
+  void cancel({String reason : "cancelled"}) {
     if (!_cancelled) {
-      if (!isCompleted) completeError(new TimeoutException('cancelled'));
+      if (!isCompleted) completeError(new CancellationException(reason));
       _cancelled = true;
     }
   }


### PR DESCRIPTION
@devoncarew PTAL

The previous cancellation exception reported that the it was due to a timeout which led me try to debug it as a services problem.

However, in this case the cancellations were occurring because of another request had been submitted.

This PR is just to tighten up the exception and give us more reporting flexibility.