### PR TITLE
adds parenthesis to completion

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -81,6 +81,7 @@ class DartCompleter extends CodeCompleter {
         if (delta > 0 && delta <= text.length) {
           text = text.substring(delta);
         }
+        if (completion.parameters == "()") text += "()";
         // TODO: Use classes to decorate the completion UI ('cm-builtin').
         if (completion.type == null) {
           return new Completion(text, displayString: displayString);


### PR DESCRIPTION
see https://github.com/dart-lang/dart-pad/issues/161
![](http://i.imgur.com/p9glwXh.gif)

This only adds parenthesis to functions with no arguments. If there are arguments, I think it is better to move the caret to the left by one position, but I don't know how to do this in codemirror.