### PR TITLE
just insert one paran if there are any params

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -63,12 +63,14 @@ class DartCompleter extends CodeCompleter {
       List<Completion> completions =  analysisCompletions.map((completion) {
         // TODO: Move to using a LabelProvider; decouple the data and rendering.
         String displayString = completion.isMethod
-            ? '${completion.text} ${completion.parameters}' : completion.text;
+            ? '${completion.text}${completion.parameters}' : completion.text;
         if (completion.isMethod && completion.returnType != null) {
           displayString += ' → ${completion.returnType}';
         }
 
         // Filter unmatching completions.
+        // TODO: This is temporary; tracking issue here:
+        // https://github.com/dart-lang/dart-services/issues/87.
         if (delta > 0) {
           if (!completion.text.toLowerCase().startsWith(lowerPrefix)) {
             return null;
@@ -81,8 +83,15 @@ class DartCompleter extends CodeCompleter {
         if (delta > 0 && delta <= text.length) {
           text = text.substring(delta);
         }
-        if (completion.parameters == "()") text += "()";
-        // TODO: Use classes to decorate the completion UI ('cm-builtin').
+
+        if (completion.parameters == "()") {
+          text += "()";
+        } else if (completion.isMethod) {
+          // TODO(devoncarew): A placeholder until we have control over the
+          // insertion location.
+          text += "(";
+        }
+
         if (completion.type == null) {
           return new Completion(text, displayString: displayString);
         } else {


### PR DESCRIPTION
@kasperpeulen, if a method is being inserted and there are any params, just append `(` instead of `()`. I think `()` tells the user that there's no args to the method. We can adjust this behavior to insert placeholder args and back the cursor up, once we have better control over the completion UI.