### PR TITLE
move to codemirror 5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   ace: '>=0.5.10 <0.6.0'
-  codemirror: '>=0.1.5 <0.2.0'
+  codemirror: '>=0.2.0 <0.3.0'
   # TODO: We need to move to a hosted (and versioned) dependency.
   comid:
     git: https://github.com/google/comid


### PR DESCRIPTION
Local testing looks good; landing this so that we can deploy to dev.dart-pad.appspot.com and test across devices.

@pq, this is a good candidate for saucelabs testing :)