### PR TITLE
add a developer options class

### DIFF
--- a/lib/dart_pad.dart
+++ b/lib/dart_pad.dart
@@ -13,6 +13,7 @@ import 'editing/editor.dart';
 import 'elements/state.dart';
 import 'modules/dartservices_module.dart';
 import 'services/execution.dart';
+import 'src/options.dart';
 
 Context get context => deps[Context];
 
@@ -27,3 +28,5 @@ Keys get keys => deps[Keys];
 EditorFactory get editorFactory => deps[EditorFactory];
 
 State get state => deps[State];
+
+Options get options => deps[Options];

--- a/lib/modules/dart_pad_module.dart
+++ b/lib/modules/dart_pad_module.dart
@@ -11,6 +11,7 @@ import '../core/event_bus.dart';
 import '../core/keys.dart';
 import '../core/modules.dart';
 import '../elements/state.dart';
+import '../src/options.dart';
 
 class DartPadModule extends Module {
   Future init() {
@@ -21,6 +22,7 @@ class DartPadModule extends Module {
     deps[EventBus] = new EventBus();
     deps[Keys] = new Keys();
     deps[State] = new HtmlState('dart_pad');
+    deps[Options] = new Options()..installIntoJsContext();
 
     return new Future.value();
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -28,6 +28,7 @@ import 'services/common.dart';
 import 'services/execution_iframe.dart';
 import 'src/ga.dart';
 import 'src/gists.dart';
+import 'src/options.dart';
 import 'src/sample.dart' as sample;
 import 'src/util.dart';
 
@@ -227,6 +228,14 @@ class Playground {
 
     _context.onDartDirty.listen((_) => dartBusyLight.on());
     _context.onDartReconcile.listen((_) => _performAnalysis());
+
+    // Set up development options.
+    options.onOptionChanged.listen((OptionChangedEvent event) {
+      // TODO: handle changes
+
+    });
+    options.registerOption('foo.bar', 'true');
+    options.registerOption('foo.baz', 'qux');
 
     _finishedInit();
   }

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -1,0 +1,68 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library options;
+
+import 'dart:async';
+import 'dart:js';
+import 'dart:html';
+
+/// This options class provides a way to configure dartpad through the JS
+/// console. This is useful for things like developer options.
+///
+/// When in the JS console, you have two functions available to you:
+/// listOptions() and setOption(key, value). `listOptions` will print out
+/// all the available options, and `setOption` will let you change the value of
+/// an option.
+class Options {
+  final String _namespace = 'dartpad';
+
+  Map<String, String> _values = {};
+  StreamController _controller = new StreamController.broadcast();
+
+  Options();
+
+  void installIntoJsContext() {
+    context['setOption'] = (name, value) {
+      setValue('${name}', value);
+    };
+
+    context['listOptions'] = () {
+      for (String key in keys) {
+        window.console.log('[dartpad] ${key}: ${_values[key]}');
+      }
+    };
+  }
+
+  void registerOption(String name, String defaultValue) {
+    // Load saved value.
+    String savedValue = window.localStorage['${_namespace}.${name}'];
+    setValue(name, savedValue == null ? defaultValue : savedValue);
+  }
+
+  Iterable<String> get keys => _values.keys;
+
+  String getValue(String name) => _values[name];
+
+  void setValue(String name, String value) {
+    if (_values.containsKey(name) && _values[name] == value) return;
+
+    _values[name] = value;
+    _controller.add(new OptionChangedEvent(name, value));
+
+    // Persistent the value across sessions.
+    window.localStorage['${_namespace}.${name}'] = value;
+  }
+
+  Stream<OptionChangedEvent> get onOptionChanged => _controller.stream;
+}
+
+class OptionChangedEvent {
+  final String name;
+  final dynamic value;
+
+  OptionChangedEvent(this.name, this.value);
+
+  String toString() => '${name}: ${value}';
+}

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -16,28 +16,32 @@ import 'dart:html';
 /// all the available options, and `setOption` will let you change the value of
 /// an option.
 class Options {
-  final String _namespace = 'dartpad';
+  final String namespace;
 
   Map<String, String> _values = {};
   StreamController _controller = new StreamController.broadcast();
 
-  Options();
+  Options({this.namespace: 'dartpad'});
 
   void installIntoJsContext() {
-    context['setOption'] = (name, value) {
-      setValue('${name}', value);
+    Map options = {};
+
+    options['setOption'] = (name, value) {
+      setValue('${name}', '${value}');
     };
 
-    context['listOptions'] = () {
+    options['listOptions'] = () {
       for (String key in keys) {
         window.console.log('[dartpad] ${key}: ${_values[key]}');
       }
     };
+
+    context[namespace] = new JsObject.jsify(options);
   }
 
   void registerOption(String name, String defaultValue) {
     // Load saved value.
-    String savedValue = window.localStorage['${_namespace}.${name}'];
+    String savedValue = window.localStorage['${namespace}.${name}'];
     setValue(name, savedValue == null ? defaultValue : savedValue);
   }
 
@@ -52,7 +56,7 @@ class Options {
     _controller.add(new OptionChangedEvent(name, value));
 
     // Persistent the value across sessions.
-    window.localStorage['${_namespace}.${name}'] = value;
+    window.localStorage['${namespace}.${name}'] = value;
   }
 
   Stream<OptionChangedEvent> get onOptionChanged => _controller.stream;
@@ -60,7 +64,7 @@ class Options {
 
 class OptionChangedEvent {
   final String name;
-  final dynamic value;
+  final String value;
 
   OptionChangedEvent(this.name, this.value);
 


### PR DESCRIPTION
Put `setOption(key, value)` and `listOptions()` functions into the JS context. These are callable from the JS console and will update listeners on the Dart side. This functionality can be used to implement develop options in dartpad.

The options will persist between session automatically.

@lukechurch 