### PR TITLE
adds typedef and keyword to completion types

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -174,7 +174,7 @@ class AnalysisCompletion implements Comparable {
   int get selectionOffset => _int(_map['selectionOffset']);
 
   // FUNCTION, GETTER, CLASS, ...
-  String get type => _map.containsKey('element') ? _map['element']['kind'] : null;
+  String get type => _map.containsKey('element') ? _map['element']['kind'] : kind;
 
   int compareTo(other) {
     if (other is! AnalysisCompletion) return -1;

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -91,11 +91,21 @@ li.CodeMirror-hint-active {
   text-align: center;
   margin-right: 5px;
   border-radius: 50%;
-  content : " ";
+  content: " ";
 }
 
+.type-keyword::before {
+  background: radial-gradient(#f0dfaf, #e0cfa1);
+  content : "k";
+}
 .type-class::before {
   content: "C";
+  background: radial-gradient(#A2D7F5, #8ebfd7);
+  line-height: 16px; /*for vertical centering */
+}
+
+.type-function_type_alias::before {
+  content: "T";
   background: radial-gradient(#A2D7F5, #8ebfd7);
   line-height: 16px; /*for vertical centering */
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1035299/6881971/c33518f4-d575-11e4-8356-2cf63dad742c.png)

![image](https://cloud.githubusercontent.com/assets/1035299/6881979/dd9d6840-d575-11e4-8088-a35981086269.png)

I actually would like to have a title attribute to all of those icons so that people can find out what they mean. But I guess it is not possible to add a title attribute to a pseudo element.