### PR TITLE
popup completion automatically triggered at a-zA-Z [behind dev flag]

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -32,6 +32,20 @@ abstract class Editor {
 
   Document get document;
 
+  /**
+   * Runs the command with the given name on the editor.
+   * Only implemented for codemirror and comid.
+   * Returns null for ace editor.
+   */
+  void execCommand(String name);
+
+  /**
+   * Checks if the completion popup is displayed.
+   * Only implemented for codemirror.
+   * Returns null for ace editor and comid.
+   */
+  bool get completionActive;
+
   String get mode;
   set mode(String str);
 

--- a/lib/editing/editor_ace.dart
+++ b/lib/editing/editor_ace.dart
@@ -115,6 +115,12 @@ class _AceEditor extends Editor {
     return new _AceDocument._(this, session);
   }
 
+  //TODO: Implement execCommand for ace.
+  void execCommand(String name) => null;
+
+  //TODO: Implement completionActive for ace.
+  bool get completionActive => null;
+
   String get mode => _document.session.mode.name;
   set mode(String str) => _document.session.mode = new ace.Mode.named(str);
 

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -113,7 +113,7 @@ class CodeMirrorFactory extends EditorFactory {
             }
         );
       }).toList();
-      if (hints.length == 0) {
+      if (hints.length == 0 && ed.completionActive) {
         hints = [new HintResult("", displayText: "No suggestions", className: "type-no_suggestions")];
       }
       return new HintResults.fromHints(hints, position, position);
@@ -138,6 +138,18 @@ class _CodeMirrorEditor extends Editor {
 
     // TODO: For `html`, enable and disable the 'autoCloseTags' option.
     return new _CodeMirrorDocument._(this, new Doc(content, mode));
+  }
+
+  void execCommand(String name) {
+    cm.execCommand(name);
+  }
+
+  bool get completionActive {
+    if (cm.jsProxy['state']['completionActive'] == null) {
+      return false;
+    } else {
+      return cm.jsProxy['state']['completionActive']['widget'] != null;
+    }
   }
 
   String get mode => cm.getMode();

--- a/lib/editing/editor_comid.dart
+++ b/lib/editing/editor_comid.dart
@@ -150,6 +150,13 @@ class _CodeMirrorEditor extends Editor {
     return new _CodeMirrorDocument._(this, new Doc(content, mode));
   }
 
+  void execCommand(String name) {
+    cm.execCommand(name);
+  }
+
+  //TODO: Implement completionActive for comid.
+  bool get completionActive => null;
+
   String get mode => cm.doc.getMode().name;
   set mode(String str) => cm.setOption('mode', str);
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -48,7 +48,7 @@ class Playground {
   DivElement get _outputpanel => querySelector('#output');
   IFrameElement get _frame => querySelector('#frame');
   DivElement get _docPanel => querySelector('#documentation');
-  bool get _isCompletionActive => querySelector(".CodeMirror-hint-active") != null;
+  bool get _isCompletionActive => editor.completionActive;
   bool get _isDocPanelOpen => querySelector("#doctab").attributes.containsKey('selected');
 
   DButton runbutton;
@@ -199,6 +199,15 @@ class Playground {
       _handleHelp();
     });
     document.onKeyUp.listen((e) {
+      if (options.getValue("autopopup_code_completion") == "true") {
+        RegExp exp = new RegExp(r"[a-zA-Z]");
+        //TODO: _isCompletionActive won't work correct
+        //TODO: which causes some issues
+        //TODO: will be fixed when we use the latest codemirror.js version
+        if (!_isCompletionActive && exp.hasMatch(new String.fromCharCode(e.keyCode)) || e.keyCode == KeyCode.PERIOD) {
+          editor.execCommand("autocomplete");
+        }
+      }
       if (_isCompletionActive || [KeyCode.LEFT,KeyCode.RIGHT,KeyCode.UP,KeyCode.DOWN].contains(e.keyCode)) {
         _handleHelp();
       }
@@ -236,6 +245,7 @@ class Playground {
     });
     options.registerOption('foo.bar', 'true');
     options.registerOption('foo.baz', 'qux');
+    options.registerOption('autopopup_code_completion', 'false');
 
     _finishedInit();
   }


### PR DESCRIPTION
couple of issues, but those will be fixed if we merge this commit at codemirror.js

https://github.com/codemirror/CodeMirror/commit/e29fecf2127bae8924d13beb06f37d9fed91d739

You can try it live her:
http://kasperpeulen.github.io/dart-pad/

Not exactly the same code as this PR (no suggestions is not yet implemented there), but the general idea of the auto popup is the same.