### PR TITLE
completion filter

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -26,7 +26,7 @@ class DartCompleter extends CodeCompleter {
 
   DartCompleter(this.servicesApi, this.document);
 
-  Future<List<Completion>> complete(Editor editor) {
+  Future<Completions> complete(Editor editor) {
     // Cancel any open completion request.
     if (_lastCompleter != null) _lastCompleter.cancel(reason: "new request");
 
@@ -44,23 +44,24 @@ class DartCompleter extends CodeCompleter {
     servicesApi.complete(request).then((CompleteResponse response) {
       if (completer.isCancelled) return;
 
+      int replacementOffset = response.replacementOffset;
+      int replacementLength = response.replacementLength;
+
       _logger.info('completion request in ${timer.elapsedMilliseconds}ms; '
           '${response.completions.length} completions, '
-          'offset=${response.replacementOffset}, '
-          'length=${response.replacementLength}');
+          'offset=${replacementOffset}, '
+          'length=${replacementLength}');
 
       List<AnalysisCompletion> analysisCompletions = response.completions.map(
           (completion) {
         return new AnalysisCompletion(
-            response.replacementOffset, response.replacementLength, completion);
+            replacementOffset, replacementLength, completion);
       }).toList();
 
-      int replacementOffset = response.replacementOffset;
-      int delta = offset - replacementOffset;
-      String lowerPrefix = editor.document.value.substring(
-          replacementOffset, replacementOffset + delta).toLowerCase();
+      String lowercaseReplacementString =  editor.document.value.substring(
+          replacementOffset, replacementOffset + replacementLength).toLowerCase();
 
-      List<Completion> completions =  analysisCompletions.map((completion) {
+      List<Completion> completionList =  analysisCompletions.map((completion) {
         // TODO: Move to using a LabelProvider; decouple the data and rendering.
         String displayString = completion.isMethod
             ? '${completion.text}${completion.parameters}' : completion.text;
@@ -71,8 +72,8 @@ class DartCompleter extends CodeCompleter {
         // Filter unmatching completions.
         // TODO: This is temporary; tracking issue here:
         // https://github.com/dart-lang/dart-services/issues/87.
-        if (delta > 0) {
-          if (!completion.text.toLowerCase().startsWith(lowerPrefix)) {
+        if (lowercaseReplacementString.isNotEmpty) {
+          if (!completion.text.toLowerCase().contains(lowercaseReplacementString)) {
             return null;
           }
         }
@@ -80,9 +81,6 @@ class DartCompleter extends CodeCompleter {
         // TODO: We need to be more precise about the text we're inserting and
         // replacing.
         String text = completion.text;
-        if (delta > 0 && delta <= text.length) {
-          text = text.substring(delta);
-        }
 
         if (completion.isMethod) {
           text += "()";
@@ -103,9 +101,7 @@ class DartCompleter extends CodeCompleter {
         }
       }).where((x) => x != null).toList();
 
-      if (completions.isEmpty) {
-        // TODO: Flash something to indicate that there were no completions.
-      }
+      Completions completions = new Completions(completionList, replacementOffset: replacementOffset, replacementLength: replacementLength);
 
       completer.complete(completions);
     }).catchError((e) {

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -126,18 +126,20 @@ class Position {
 }
 
 abstract class CodeCompleter {
-  Future<Completions> complete(Editor editor);
+  Future<CompletionResult> complete(Editor editor);
 }
 
-class Completions {
+class CompletionResult {
 
-  List<Completion> completionList;
+  final List<Completion> completions;
 
-  int replacementOffset;
+  /// The start offset of the text to be replaced by a completion.
+  final int replacementOffset;
 
-  int replacementLength;
+  /// The length of the text to be replaced by a completion.
+  final int replacementLength;
 
-  Completions(this.completionList, {this.replacementOffset, this.replacementLength});
+  CompletionResult(this.completions, {this.replacementOffset, this.replacementLength});
 }
 
 class Completion {

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -126,7 +126,18 @@ class Position {
 }
 
 abstract class CodeCompleter {
-  Future<List<Completion>> complete(Editor editor);
+  Future<Completions> complete(Editor editor);
+}
+
+class Completions {
+
+  List<Completion> completionList;
+
+  int replacementOffset;
+
+  int replacementLength;
+
+  Completions(this.completionList, {this.replacementOffset, this.replacementLength});
 }
 
 class Completion {

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -94,11 +94,10 @@ class CodeMirrorFactory extends EditorFactory {
 
   Future<HintResults> _completionHelper(CodeMirror editor,
       CodeCompleter completer, HintsOptions options) {
-    pos.Position position = editor.getCursor();
     _CodeMirrorEditor ed = new _CodeMirrorEditor._(this, editor);
 
-    return completer.complete(ed).then((List<Completion> completions) {
-      List<HintResult> hints = completions.map((Completion completion) {
+    return completer.complete(ed).then((Completions completions) {
+      List<HintResult> hints = completions.completionList.map((Completion completion) {
         return new HintResult(
             completion.value,
             displayText: completion.displayString,
@@ -113,15 +112,14 @@ class CodeMirrorFactory extends EditorFactory {
             }
         );
       }).toList();
-
-      if (hints.length == 0 && ed.completionActive) {
-        hints = [
-          new HintResult("", displayText: "No suggestions",
-              className: "type-no_suggestions")
-        ];
+      pos.Position from =  editor.getDoc().posFromIndex(completions.replacementOffset);
+      pos.Position to = editor.getDoc().posFromIndex(completions.replacementOffset + completions.replacementLength);
+      String stringToReplace = editor.getDoc().getValue().substring(
+          completions.replacementOffset, completions.replacementOffset + completions.replacementLength);
+      if (hints.length == 0) {
+        hints = [new HintResult(stringToReplace, displayText: "No suggestions", className: "type-no_suggestions")];
       }
-
-      return new HintResults.fromHints(hints, position, position);
+      return new HintResults.fromHints(hints, from, to);
     });
   }
 }

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -96,8 +96,8 @@ class CodeMirrorFactory extends EditorFactory {
       CodeCompleter completer, HintsOptions options) {
     _CodeMirrorEditor ed = new _CodeMirrorEditor._(this, editor);
 
-    return completer.complete(ed).then((Completions completions) {
-      List<HintResult> hints = completions.completionList.map((Completion completion) {
+    return completer.complete(ed).then((CompletionResult completionResult) {
+      List<HintResult> hints = completionResult.completions.map((Completion completion) {
         return new HintResult(
             completion.value,
             displayText: completion.displayString,
@@ -112,10 +112,10 @@ class CodeMirrorFactory extends EditorFactory {
             }
         );
       }).toList();
-      pos.Position from =  editor.getDoc().posFromIndex(completions.replacementOffset);
-      pos.Position to = editor.getDoc().posFromIndex(completions.replacementOffset + completions.replacementLength);
+      pos.Position from =  editor.getDoc().posFromIndex(completionResult.replacementOffset);
+      pos.Position to = editor.getDoc().posFromIndex(completionResult.replacementOffset + completionResult.replacementLength);
       String stringToReplace = editor.getDoc().getValue().substring(
-          completions.replacementOffset, completions.replacementOffset + completions.replacementLength);
+          completionResult.replacementOffset, completionResult.replacementOffset + completionResult.replacementLength);
       if (hints.length == 0) {
         hints = [new HintResult(stringToReplace, displayText: "No suggestions", className: "type-no_suggestions")];
       }

--- a/lib/editing/editor_comid.dart
+++ b/lib/editing/editor_comid.dart
@@ -117,10 +117,10 @@ class ComidFactory extends EditorFactory {
       [hints.ShowProposals displayProposals]) {
     assert(displayProposals != null); // ensure async
     _CodeMirrorEditor ed = new _CodeMirrorEditor._(this, cm); // new instance!?
-    Future<Completions> props = completer.complete(ed);
+    Future<CompletionResult> props = completer.complete(ed);
     Pos pos = cm.getCursor();
-    props.then((Completions completions) {
-      List<Completion> completionList = completions.completionList;
+    props.then((CompletionResult completions) {
+      List<Completion> completionList = completions.completions;
       hints.ProposalList proposals;
       List<hints.Proposal> list = completionList.map((Completion completion) =>
           // this map is broken -- should use custom display ala Dart Editor

--- a/lib/editing/editor_comid.dart
+++ b/lib/editing/editor_comid.dart
@@ -117,11 +117,12 @@ class ComidFactory extends EditorFactory {
       [hints.ShowProposals displayProposals]) {
     assert(displayProposals != null); // ensure async
     _CodeMirrorEditor ed = new _CodeMirrorEditor._(this, cm); // new instance!?
-    Future<List<Completion>> props = completer.complete(ed);
+    Future<Completions> props = completer.complete(ed);
     Pos pos = cm.getCursor();
-    props.then((List<Completion> completions) {
+    props.then((Completions completions) {
+      List<Completion> completionList = completions.completionList;
       hints.ProposalList proposals;
-      List<hints.Proposal> list = completions.map((Completion completion) =>
+      List<hints.Proposal> list = completionList.map((Completion completion) =>
           // this map is broken -- should use custom display ala Dart Editor
           new hints.Proposal(completion.value)).toList();
       proposals = new hints.ProposalList(list: list, from: pos, to: pos);


### PR DESCRIPTION
This would solve both:
fix https://github.com/dart-lang/dart-pad/issues/152
and:
fix https://github.com/dart-lang/dart-pad/issues/202

I think this would also make the code of DartCompleter a little bit more logical. Not sure if you guys like it if I go this direciton, so before I move to fixing https://github.com/dart-lang/dart-pad/issues/203, I would like to hear if you guys agree with going this direction.

Basicly, I added the class Completions, and I now use the suggestions of the analyzer about which text to replace.

![](http://g.recordit.co/h6qoUKl3VV.gif)
![](http://g.recordit.co/BTX1ZNhWpl.gif)