### PR TITLE
fix an issue with the no suggestions logic

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -123,13 +123,13 @@ class CodeMirrorFactory extends EditorFactory {
           result.replaceOffset, result.replaceOffset + result.replaceLength);
 
       if (hints.isEmpty) {
-        return [
+        hints = [
           new HintResult(stringToReplace,
               displayText: "No suggestions", className: "type-no_suggestions")
         ];
-      } else {
-        return new HintResults.fromHints(hints, from, to);
       }
+
+      return new HintResults.fromHints(hints, from, to);
     });
   }
 }


### PR DESCRIPTION
Fix an issue with the 'no suggestions' logic. I had changed the method to return a list, when it should have been returning a `HintResults` object.

@kasperpeulen 