### PR TITLE
new styling for getters and setters

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -161,5 +161,6 @@ class Completion {
   Completion(this.value, {this.displayString, this.type, this.cursorOffset});
 
   bool isSetterAndMatchesGetter(Completion other) =>
-    displayString == other.displayString && (type == "type-getter" && other.type == "type-setter");
+      displayString == other.displayString &&
+      (type == "type-getter" && other.type == "type-setter");
 }

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -110,9 +110,13 @@ li.CodeMirror-hint-active {
   line-height: 16px; /*for vertical centering */
 }
 
-.type-getter::before,
+.type-getter::before {
+  content: "⇽";
+  background: radial-gradient(#e1C2ff, #cdb7e8);
+}
+
 .type-setter::before {
-  content: "p";
+  content: "⇾";
   background: radial-gradient(#e1C2ff, #cdb7e8);
 }
 

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -94,10 +94,15 @@ li.CodeMirror-hint-active {
   content: " ";
 }
 
+.deprecated {
+  text-decoration: line-through;
+}
+
 .type-keyword::before {
   background: radial-gradient(#f0dfaf, #e0cfa1);
   content : "k";
 }
+
 .type-class::before {
   content: "C";
   background: radial-gradient(#A2D7F5, #8ebfd7);


### PR DESCRIPTION
Use separate styling for getters and setters, so they can be easily differentiated in the code completion UI.

Some unicode arrows: http://en.wikipedia.org/wiki/Template:Unicode_chart_Arrows

@kasperpeulen; fix for https://github.com/dart-lang/dart-services/issues/90