### PR TITLE
vertical styling in chrome

### DIFF
--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -169,7 +169,19 @@ li.CodeMirror-hint-active {
 
 .type-no_suggestions::before {
   content: "?";
-  line-height: 14px; /*for vertical centering */
   background: radial-gradient(#fff, #eee);
-  vertical-align: text-bottom;
 }
+
+/*Chrome specific styling hack*/
+@media all and (-webkit-min-device-pixel-ratio:0) and (min-resolution: .001dpcm) {
+  #documentation h1::before, .CodeMirror-hint::before {
+    line-height: 16px;
+  }
+  .type-field::before,
+  .type-function_type_alias::before,
+  .type-function::before,
+  .type-class::before {
+    line-height: 18px; /*for vertical centering */
+  }
+}
+

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -172,10 +172,10 @@ li.CodeMirror-hint-active {
   background: radial-gradient(#fff, #eee);
 }
 
-/*Chrome specific styling hack*/
+/*Chrome specific styling hack, see #236*/
 @media all and (-webkit-min-device-pixel-ratio:0) and (min-resolution: .001dpcm) {
   #documentation h1::before, .CodeMirror-hint::before {
-    line-height: 16px;
+    line-height: 16px;  /*for vertical centering */
   }
   .type-field::before,
   .type-function_type_alias::before,


### PR DESCRIPTION
fix https://github.com/dart-lang/dart-pad/issues/236

the only downside of this is that the text of the icons are not centered in dartium/chromium, but all other browser I've tested it looks good (chrome, safari, opera, firefox)