### PR TITLE
shows doc after a completion popup

### DIFF
--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -21,8 +21,14 @@ class Keys {
     _sub = document.onKeyDown.listen(_handleKeyEvent);
   }
 
-  void bind(String key, Function action) {
-    _bindings[key] = action;
+  /**
+   * Bind a list of keys to an action.
+   * The key is a string, with a specific format.
+   * Here are some examples of this format:
+   * `ctrl-space`, `f1`, `macctrl-a`, `shift-left`, `alt-.`
+   */
+  void bind(List<String> keys, Function action) {
+    keys.forEach((key) => _bindings[key] = action);
   }
 
   void dispose() {
@@ -145,6 +151,7 @@ final Map _codeMap = {
   KeyCode.BACKSLASH: '\\', //
 
   KeyCode.ENTER: 'enter', //
+  KeyCode.SPACE: 'space', //
 
   KeyCode.OPEN_SQUARE_BRACKET: '[', //
   KeyCode.CLOSE_SQUARE_BRACKET: ']', //

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -68,12 +68,6 @@ class CodeMirrorFactory extends EditorFactory {
         'cursorHeight': 0.85,
         //'gutters': [_gutterId],
         'extraKeys': {
-          'Ctrl-Space': (jsEditor) {
-            // TODO: maybe move this to playground ?
-            CodeMirror editor = new CodeMirror.fromJsObject(jsEditor);
-            editor.jsProxy['state']['completionAutoInvoked'] = false;
-            editor.execCommand('autocomplete');
-          },
           'Cmd-/': 'toggleComment',
           'Ctrl-/': 'toggleComment'
         },

--- a/lib/mobile/mobile.dart
+++ b/lib/mobile/mobile.dart
@@ -301,9 +301,9 @@ class PlaygroundMobile {
     // TODO: Add a real code completer here.
     //editorFactory.registerCompleter('dart', new DartCompleter());
 
-    keys.bind('ctrl-s', _handleSave);
-    keys.bind('ctrl-enter', _handleRun);
-    keys.bind('f1', _handleHelp);
+    keys.bind(['ctrl-s'], _handleSave);
+    keys.bind(['ctrl-enter'], _handleRun);
+    keys.bind(['f1'], _handleHelp);
 
     _context = new PlaygroundContext(editor);
     deps[Context] = _context;

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -193,12 +193,19 @@ class Playground {
     _editpanel.children.first.attributes['flex'] = '';
     editor.resize();
 
-    keys.bind('ctrl-s', _handleSave);
-    keys.bind('ctrl-enter', _handleRun);
-    keys.bind('f1', () {
+    keys.bind(['ctrl-s'], _handleSave);
+    keys.bind(['ctrl-enter'], _handleRun);
+    keys.bind(['f1'], () {
       _toggleDocTab();
       _handleHelp();
     });
+
+    keys.bind(['crtl-space', 'macctrl-space'], (){
+      editor.completionAutoInvoked = false;
+      editor.execCommand('autocomplete');
+      new Timer(const Duration(milliseconds: 500), _handleHelp);
+    });
+
     document.onKeyUp.listen((e) {
       if (_isCompletionActive || cursorKeys.contains(e.keyCode)) _handleHelp();
 
@@ -207,11 +214,13 @@ class Playground {
 
       if (e.keyCode == KeyCode.PERIOD) {
         editor.execCommand("autocomplete");
+        new Timer(const Duration(milliseconds: 500), _handleHelp);
       } else if (options.getValueBool('autopopup_code_completion')) {
         RegExp exp = new RegExp(r"[A-Z]");
         if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
           editor.completionAutoInvoked = true;
           editor.execCommand("autocomplete");
+          new Timer(const Duration(milliseconds: 500), _handleHelp);
         }
       }
     });


### PR DESCRIPTION
fix https://github.com/dart-lang/dart-pad/issues/228

This is now done with a timer, which I think works quite well, but I'm still interested in finding a way to show the doc exactly after the completion popup is attached to the dom.

For example could we fake an F1 press after we construct the completion ? 
I tried something like:
`document.dispatchEvent(new KeyEvent('keypress', keyCode: KeyCode.F1));`

but this made dartium crash