### PR TITLE
autocomplete html css

### DIFF
--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -149,13 +149,42 @@ final Map _codeMap = {
   KeyCode.COMMA: ',', //
   KeyCode.SLASH: '/', //
   KeyCode.BACKSLASH: '\\', //
+  KeyCode.SEMICOLON: ";", //
+  KeyCode.DASH: "-", //
+  KeyCode.EQUALS: "=", //
+  KeyCode.APOSTROPHE: "`", //
+  KeyCode.SINGLE_QUOTE: "'", //
+  KeyCode.QUESTION_MARK: "?", //
 
   KeyCode.ENTER: 'enter', //
   KeyCode.SPACE: 'space', //
+  KeyCode.TAB: "tab", //
 
   KeyCode.OPEN_SQUARE_BRACKET: '[', //
   KeyCode.CLOSE_SQUARE_BRACKET: ']', //
 
   KeyCode.LEFT: 'left', //
   KeyCode.RIGHT: 'right', //
+  KeyCode.UP: "up", //
+  KeyCode.DOWN: "down", //
+
+  KeyCode.BACKSPACE: "backsapce", //
+  KeyCode.CAPS_LOCK: "caps_lock", //
+  KeyCode.DELETE: "delete", //
+  KeyCode.END: "end", //
+  KeyCode.ESC: "esc", //
+  KeyCode.HOME: "home", //
+  KeyCode.INSERT: "insert", //
+  KeyCode.NUMLOCK: "numlock", //
+  KeyCode.PAGE_DOWN: "page_down", //
+  KeyCode.PAGE_UP: "page_up", //
+  KeyCode.PAUSE: "pause", //
+  KeyCode.PRINT_SCREEN: "print_screen", //
+
+  // Already handled above.
+  // If you press ctrl and nothing more,
+  // then printKeyEvent will print ctrl-.
+  KeyCode.CTRL: "", //
+  KeyCode.META: "", //
+  KeyCode.SHIFT: "", //
 };

--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -21,8 +21,14 @@ class Keys {
     _sub = document.onKeyDown.listen(_handleKeyEvent);
   }
 
-  void bind(String key, Function action) {
-    _bindings[key] = action;
+  /**
+   * Bind a list of keys to an action.
+   * The key is a string, with a specific format.
+   * Here are some examples of this format:
+   * `ctrl-space`, `f1`, `macctrl-a`, `shift-left`, `alt-.`
+   */
+  void bind(List<String> keys, Function action) {
+    keys.forEach((key) => _bindings[key] = action);
   }
 
   void dispose() {
@@ -145,6 +151,7 @@ final Map _codeMap = {
   KeyCode.BACKSLASH: '\\', //
 
   KeyCode.ENTER: 'enter', //
+  KeyCode.SPACE: 'space', //
 
   KeyCode.OPEN_SQUARE_BRACKET: '[', //
   KeyCode.CLOSE_SQUARE_BRACKET: ']', //

--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -24,7 +24,7 @@ class Keys {
   /**
    * Bind a list of keys to an action.
    * The key is a string, with a specific format.
-   * Here are some examples of this format:
+   * Some examples of this format:
    * `ctrl-space`, `f1`, `macctrl-a`, `shift-left`, `alt-.`
    */
   void bind(List<String> keys, Function action) {

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -59,6 +59,11 @@
   padding-right: 10px;
 }
 
+.CodeMirror-hint em {
+  font-style: normal;
+  font-weight: bold;
+}
+
 li.CodeMirror-hint-active {
   background: #545454;
 }

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -97,6 +97,13 @@ class CodeMirrorFactory extends EditorFactory {
 
     return completer.complete(ed).then((CompletionResult result) {
       Doc doc = editor.getDoc();
+      pos.Position from =  doc.posFromIndex(result.replaceOffset);
+      pos.Position to = doc.posFromIndex(
+          result.replaceOffset + result.replaceLength);
+      String stringToReplace = doc.getValue().substring(
+          result.replaceOffset, result.replaceOffset + result.replaceLength);
+
+
 
       List<HintResult> hints = result.completions.map((Completion completion) {
         return new HintResult(
@@ -111,15 +118,12 @@ class CodeMirrorFactory extends EditorFactory {
                 doc.setCursor(new pos.Position(
                     editor.getCursor().line, editor.getCursor().ch - diff));
               }
+            },
+            hintRenderer: (html.Element element, HintResult hint) {
+              element.innerHtml = completion.displayString.replaceFirst(stringToReplace,"<em>${stringToReplace}</em>");
             }
         );
       }).toList();
-
-      pos.Position from =  doc.posFromIndex(result.replaceOffset);
-      pos.Position to = doc.posFromIndex(
-          result.replaceOffset + result.replaceLength);
-      String stringToReplace = doc.getValue().substring(
-          result.replaceOffset, result.replaceOffset + result.replaceLength);
 
       // Only show 'no suggestions' if the completion was explicitly invoked
       // or if the popup was already active.

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -68,12 +68,6 @@ class CodeMirrorFactory extends EditorFactory {
         'cursorHeight': 0.85,
         //'gutters': [_gutterId],
         'extraKeys': {
-          'Ctrl-Space': (jsEditor) {
-            // TODO: maybe move this to playground ?
-            CodeMirror editor = new CodeMirror.fromJsObject(jsEditor);
-            editor.jsProxy['state']['completionAutoInvoked'] = false;
-            editor.execCommand('autocomplete');
-          },
           'Cmd-/': 'toggleComment',
           'Ctrl-/': 'toggleComment'
         },

--- a/lib/mobile/mobile.dart
+++ b/lib/mobile/mobile.dart
@@ -301,9 +301,9 @@ class PlaygroundMobile {
     // TODO: Add a real code completer here.
     //editorFactory.registerCompleter('dart', new DartCompleter());
 
-    keys.bind('ctrl-s', _handleSave);
-    keys.bind('ctrl-enter', _handleRun);
-    keys.bind('f1', _handleHelp);
+    keys.bind(['ctrl-s'], _handleSave);
+    keys.bind(['ctrl-enter'], _handleRun);
+    keys.bind(['f1'], _handleHelp);
 
     _context = new PlaygroundContext(editor);
     deps[Context] = _context;

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -193,12 +193,19 @@ class Playground {
     _editpanel.children.first.attributes['flex'] = '';
     editor.resize();
 
-    keys.bind('ctrl-s', _handleSave);
-    keys.bind('ctrl-enter', _handleRun);
-    keys.bind('f1', () {
+    keys.bind(['ctrl-s'], _handleSave);
+    keys.bind(['ctrl-enter'], _handleRun);
+    keys.bind(['f1'], () {
       _toggleDocTab();
       _handleHelp();
     });
+
+    keys.bind(['crtl-space', 'macctrl-space'], (){
+      editor.completionAutoInvoked = false;
+      editor.execCommand('autocomplete');
+      new Timer(const Duration(milliseconds: 500), _handleHelp);
+    });
+
     document.onKeyUp.listen((e) {
       if (_isCompletionActive || cursorKeys.contains(e.keyCode)) _handleHelp();
 
@@ -207,11 +214,13 @@ class Playground {
 
       if (e.keyCode == KeyCode.PERIOD) {
         editor.execCommand("autocomplete");
+        new Timer(const Duration(milliseconds: 500), _handleHelp);
       } else if (options.getValueBool('autopopup_code_completion')) {
         RegExp exp = new RegExp(r"[A-Z]");
         if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
           editor.completionAutoInvoked = true;
           editor.execCommand("autocomplete");
+          new Timer(const Duration(milliseconds: 500), _handleHelp);
         }
       }
     });

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -201,10 +201,10 @@ class Playground {
       _handleHelp();
     });
 
-    keys.bind(['crtl-space', 'macctrl-space'], (){
+    keys.bind(['ctrl-space', 'macctrl-space'], (){
       editor.completionAutoInvoked = false;
       editor.execCommand('autocomplete');
-      new Timer(const Duration(milliseconds: 500), _handleHelp);
+      _handleHelp();
     });
 
     document.onKeyUp.listen((e) {
@@ -303,7 +303,7 @@ class Playground {
       if (e.keyCode == KeyCode.PERIOD) {
         editor.completionAutoInvoked = true;
         editor.execCommand("autocomplete");
-        new Timer(const Duration(milliseconds: 500), _handleHelp);
+        _handleHelp();
       }
     }
     if (!options.getValueBool('autopopup_code_completion')) {
@@ -315,7 +315,7 @@ class Playground {
         if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
           editor.completionAutoInvoked = true;
           editor.execCommand("autocomplete");
-          new Timer(const Duration(milliseconds: 500), _handleHelp);
+          _handleHelp();
         }
     } else if (context.focusedEditor == "html") {
       if (options.getValueBool('autopopup_code_completion')) {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -12,6 +12,7 @@ import 'dart:convert';
 import 'package:logging/logging.dart';
 import 'package:markd/markdown.dart' as markdown;
 import 'package:route_hierarchical/client.dart';
+import 'package:dart_pad/core/keys.dart';
 
 import 'completion.dart';
 import 'context.dart';
@@ -209,20 +210,7 @@ class Playground {
     document.onKeyUp.listen((e) {
       if (_isCompletionActive || cursorKeys.contains(e.keyCode)) _handleHelp();
 
-      // If we're already in completion bail.
-      if (_isCompletionActive) return;
-
-      if (e.keyCode == KeyCode.PERIOD) {
-        editor.execCommand("autocomplete");
-        new Timer(const Duration(milliseconds: 500), _handleHelp);
-      } else if (options.getValueBool('autopopup_code_completion')) {
-        RegExp exp = new RegExp(r"[A-Z]");
-        if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
-          editor.completionAutoInvoked = true;
-          editor.execCommand("autocomplete");
-          new Timer(const Duration(milliseconds: 500), _handleHelp);
-        }
-      }
+      _handleAutoCompletion(e);
     });
     document.onClick.listen((e) => _handleHelp());
 
@@ -304,6 +292,46 @@ class Playground {
 
     _outputpanel.style.display = "block";
     querySelector("#consoletab").setAttribute('selected','');
+  }
+
+
+  _handleAutoCompletion(KeyboardEvent e) {
+    // If we're already in completion bail.
+    if (_isCompletionActive) return;
+
+    if (context.focusedEditor == 'dart') {
+      if (e.keyCode == KeyCode.PERIOD) {
+        editor.completionAutoInvoked = true;
+        editor.execCommand("autocomplete");
+        new Timer(const Duration(milliseconds: 500), _handleHelp);
+      }
+    }
+    if (!options.getValueBool('autopopup_code_completion')) {
+      return;
+    }
+
+    if (context.focusedEditor == 'dart') {
+      RegExp exp = new RegExp(r"[A-Z]");
+        if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
+          editor.completionAutoInvoked = true;
+          editor.execCommand("autocomplete");
+          new Timer(const Duration(milliseconds: 500), _handleHelp);
+        }
+    } else if (context.focusedEditor == "html") {
+      if (options.getValueBool('autopopup_code_completion')) {
+        // TODO: autocompletion for attirbutes
+        if (printKeyEvent(e) == "shift-,") {
+          editor.completionAutoInvoked = true;
+          editor.execCommand("autocomplete");
+        }
+      }
+    } else if (context.focusedEditor == "css") {
+      RegExp exp = new RegExp(r"[A-Z]");
+      if (exp.hasMatch(new String.fromCharCode(e.keyCode))) {
+        editor.completionAutoInvoked = true;
+        editor.execCommand("autocomplete");
+      }
+    }
   }
 
   void _handleRun() {


### PR DESCRIPTION
triggers it on a-zA-Z for css with seems to work quite nice, and this triggers it on `<` for html

triggering it also for attributes is a bit more tricky, will look at that later

fix https://github.com/dart-lang/dart-pad/issues/207