### PR TITLE
make sure that the completion callback returns the same editor wrappers

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -71,6 +71,9 @@ abstract class Editor {
   void focus();
 
   void swapDocument(Document document);
+
+  /// Let the `Editor` instance know that it will no longer be used.
+  void dispose() { }
 }
 
 abstract class Document {

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -25,6 +25,8 @@ abstract class EditorFactory {
 abstract class Editor {
   final EditorFactory factory;
 
+  bool completionAutoInvoked = false;
+
   Editor(this.factory);
 
   Document createDocument({String content, String mode});
@@ -42,8 +44,6 @@ abstract class Editor {
    * codemirror; returns `null` for ace editor and comid.
    */
   bool get completionActive;
-
-  bool completionAutoInvoked;
 
   String get mode;
   set mode(String str);

--- a/lib/editing/editor_ace.dart
+++ b/lib/editing/editor_ace.dart
@@ -97,6 +97,8 @@ class AceFactory extends EditorFactory {
 class _AceEditor extends Editor {
   final ace.Editor editor;
 
+  bool completionAutoInvoked = false;
+
   _AceDocument _document;
 
   _AceEditor._(AceFactory factory, this.editor) : super(factory) {
@@ -121,10 +123,6 @@ class _AceEditor extends Editor {
 
   // TODO: Implement completionActive for ace.
   bool get completionActive => false;
-
-  // TODO: Implement completionActivelyInvoked for comid.
-  bool get completionAutoInvoked => false;
-  set completionAutoInvoked(bool value) { }
 
   String get mode => _document.session.mode.name;
   set mode(String str) => _document.session.mode = new ace.Mode.named(str);

--- a/lib/editing/editor_ace.dart
+++ b/lib/editing/editor_ace.dart
@@ -97,8 +97,6 @@ class AceFactory extends EditorFactory {
 class _AceEditor extends Editor {
   final ace.Editor editor;
 
-  bool completionAutoInvoked = false;
-
   _AceDocument _document;
 
   _AceEditor._(AceFactory factory, this.editor) : super(factory) {

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -95,7 +95,7 @@ class CodeMirrorFactory extends EditorFactory {
 
   Future<HintResults> _completionHelper(CodeMirror editor,
       CodeCompleter completer, HintsOptions options) {
-    _CodeMirrorEditor ed = new _CodeMirrorEditor._(this, editor);
+    _CodeMirrorEditor ed = new _CodeMirrorEditor._fromExisting(this, editor);
 
     return completer.complete(ed).then((CompletionResult result) {
       Doc doc = editor.getDoc();
@@ -144,12 +144,29 @@ class CodeMirrorFactory extends EditorFactory {
 }
 
 class _CodeMirrorEditor extends Editor {
+  // Map from JsObject codemirror instances to existing dartpad wrappers.
+  static Map<dynamic, _CodeMirrorEditor> _instances = {};
+
   final CodeMirror cm;
+
+  bool completionAutoInvoked = false;
 
   _CodeMirrorDocument _document;
 
   _CodeMirrorEditor._(CodeMirrorFactory factory, this.cm) : super(factory) {
     _document = new _CodeMirrorDocument._(this, cm.getDoc());
+    _instances[cm.jsProxy] = this;
+  }
+
+  factory _CodeMirrorEditor._fromExisting(CodeMirrorFactory factory, CodeMirror cm) {
+    // TODO: We should ensure that the Dart `CodeMirror` wrapper returns the
+    // same instances to us when possible (or, identity is based on the
+    // underlying JS proxy).
+    if (_instances.containsKey(cm.jsProxy)) {
+      return _instances[cm.jsProxy];
+    } else {
+      return new _CodeMirrorEditor._(factory,  cm);
+    }
   }
 
   Document get document => _document;
@@ -162,9 +179,7 @@ class _CodeMirrorEditor extends Editor {
     return new _CodeMirrorDocument._(this, new Doc(content, mode));
   }
 
-  void execCommand(String name) {
-    cm.execCommand(name);
-  }
+  void execCommand(String name) => cm.execCommand(name);
 
   bool get completionActive {
     if (cm.jsProxy['state']['completionActive'] == null) {
@@ -173,11 +188,6 @@ class _CodeMirrorEditor extends Editor {
       return cm.jsProxy['state']['completionActive']['widget'] != null;
     }
   }
-
-  bool get completionAutoInvoked
-      => cm.jsProxy['state']['completionAutoInvoked'];
-  set completionAutoInvoked(bool value)
-      => cm.jsProxy['state']['completionAutoInvoked'] = value;
 
   String get mode => cm.getMode();
   set mode(String str) => cm.setMode(str);
@@ -200,6 +210,10 @@ class _CodeMirrorEditor extends Editor {
   void swapDocument(Document document) {
     _document = document;
     cm.swapDoc(_document.doc);
+  }
+
+  void dispose() {
+    _instances.remove(cm.jsProxy);
   }
 }
 

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -149,8 +149,6 @@ class _CodeMirrorEditor extends Editor {
 
   final CodeMirror cm;
 
-  bool completionAutoInvoked = false;
-
   _CodeMirrorDocument _document;
 
   _CodeMirrorEditor._(CodeMirrorFactory factory, this.cm) : super(factory) {

--- a/lib/editing/editor_comid.dart
+++ b/lib/editing/editor_comid.dart
@@ -138,6 +138,8 @@ class _CodeMirrorEditor extends Editor {
 
   _CodeMirrorDocument _document;
 
+  // TODO: Return an existing _CodeMirrorEditor instance if we already have one
+  // for the given instance of `CodeMirror`.
   _CodeMirrorEditor._(ComidFactory factory, this.cm) : super(factory) {
     _document = new _CodeMirrorDocument._(this, cm.getDoc());
   }
@@ -158,10 +160,6 @@ class _CodeMirrorEditor extends Editor {
 
   // TODO: Implement completionActive for comid.
   bool get completionActive => false;
-
-  // TODO: Implement completionActivelyInvoked for comid.
-  bool get completionAutoInvoked => false;
-  set completionAutoInvoked(bool value) { }
 
   String get mode => cm.doc.getMode().name;
   set mode(String str) => cm.setOption('mode', str);


### PR DESCRIPTION
@kasperpeulen for review

Return the same `Editor` instance from the completion callbacks as we are using in the rest of the UI.