### PR TITLE
Devoncarew toast ui

### DIFF
--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -200,12 +200,9 @@
   position: absolute;
   right: 16px;
   top: 0;
-  box-shadow: rgba(255, 255, 255, 0.1) 0 1px 0, rgba(0, 0, 0, 0.4) 0 1px 7px 0 inset;
   min-width: 12em;
   max-width: 40em;
-  background-color: inherit;
 
-  z-index: 10;
   opacity: 0;
   transition: 400ms;
   -webkit-user-select: none;
@@ -214,6 +211,15 @@
 .toast.showing {
   opacity: 1;
   top: 72px;
+}
+
+.dialog {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid;
+  border-color: rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+  box-shadow: rgba(255, 255, 255, 0.1) 0 0 0, rgba(0, 0, 0, 0.4) 0 1px 7px 0;
+  z-index: 20;
 }
 
 /* contenteditable elements */

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -313,7 +313,7 @@ class DToast extends DElement {
   final String message;
 
   DToast(this.message) : super.tag('div') {
-    element.classes.toggle('toast', true);
+    element.classes..toggle('toast', true)..toggle('dialog', true);
     element.text = message;
   }
 
@@ -326,7 +326,7 @@ class DToast extends DElement {
     });
   }
 
-  void hide([Duration delay = const Duration(seconds: 4)]) {
+  void hide([Duration delay = const Duration(seconds: 4000)]) {
     // Start a timer, hide, remove from dom.
     new Timer(delay, () {
       element.classes.toggle('showing', false);

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -326,7 +326,7 @@ class DToast extends DElement {
     });
   }
 
-  void hide([Duration delay = const Duration(seconds: 4000)]) {
+  void hide([Duration delay = const Duration(seconds: 4)]) {
     // Start a timer, hide, remove from dom.
     new Timer(delay, () {
       element.classes.toggle('showing', false);


### PR DESCRIPTION
- improve the UI of the toast component; the goal being to make it clear that the toast is separate from the page, and not an editable component embedded in the page. Added a border, removed the insets, added a shadow under the component
- added a `.dialog` css class, used by the toast, and hopefully will help define other components (modal alerts, dialogs, ...)

@lukechurch @kasperpeulen 

![screen shot 2015-04-12 at 2 03 18 pm](https://cloud.githubusercontent.com/assets/1269969/7107537/fadabf54-e11c-11e4-9f29-ac2a6f6dc324.png)
![screen shot 2015-04-12 at 2 01 38 pm](https://cloud.githubusercontent.com/assets/1269969/7107538/fe804976-e11c-11e4-9ebf-f1330c9dd80d.png)
