### PR TITLE
Devoncarew sharing ui

### DIFF
--- a/lib/actions.dart
+++ b/lib/actions.dart
@@ -40,8 +40,9 @@ class NewPadAction {
 class SharePadAction {
   final DButton _button;
   final GistContainer _gistContainer;
+  final DDialog sharingDialog;
 
-  SharePadAction(Element element, this._gistContainer) :
+  SharePadAction(Element element, this._gistContainer, this.sharingDialog) :
       _button = new DButton(element) {
     _button.onClick.listen((e) => _handleButtonPress());
     _gist.onDirtyChanged.listen((dirty) => _button.disabled = !dirty);
@@ -50,6 +51,11 @@ class SharePadAction {
   MutableGist get _gist => _gistContainer.mutableGist;
 
   void _handleButtonPress() {
+    if (true) {
+      sharingDialog.show();
+      return;
+    }
+
     final String message = 'Sharing this pad will create a permanent, publicly '
         'visible copy on gist.github.com.';
 

--- a/lib/actions.dart
+++ b/lib/actions.dart
@@ -6,7 +6,6 @@ library dartpad.actions;
 
 import 'dart:html';
 
-import 'dart_pad.dart';
 import 'elements/elements.dart';
 import 'sharing/gists.dart';
 import 'sharing/mutable_gist.dart';
@@ -15,9 +14,9 @@ import 'sharing/mutable_gist.dart';
 class NewPadAction {
   final DButton _button;
   final MutableGist _gist;
-  final GistStorage _gistStorage;
+  final GistController _gistController;
 
-  NewPadAction(Element element, this._gist, this._gistStorage) :
+  NewPadAction(Element element, this._gist, this._gistController) :
       _button = new DButton(element) {
     _button.onClick.listen((e) => _handleButtonPress());
   }
@@ -27,54 +26,6 @@ class NewPadAction {
       if (!window.confirm('Discard changes to the current pad?')) return;
     }
 
-    _gistStorage.clearStoredGist();
-
-    if (ga != null) ga.sendEvent('main', 'new');
-
-    DToast.showMessage('New pad created');
-    router.go('gist', {'gist': ''}, forceReload: true);
-  }
-}
-
-/// An action that creates a new anonymous copy of the current pad.
-class SharePadAction {
-  final DButton _button;
-  final GistContainer _gistContainer;
-  final DDialog sharingDialog;
-
-  SharePadAction(Element element, this._gistContainer, this.sharingDialog) :
-      _button = new DButton(element) {
-    _button.onClick.listen((e) => _handleButtonPress());
-    _gist.onDirtyChanged.listen((dirty) => _button.disabled = !dirty);
-  }
-
-  MutableGist get _gist => _gistContainer.mutableGist;
-
-  void _handleButtonPress() {
-    if (true) {
-      sharingDialog.show();
-      return;
-    }
-
-    final String message = 'Sharing this pad will create a permanent, publicly '
-        'visible copy on gist.github.com.';
-
-    if (!window.confirm(message)) return;
-
-    if (ga != null) ga.sendEvent('main', 'share');
-
-    gistLoader.createAnon(_gist.createGist()).then((Gist newGist) {
-      _gistContainer.overrideNextRoute(newGist);
-      router.go('gist', {'gist': newGist.id});
-      var toast = new DToast('Created ${newGist.id}')..show()..hide();
-      toast.element
-        ..style.cursor = "pointer"
-        ..onClick.listen((e)
-            => window.open("https://gist.github.com/anonymous/${newGist.id}", '_blank'));
-    }).catchError((e) {
-      String message = 'Error saving gist: ${e}';
-      DToast.showMessage(message);
-      ga.sendException('GistLoader.createAnon: failed to create gist');
-    });
+    _gistController.createNewGist();
   }
 }

--- a/lib/actions.dart
+++ b/lib/actions.dart
@@ -4,8 +4,10 @@
 
 library dartpad.actions;
 
+import 'dart:async';
 import 'dart:html';
 
+import 'dialogs.dart';
 import 'elements/elements.dart';
 import 'sharing/gists.dart';
 import 'sharing/mutable_gist.dart';
@@ -22,10 +24,17 @@ class NewPadAction {
   }
 
   void _handleButtonPress() {
+    Future<bool> response = new Future.value(true);
+
     if (_gist.dirty) {
-      if (!window.confirm('Discard changes to the current pad?')) return;
+      response = confirm(
+          'Create New Pad',
+          'Discard changes to the current pad?',
+          okText: 'Discard');
     }
 
-    _gistController.createNewGist();
+    response.then((val) {
+      if (val) _gistController.createNewGist();
+    });
   }
 }

--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library dartpad.dialogs;
+
+import 'dart:html';
+
+import 'elements/elements.dart';
+
+// TODO: closeable
+
+// TODO: submit button
+
+class SharingDialog extends DDialog {
+
+  SharingDialog() {
+    element.classes.toggle('sharing-dialog', true);
+
+    var text = new ParagraphElement();
+    text.text = 'Sharing this pad will create a permanent, publicly visible '
+        'copy on gist.github.com.';
+    element.children.add(text);
+  }
+}

--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -7,19 +7,99 @@ library dartpad.dialogs;
 import 'dart:html';
 
 import 'elements/elements.dart';
-
-// TODO: closeable
-
-// TODO: submit button
+import 'sharing/gists.dart';
+import 'sharing/mutable_gist.dart';
 
 class SharingDialog extends DDialog {
+  final GistContainer gistContainer;
+  final GistController gistController;
 
-  SharingDialog() {
+  ParagraphElement _text;
+  DButton _cancelButton;
+  DButton _shareButton;
+  DButton _closeButton;
+  DElement _div;
+  DInput _padUrl;
+  DInput _gistUrl;
+
+  SharingDialog(this.gistContainer, this.gistController) : super(title: 'Sharing') {
     element.classes.toggle('sharing-dialog', true);
 
-    var text = new ParagraphElement();
-    text.text = 'Sharing this pad will create a permanent, publicly visible '
-        'copy on gist.github.com.';
-    element.children.add(text);
+    _text = content.add(new ParagraphElement());
+
+    // About to share.
+    _cancelButton = new DButton.button(text: 'Cancel');
+    _cancelButton.onClick.listen((_) => hide());
+    _shareButton = new DButton.button(text: 'Share it!', classes: 'default');
+    _shareButton.onClick.listen((_) => _performShare());
+
+    // Already sharing.
+    _closeButton = new DButton.button(text: 'Close', classes: 'default');
+    _closeButton.onClick.listen((_) => hide());
+    _div = new DElement.tag('div')..layoutVertical();
+
+    DElement div = _div.add(new DElement.tag('div', classes: 'row')..layoutHorizontal());
+    div.add(new DElement.tag('span', classes: 'sharinglabel'))..text = 'DartPad:';
+    DElement inputGroup = div.add(new DElement.tag('div'))
+        ..layoutHorizontal()..flex();
+    _padUrl = inputGroup.add(new DInput.input(type: 'text'))..flex()..readonly();
+    _padUrl.onClick.listen((_) => _padUrl.selectAll());
+
+    div = _div.add(new DElement.tag('div', classes: 'row')..layoutHorizontal());
+    div.add(new DElement.tag('span', classes: 'sharinglabel'))..text = 'gist.github.com:';
+    inputGroup = div.add(new DElement.tag('div'))..layoutHorizontal()..flex();
+    _gistUrl = inputGroup.add(new DInput.input(type: 'text'))..flex()..readonly();
+    _gistUrl.onClick.listen((_) => _gistUrl.selectAll());
+  }
+
+  void show() {
+    _configure(gistContainer.mutableGist);
+    super.show();
+  }
+
+  void _configure(MutableGist gist) {
+    if (!gist.hasId || gist.dirty) {
+      _switchTo(aboutToShare: true);
+    } else {
+      _switchTo(aboutToShare: false);
+    }
+  }
+
+  void _switchTo({bool aboutToShare: true}) {
+    buttonArea.element.children.clear();
+    _div.dispose();
+
+    if (aboutToShare) {
+      // Show 'about to share'.
+      _text.text = 'Sharing this pad will create a permanent, publicly visible '
+          'copy on gist.github.com.';
+
+      buttonArea.add(_cancelButton);
+      buttonArea.add(new SpanElement()..attributes['flex'] = '');
+      buttonArea.add(_shareButton);
+    } else {
+      // Show the existing sharing info.
+      _text.text = 'Share the DartPad link or view the source at gist.github.com.';
+
+      MutableGist gist = gistContainer.mutableGist;
+
+      content.add(_div);
+      _padUrl.value = gist.html_url;
+      _gistUrl.value = 'https://dartpad.dartlang.org/${gist.id}';
+
+      buttonArea.add(new SpanElement()..attributes['flex'] = '');
+      buttonArea.add(_closeButton);
+    }
+  }
+
+  void _performShare() {
+    _shareButton.disabled = true;
+
+    // TODO: Show a spinner.
+    gistController.shareAnon().then((_) {
+      _switchTo(aboutToShare: false);
+    }).whenComplete(() {
+      _shareButton.disabled = false;
+    });
   }
 }

--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -200,12 +200,17 @@
   top: 0;
   min-width: 12em;
   max-width: 40em;
+  padding: 0.5em 1em;
 
   -webkit-user-select: none;
 }
 
 .toast.showing {
   top: 72px;
+}
+
+.toast.dialog {
+  z-index: 18;
 }
 
 .glass-pane {
@@ -222,7 +227,7 @@
 
 .dialog {
   position: absolute;
-  padding: 0.5em 1em;
+  padding: 10px;
   background-color: #444;
   border: 1px solid;
   border-color: rgba(0, 0, 0, 0.5);
@@ -238,8 +243,61 @@
   opacity: 1;
 }
 
+.dialog .title {
+  font-size: 16pt;
+  white-space: nowrap;
+}
+
+.dialog .content {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  min-width: 300px;
+  min-height: 60px;
+}
+
+.dialog .buttons button + button {
+  margin-left: 10px;
+}
+
 /* contenteditable elements */
 
 [contenteditable]:focus {
   outline: 0 solid transparent;
+}
+
+.button {
+  outline: none;
+  color: #aaa;
+  fill: #aaa;
+  border: 1px solid #222;
+  border-radius: 2px;
+  font-family: 'Roboto', sans-serif;
+  font-size: 12pt;
+  line-height: 18px;
+  height: 24px;
+  cursor: pointer;
+  padding: 2px 6px;
+  transition: 100ms;
+  min-width: 75px;
+  background-color: #444;
+  background-image: linear-gradient(to bottom, #444, #333);
+}
+
+.button.default,
+.button:hover {
+  color: #fff;
+  fill: #fff;
+}
+
+.button:active {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.button[disabled] {
+  color: #555;
+  fill: #555;
+  pointer-events: none;
+  border-color: #272727;
+  background-color: #3b3b3b;
+  background-image: none;
 }

--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -196,30 +196,46 @@
 }
 
 .toast {
-  padding: 0.5em 1em;
-  position: absolute;
   right: 16px;
   top: 0;
   min-width: 12em;
   max-width: 40em;
 
-  opacity: 0;
-  transition: 400ms;
   -webkit-user-select: none;
 }
 
 .toast.showing {
-  opacity: 1;
   top: 72px;
 }
 
+.glass-pane {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  opacity: 0.40;
+  background-color: #222;
+  z-index: 15;
+  transition: 200ms;
+}
+
 .dialog {
-  background: rgba(255, 255, 255, 0.06);
+  position: absolute;
+  padding: 0.5em 1em;
+  background-color: #444;
   border: 1px solid;
   border-color: rgba(0, 0, 0, 0.5);
   border-radius: 4px;
   box-shadow: rgba(255, 255, 255, 0.1) 0 0 0, rgba(0, 0, 0, 0.4) 0 1px 7px 0;
+  
+  opacity: 0;
+  transition: 400ms;
   z-index: 20;
+}
+
+.dialog.showing {
+  opacity: 1;
 }
 
 /* contenteditable elements */

--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -239,13 +239,26 @@
   z-index: 20;
 }
 
+.dialog-position {
+  top: 100px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 550px;
+}
+
 .dialog.showing {
   opacity: 1;
 }
 
 .dialog .title {
   font-size: 16pt;
+  text-shadow: rgba(0,0,0,0.75) 0 1px;
   white-space: nowrap;
+  padding: 5px 10px 10px 10px;
+  margin: 0 -10px;
+  box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+  border-bottom: 1px solid #333;
 }
 
 .dialog .content {
@@ -257,6 +270,10 @@
 
 .dialog .buttons button + button {
   margin-left: 10px;
+}
+
+.dialog p {
+  margin-top: 0.5em;
 }
 
 /* contenteditable elements */

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -435,7 +435,7 @@ abstract class DDialog extends DElement {
   DElement buttonArea;
 
   DDialog({String title}) : super.tag('div') {
-    element.classes.toggle('dialog', true);
+    element.classes.addAll(['dialog', 'dialog-position']);
     setAttr('layout');
     setAttr('vertical');
     pane.onCancel.listen((_) {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -102,6 +102,9 @@ class Playground implements GistContainer, GistController {
         querySelector('header .header-gist-name'));
     bind(titleEditable.onChanged, editableGist.property('description'));
     bind(editableGist.property('description'), titleEditable.textProperty);
+    editableGist.onDirtyChanged.listen((val) {
+      titleEditable.element.classes.toggle('dirty', val);
+    });
 
     // If there was a change, and the gist is dirty, write the gist's contents
     // to storage.

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -19,6 +19,7 @@ import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
 import 'dartservices_client/v1.dart';
+import 'dialogs.dart';
 import 'documentation.dart';
 import 'editing/editor.dart';
 import 'elements/bind.dart';
@@ -70,6 +71,8 @@ class Playground implements GistContainer {
 
   ModuleManager modules = new ModuleManager();
 
+  SharingDialog sharingDialog = new SharingDialog();
+
   Playground() {
     _registerTab(querySelector('#darttab'), 'dart');
     _registerTab(querySelector('#htmltab'), 'html');
@@ -79,7 +82,7 @@ class Playground implements GistContainer {
 
     new NewPadAction(querySelector('#newbutton'), editableGist, _gistStorage);
 
-    new SharePadAction(querySelector('#sharebutton'), this);
+    new SharePadAction(querySelector('#sharebutton'), this, sharingDialog);
 
     runButton = new DButton(querySelector('#runbutton'));
     runButton.onClick.listen((e) {

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -244,6 +244,11 @@ class GistFile {
   String toString() => '[${name}, ${content.length} chars]';
 }
 
+abstract class GistController {
+  Future createNewGist();
+  Future shareAnon();
+}
+
 /// A class to store gists in html's localStorage.
 class GistStorage {
   static final String _key = 'gist';

--- a/lib/sharing/mutable_gist.dart
+++ b/lib/sharing/mutable_gist.dart
@@ -22,6 +22,8 @@ class MutableGist implements PropertyOwner {
 
   MutableGist(this._backingGist);
 
+  bool get hasId => id != null && id.isNotEmpty;
+
   bool get dirty => _localValues.isNotEmpty;
 
   String get id => _backingGist.id;
@@ -93,6 +95,8 @@ class MutableGist implements PropertyOwner {
     if (wasDirty != dirty) _dirtyChangedController.add(dirty);
     _changedController.add(null);
   }
+
+  String toString() => _backingGist.toString();
 }
 
 class MutableGistFile {

--- a/web/index.css
+++ b/web/index.css
@@ -407,3 +407,11 @@ div.toggle {
   padding: 4px;
   background: #3f3f3f;
 }
+
+.sharing-dialog {
+  min-width: 400px;
+  min-height: 200px;
+  top: 100px;
+  left: 100px;
+  right: 100px;
+}

--- a/web/index.css
+++ b/web/index.css
@@ -153,24 +153,6 @@ a[selected]:hover {
   line-height: 18px;
 }
 
-button {
-  outline: none;
-  color: #aaa;
-  fill: #aaa;
-  border: 1px solid #222;
-  border-radius: 2px;
-  font-family: 'Roboto', sans-serif;
-  font-size: 12pt;
-  line-height: 18px;
-  height: 24px;
-  cursor: pointer;
-  padding: 2px 6px;
-  transition: 100ms;
-  min-width: 75px;
-  background-color: #444;
-  background-image: linear-gradient(to bottom, #444, #333);
-}
-
 #runbutton svg {
   width: 18px;
   height: 18px;
@@ -189,24 +171,6 @@ button {
   width: 17px;
   height: 17px;
   fill: #FFF79A;
-}
-
-button:hover {
-  color: #fff;
-  fill: #fff;
-}
-
-button:active {
-  background: rgba(255, 255, 255, 0.2);
-}
-
-button[disabled] {
-  color: #555;
-  fill: #555;
-  pointer-events: none;
-  border-color: #272727;
-  background-color: #3b3b3b;
-  background-image: none;
 }
 
 #runbutton {
@@ -418,9 +382,29 @@ div.toggle {
 }
 
 .sharing-dialog {
-  min-width: 400px;
-  min-height: 200px;
   top: 100px;
   left: 100px;
   right: 100px;
+}
+
+.sharing-dialog .sharinglabel {
+  min-width: 110px;
+  margin-right: 10px;
+  display: inline-block;
+}
+
+.sharing-dialog .row {
+  margin-bottom: 8px;
+}
+
+.sharing-dialog .inputgroup {
+  display: inline-block;
+}
+
+.sharing-dialog input {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 4px 8px;
+  outline: none;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
 }

--- a/web/index.css
+++ b/web/index.css
@@ -55,6 +55,10 @@ header {
   min-width: 2em;
 }
 
+.header-gist-name.dirty::before {
+  content: "• ";
+}
+
 #newbutton {
   margin-left: 10px;
 }
@@ -379,12 +383,6 @@ div.toggle {
 .parameter-hint {
   padding: 4px;
   background: #3f3f3f;
-}
-
-.sharing-dialog {
-  top: 100px;
-  left: 100px;
-  right: 100px;
 }
 
 .sharing-dialog .sharinglabel {

--- a/web/index.html
+++ b/web/index.html
@@ -40,12 +40,11 @@
     <header layout horizontal>
       <div class="header-title">DartPad <span class="minor">(β)</span></div>
       <div>
-        <button type="button" id="newbutton">New…</button>
+        <button type="button" id="newbutton" class="button">New…</button>
       </div>
       <div class="header-gist-name" flex></div>
       <div>
-        <button type="button" id="sharebutton" disabled>Share</button>
-        <!-- button type="button" id="reloadbutton" disabled>Reload</button -->
+        <button type="button" id="sharebutton" class="button">Share</button>
       </div>
       <div>
         <select id="samples" required="false" style="width: 80px;">
@@ -75,7 +74,8 @@
           <div flex></div>
           <div id="dartbusy" class="busylight"></div>
           <div>
-            <button type="button" id="runbutton" title="Run (ctrl-enter / ⌘-enter)">
+            <button type="button" id="runbutton" class="button"
+                title="Run (ctrl-enter / ⌘-enter)">
               <svg width="18" height="18" viewBox="0 0 24 24"
                   style="vertical-align: text-bottom;">
                 <path d="M8 5v14l11-7z"/>


### PR DESCRIPTION
- create a dialog component
- create a glass pane component
- create a new, DOM based sharing dialog
- move dialog related code to `dialogs.dart`
- the sharing button is always enabled now
- clicking on it, with an unmodified gist, will show you the links for that gist
- clicking on it, with a modified gist, will show ask if you want to share publicly. if so, it'll save to gist.github.com and show you the links created for that gist

@kasperpeulen @lukechurch @sethladd 

This does not include any behavior to re-write the current URL to an '/unsaved' url. The mechanics of that were a bit hard. Perhaps instead we make it clearer when your gist is in an unsaved state? Change something about the UI?

![screen shot 2015-04-14 at 11 48 03 am](https://cloud.githubusercontent.com/assets/1269969/7144847/f9c24bb0-e29c-11e4-9eb2-8d94c1bb3ab8.png)

![screen shot 2015-04-14 at 11 48 11 am](https://cloud.githubusercontent.com/assets/1269969/7144848/01af2a64-e29d-11e4-81c0-9689915d99a3.png)
