### PR TITLE
clean up our compile errors

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -469,6 +469,7 @@ class Playground implements GistContainer, GistController {
       return executionService.execute(
           _context.htmlSource, _context.cssSource, response.result);
     }).catchError((e) {
+      if (e is DetailedApiRequestError) e = e.message;
       DToast.showMessage('Error compiling to JavaScript');
       ga.sendException("${e.runtimeType}");
       _showOuput('Error compiling to JavaScript:\n${e}', error: true);


### PR DESCRIPTION
Address https://github.com/dart-lang/dart-pad/issues/3. Change from:
```
Error compiling to JavaScript:
DetailedApiRequestError(status: 400, message: Compilation of e9a619af3df7cb03f9a8556ede5968ce2892b768 failed with errors: [error, line 1] Library not found 'dart:io'.
```

to
```
Error compiling to JavaScript:
Compilation of e9a619af3df7cb03f9a8556ede5968ce2892b768 failed with errors: [error, line 1] Library not found 'dart:io'.
```