### PR TITLE
peg the commit we pull comid from

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,9 @@ dependencies:
   codemirror: '>=0.2.3 <0.3.0'
   # TODO: We need to move to a hosted (and versioned) dependency.
   comid:
-    git: https://github.com/google/comid
+    git:
+      url: https://github.com/google/comid
+      ref: c61d851d52ff098d02ea29a84b1f083ed0aee62a
   crypto: '>=0.9.0 <0.10.0'
   haikunator: ^0.1.0
   http: '>=0.11.1 <0.12.0'


### PR DESCRIPTION
Pull comid from a specific commit. This will isolate us from any unreleased changes. We'll want to move to a hosted reference when that is available.

@lukechurch @stevemessick 