### PR TITLE
change opacity of keyboard.svg

### DIFF
--- a/lib/elements/keyboard.svg
+++ b/lib/elements/keyboard.svg
@@ -4,5 +4,5 @@
 <svg xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" 
      width="24" height="24" viewBox="0 0 24 24">
-    <path d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"/>
+    <path fill="#fff" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"/>
 </svg>

--- a/lib/elements/keyboard.svg
+++ b/lib/elements/keyboard.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" 
+     width="24" height="24" viewBox="0 0 24 24">
+    <path d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"/>
+</svg>

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -97,6 +97,9 @@ class Playground implements GistContainer, GistController {
       if (!isMobile()) _context.focus();
     });
 
+    // Listen for the keyboard button.
+    querySelector('#keyboard-button').onClick.listen((_) => settings.show());
+
     busyLight = new DBusyLight(querySelector('#dartbusy'));
     consoleBusyLight = new DBusyLight(querySelector('#consolebusy'));
 

--- a/web/index.css
+++ b/web/index.css
@@ -440,9 +440,15 @@ div.toggle {
 
 .keyboard {
   display: inline-block;
-  background: #333 url('packages/dart_pad/elements/keyboard.svg') center no-repeat;
-  background-size: 100%;
+  background: url('packages/dart_pad/elements/keyboard.svg') center no-repeat;
   width: 24px;
   height: 20px;
   cursor: pointer;
+  border: none;
+  opacity: 0.8;
 }
+
+.keyboard:hover {
+  opacity: 1;
+}
+

--- a/web/index.css
+++ b/web/index.css
@@ -266,7 +266,7 @@ div.toggle {
 }
 
 .footer-item {
-  margin-left: 10px;
+  margin-right: 10px;
 }
 
 #frame_overlay {
@@ -416,6 +416,7 @@ div.toggle {
 .keys-dialog dl {
   padding: 0.5em;
 }
+
 .keys-dialog dt {
   float: left;
   clear: left;
@@ -435,4 +436,13 @@ div.toggle {
   margin: 2px 2px;
   white-space: nowrap;
   display: inline-block;
+}
+
+.keyboard {
+  display: inline-block;
+  background: #333 url('packages/dart_pad/elements/keyboard.svg') center no-repeat;
+  background-size: 100%;
+  width: 24px;
+  height: 20px;
+  cursor: pointer;
 }

--- a/web/index.css
+++ b/web/index.css
@@ -441,14 +441,13 @@ div.toggle {
 .keyboard {
   display: inline-block;
   background: url('packages/dart_pad/elements/keyboard.svg') center no-repeat;
+  background-size: 100%;
   width: 24px;
   height: 20px;
   cursor: pointer;
-  border: none;
   opacity: 0.8;
 }
 
 .keyboard:hover {
   opacity: 1;
 }
-

--- a/web/index.html
+++ b/web/index.html
@@ -119,11 +119,12 @@
         <a href="https://api.dartlang.org/" target="docs">API documentation</a>
       </div>
       <div flex></div>
+      <div id="keyboard-button" class="keyboard footer-item"></div>
       <div>
         <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
-            target="privacy">Privacy policy</a>
+            target="privacy" class="footer-item">Privacy policy</a>
         <a href="https://github.com/dart-lang/dart-pad/issues"
-            target="send_feedback" class="footer-item">
+            target="send_feedback">
           Send feedback
         </a>
       </div>


### PR DESCRIPTION
I think there is no trivial way to change the fill using css of an svg, but using opacity instead seems like a good enough hack in our case (as we use grey tints)