### PR TITLE
tweak the behavior of cmd-left

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -85,8 +85,9 @@ class CodeMirrorFactory extends EditorFactory {
       };
     }
 
-    return new _CodeMirrorEditor._(this,
-        new CodeMirror.fromElement(element, options: options));
+    CodeMirror editor = new CodeMirror.fromElement(element, options: options);
+    editor.addCommand('goLineLeft', _handleGoLineLeft);
+    return new _CodeMirrorEditor._(this, editor);
   }
 
   bool get supportsCompletionPositioning => true;
@@ -95,6 +96,11 @@ class CodeMirrorFactory extends EditorFactory {
     Hints.registerHintsHelperAsync(mode, (CodeMirror editor, [HintsOptions options]) {
       return _completionHelper(editor, completer, options);
     });
+  }
+
+  // Change the cmd-left behavior to move the cursor to the leftmost non-ws char.
+  void _handleGoLineLeft(CodeMirror editor) {
+    editor.execCommand('goLineLeftSmart');
   }
 
   Future<HintResults> _completionHelper(CodeMirror editor,


### PR DESCRIPTION
Change the behavior of codemirror's `goLineLeft` command to the `goLineLeftSmart` one. command-left now moves to the leftmost non-ws char.

TBR