### PR TITLE
add a link to www.dartlang.org

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -118,17 +118,17 @@
 
     <footer layout horizontal>
       <div>
-        <a href="https://api.dartlang.org/" target="docs">API documentation</a>
+        <a href="https://www.dartlang.org/" class="footer-item"
+            target="dartlang">www.dartlang.org</a>
+        <a href="https://api.dartlang.org/" target="dartlang">API documentation</a>
       </div>
       <div flex></div>
       <div id="keyboard-button" class="keyboard footer-item"></div>
       <div>
         <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
-            target="privacy" class="footer-item">Privacy policy</a>
+            target="repo" class="footer-item">Privacy policy</a>
         <a href="https://github.com/dart-lang/dart-pad/issues"
-            target="send_feedback">
-          Send feedback
-        </a>
+            target="repo">Send feedback</a>
       </div>
     </footer>
 


### PR DESCRIPTION
Add a link to www.dartlang.org; fix #412.

@kwalrath, @Sfshaza 