### PR TITLE
Error location, width changes

### DIFF
--- a/web/index.css
+++ b/web/index.css
@@ -99,7 +99,7 @@ footer {
 .view {
   position: relative;
   margin: 0 0;
-  min-width: 75px;
+  min-width: 240px;
   min-height: 50px;
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -89,7 +89,6 @@
       <div class="view" flex two layout vertical>
         <div class="view" flex two layout vertical>
           <div class="header" layout horizontal reverse wrap>
-            <div id="keyboard-button" class="keyboard"></div>
             <div id="consolebusy" class="busylight"></div>
             <li><a id="consoletab" selected><span>Console</span></a></li>
             <li><a id="resulttab"><span>HTML Output</span></a></li>
@@ -118,6 +117,7 @@
         <a href="https://api.dartlang.org/" target="dartlang">API documentation</a>
       </div>
       <div flex></div>
+      <div id="keyboard-button" class="keyboard footer-item"></div>
       <div>
         <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
             target="repo" class="footer-item">Privacy policy</a>

--- a/web/index.html
+++ b/web/index.html
@@ -80,7 +80,6 @@
         </div>
         <div id="editpanel" flex layout vertical>
         </div>
-        <div id="issues"></div>
       </div>
 
       <div class="splitter" vertical id="editor_split">
@@ -90,6 +89,7 @@
       <div class="view" flex two layout vertical>
         <div class="view" flex two layout vertical>
           <div class="header" layout horizontal reverse wrap>
+            <div id="keyboard-button" class="keyboard"></div>
             <div id="consolebusy" class="busylight"></div>
             <li><a id="consoletab" selected><span>Console</span></a></li>
             <li><a id="resulttab"><span>HTML Output</span></a></li>
@@ -107,6 +107,7 @@
           <div id="documentation" flex layout vertical></div>
         </div>
         <div id="frame_overlay"></div>
+        <div id="issues"></div>
       </div>
     </section>
 
@@ -117,7 +118,6 @@
         <a href="https://api.dartlang.org/" target="dartlang">API documentation</a>
       </div>
       <div flex></div>
-      <div id="keyboard-button" class="keyboard footer-item"></div>
       <div>
         <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
             target="repo" class="footer-item">Privacy policy</a>


### PR DESCRIPTION
Moved error location to show up in 'document' view frame.
Minimum width of documents now 240px so minimizing screen will not cause output frames to wrap into itself.