### PR TITLE
implement a reset (discard) changes button

### DIFF
--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -206,7 +206,7 @@ button.close:hover {
 #issues.showing {
   margin-top: 8px;
   overflow-y: auto;
-  max-height: 68px;
+  max-height: 120px;
 }
 
 #issues .issue {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -98,6 +98,20 @@ class Playground implements GistContainer, GistController {
 
     new NewPadAction(querySelector('#newbutton'), this);
 
+    DButton resetButton = new DButton(querySelector('#resetbutton'));
+    resetButton.onClick.listen((_) {
+      confirm('Reset Pad', 'Discard changes to the current pad?',
+          okText: 'Discard', cancelText: 'Cancel').then((bool val) {
+        if (val) {
+          _gistStorage.clearStoredGist();
+          editableGist.reset();
+        }
+      });
+    });
+    editableGist.onDirtyChanged.listen((val) {
+      resetButton.disabled = !val;
+    });
+
     DButton shareButton = new DButton(querySelector('#sharebutton'));
     shareButton.onClick.listen((e) => _createSummary()
         .then((String sum) => sharingDialog.showWithSummary(sum)));

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -105,6 +105,10 @@ class Playground implements GistContainer, GistController {
         if (val) {
           _gistStorage.clearStoredGist();
           editableGist.reset();
+          // Delay to give time for the model change event to propogate through
+          // to the editor component (which is where `_performAnalysis()` pulls
+          // the Dart source from).
+          Timer.run(() => _performAnalysis());
         }
       });
     });

--- a/lib/sharing/mutable_gist.dart
+++ b/lib/sharing/mutable_gist.dart
@@ -87,6 +87,13 @@ class MutableGist implements PropertyOwner {
     return gist;
   }
 
+  void reset() {
+    bool wasDirty = dirty;
+    _localValues.clear();
+    if (wasDirty != dirty) _dirtyChangedController.add(dirty);
+    _changedController.add(null);
+  }
+
   String _getProperty(String key) {
     if (_localValues.containsKey(key)) return _localValues[key];
     return _backingGist[key];

--- a/web/index.css
+++ b/web/index.css
@@ -78,13 +78,13 @@ textarea {
 }
 
 #sharebutton {
-  margin-left: 10px;
+  margin-left: 8px;
   margin-right: 10px;
 }
 
-/*#reloadbutton {
-  margin-right: 10px;
-}*/
+#resetbutton {
+  margin-left: 8px;
+}
 
 section {
   padding: 0 24px 24px 24px;

--- a/web/index.html
+++ b/web/index.html
@@ -105,9 +105,9 @@
         </div>
         <div class="view" flex layout vertical>
           <div id="documentation" flex layout vertical></div>
+          <div id="issues"></div>
         </div>
         <div id="frame_overlay"></div>
-        <div id="issues"></div>
       </div>
     </section>
 

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,7 @@
       <div class="header-title">DartPad</div>
       <div>
         <button type="button" id="newbutton" class="button">New Pad…</button>
+        <button type="button" id="resetbutton" class="button" disabled>Reset…</button>
       </div>
       <div class="header-gist-name" flex></div>
       <div>


### PR DESCRIPTION
fix #431

Add a `Reset...` button to the UI, to discard changes to the current pad and revert back to what's currently persisted on gist.github.com.

![screen shot 2015-06-10 at 3 22 34 pm](https://cloud.githubusercontent.com/assets/1269969/8095626/9f02d9c8-0f84-11e5-9c74-ff11b66c0a54.png)
