### PR TITLE
improve the performance of console output

### DIFF
--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -298,7 +298,11 @@ class DBusyLight extends DElement {
     _reconcile();
   }
 
-  _reconcile() => element.classes.toggle('on', _count > 0);
+  void _reconcile() {
+    if (_count == 0 || _count == 1) {
+      element.classes.toggle('on', _count > 0);
+    }
+  }
 }
 
 // TODO: The label needs an extremely rich tooltip.


### PR DESCRIPTION
Fix for https://github.com/dart-lang/dart-pad/issues/491, improve the performance of console output.

- only toggle the classes on the `DBusyLight` element when necessary
- batch the writes to the console div - don't write more frequently than 30 Hz, and give time to the DOM thread when there is heavy writing

@lukechurch 