### PR TITLE
Devoncarew embeddings

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -49,10 +49,10 @@ class PlaygroundMobile {
   PaperIconButton _affirmButton;
   PaperIconButton _resetButton;
   PaperTabs _tabs;
-  
+
   Gist backupGist;
   Router _router;
-  
+
   Editor editor;
   PlaygroundContext _context;
   Future _analysisRequest;
@@ -65,16 +65,16 @@ class PlaygroundMobile {
   PaperDialog _exportDialog;
   PolymerElement _output;
   PaperProgress _editProgress;
-  
+
   DivElement _docPanel;
-  
+
   DocHandler docHandler;
   String _gistId;
-  
+
   Future createNewGist() {
       return null;
   }
-  
+
   ModuleManager modules = new ModuleManager();
 
   PlaygroundMobile() {
@@ -122,7 +122,7 @@ class PlaygroundMobile {
     _messageToast = new PaperToast();
     document.body.children.add(_messageToast.element);
   }
-  
+
   void registerErrorToast() {
     if ($('#errorToast') != null) {
       _errorsToast = new PaperToast.from($('#errorToast'));
@@ -131,7 +131,7 @@ class PlaygroundMobile {
     }
     _errorsToast.duration = 100000;
   }
-  
+
   void registerResetToast() {
     if ($('#resetToast') != null) {
       _resetToast = new PaperToast.from($('#resetToast'));
@@ -140,13 +140,13 @@ class PlaygroundMobile {
     }
       _resetToast.duration = 3000;
     }
-  
+
   void registerMessageDialog() {
     if ($("#messageDialog") != null) {
       _messageDialog = new PaperDialog.from($("#messageDialog"));
     }
   }
-  
+
   void registerResetDialog() {
     if ($("#resetDialog") != null) {
       _resetDialog = new PaperDialog.from($("#resetDialog"));
@@ -154,15 +154,15 @@ class PlaygroundMobile {
       _resetDialog = new PaperDialog();
     }
   }
-  
+
   void registerExportDialog() {
     if ($("#exportDialog") != null) {
       _exportDialog = new PaperDialog.from($("#exportDialog"));
     } else {
-      _exportDialog = new PaperDialog(); 
+      _exportDialog = new PaperDialog();
     }
   }
-  
+
   void registerDocPanel() {
     if ($('#documentation') != null) {
       _docPanel = $('#documentation');
@@ -170,7 +170,7 @@ class PlaygroundMobile {
       _docPanel = new DivElement();
     }
   }
-  
+
   void registerSelectorTabs() {
     if ($("#selector-tabs") != null) {
     _tabs = new PaperTabs.from($("#selector-tabs"));
@@ -181,19 +181,19 @@ class PlaygroundMobile {
       });
     }
   }
-  
+
   void registerEditProgress() {
     if ($("#edit-progress") != null) {
       _editProgress = new PaperProgress.from($("#edit-progress"));
     }
   }
-  
+
   void registerRunButton() {
     _runButton = new PaperFab.from($("#run-button"));
     _runButton = _runButton != null ? _runButton : new PaperFab();
     _runButton.onTap.listen((_) => _handleRun());
   }
-  
+
   void registerExportButton() {
     if ($('[icon="launch"]') != null) {
       _exportButton = new PaperIconButton.from($('[icon="launch"]'));
@@ -202,7 +202,7 @@ class PlaygroundMobile {
       });
     }
   }
-  
+
   void registerResetButton() {
     if ($('[icon="refresh"]') != null) {
       _resetButton = new PaperIconButton.from($('[icon="refresh"]'));
@@ -211,7 +211,7 @@ class PlaygroundMobile {
       });
     }
   }
-  
+
   void registerCancelRefreshButton() {
     if ($('#cancelButton') != null) {
       _cancelButton = new PaperIconButton.from($('#cancelButton'));
@@ -220,7 +220,7 @@ class PlaygroundMobile {
       });
     }
   }
-  
+
   void registerAffirmRefreshButton() {
     if ($('#affirmButton') != null) {
       _affirmButton = new PaperIconButton.from($('#affirmButton'));
@@ -230,7 +230,7 @@ class PlaygroundMobile {
     });
     }
   }
-  
+
   void registerCancelExportButton() {
       if ($('#cancelButton') != null) {
         _cancelButton = new PaperIconButton.from($('#cancelExportButton'));
@@ -239,7 +239,7 @@ class PlaygroundMobile {
         });
       }
     }
-    
+
   void registerAffirmExportButton() {
     if ($('#affirmButton') != null) {
       _affirmButton = new PaperIconButton.from($('#affirmExportButton'));
@@ -249,12 +249,12 @@ class PlaygroundMobile {
     });
     }
   }
-  
+
   //Console must exist
   void registerConsole() {
     _output = new PolymerElement.from($("#console"));
   }
-  
+
   void _createUi() {
     registerMessageToast();
     registerErrorToast();
@@ -273,14 +273,14 @@ class PlaygroundMobile {
     registerCancelExportButton();
     registerAffirmExportButton();
     registerConsole();
-    
+
     _clearOutput();
   }
-  
+
   void _export() {
-    
+
   }
-  
+
   void _reset() {
     _router = new Router();
     _router
@@ -288,7 +288,7 @@ class PlaygroundMobile {
       ..root.addRoute(name: 'gist', path: '/:gist', enter: showGist)
       ..listen();
   }
-  
+
   void _showGist(String gistId, {bool run: false}) {
     gistLoader.loadGist(gistId).then((Gist gist) {
       _setGistDescription(gist.description);
@@ -332,13 +332,13 @@ class PlaygroundMobile {
       deps[ExecutionService] = new ExecutionServiceIFrame(new IFrameElement());
     }
   }
-  
+
   void _initPlayground() {
     // Set up the iframe.execution
     registerExecutionService();
     executionService.onStdout.listen(_showOuput);
     executionService.onStderr.listen((m) => _showOuput(m, error: true));
-    
+
     // Set up the editing area.
     editor = editorFactory.createFromElement($('#editpanel'));
     //$('editpanel').children.first.attributes['flex'] = '';
@@ -357,7 +357,7 @@ class PlaygroundMobile {
         docHandler.generateDoc(_docPanel);
       }
     });
-    
+
     // Listen for changes that would effect the documentation panel.
      editor.onMouseDown.listen((e) {
        // Delay to give codemirror time to process the mouse event.
@@ -367,13 +367,13 @@ class PlaygroundMobile {
          }
        });
      });
-    
+
     _context = new PlaygroundContext(editor);
     deps[Context] = _context;
 
 
     context.onModeChange.listen((_) => docHandler.generateDoc(_docPanel));
-    
+
     _context.onHtmlReconcile.listen((_) {
       executionService.replaceHtml(_context.htmlSource);
     });
@@ -385,7 +385,7 @@ class PlaygroundMobile {
     _context.onDartReconcile.listen((_) => _performAnalysis());
 
     docHandler = new DocHandler(editor, _context);
-    
+
     _finishedInit();
   }
 
@@ -482,7 +482,7 @@ class PlaygroundMobile {
     span.classes.add(error ? 'errorOutput' : 'normal');
     span.text = message;
     _output.add(span);
-    span.scrollIntoView(ScrollAlignment.BOTTOM);
+    span.scrollIntoView();
   }
 
   void _setGistDescription(String description) {
@@ -508,7 +508,7 @@ class PlaygroundMobile {
       _clearErrors();
     } else {
       Element element = _errorsToast.element;
-      
+
       element.children.clear();
 
       issues.sort((a, b) => a.charStart - b.charStart);
@@ -658,7 +658,7 @@ class PlaygroundContext extends Context {
       });
     });
   }
-  
+
   bool cursorPositionIsWhitespace() {
     Document document = editor.document;
     String str = document.value;

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -61,7 +61,7 @@
         </div>
         <dartpad-editor dart class="flex-5 layout vertical"></dartpad-editor>
         <horizontal-splitter class="splitter"></horizontal-splitter>
-        <console-item class="flex-2 layout vertical"></console-item>
+        <dartpad-console class="flex-2 layout vertical"></dartpad-console>
       </div>
       <vertical-splitter></vertical-splitter>
       <dartpad-documentation class="flex-4 layout vertical"></dartpad-documentation>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -16,6 +16,7 @@
     <title>DartPad</title>
 
     <script src="packages/dart_pad/bower/webcomponentsjs/webcomponents-lite.min.js"></script>
+
     <link rel="import" href="imports.html"/>
     <link rel="import" href="animated-dropdown.html">
     <link rel="import" href="embed_style.html"/>
@@ -29,26 +30,46 @@
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
-    <link href="packages/dart_pad/editing/editor_codemirror.css"
-          rel="stylesheet" media="screen">
+    <link href="packages/dart_pad/editing/editor_codemirror.css" rel="stylesheet" media="screen">
+
     <link rel="import" href="embed_components.html">
     <script type="application/dart" src="embed.dart"></script>
+    <style>
+      #run-button {
+        background-color: #d23f31;
+      }
+
+      .button-bar {
+        position: absolute;
+        right: 16px;
+        top: 16px;
+        z-index: 20;
+      }
+
+      paper-fab + paper-fab {
+        margin-left: 8px;
+      }
+    </style>
   </head>
+
   <body class="fullbleed vertical layout" unresolved>
-    <div class="height-max layout horizontal">
-      <div id="leftContainer" class = "vertical layout flex-6">
-        <dart-box-v2 dart class = "flex-5"></dart-box-v2>
-        <horizontal-splitter class = "splitter"></horizontal-splitter>
-        <console-item class = "flex-2 layout vertical"></console-item>
+    <div class="flex layout horizontal">
+      <div class="relative vertical layout flex-6">
+        <div class="button-bar">
+          <paper-fab id="run-button" icon="av:play-arrow" mini></paper-fab>
+          <paper-fab id="export-pad" icon="launch" mini></paper-fab>
+        </div>
+        <dartpad-editor dart class="flex-5 layout vertical"></dartpad-editor>
+        <horizontal-splitter class="splitter"></horizontal-splitter>
+        <console-item class="flex-2 layout vertical"></console-item>
       </div>
       <vertical-splitter></vertical-splitter>
-      <div id = "rightContainer" class ="flex-4">
-        <export-floater></export-floater>
-        <documentation-box class = "flex layout vertical"></documentation-box>
-      </div>
+      <dartpad-documentation class="flex-4 layout vertical"></dartpad-documentation>
+
       <paper-toast id="errorToast" text=""></paper-toast>
     </div>
-    <html-output class = "invisible flex absolute"></html-output>
+
+    <dartpad-dom-output class="invisible"></dartpad-dom-output>
     <reset-dialog></reset-dialog>
     <export-dialog></export-dialog>
 

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -34,17 +34,18 @@
     <link rel="import" href="embed_components.html">
     <script type="application/dart" src="embed.dart"></script>
   </head>
+
   <body class="fullbleed vertical layout" unresolved>
     <menu-bar-icons></menu-bar-icons>
     <div class="height-max layout horizontal">
-      <div id="leftContainer" class = "vertical layout flex-6">
-        <dart-box dart class = "flex-5"></dart-box>
-        <horizontal-splitter class = "splitter"></horizontal-splitter>
-        <console-item class = "flex-2 layout vertical"></console-item>
+      <div id="leftContainer" class="vertical layout flex-6">
+        <dart-box-v2 dart class="flex-5"></dart-box-v2>
+        <horizontal-splitter class="splitter"></horizontal-splitter>
+        <console-item class="flex-2 layout vertical"></console-item>
       </div>
       <vertical-splitter></vertical-splitter>
-      <div id = "rightContainer" class ="vertical layout flex-4">
-        <html-output class = "flex"></html-output>
+      <div id="rightContainer" class ="vertical layout flex-4">
+        <dartpad-dom-output class="flex"></dartpad-dom-output>
       </div>
     </div>
     <paper-toast id="errorToast" text=""></paper-toast>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -41,7 +41,7 @@
       <div id="leftContainer" class="vertical layout flex-6">
         <dart-box-v2 dart class="flex-5"></dart-box-v2>
         <horizontal-splitter class="splitter"></horizontal-splitter>
-        <console-item class="flex-2 layout vertical"></console-item>
+        <dartpad-console class="flex-2 layout vertical"></dartpad-console>
       </div>
       <vertical-splitter></vertical-splitter>
       <div id="rightContainer" class ="vertical layout flex-4">

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -38,7 +38,7 @@
   <body class="fullbleed vertical layout" unresolved>
     <dart-box-v2 dart class="flex-5"></dart-box-v2>
     <horizontal-splitter class="splitter"></horizontal-splitter>
-    <console-item class="flex-2 layout vertical"></console-item>
+    <dartpad-console class="flex-2 layout vertical"></dartpad-console>
     <paper-toast id="errorToast" text=""></paper-toast>
     <dartpad-dom-output class="invisible flex absolute"></dartpad-dom-output>
 

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -34,12 +34,13 @@
     <link rel="import" href="embed_components.html">
     <script type="application/dart" src="embed.dart"></script>
   </head>
+
   <body class="fullbleed vertical layout" unresolved>
-    <dart-box dart class = "flex-5"></dart-box>
-    <horizontal-splitter class = "splitter"></horizontal-splitter>
-    <console-item class = "flex-2 layout vertical"></console-item>
+    <dart-box-v2 dart class="flex-5"></dart-box-v2>
+    <horizontal-splitter class="splitter"></horizontal-splitter>
+    <console-item class="flex-2 layout vertical"></console-item>
     <paper-toast id="errorToast" text=""></paper-toast>
-    <html-output class = "invisible flex absolute"></html-output>
+    <dartpad-dom-output class="invisible flex absolute"></dartpad-dom-output>
 
     <script src="packages/codemirror/codemirror.js"></script>
     <script src="packages/browser/dart.js" async></script>

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -2,28 +2,28 @@
      for details. All rights reserved. Use of this source code is governed by a
      BSD-style license that can be found in the LICENSE file. -->
 
-
 <link rel="import" href="imports.html"/>
+
 <dom-module id="selection-toolbar">
   <style>
-  .tabs {
-    background: #485D67;
-    top: inherit;
-    position: relative;
-  }
-  paper-tabs {
-    height: 36px;
-    font-weight: 400;
-  }
+    .tabs {
+      background: #485D67;
+      top: inherit;
+      position: relative;
+    }
+
+    paper-tabs {
+      height: 36px;
+      font-weight: 400;
+    }
   </style>
   <template>
-    <paper-tabs id = "selector-tabs" class ="tabs" selected="0" class="bottom fit vertical" >
-        <paper-tab name="dart">Dart</paper-tab>
-        <paper-tab name="html">HTML</paper-tab>
-        <paper-tab name="css">CSS</paper-tab>
-      </paper-tabs>
-    <paper-progress id="edit-progress"  class="bottom fit" hidden
-        style="top: inherit"></paper-progress>
+    <paper-tabs id="selector-tabs" class ="tabs" selected="0" class="bottom fit vertical">
+      <paper-tab name="dart">Dart</paper-tab>
+      <paper-tab name="html">HTML</paper-tab>
+      <paper-tab name="css">CSS</paper-tab>
+    </paper-tabs>
+    <paper-progress id="edit-progress"  class="bottom fit" hidden style="top: inherit"></paper-progress>
   </template>
 
   <script>
@@ -35,22 +35,23 @@
 
 <dom-module id="output-toolbar">
   <style>
-  .tabs {
-    background: #485D67;
-    top: inherit;
-    position: relative;
-  }
-  paper-tabs {
-    height: 36px;
-    font-weight: 400;
-  }
+    .tabs {
+      background: #485D67;
+      top: inherit;
+      position: relative;
+    }
+
+    paper-tabs {
+      height: 36px;
+      font-weight: 400;
+    }
   </style>
   <template>
     <div>
-      <paper-tabs class="tabs" selected="0" style = "position:relative" class="bottom fit vertical" style="top: inherit">
-          <span class="flex"></span>
-          <paper-icon-button id = "refresh" icon="refresh"></paper-icon-button>
-          <paper-icon-button id = "launch" icon="launch"></paper-icon-button>
+      <paper-tabs class="tabs" selected="0" style="position:relative" class="bottom fit vertical" style="top: inherit">
+        <span class="flex"></span>
+        <paper-icon-button id="refresh" icon="refresh"></paper-icon-button>
+        <paper-icon-button id="launch" icon="launch"></paper-icon-button>
       </paper-tabs>
     </div>
   </template>
@@ -63,15 +64,15 @@
 
 <dom-module id="export-floater">
   <style>
-  .rightFloater {
-    position: absolute;
-    right: 5px;
-    z-index: 10;
-  }
+    .rightFloater {
+      position: absolute;
+      right: 5px;
+      z-index: 10;
+    }
   </style>
   <template>
-    <div class = 'rightFloater'>
-      <paper-icon-button id = "launch" icon="launch"></paper-icon-button>
+    <div class='rightFloater'>
+      <paper-icon-button id="launch" icon="launch"></paper-icon-button>
     </div>
   </template>
   <script>
@@ -95,7 +96,7 @@
     }
   </style>
   <template>
-    <div id="documentation" class = 'flex'></div>
+    <div id="documentation" class='flex'></div>
   </template>
   <script>
     Polymer({
@@ -106,17 +107,16 @@
 
 <dom-module id="reset-dialog">
   <style>
-   #resetDialog {
-    min-height: 90px;
-   }
+    #resetDialog {
+      min-height: 90px;
+    }
   </style>
   <template>
-    <paper-dialog id="resetDialog" heading="Reset"
-                  transition="paper-dialog-transition-bottom">
+    <paper-dialog id="resetDialog" heading="Reset" transition="paper-dialog-transition-bottom">
       <p>This will reset all changes. Are you sure?</p>
-      <paper-button id = "cancelButton" dismissive>Cancel</paper-button>
+      <paper-button id="cancelButton" dismissive>Cancel</paper-button>
       <span class="flex"></span>
-      <paper-button id = "affirmButton" affirmative default>OK</paper-button>
+      <paper-button id="affirmButton" affirmative default>OK</paper-button>
     </paper-dialog>
   </template>
   <script>
@@ -133,28 +133,28 @@
       top: inherit;
       position: relative;
     }
+
     paper-tabs {
-      width:100%;
+      width: 100%;
       height: 36px;
       font-weight: 400;
     }
   </style>
   <template>
-    <div class = "layout horizontal flex">
-      <div class = "layout horizontal flex-6">
-        <paper-tabs id = "selector-tabs" class ="tabs" selected="0" class=flex" >
-            <paper-tab name="dart">Dart</paper-tab>
-            <paper-tab name="html">HTML</paper-tab>
-            <paper-tab name="css">CSS</paper-tab>
-          </paper-tabs>
-        <paper-progress id="edit-progress"  class="bottom fit" hidden
-            style="top: inherit"></paper-progress>
+    <div class="layout horizontal flex">
+      <div class="layout horizontal flex-6">
+        <paper-tabs id="selector-tabs" class ="tabs" selected="0" class="flex">
+          <paper-tab name="dart">Dart</paper-tab>
+          <paper-tab name="html">HTML</paper-tab>
+          <paper-tab name="css">CSS</paper-tab>
+        </paper-tabs>
+        <paper-progress id="edit-progress"  class="bottom fit" hidden style="top: inherit"></paper-progress>
       </div>
-      <div class = "layout horizontal flex-4"> 
+      <div class="layout horizontal flex-4">
         <paper-tabs class="tabs" selected="0" class="flex" style="top: inherit">
-            <span class="flex"></span>
-            <paper-icon-button id = "refresh" icon="refresh"></paper-icon-button>
-            <paper-icon-button id = "launch" icon="launch"></paper-icon-button>
+          <span class="flex"></span>
+          <paper-icon-button id="refresh" icon="refresh"></paper-icon-button>
+          <paper-icon-button id="launch" icon="launch"></paper-icon-button>
         </paper-tabs>
       </div>
     </div>
@@ -166,20 +166,19 @@
   </script>
 </dom-module>
 
-
 <dom-module id="export-dialog">
   <style>
-   #exportDialog {
-    min-height: 90px;
-   }
+    #exportDialog {
+      min-height: 90px;
+    }
   </style>
   <template>
     <paper-dialog id="exportDialog" heading="Reset"
                   transition="paper-dialog-transition-bottom">
       <p>Export button under construction!</p>
-      <paper-button id = "cancelExportButton" dismissive>Cancel</paper-button>
+      <paper-button id="cancelExportButton" dismissive>Cancel</paper-button>
       <span class="flex"></span>
-      <paper-button id = "affirmExportButton" affirmative default>OK</paper-button>
+      <paper-button id="affirmExportButton" affirmative default>OK</paper-button>
     </paper-dialog>
   </template>
   <script>
@@ -209,24 +208,27 @@
 
 <dom-module id="html-output">
   <style>
-   #frameContainer {
-     position: fixed;
-   }
-   #frame {
-     width: 100%;
-     height: 100%;
-     border: 0px;
-   }
-   .maxHeight {
-     height: 100%;
-   }
-   .maxWidth {
-     width: 100%;
-   }
+    #frameContainer {
+      position: fixed;
+    }
+
+    #frame {
+      width: 100%;
+      height: 100%;
+      border: 0px;
+    }
+
+    .maxHeight {
+      height: 100%;
+    }
+
+    .maxWidth {
+      width: 100%;
+    }
   </style>
   <template>
     <div id="frameContainer" class="flex-2 layout vertical maxHeight maxWidth">
-      <div class = "flex maxHeight">
+      <div class="flex maxHeight">
         <iframe class="flex maxHeight maxWidth" id="frame" sandbox="allow-scripts" src="frame.html">
         </iframe>
       </div>
@@ -241,11 +243,11 @@
 
 <dom-module id="error-toast">
   <style>
-   :host{
-    height:0px;
-    widht:0px;
-    position:relative;
-   }
+    :host {
+      height: 0;
+      width: 0;
+      position: relative;
+     }
   </style>
   <template>
     <div id="larger">
@@ -261,18 +263,19 @@
 
 <dom-module id="dart-box">
   <style>
-  #editpanel {
-    height: 100%;
-    position: relative;
-    margin: 8px;
-  }
-  #run-button {
-    background-color: #d23f31;
-    position: absolute;
-    bottom: 16px;
-    right: 16px;
-    z-index: 10;
-  }
+    #editpanel {
+      height: 100%;
+      position: relative;
+      margin: 8px;
+    }
+
+    #run-button {
+      background-color: #d23f31;
+      position: absolute;
+      bottom: 16px;
+      right: 16px;
+      z-index: 10;
+    }
   </style>
   <template>
     <div id="editpanel" class="editor">
@@ -292,24 +295,24 @@
 
 <dom-module id="dart-box-v2">
   <style>
-  #editpanel {
-    height: 100%;
-    position: relative;
-    margin: 8px;
-  }
-  #run-button {
-    position: absolute;
-    right: 16px;
-    top: 10px;
-    z-index: 10;
-  }
+    #editpanel {
+      height: 100%;
+      position: relative;
+      margin: 8px;
+    }
+
+    #run-button {
+      position: absolute;
+      right: 16px;
+      top: 10px;
+      z-index: 10;
+    }
   </style>
   <template>
     <div id="editpanel" class="editor">
       <paper-fab id="run-button" icon="av:play-arrow" mini></paper-fab>
-    </div> 
+    </div>
   </template>
-
   <script>
     Polymer({
       is: 'dart-box-v2',
@@ -322,11 +325,11 @@
 
 <dom-module id="horizontal-splitter">
   <style>
-  :host {
-  min-height: 5px;
-  box-shadow:rgba(255, 255, 255, 0.07) 0 1px 0;
-  border-bottom:1px solid #121212;
-  }
+    :host {
+      min-height: 5px;
+      box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+      border-bottom: 1px solid #121212;
+    }
   </style>
   <template>
   </template>
@@ -339,17 +342,16 @@
 
 <dom-module id="vertical-splitter">
   <style>
-  :host {
-  min-height: 5px;
-  min-width: 2px;
-  box-shadow: rgba(255, 255, 255, 0.07) 1px 1px 0;
-  border-left: 1px solid #121212;
-  margin-right: 8px;
-  }
+    :host {
+      min-height: 5px;
+      min-width: 2px;
+      box-shadow: rgba(255, 255, 255, 0.07) 1px 1px 0;
+      border-left: 1px solid #121212;
+      margin-right: 8px;
+    }
   </style>
   <template>
   </template>
-
   <script>
     Polymer({
       is: 'vertical-splitter'
@@ -359,28 +361,28 @@
 
 <dom-module id="console-item">
   <style>
-  #console {
-    font-family: 'Inconsolata', monospace;
-    font-size: 12pt;
-    line-height: 20px;
-    overflow-y: auto;
-    margin: 2px;
-    padding: 8px;
-    white-space: pre-wrap;
-    background-color: var(--secondary-text-color);
-  }
-  #console .normal {
-    color: var(--text-primary-color);
-  }
+    #console {
+      font-family: 'Inconsolata', monospace;
+      font-size: 12pt;
+      line-height: 20px;
+      overflow-y: auto;
+      margin: 2px;
+      padding: 8px;
+      white-space: pre-wrap;
+      background-color: var(--secondary-text-color);
+    }
 
-  #console .errorOutput {
-    color: #F7977A;
-  }
+    #console .normal {
+      color: var(--text-primary-color);
+    }
+
+    #console .errorOutput {
+      color: #F7977A;
+    }
   </style>
   <template>
     <div id="console" class="flex-1 maxHeight"></div>
   </template>
-
   <script>
     Polymer({
       is: 'console-item'

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -357,7 +357,7 @@
   </script>
 </dom-module>
 
-<dom-module id="console-item">
+<dom-module id="dartpad-console">
   <style>
     :host {
       padding: 8px;
@@ -369,6 +369,7 @@
       line-height: 20px;
       overflow-y: auto;
       white-space: pre-wrap;
+      height: 0;
     }
 
     #console .normal {
@@ -380,11 +381,11 @@
     }
   </style>
   <template>
-    <div id="console" class="flex-1 maxHeight"></div>
+    <div id="console" class="flex"></div>
   </template>
   <script>
     Polymer({
-      is: 'console-item'
+      is: 'dartpad-console'
     });
   </script>
 </dom-module>

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -91,10 +91,11 @@
 
     #documentation {
       overflow-y: auto;
+      overflow-x: hidden;
     }
 
-    code {
-      white-space: pre-wrap;
+    pre {
+      overflow-x: auto;
     }
   </style>
   <template>

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -16,6 +16,10 @@
       height: 36px;
       font-weight: 400;
     }
+
+    #edit-progress {
+      top: inherit;
+    }
   </style>
   <template>
     <paper-tabs id="selector-tabs" class ="tabs" selected="0" class="bottom fit vertical">
@@ -23,7 +27,7 @@
       <paper-tab name="html">HTML</paper-tab>
       <paper-tab name="css">CSS</paper-tab>
     </paper-tabs>
-    <paper-progress id="edit-progress"  class="bottom fit" hidden style="top: inherit"></paper-progress>
+    <paper-progress id="edit-progress" class="bottom fit" hidden></paper-progress>
   </template>
 
   <script>
@@ -48,7 +52,7 @@
   </style>
   <template>
     <div>
-      <paper-tabs class="tabs" selected="0" style="position:relative" class="bottom fit vertical" style="top: inherit">
+      <paper-tabs selected="0" class="tabs bottom fit vertical">
         <span class="flex"></span>
         <paper-icon-button id="refresh" icon="refresh"></paper-icon-button>
         <paper-icon-button id="launch" icon="launch"></paper-icon-button>
@@ -142,6 +146,10 @@
       height: 36px;
       font-weight: 400;
     }
+
+    #edit-progress {
+      top: inherit;
+    }
   </style>
   <template>
     <div class="layout horizontal flex">
@@ -151,10 +159,10 @@
           <paper-tab name="html">HTML</paper-tab>
           <paper-tab name="css">CSS</paper-tab>
         </paper-tabs>
-        <paper-progress id="edit-progress"  class="bottom fit" hidden style="top: inherit"></paper-progress>
+        <paper-progress id="edit-progress" class="bottom fit" hidden></paper-progress>
       </div>
       <div class="layout horizontal flex-4">
-        <paper-tabs class="tabs" selected="0" class="flex" style="top: inherit">
+        <paper-tabs selected="0" class="tabs flex">
           <span class="flex"></span>
           <paper-icon-button id="refresh" icon="refresh"></paper-icon-button>
           <paper-icon-button id="launch" icon="launch"></paper-icon-button>
@@ -224,7 +232,7 @@
     #frame {
       width: 100%;
       height: 100%;
-      border: 0px;
+      border: 0;
     }
 
     .maxHeight {

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -82,15 +82,17 @@
   </script>
 </dom-module>
 
-<dom-module id="documentation-box">
+<dom-module id="dartpad-documentation">
   <style>
+    :host {
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+
     #documentation {
       overflow-y: auto;
-      white-space: pre-wrap;
-      position: absolute;
-      width: 100%;
-      height: 100%;
     }
+
     code {
       white-space: pre-wrap;
     }
@@ -100,7 +102,7 @@
   </template>
   <script>
     Polymer({
-      is: 'documentation-box'
+      is: 'dartpad-documentation'
     });
   </script>
 </dom-module>
@@ -168,17 +170,23 @@
 
 <dom-module id="export-dialog">
   <style>
-    #exportDialog {
-      min-height: 90px;
-    }
+
   </style>
   <template>
-    <paper-dialog id="exportDialog" heading="Reset"
-                  transition="paper-dialog-transition-bottom">
-      <p>Export button under construction!</p>
-      <paper-button id="cancelExportButton" dismissive>Cancel</paper-button>
-      <span class="flex"></span>
-      <paper-button id="affirmExportButton" affirmative default>OK</paper-button>
+    <!-- entry-animation="scale-up-animation" exit-animation="fade-out-animation" -->
+    <paper-dialog id="exportDialog" heading="Export">
+      <h2>Export</h2>
+
+      <br>
+
+      <paper-dialog-scrollable>
+        Export button under construction!
+      </paper-dialog-scrollable>
+
+      <div class="buttons">
+        <paper-button dialog-dismiss id="cancelExportButton">Cancel</paper-button>
+        <paper-button dialog-confirm id="affirmExportButton">Export</paper-button>
+      </div>
     </paper-dialog>
   </template>
   <script>
@@ -206,7 +214,7 @@
   </script>
 </dom-module>
 
-<dom-module id="html-output">
+<dom-module id="dartpad-dom-output">
   <style>
     #frameContainer {
       position: fixed;
@@ -236,7 +244,7 @@
   </template>
   <script>
     Polymer({
-      is: 'html-output'
+      is: 'dartpad-dom-output'
     });
   </script>
 </dom-module>
@@ -261,7 +269,27 @@
   </script>
 </dom-module>
 
-<dom-module id="dart-box">
+<dom-module id="dartpad-editor">
+  <style>
+    #editpanel {
+      position: relative;
+      margin: 8px;
+    }
+  </style>
+  <template>
+    <div id="editpanel" class="editor flex"></div>
+  </template>
+  <script>
+    Polymer({
+      is: 'dartpad-editor',
+      properties: {
+        dart: String
+      }
+    });
+  </script>
+</dom-module>
+
+<dom-module id="dart-box-v2">
   <style>
     #editpanel {
       height: 100%;
@@ -283,36 +311,6 @@
     </div>
   </template>
 
-  <script>
-    Polymer({
-      is: 'dart-box',
-      properties: {
-        dart: String
-      }
-    });
-  </script>
-</dom-module>
-
-<dom-module id="dart-box-v2">
-  <style>
-    #editpanel {
-      height: 100%;
-      position: relative;
-      margin: 8px;
-    }
-
-    #run-button {
-      position: absolute;
-      right: 16px;
-      top: 10px;
-      z-index: 10;
-    }
-  </style>
-  <template>
-    <div id="editpanel" class="editor">
-      <paper-fab id="run-button" icon="av:play-arrow" mini></paper-fab>
-    </div>
-  </template>
   <script>
     Polymer({
       is: 'dart-box-v2',
@@ -361,15 +359,16 @@
 
 <dom-module id="console-item">
   <style>
+    :host {
+      padding: 8px;
+    }
+
     #console {
       font-family: 'Inconsolata', monospace;
       font-size: 12pt;
       line-height: 20px;
       overflow-y: auto;
-      margin: 2px;
-      padding: 8px;
       white-space: pre-wrap;
-      background-color: var(--secondary-text-color);
     }
 
     #console .normal {

--- a/web/embed_style.html
+++ b/web/embed_style.html
@@ -100,6 +100,7 @@
     padding: 0;
     margin: 0;
   }
+
   animated-dropdown paper-menu {
     padding: 0;
     margin: 0;


### PR DESCRIPTION
- re-layout the `embed-dart.html` embedding (the two other embeddings are largely unchanged)
- whitespace and style changes to the html and css code
- move more style and layout behavior into the embed-dart.html file and out of the components file
- use divs to help with the positioning and layout
- prefer flexbox to width / height 100%
- rename some custom elements to have more descriptive names

![screen shot 2015-06-19 at 12 10 31 am](https://cloud.githubusercontent.com/assets/1269969/8249399/45c4853c-161e-11e5-9d46-eda8603a90ee.png)

http://dev.dart-pad.appspot.com/embeddings_demo.html

@Georgehe4 for review; let's talk in person as well - I want to make sure that these changes make sense