### PR TITLE
fix an issue with focus jump on page load and on console output

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -61,7 +61,7 @@ class CodeMirrorFactory extends EditorFactory {
     if (options == null) {
       options = {
         'continueComments': {'continueLineComment': false},
-        'autofocus': true,
+        'autofocus': false,
         // Removing this - with this enabled you can't type a forward slash.
         //'autoCloseTags': true,
         'autoCloseBrackets': true,

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -486,13 +486,15 @@ class PlaygroundMobile {
   }
 
   void _showOutput(String message, {bool error: false}) {
-    $('.consoleTitle').hidden = true;
+    if (message == null) return;
+    Element title = $('.consoleTitle');
+    if (title != null) title.hidden = true;
     message = message + '\n';
     SpanElement span = new SpanElement();
     span.classes.add(error ? 'errorOutput' : 'normal');
     span.text = message;
     _output.add(span);
-    span.scrollIntoView();
+    _output.element.scrollTop = _output.element.scrollHeight;
   }
 
   void _setGistDescription(String description) {
@@ -632,7 +634,10 @@ class PlaygroundContext extends Context {
       editor.swapDocument(_cssDoc);
     }
 
-    if (oldMode != name) _modeController.add(name);
+    if (oldMode != name) {
+      _modeController.add(name);
+      focus();
+    }
   }
 
   String get focusedEditor {


### PR DESCRIPTION
- change codemirror to not try and focus the editing area on page load
- don't scroll the console area into view on output; adjust the scrolled portion of the view
- focus the editing area when the user manually switches between tabs (dart/html/css)