### PR TITLE
show better stack traces

### DIFF
--- a/lib/_docs.dart
+++ b/lib/_docs.dart
@@ -130,7 +130,7 @@ class DocSnippet {
 
     deps[ExecutionService] = new ExecutionServiceIFrame(querySelector("iframe"));
     executionService.onStdout.listen((m) => _appendOutput(m));
-    executionService.onStderr.listen((m) => _displayErrors(m));
+    executionService.onStderr.listen((ex) => _displayErrors(ex));
 
     var input = new CompileRequest()..source = "void main(){${preElement.text}}";
     dartServices.compile(input).then(
@@ -184,8 +184,8 @@ class DocSnippet {
     _output.text += str + '\n';
   }
 
-  void _displayErrors(String str) {
-    _output.text = str;
+  void _displayErrors(ExecutionException ex) {
+    _output.text = ex.message;
     _output.classes.toggle('errors', true);
   }
 

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -7,7 +7,7 @@ library execution;
 import 'dart:async';
 
 abstract class ExecutionService {
-  Future execute(String html, String css, String javaScript);
+  Future execute(String html, String css, String javaScript, [String sourceMap]);
 
   void replaceHtml(String html);
   void replaceCss(String css);
@@ -17,5 +17,21 @@ abstract class ExecutionService {
   Future tearDown();
 
   Stream<String> get onStdout;
-  Stream<String> get onStderr;
+  Stream<ExecutionException> get onStderr;
+
+  bool get hasSourceMap;
+  String revereStackTrace(String jsStackTrace);
+}
+
+class ExecutionException {
+  final String message;
+  final int line;
+  final int column;
+  final String stackTrace;
+
+  ExecutionException(this.message, [this.line, this.column, this.stackTrace]);
+
+  bool get hasStackTrace => stackTrace != null;
+
+  String toString() => message;
 }

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -5,19 +5,29 @@
 library execution_iframe;
 
 import 'dart:async';
+import 'dart:convert' show JSON;
 import 'dart:html';
 import 'dart:js';
+
+//import 'package:source_map_stack_trace/source_map_stack_trace.dart';
+//import 'package:source_maps/source_maps.dart' as source_maps;
+import 'package:stack_trace/stack_trace.dart';
 
 import 'execution.dart';
 export 'execution.dart';
 
 class ExecutionServiceIFrame implements ExecutionService {
-  final StreamController _stdoutController = new StreamController.broadcast();
-  final StreamController _stderrController = new StreamController.broadcast();
+  final StreamController<String> _stdoutController =
+      new StreamController.broadcast();
+  final StreamController<ExecutionException> _stderrController =
+      new StreamController.broadcast();
 
   IFrameElement _frame;
   String _frameSrc;
+
   Completer _readyCompleter = new Completer();
+
+  String _sourceMap;
 
   ExecutionServiceIFrame(this._frame) {
     _frameSrc = _frame.src;
@@ -27,8 +37,9 @@ class ExecutionServiceIFrame implements ExecutionService {
 
   IFrameElement get frame => _frame;
 
-  Future execute(String html, String css, String javaScript) {
+  Future execute(String html, String css, String javaScript, [String sourceMap]) {
     return _reset().whenComplete(() {
+      this._sourceMap = sourceMap;
       return _send('execute', {
         'html': html,
         'css': css,
@@ -47,6 +58,31 @@ class ExecutionServiceIFrame implements ExecutionService {
     _send('setCss', {'css': css});
   }
 
+  bool get hasSourceMap => _sourceMap != null;
+
+  String revereStackTrace(String jsStackTrace) {
+    if (_sourceMap == null) return null;
+
+    Trace trace = new Trace.parse(jsStackTrace);
+    Iterable<Frame> sanitizedFrames = trace.frames.reversed.skipWhile((Frame frame) {
+      if (frame.member == '<fn>') return true;
+      if (frame.uri.path.endsWith('frame.html')) return true;
+      return false;
+    });
+    Trace sanitizedTrace = new Trace(new List.from(sanitizedFrames).reversed);
+    return sanitizedTrace.toString().replaceAll('%3Canonymous%3E', '<compiled>');
+
+    // Map m = JSON.decode(_sourceMap);
+    // m['sources'] = [
+    //   'file:/a.dart', 'file:/b.dart', 'file:/c.dart', 'file:/d.dart',
+    //   'file:/e.dart', 'file:/f.dart', 'file:/g.dart', 'file:/h.dart',
+    //   'file:/i.dart', 'file:/j.dart', 'file:/k.dart', 'file:/l.dart'
+    // ];
+    // source_maps.Mapping mapping = source_maps.parseJson(m);
+    // StackTrace result = mapStackTrace(mapping, trace.vmTrace);
+    // return result.toString();
+  }
+
   String _decorateJavaScript(String javaScript) {
     final String postMessagePrint = '''
 function dartPrint(message) {
@@ -56,9 +92,24 @@ function dartPrint(message) {
 ''';
 
     final String exceptionHandler = '''
-window.onerror = function(message, url, lineNumber) {
-  parent.postMessage(
-    {'sender': 'frame', 'type': 'stderr', 'message': message.toString()}, '*');
+window.onerror = function(message, url, lineNumber, columnNumber, err) {
+  // lineNumber, colNumber, err
+  var data = message;
+
+  if (err && err.stack) {
+    parent.postMessage({
+      'sender': 'frame',
+      'type': 'stderr',
+      'message': message.toString(),
+      'lineNumber': lineNumber,
+      'columnNumber': columnNumber,
+      'stack': err.stack.toString()
+    }, '*');
+  } else {
+    parent.postMessage(
+      {'sender': 'frame', 'type': 'stderr', 'message': message.toString()}, '*');
+  }
+  return true;
 };
 ''';
 
@@ -67,7 +118,7 @@ window.onerror = function(message, url, lineNumber) {
 
   Stream<String> get onStdout => _stdoutController.stream;
 
-  Stream<String> get onStderr => _stderrController.stream;
+  Stream<ExecutionException> get onStderr => _stderrController.stream;
 
   Future _send(String command, Map params) {
     Map m = {'command': command};
@@ -78,6 +129,8 @@ window.onerror = function(message, url, lineNumber) {
 
   /// Destroy and re-load the iframe.
   Future _reset() {
+    _sourceMap = null;
+
     if (frame.parent != null) {
       _readyCompleter = new Completer();
 
@@ -105,7 +158,10 @@ window.onerror = function(message, url, lineNumber) {
       if (type == 'stderr') {
         // Ignore any exceptions before the iframe has completed initialization.
         if (_readyCompleter.isCompleted) {
-          _stderrController.add(data['message']);
+          ExecutionException ex = new ExecutionException(
+              data['message'], data['lineNumber'], data['columnNumber'],
+              data['stack']);
+          _stderrController.add(ex);
         }
       } else if (type == 'ready' && !_readyCompleter.isCompleted) {
         _readyCompleter.complete();

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -5,7 +5,7 @@
 library execution_iframe;
 
 import 'dart:async';
-import 'dart:convert' show JSON;
+//import 'dart:convert' show JSON;
 import 'dart:html';
 import 'dart:js';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,9 @@ dependencies:
   markd: '>=0.7.1+4 <0.8.0'
   rate_limit: '>=0.1.0 <0.2.0'
   route_hierarchical: '>=0.6.0 <0.6.2'
+  source_map_stack_trace: ^1.0.0
+  source_maps: ^0.10.0
+  stack_trace: ^1.0.0
 dev_dependencies:
   dart_to_js_script_rewriter: any
   git: any

--- a/web/frame.html
+++ b/web/frame.html
@@ -35,6 +35,7 @@ replaceJavaScript = function(value) {
   // Create a new node.
   var s = document.createElement('script');
   s.setAttribute('defer', 'true');
+  //s.setAttribute('crossorigin', 'anonymous');
   s.text = value;
   document.head.appendChild(s);
 }


### PR DESCRIPTION
Catch javascript exceptions in the iframe; send them to the embedding page. Clean the exceptions up and display them in the console. Some work towards reversing the stack traces using source maps; still in progress.

TODO:
- catch more exceptions in from the iframe
- investigate the `crossorigin=anonymous` attribute on iframes
- debug the source map reversing

Not yet ready for review...
