### PR TITLE
Remove unneeded abstract class

### DIFF
--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -11,12 +11,6 @@ final Duration serviceCallTimeout = new Duration(seconds: 10);
 final Duration shortServiceCallTimeout = new Duration(seconds: 4);
 final Duration longServiceCallTimeout = new Duration(seconds: 20);
 
-abstract class TextProvider {
-  // TODO: current location as well
-
-  String getText();
-}
-
 class StringTextProvider {
   final String _text;
   StringTextProvider(this._text);


### PR DESCRIPTION
@devoncarew 
Not sure if you wanted the abstract class TextProvider for StringTextProvider, but it is unused as of right now.