### PR TITLE
Safari and chrome popups compliant

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -250,9 +250,9 @@ class PlaygroundMobile {
     if ($('#affirmExportButton') != null) {
       _affirmButton = new PaperIconButton.from($('#affirmExportButton'));
       _affirmButton.clickAction(() {
-        WindowBase wind = window.open("", 'Window');
+        WindowBase exportWindow = window.open("", 'Window');
         _exportDialog.toggle();
-        _export(wind);
+        _export(exportWindow);
       });
     }
   }

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -250,9 +250,8 @@ class PlaygroundMobile {
     if ($('#affirmExportButton') != null) {
       _affirmButton = new PaperIconButton.from($('#affirmExportButton'));
       _affirmButton.clickAction(() {
-        WindowBase exportWindow = window.open("", 'Window');
+        _export();
         _exportDialog.toggle();
-        _export(exportWindow);
       });
     }
   }
@@ -284,7 +283,8 @@ class PlaygroundMobile {
     _clearOutput();
   }
 
-  void _export(WindowBase exportWindow) {
+  void _export() {
+    WindowBase exportWindow = window.open("", 'Export');
     PadSaveObject exportObject = new PadSaveObject()..html = context.htmlSource
         ..css = context.cssSource ..dart = context.dartSource;
     Future<UuidContainer> id = dartSupportServices.export(exportObject);

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -47,6 +47,8 @@ void init() {
 }
 
 class PlaygroundMobile {
+  final String webURL = "https://dartpad.dartlang.org/";
+  
   PaperFab _runButton;
   PaperIconButton _exportButton;
   PaperIconButton _cancelButton;
@@ -248,8 +250,9 @@ class PlaygroundMobile {
     if ($('#affirmExportButton') != null) {
       _affirmButton = new PaperIconButton.from($('#affirmExportButton'));
       _affirmButton.clickAction(() {
+        WindowBase wind = window.open("", 'Window');
         _exportDialog.toggle();
-        _export();
+        _export(wind);
       });
     }
   }
@@ -281,12 +284,12 @@ class PlaygroundMobile {
     _clearOutput();
   }
 
-  void _export() {
+  void _export(WindowBase exportWindow) {
     PadSaveObject exportObject = new PadSaveObject()..html = context.htmlSource
         ..css = context.cssSource ..dart = context.dartSource;
     Future<UuidContainer> id = dartSupportServices.export(exportObject);
     id.then((UuidContainer container) {
-      window.open('/index.html?export=${container.uuid}', 'Export');
+      exportWindow.location.href='$webURL/index.html?export=${container.uuid}';
     });
   }
 


### PR DESCRIPTION
#601 
Fixed issue with Safari not exporting and chrome's popup blocker preventing export.
Issue resolved by calling window.open() as the first item in the onclick event sequence, and then manipulating the window's URL after we receive more data.

@devoncarew @lukechurch 