### PR TITLE
Local variables used to eliminate compile time

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -540,7 +540,7 @@ class PlaygroundMobile {
       _editProgress.hidden(false);
     }
 
-    if (_hasStoredRequest()) {
+    if (_hasStoredRequest) {
       try {
         CompileResponse response = _cachedCompile;
         if (executionService != null) {
@@ -583,7 +583,7 @@ class PlaygroundMobile {
     });
   }
 
-  bool _hasStoredRequest() {
+  bool get _hasStoredRequest {
     return (_lastRun != null && _lastRun[_FileType.DART] == context.dartSource && _lastRun[_FileType.CSS] == context.htmlSource 
         &&  _lastRun[_FileType.CSS] == context.cssSource && _cachedCompile != null);
   }

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -310,7 +310,7 @@ class PlaygroundMobile {
     gistLoader.loadGist(gistId).then((Gist gist) {
       _setGistDescription(gist.description);
       _setGistId(gist.id);
-      
+
       GistFile dart =
           chooseGistFile(gist, ['main.dart'], (f) => f.endsWith('.dart'));
       GistFile html = chooseGistFile(gist, ['index.html', 'body.html']);
@@ -599,6 +599,7 @@ class PlaygroundMobile {
   void _performAnalysis() {
     var input = new SourceRequest()..source = _context.dartSource;
     Lines lines = new Lines(input.source);
+    
     Future<AnalysisResults> request =
         dartServices.analyze(input).timeout(serviceCallTimeout);
 

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -46,7 +46,7 @@ void init() {
   _playground = new PlaygroundMobile();
 }
 
-enum FileType {
+enum _FileType {
   DART, CSS, HTML
 }
 
@@ -60,7 +60,7 @@ class PlaygroundMobile {
   PaperIconButton _resetButton;
   PaperTabs _tabs;
 
-  Map<FileType, String> _lastRun;
+  Map<_FileType, String> _lastRun;
   Router _router;
   
   CompileResponse _cachedCompile;
@@ -584,8 +584,8 @@ class PlaygroundMobile {
   }
 
   bool _hasStoredRequest() {
-    return (_lastRun != null && _lastRun[FileType.DART] == context.dartSource && _lastRun[FileType.CSS] == context.htmlSource 
-        &&  _lastRun[FileType.CSS] == context.cssSource && _cachedCompile != null);
+    return (_lastRun != null && _lastRun[_FileType.DART] == context.dartSource && _lastRun[_FileType.CSS] == context.htmlSource 
+        &&  _lastRun[_FileType.CSS] == context.cssSource && _cachedCompile != null);
   }
  
   void _storePreviousResult() {
@@ -671,10 +671,10 @@ class PlaygroundMobile {
   }
   
   void _setBackup () {
-    _lastRun = new Map<FileType, String>();
-    _lastRun[FileType.DART] = context.dartSource;
-    _lastRun[FileType.HTML] = context.htmlSource;
-    _lastRun[FileType.CSS] = context.cssSource;
+    _lastRun = new Map<_FileType, String>();
+    _lastRun[_FileType.DART] = context.dartSource;
+    _lastRun[_FileType.HTML] = context.htmlSource;
+    _lastRun[_FileType.CSS] = context.cssSource;
   }
   
   void _setGistId(String id) {

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -46,6 +46,10 @@ void init() {
   _playground = new PlaygroundMobile();
 }
 
+enum FileType {
+  DART, CSS, HTML
+}
+
 class PlaygroundMobile {
   final String webURL = "https://dartpad.dartlang.org";
   
@@ -56,7 +60,7 @@ class PlaygroundMobile {
   PaperIconButton _resetButton;
   PaperTabs _tabs;
 
-  Map<String, String> _lastRun;
+  Map<FileType, String> _lastRun;
   Router _router;
   
   CompileResponse _cachedCompile;
@@ -580,8 +584,8 @@ class PlaygroundMobile {
   }
 
   bool _hasStoredRequest() {
-    return (_lastRun != null && _lastRun['dart'] == context.dartSource && _lastRun['html'] == context.htmlSource 
-        &&  _lastRun['css'] == context.cssSource && _cachedCompile != null);
+    return (_lastRun != null && _lastRun[FileType.DART] == context.dartSource && _lastRun[FileType.CSS] == context.htmlSource 
+        &&  _lastRun[FileType.CSS] == context.cssSource && _cachedCompile != null);
   }
  
   void _storePreviousResult() {
@@ -667,10 +671,10 @@ class PlaygroundMobile {
   }
   
   void _setBackup () {
-    _lastRun = new Map<String, String>();
-    _lastRun['dart'] = context.dartSource;
-    _lastRun['html'] = context.htmlSource;
-    _lastRun['css'] = context.cssSource;
+    _lastRun = new Map<FileType, String>();
+    _lastRun[FileType.DART] = context.dartSource;
+    _lastRun[FileType.HTML] = context.htmlSource;
+    _lastRun[FileType.CSS] = context.cssSource;
   }
   
   void _setGistId(String id) {

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -560,7 +560,7 @@ class PlaygroundMobile {
     }
 
     var input = new CompileRequest()..source = context.dartSource;
-    _setBackup();
+    _setLastRunCondition();
     _cachedCompile = null;
     dartServices
         .compile(input)
@@ -590,7 +590,7 @@ class PlaygroundMobile {
  
   void _storePreviousResult() {
     var input = new CompileRequest()..source = context.dartSource;
-    _setBackup();
+    _setLastRunCondition();
     dartServices
         .compile(input)
         .timeout(longServiceCallTimeout)
@@ -670,7 +670,7 @@ class PlaygroundMobile {
     }
   }
   
-  void _setBackup () {
+  void _setLastRunCondition () {
     _lastRun = new Map<_FileType, String>();
     _lastRun[_FileType.DART] = context.dartSource;
     _lastRun[_FileType.HTML] = context.htmlSource;


### PR DESCRIPTION
#611 
@lukechurch @devoncarew 
Send a compile request on load for the embed views & save it locally for repeat requests. This means users don't experience the round trip latency of communicating with the server.