### PR TITLE
Splitter resizing

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -457,13 +457,13 @@ class PlaygroundMobile {
     Element bottomPanel = $('#bottomPanel');
     if (rightPanel != null && leftPanel != null) {
       num percent = validFlex(h) ? int.parse(h) : defaultVerticalRatio;
-      leftPanel.style.width = '${leftPanel.parent.client.width * percent / 100}px';
+      leftPanel.style.width = '${percent}%';
       editor.resize();
       _syncToolbar();
     }
     if (topPanel != null && bottomPanel != null) {
       num percent = validFlex(v) ? int.parse(v) : defaultHorizontalRatio;
-      topPanel.style.height = '${topPanel.parent.client.height * percent / 100}px';
+      topPanel.style.height = '${percent}%';
     }
     var disablePointerEvents = () {
       if ($("#frame") != null) $("#frame").style.pointerEvents = "none";

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -49,6 +49,7 @@
         <dartpad-editor id='topPanel' dart class="layout vertical"></dartpad-editor>
         <horizontal-splitter class="splitter" horizontal></horizontal-splitter>
         <dartpad-console id='bottomPanel' class="flex layout vertical"></dartpad-console>
+        <!--This buffer is needed due to different display settings in chrome/safari/firefix-->
         <div id="buffer"></div>
       </div>
       <vertical-splitter class="splitter layout horizontal" vertical></vertical-splitter>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -49,6 +49,7 @@
         <dartpad-editor id='topPanel' dart class="layout vertical"></dartpad-editor>
         <horizontal-splitter class="splitter" horizontal></horizontal-splitter>
         <dartpad-console id='bottomPanel' class="flex layout vertical"></dartpad-console>
+        <div id="buffer"></div>
       </div>
       <vertical-splitter class="splitter layout horizontal" vertical></vertical-splitter>
       <div id="rightPanel" class ="relative vertical layout flex">

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -199,6 +199,10 @@
 
 <dom-module id="menu-bar-icons">
   <style>
+    :host {
+      height: 36px;
+    }
+    
     .tabs {
       background: #485D67;
       top: inherit;

--- a/web/embed_style.html
+++ b/web/embed_style.html
@@ -56,7 +56,7 @@
 
   #leftPanel {
     width: 60%;
-    /*height: 100%;*/
+    height: 100%;
   }
 
   #errorToast {

--- a/web/embed_style.html
+++ b/web/embed_style.html
@@ -54,6 +54,10 @@
     height: 70%;
   }
 
+  #buffer {
+    height: 36px;
+  }
+
   #leftPanel {
     width: 60%;
     height: 100%;

--- a/web/embed_style.html
+++ b/web/embed_style.html
@@ -56,11 +56,16 @@
 
   #buffer {
     height: 36px;
+    height: -moz-calc(0px);
   }
 
   #leftPanel {
     width: 60%;
     height: 100%;
+  }
+
+  #bottomPanel {
+    overflow: auto;
   }
 
   #errorToast {

--- a/web/embed_style.html
+++ b/web/embed_style.html
@@ -55,7 +55,9 @@
   }
 
   #buffer {
+    /* This is to account for toolbar height in non-firefox browsers*/
     height: 36px;
+    /* This is for firefox's flex display difference */
     height: -moz-calc(0px);
   }
 


### PR DESCRIPTION
@devoncarew @kwalrath @Sfshaza
This change make it so that splitters will scale as a percentage until the user interacts with it.
This will fix the sizing issues on the homepage - and make it more sensible for other users who may want to use embeddings in animations as well.

https://github.com/dart-lang/www.dartlang.org/pull/1407#issuecomment-125780805