### PR TITLE
Export wiki added

### DIFF
--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -267,7 +267,7 @@
       <paper-dialog-scrollable>
         <div id = "guide-text">
           Open this sample in DartPad? <br/>
-          <span id="small-font">View our <a id="export-guide" onclick="window.open('https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide');">export guide</a> for help.</span>
+          <span id="small-font">View our <a id="export-guide" onclick="window.open('https://github.com/dart-lang/dart-pad/wiki/Exporting-Guide');">export guide</a> for help.</span>
         </div>
       </paper-dialog-scrollable>
 

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -262,7 +262,7 @@
   </style>
   <template>
     <paper-dialog id="exportDialog" heading="Export" entry-animation="scale-up-animation" exit-animation="fade-out-animation">
-      <h2>Export to DartPad</h2>
+      <h2>Open in DartPad</h2>
       <br>
       <paper-dialog-scrollable>
         <div id = "guide-text">

--- a/web/embed_components.html
+++ b/web/embed_components.html
@@ -247,13 +247,28 @@
     paper-button {
       color: #44ccff;
     }
+
+    #guide-text {
+      padding: 0 24px;
+    }
+
+    #small-font {
+      font-size: 12px;
+    }
+    #export-guide {
+      cursor: pointer;
+      text-decoration: underline;
+    }
   </style>
   <template>
     <paper-dialog id="exportDialog" heading="Export" entry-animation="scale-up-animation" exit-animation="fade-out-animation">
       <h2>Export to DartPad</h2>
       <br>
       <paper-dialog-scrollable>
-        Open this sample in DartPad?
+        <div id = "guide-text">
+          Open this sample in DartPad? <br/>
+          <span id="small-font">View our <a id="export-guide" onclick="window.open('https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide');">export guide</a> for help.</span>
+        </div>
       </paper-dialog-scrollable>
 
       <div class="buttons">


### PR DESCRIPTION
<img width="552" alt="screen shot 2015-07-30 at 4 12 20 pm" src="https://cloud.githubusercontent.com/assets/3150228/8986862/178680a2-36d6-11e5-8e31-117aea6e7b4d.png">

#622
Added link to guide on exporting. Links to 
https://github.com/dart-lang/dart-pad/wiki/Exporting-Guide.