### PR TITLE
remove unused code

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -119,11 +119,6 @@ class Playground implements GistContainer, GistController {
     runButton.onClick.listen((e) {
       _handleRun();
 
-      // On a mobile device, focusing the editing area causes the keyboard to
-      // pop up when the user hits the run button.
-      if (!isMobile()) _context.focus();
-    });
-
     // Listen for the keyboard button.
     querySelector('#keyboard-button').onClick.listen((_) => settings.show());
 
@@ -179,7 +174,7 @@ class Playground implements GistContainer, GistController {
     Timer.run(() => _performAnalysis());
     _clearOutput();
   }
-  
+
   Future showHome(RouteEnterEvent event) async {
     // Don't auto-run if we're re-loading some unsaved edits; the gist might
     // have halting issues (#384).
@@ -213,7 +208,7 @@ class Playground implements GistContainer, GistController {
     } else {
       editableGist.setBackingGist(createSampleGist());
     }
-    
+
     _clearOutput();
     // We delay this because of the latency in populating the editors from the
     // gist data.

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -34,7 +34,6 @@ import 'sharing/gists.dart';
 import 'sharing/mutable_gist.dart';
 import 'src/ga.dart';
 import 'src/summarize.dart';
-import 'src/util.dart';
 
 Playground get playground => _playground;
 
@@ -118,6 +117,7 @@ class Playground implements GistContainer, GistController {
     runButton = new DButton(querySelector('#runbutton'));
     runButton.onClick.listen((e) {
       _handleRun();
+    });
 
     // Listen for the keyboard button.
     querySelector('#keyboard-button').onClick.listen((_) => settings.show());

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -8,18 +8,6 @@ import 'dart:async';
 import 'dart:html';
 
 /**
- * Return whether we are running on a mobile device.
- */
-bool isMobile() {
-  final int mobileSize = 610;
-
-  int width = document.documentElement.clientWidth;
-  int height = document.documentElement.clientHeight;
-
-  return width <= mobileSize || height <= mobileSize;
-}
-
-/**
  * A [NodeValidator] which allows everything.
  */
 class PermissiveNodeValidator implements NodeValidator {


### PR DESCRIPTION
It appears that the Python handler serves the correct UI depending on the type of device. If that's so, then the removed code is probably not necessary any more?

OTOH, it may be a fallback for undetected mobile devices. In that case, just close this PR.