### PR TITLE
tweak embedded styles

### DIFF
--- a/web/scripts/embed_components.html
+++ b/web/scripts/embed_components.html
@@ -264,13 +264,10 @@
       color: #c6c6c6;
     }
 
-    #guide-text {
+    .guide-text {
       padding: 0 24px;
     }
 
-    #small-font {
-      font-size: 12px;
-    }
     #export-guide {
       cursor: pointer;
       text-decoration: underline;
@@ -281,9 +278,13 @@
       <h2>Open in DartPad</h2>
       <br>
       <paper-dialog-scrollable>
-        <div id = "guide-text">
+        <div class="guide-text">
           Open this sample in DartPad? <br/>
-          <span id="small-font">View our <a id="export-guide" onclick="window.open('https://github.com/dart-lang/dart-pad/wiki/Exporting-Guide');">export guide</a> for help.</span>
+          <span>
+            View our
+            <a id="export-guide" onclick="window.open('https://github.com/dart-lang/dart-pad/wiki/Exporting-Guide');">export guide</a>
+            for help.
+          </span>
         </div>
       </paper-dialog-scrollable>
 
@@ -431,7 +432,7 @@
 <dom-module id="dartpad-console">
   <style>
     :host {
-      padding: 0px 4px;
+      padding: 0 0 8px 8px;
     }
 
     #console {


### PR DESCRIPTION
Tweak the embedded styles:

- minimize the number of font sizes in the export dialog
- make the padding around the console area match the padding for the codemirror area above it
- prefer classes over ids for styling

<img width="255" alt="screen shot 2015-08-17 at 11 07 47 pm" src="https://cloud.githubusercontent.com/assets/1269969/9323528/511f05aa-4536-11e5-9c15-b8884cb5d16b.png">

<img width="117" alt="screen shot 2015-08-17 at 11 15 28 pm" src="https://cloud.githubusercontent.com/assets/1269969/9323527/511ef0d8-4536-11e5-8468-3fa170283ef6.png">

@Georgehe4 