### PR TITLE
Button zindex set lower than dialogs

### DIFF
--- a/web/scripts/embed_components.html
+++ b/web/scripts/embed_components.html
@@ -38,7 +38,7 @@
       position: absolute;
       right: 16px;
       top: 16px;
-      z-index: 20;
+      z-index: 10;
     }
 
     paper-fab + paper-fab {
@@ -76,7 +76,7 @@
       position: absolute;
       right: 16px;
       top: 16px;
-      z-index: 20;
+      z-index: 10;
     }
 
     paper-fab + paper-fab {


### PR DESCRIPTION
@devoncarew 
Fixed a visual bug with buttons having higher zindex than the export dialog.
<img width="348" alt="screen shot 2015-08-21 at 11 17 19 am" src="https://cloud.githubusercontent.com/assets/3150228/9415746/3b354b1a-47f6-11e5-982e-06402d531d22.png">
