### PR TITLE
make the dartpad source strong mode compliant

### DIFF
--- a/lib/parameter_popup.dart
+++ b/lib/parameter_popup.dart
@@ -132,9 +132,10 @@ class ParameterPopup {
 
   void _showParameterPopup(String string, int methodOffset) {
     DivElement editorDiv = querySelector("#editpanel .CodeMirror");
-    var lineHeight =
+    String lineHeightStr =
         editorDiv.getComputedStyle().getPropertyValue('line-height');
-    lineHeight = int.parse(lineHeight.substring(0, lineHeight.indexOf("px")));
+    num lineHeight = int.parse(
+        lineHeightStr.substring(0, lineHeightStr.indexOf("px")));
     // var charWidth = editorDiv.getComputedStyle().getPropertyValue('letter-spacing');
     int charWidth = 8;
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -204,14 +204,11 @@ class Playground implements GistContainer, GistController {
         editableGist.setBackingGist(blankGist);
       });
     } else if (url.hasQuery && url.queryParameters['source'] != null) {
-      Future<UuidContainer> futureGistId =
-          dartSupportServices.retrieveGist(id: url.queryParameters['source']);
-      await futureGistId
-          .then((UuidContainer gistId) => gistLoader.loadGist(gistId.uuid))
-          .then((Gist backing) {
-        editableGist.setBackingGist(backing);
-        router.go('gist', {'gist': backing.id});
-      });
+      UuidContainer gistId =
+          await dartSupportServices.retrieveGist(id: url.queryParameters['source']);
+      Gist backing = await gistLoader.loadGist(gistId.uuid);
+      editableGist.setBackingGist(backing);
+      router.go('gist', {'gist': backing.id});
     } else if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
       loadedFromSaved = true;
 

--- a/lib/polymer/base.dart
+++ b/lib/polymer/base.dart
@@ -18,7 +18,7 @@ Element queryId(String id) => querySelector('#${id}');
 Element $(String selectors) => querySelector(selectors);
 
 class WebElement {
-  final HtmlElement element;
+  final Element element;
 
   WebElement(String tag, {String text}) : element = new Element.tag(tag) {
     if (text != null) element.text = text;


### PR DESCRIPTION
Make the dartpad source strong mode compliant. Note: most (nearly all) of our issues are in direct and transitive package imports.