### PR TITLE
more strong mode fixes

### DIFF
--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -9,7 +9,7 @@ import 'dart:convert';
 import 'dart:html';
 import 'dart:math' as math;
 
-import 'package:markd/markdown.dart' as markdown;
+import 'package:markdown/markdown.dart' as markdown;
 
 import 'context.dart';
 import 'dart_pad.dart';
@@ -152,11 +152,12 @@ class DocHandler {
     }
 
     return mdnCheck.then((String mdnLink) {
+      var propagatedType = info['propagatedType'];
       String _mdDocs = '''# `${info['description']}`\n\n
 ${hasDartdoc ? info['dartdoc'] + "\n\n" : ''}
 ${mdnLink != null ? "## External resources:\n * ${mdnLink} at MDN" : ''}
 ${isVariable ? "${kind}\n\n" : ''}
-${isVariable ? "**Propagated type:** ${info["propagatedType"]}\n\n" : ''}
+${(isVariable && propagatedType != null)? "**Propagated type:** ${propagatedType}\n\n" : ''}
 ${libraryName == null ? '' : apiLink }\n\n''';
 
       String _htmlDocs = markdown.markdownToHtml(_mdDocs,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   haikunator: ^0.1.0
   http: '>=0.11.1 <0.12.0'
   logging: '>=0.9.0 <0.12.0'
-  markd: '>=0.7.1+4 <0.8.0'
+  markdown: '>=0.8.0 <0.9.0'
   rate_limit: '>=0.1.0 <0.2.0'
   route_hierarchical: '>=0.6.0 <0.6.2'
 dev_dependencies:

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -24,6 +24,12 @@ analyze() {
   new PubApp.global('tuneup')..run(['check']);
 }
 
+@Task('Analyze the source code with the ddc compiler')
+ddc() {
+  PubApp ddc = new PubApp.global('dev_compiler');
+  ddc.run(['web/scripts/main.dart']);
+}
+
 @Task()
 testCli() => new TestRunner().testAsync(platformSelector: 'vm');
 


### PR DESCRIPTION
- change from using `markd` to `markdown` to fix several strong mode errors.
- add a `ddc` grinder task to check the source code with the ddc