### PR TITLE
move from rate_limit to frappe to fix ddc issues

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-//Currently not in use
-
 library dart_pad.embed_ui;
 
 import 'dart:async';
@@ -13,23 +11,23 @@ import 'package:logging/logging.dart';
 import 'package:route_hierarchical/client.dart';
 
 import '../completion.dart';
-import '../elements/elements.dart';
-import '../dart_pad.dart';
-import '../documentation.dart';
 import '../context.dart';
 import '../core/dependencies.dart';
 import '../core/keys.dart';
 import '../core/modules.dart';
+import '../dart_pad.dart';
+import '../documentation.dart';
 import '../editing/editor.dart';
+import '../elements/elements.dart';
 import '../modules/codemirror_module.dart';
-import '../modules/dartservices_module.dart';
 import '../modules/dart_pad_module.dart';
+import '../modules/dartservices_module.dart';
 import '../polymer/base.dart';
 import '../polymer/iron.dart';
 import '../polymer/paper.dart';
+import '../services/_dartpadsupportservices.dart';
 import '../services/common.dart';
 import '../services/dartservices.dart';
-import '../services/_dartpadsupportservices.dart';
 import '../services/execution_iframe.dart';
 import '../sharing/gists.dart';
 import '../src/ga.dart';
@@ -273,7 +271,7 @@ class PlaygroundMobile {
     }
   }
 
-  //Console must exist
+  // Console must exist.
   void registerConsole() {
     _output = new PolymerElement.from($("#console"));
   }

--- a/lib/mobile/mobile.dart
+++ b/lib/mobile/mobile.dart
@@ -10,14 +10,14 @@ import 'dart:html' hide Document;
 import 'package:logging/logging.dart';
 import 'package:route_hierarchical/client.dart';
 
-import '../dart_pad.dart';
 import '../context.dart';
 import '../core/dependencies.dart';
 import '../core/modules.dart';
+import '../dart_pad.dart';
 import '../editing/editor.dart';
 import '../modules/codemirror_module.dart';
-import '../modules/dartservices_module.dart';
 import '../modules/dart_pad_module.dart';
+import '../modules/dartservices_module.dart';
 import '../polymer/base.dart';
 import '../polymer/iron.dart';
 import '../polymer/paper.dart';

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -7,8 +7,8 @@ library playground;
 import 'dart:async';
 import 'dart:html' hide Document;
 
+import 'package:frappe/frappe.dart' as frappe;
 import 'package:logging/logging.dart';
-import 'package:rate_limit/rate_limit.dart';
 import 'package:route_hierarchical/client.dart';
 
 import 'completion.dart';
@@ -26,9 +26,9 @@ import 'modules/codemirror_module.dart';
 import 'modules/dart_pad_module.dart';
 import 'modules/dartservices_module.dart';
 import 'parameter_popup.dart';
+import 'services/_dartpadsupportservices.dart';
 import 'services/common.dart';
 import 'services/dartservices.dart';
-import 'services/_dartpadsupportservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/gists.dart';
 import 'sharing/mutable_gist.dart';
@@ -142,8 +142,8 @@ class Playground implements GistContainer, GistController {
 
     // If there was a change, and the gist is dirty, write the gist's contents
     // to storage.
-    Throttler throttle = new Throttler(const Duration(milliseconds: 100));
-    mutableGist.onChanged.transform(throttle).listen((_) {
+    frappe.Property gistChanged = new frappe.Property.fromStream(mutableGist.onChanged);
+    gistChanged.debounce(new Duration(milliseconds: 100)).listen((_) {
       if (mutableGist.dirty) {
         _gistStorage.setStoredGist(mutableGist.createGist());
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
   comid: 0.0.4+5.2.1
   crypto: '>=0.9.0 <0.10.0'
   haikunator: ^0.1.0
+  frappe: ^0.4.0
   http: '>=0.11.1 <0.12.0'
   logging: '>=0.9.0 <0.12.0'
   markdown: '>=0.8.0 <0.9.0'
-  rate_limit: '>=0.1.0 <0.2.0'
   route_hierarchical: '>=0.6.0 <0.6.2'
 dev_dependencies:
   dart_to_js_script_rewriter: any

--- a/web/scripts/main.dart
+++ b/web/scripts/main.dart
@@ -5,8 +5,6 @@
 import 'package:dart_pad/playground.dart' as playground;
 import 'package:logging/logging.dart';
 
-// TODO: create a hidden ping time counter - display it on a key combination
-
 void main() {
   Logger.root.onRecord.listen(print);
 


### PR DESCRIPTION
Move from `rate_limit` to `frappe` to fix 2 ddc issues.

```
severe: [InvalidMethodOverride] Invalid override. The type of Throttler.bind ((Stream<T>) → Stream<T>) is not a subtype of StreamTransformer<dynamic, dynamic>.bind ((Stream<dynamic>) → Stream<dynamic>). (package:rate_limit/rate_limit.dart, line 33, col 3)
severe: [InvalidMethodOverride] Invalid override. The type of Debouncer.bind ((Stream<T>) → Stream<T>) is not a subtype of StreamTransformer<dynamic, dynamic>.bind ((Stream<dynamic>) → Stream<dynamic>). (package:rate_limit/rate_limit.dart, line 173, col 3)
```