### PR TITLE
Defer updated, imports fixed

### DIFF
--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -17,8 +17,6 @@
 
     <script src="packages/dart_pad/bower/webcomponentsjs/webcomponents-lite.min.js"></script>
 
-    <link rel="import" href="styles/embed_style.html"/>
-    <link rel="import" href="scripts/imports.html"/>
     <link rel="import" href="scripts/embed_components.html"/>
 
     <link href='text-fonts/inconsolata.css'
@@ -36,9 +34,9 @@
 
     <script src="scripts/codemirror.js" defer></script>
     <script type="application/dart" src="scripts/embed.dart" defer></script>
-    <script src="packages/browser/dart.js" async></script>
-    <script src="scripts/ga.js" async></script>
-    <script src="scripts/polymerpatch.js" async></script>
+    <script src="packages/browser/dart.js" defer></script>
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
     <style>
       horizontal-splitter.splitter {
         margin-right: 0 !important;

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -17,8 +17,6 @@
 
     <script src="packages/dart_pad/bower/webcomponentsjs/webcomponents-lite.min.js"></script>
 
-    <link rel="import" href="styles/embed_style.html"/>
-    <link rel="import" href="scripts/imports.html"/>
     <link rel="import" href="scripts/embed_components.html"/>
 
     <link href='text-fonts/inconsolata.css'
@@ -36,9 +34,9 @@
           rel="stylesheet" media="screen">
     <script src="scripts/codemirror.js" defer></script>
     <script type="application/dart" src="scripts/embed.dart" defer></script>
-    <script src="packages/browser/dart.js" async></script>
-    <script src="scripts/ga.js" async></script>
-    <script src="scripts/polymerpatch.js" async></script>
+    <script src="packages/browser/dart.js" defer></script>
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
     <style>
       horizontal-splitter.splitter {
         margin-right: 0 !important;

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -17,8 +17,6 @@
 
     <script src="packages/dart_pad/bower/webcomponentsjs/webcomponents-lite.min.js"></script>
 
-    <link rel="import" href="styles/embed_style.html"/>
-    <link rel="import" href="scripts/imports.html"/>
     <link rel="import" href="scripts/embed_components.html"/>
 
     <link href='text-fonts/inconsolata.css' rel='stylesheet' type='text/css'>
@@ -35,9 +33,9 @@
         rel="stylesheet" media="screen">
     <script src="scripts/codemirror.js" defer></script>
     <script type="application/dart" src="scripts/embed.dart" defer></script>
-    <script src="packages/browser/dart.js" async></script>
-    <script src="scripts/ga.js" async></script>
-    <script src="scripts/polymerpatch.js" async></script>
+    <script src="packages/browser/dart.js" defer></script>
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
   </head>
 
   <body class="fullbleed vertical layout" unresolved>

--- a/web/index.html
+++ b/web/index.html
@@ -31,8 +31,8 @@
 
     <script src="scripts/codemirror.js" defer></script>
     <script type="application/dart" src="scripts/main.dart" defer></script>
-    <script src="scripts/ga.js" async></script>
-    <script src="scripts/polymerpatch.js" async></script>
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
   </head>
 
   <body fullbleed layout vertical>

--- a/web/mobile.html
+++ b/web/mobile.html
@@ -16,8 +16,6 @@
 
     <script src="packages/dart_pad/bower/webcomponentsjs/webcomponents-lite.min.js"></script>
 
-    <link rel="import" href="styles/mobile_style.html"/>
-    <link rel="import" href="scripts/imports.html"/>
     <link rel="import" href="scripts/mobile_components.html">
 
     <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'
@@ -38,9 +36,9 @@
     <!-- scripts -->
     <script src="scripts/codemirror.js" defer></script>
     <script type="application/dart" src="scripts/mobile.dart" defer></script>
-    <script src="packages/browser/dart.js" async></script>
-    <script src="scripts/ga.js" async></script>
-    <script src="scripts/polymerpatch.js" async></script>
+    <script src="packages/browser/dart.js" defer></script>
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
   </head>
 
   <body class="fullbleed vertical layout" unresolved>


### PR DESCRIPTION
#707 
Async scripts now switched to defer in order to make sure page has fully loaded before executing. There are no noticeable increases in load time. Functional across all major browsers.
Also removed extra set of imports causing Polymer build to break [should check this across different systems].
Test site located [here](http://dev.crazy-monkey-721.appspot.com/)