### PR TITLE
use browser package to make pub serve work in chrome

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,10 +4,11 @@ author: Dart Team <misc@dartlang.org>
 description: The UI client for a web based interactive Dart service.
 homepage: https://github.com/dart-lang/dart-pad
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.13.0 <2.0.0'
 dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   ace: '>=0.5.10 <0.6.0'
+  browser: ^0.10.0+2
   codemirror: ^0.3.2
   comid: 0.0.4+5.2.1
   crypto: '>=0.9.0 <0.10.0'

--- a/web/index.html
+++ b/web/index.html
@@ -28,9 +28,11 @@
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/editing/editor_codemirror.css" rel="stylesheet" media="screen">
-
     <script src="scripts/codemirror.js" defer></script>
-    <script type="application/dart" src="scripts/main.dart" defer></script>
+
+    <script defer src="scripts/main.dart" type="application/dart"></script>
+    <script defer src="packages/browser/dart.js"></script>
+
     <script src="scripts/ga.js" defer></script>
     <script src="scripts/polymerpatch.js" defer></script>
   </head>


### PR DESCRIPTION
I also updated the sdk version, for using caret syntax we need at least 1.6 or something. But just to be save, I used 1.13.0. 

Making sure that development is happening on at least 1.13.0 will not hurt anyone I guess.