### PR TITLE
upgrade old versions

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -12,7 +12,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0+1"
+    version: "0.30.0"
   ansicolor:
     description:
       name: ansicolor
@@ -61,6 +61,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  cli_util:
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
   codemirror:
     description:
       name: codemirror
@@ -78,13 +84,13 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.1"
   crypto:
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.2+1"
+    version: "2.0.1"
   csslib:
     description:
       name: csslib
@@ -103,6 +109,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0+6"
+  front_end:
+    description:
+      name: front_end
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0-alpha.4"
   git:
     description:
       name: git
@@ -151,12 +163,24 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.1"
+  isolate:
+    description:
+      name: isolate
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  kernel:
+    description:
+      name: kernel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0-alpha.1"
   librato:
     description:
       name: librato
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3"
+    version: "0.1.0"
   logging:
     description:
       name: logging
@@ -211,6 +235,12 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.1"
+  plugin:
+    description:
+      name: plugin
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   pool:
     description:
       name: pool

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   browser: ^0.10.0+2
   codemirror: ^0.4.1
-  crypto: '>=0.9.0 <0.10.0'
   haikunator: ^0.1.0
   frappe: ^0.4.0
   http: '>=0.11.1 <0.12.0'
@@ -20,7 +19,7 @@ dev_dependencies:
   dart_to_js_script_rewriter: any
   git: any
   grinder: ^0.8.0
-  librato: '>=0.0.1 <0.1.0'
+  librato: ^0.1.0
   test: ^0.12.0
   which: ^0.1.0
   yaml: any


### PR DESCRIPTION
- upgrade our version of `librato`
- remove our dep on `crypto` (we had no direct usages)

This fixes the issue w/ selecting very old versions of packages.

@lukechurch 