### PR TITLE
Enable strong mode toggling in dartpad web

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -97,7 +97,7 @@ class PlaygroundMobile {
   }
 
   /**
-   * Return if strong mode should be enabled
+   * Return true if strong mode should be enabled
    */
   bool _parseStrongModeParam(String strongModeValueString) {
     if (strongModeValueString == null) return false;
@@ -107,7 +107,7 @@ class PlaygroundMobile {
   /**
    * Update query parameters for strong mode
    */
-  void showStrong() {
+  void setStrongModeFromUri() {
     Uri url = Uri.parse(window.location.toString());
     String strong = url.queryParameters['strong'];
     if (_parseStrongModeParam(strong)) {
@@ -157,7 +157,7 @@ class PlaygroundMobile {
   }
 
   void registerStrongMode() {
-    showStrong();
+    setStrongModeFromUri();
     querySelector('#strongmode').onChange.listen((e) {
       _performAnalysis();
     });

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -337,8 +337,9 @@ class PlaygroundMobile {
       ..dart = context.dartSource;
     Future<UuidContainer> id = dartSupportServices.export(exportObject);
     id.then((UuidContainer container) {
+      bool strongMode = (querySelector('#strongmode') as InputElement).checked;
       exportWindow.location.href =
-          '$webURL/index.html?export=${container.uuid}';
+          '$webURL/index.html?export=${container.uuid}&strong=${strongMode}';
     });
   }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -174,9 +174,7 @@ class Playground implements GistContainer, GistController {
       });
     });
 
-    querySelector('#strongmode').onChange.listen((e) {
-      _performAnalysis();
-    });
+    registerStrongMode();
 
     _initModules().then((_) {
       _initPlayground();
@@ -191,6 +189,33 @@ class Playground implements GistContainer, GistController {
     // the Dart source from).
     Timer.run(() => _performAnalysis());
     _clearOutput();
+  }
+
+
+  /**
+   * Return if strong mode should be enabled
+   */
+  bool _parseStrongModeParam(String strongModeValueString) {
+    if (strongModeValueString == null) return false;
+    return (strongModeValueString == 'true' || strongModeValueString == 't');
+  }
+
+  /**
+   * Update query parameters for strong mode
+   */
+  void showStrong() {
+    Uri url = Uri.parse(window.location.toString());
+    String strong = url.queryParameters['strong'];
+    if (_parseStrongModeParam(strong)) {
+      (querySelector('#strongmode') as InputElement).checked = true;
+    }
+  }
+
+  void registerStrongMode() {
+    showStrong();
+    querySelector('#strongmode').onChange.listen((e) {
+      _performAnalysis();
+    });
   }
 
   Future showHome(RouteEnterEvent event) async {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -191,9 +191,8 @@ class Playground implements GistContainer, GistController {
     _clearOutput();
   }
 
-
   /**
-   * Return if strong mode should be enabled
+   * Return true if strong mode should be enabled
    */
   bool _parseStrongModeParam(String strongModeValueString) {
     if (strongModeValueString == null) return false;
@@ -203,7 +202,7 @@ class Playground implements GistContainer, GistController {
   /**
    * Update query parameters for strong mode
    */
-  void showStrong() {
+  void setStrongModeFromUri() {
     Uri url = Uri.parse(window.location.toString());
     String strong = url.queryParameters['strong'];
     if (_parseStrongModeParam(strong)) {
@@ -212,7 +211,7 @@ class Playground implements GistContainer, GistController {
   }
 
   void registerStrongMode() {
-    showStrong();
+    setStrongModeFromUri();
     querySelector('#strongmode').onChange.listen((e) {
       _performAnalysis();
     });


### PR DESCRIPTION
#736
#759

This PR resolves feature requests for strong mode in dartpad.
1) Enable toggling of strong mode in dartpad. (by toggling strong=true)
2) Exported views are in strong mode if they were the embedded views were in strong mode

Example: http://crazy-monkey-721.appspot.com/c162b1c0eaa37142eeedf3226b47200d?strong=true