### PR TITLE
Update polymer to 1.11.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~1.0.2",
+    "polymer": "Polymer/polymer#~1.11.2",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-icons": "PolymerElements/iron-icons#^1.0.0",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -471,4 +471,4 @@ packages:
     source: hosted
     version: "2.1.12"
 sdks:
-  dart: ">=1.23.0 <=2.0.0-dev.16.0"
+  dart: ">=1.23.0 <=2.0.0-dev.23.0"


### PR DESCRIPTION
Upgrade polymer versions.

These changes will address issues highlighted in #791.

While the deprecation notices will not go away, these changes will make sure that the site will still support Chrome M65 and that the notices will not impact the UI. 
More detailed discussion in https://github.com/Polymer/polymer/issues/4679