### PR TITLE
Remove anonymous sharing 

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -69,7 +69,7 @@ class PlaygroundMobile {
   PaperToast _errorsToast;
   PaperDialog _messageDialog;
   PaperDialog _resetDialog;
-  PaperDialog _exportDialog;
+  // PaperDialog _exportDialog;
   PolymerElement _output;
   PaperProgress _runProgress;
 
@@ -175,11 +175,11 @@ class PlaygroundMobile {
   }
 
   void registerExportDialog() {
-    if ($("#exportDialog") != null) {
+    /* if ($("#exportDialog") != null) {
       _exportDialog = new PaperDialog.from($("#exportDialog"));
     } else {
       _exportDialog = new PaperDialog();
-    }
+    } */
   }
 
   void registerDocPanel() {
@@ -223,8 +223,10 @@ class PlaygroundMobile {
     if ($('[icon="launch"]') != null) {
       _exportButton = new PaperIconButton.from($('[icon="launch"]'));
       _exportButton.clickAction(() {
-        _exportDialog.open();
+        // Sharing is currently disabled pending establishing OAuth2 configurations with Github.
+        //_exportDialog.open();
         ga.sendEvent("embed", "export");
+        window.open("/${_gistId}", "_export");
       });
     }
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -115,8 +115,14 @@ class Playground implements GistContainer, GistController {
     });
 
     DButton shareButton = new DButton(querySelector('#sharebutton'));
-    shareButton.onClick.listen((Event e) => _createSummary()
-        .then((GistSummary summary) => sharingDialog.showWithSummary(summary)));
+
+    shareButton.onClick.listen((Event e) => window.open(
+        "https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide",
+        '_sharing'));
+
+    // Sharing is currently disabled pending establishing OAuth2 configurations with Github.
+    // shareButton.onClick.listen((Event e) => _createSummary()
+    //    .then((GistSummary summary) => sharingDialog.showWithSummary(summary)));
 
     formatButton = new DButton(querySelector('#formatbutton'));
     formatButton.onClick.listen((Event e) => _format());
@@ -622,7 +628,7 @@ class Playground implements GistContainer, GistController {
     }
   }
 
-  Future<GistSummary> _createSummary() {
+  /* Future<GistSummary> _createSummary() {
     return dartSupportServices.getUnusedMappingId().then((UuidContainer id) {
       _mappingId = id.uuid;
       SourcesRequest input = new SourcesRequest()
@@ -638,7 +644,7 @@ class Playground implements GistContainer, GistController {
     }).catchError((e) {
       _logger.severe(e);
     });
-  }
+  } */
 
   /// Perform static analysis of the source code. Return whether the code
   /// analyzed cleanly (had no errors or warnings).

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -450,4 +450,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.35.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.32.0"


### PR DESCRIPTION
As outlined in #802, anonymous sharing is being removed from github gists.

This CL: 
1) Links users who wish to share to the sharing guide.
2) Changes the export button to open the current gist id instead.

