### PR TITLE
revert the dart2js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 sudo: false
 script: ./tool/travis.sh
 dart:
-- dev
+- "dev/release/2.0.0-dev.35.0"
 
 # Saucelabs setup.
 env:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,7 +224,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
@@ -450,4 +450,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.32.0"
+  dart: ">=2.0.0-dev.23.0 <=2.0.0-dev.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   frappe: ^0.4.0
   http: '>=0.11.1 <0.12.0'
   logging: '>=0.9.0 <0.12.0'
-  markdown: ^0.9.0
+  markdown: ^1.0.0
   route_hierarchical: ^0.7.0
 dev_dependencies:
   dart_to_js_script_rewriter: any


### PR DESCRIPTION
- revert back to an earlier Dart sdk - the latest dev release of dart2js can no longer compile some of the packages in our transitive dependencies

TBR