### PR TITLE
dart-pad doesn't analyze cleanly on 1.x anymore

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -394,4 +394,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.55.0"
+  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.56.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ author: Dart Team <misc@dartlang.org>
 description: The UI client for a web based interactive Dart service.
 homepage: https://github.com/dart-lang/dart-pad
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=2.0.0-dev.17.0 <2.0.0'
 dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   codemirror: ^0.4.1


### PR DESCRIPTION
Update sdk field in pubspec.yaml to reflect that dart-pad doesn't analyze cleanly on 1.x SDKs.