### PR TITLE
Dart 2 changes for dart-pad

### DIFF
--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -5,7 +5,8 @@
 library dart_pad.common;
 
 final String serverURL = 'https://dart-services.appspot.com/';
-//final String serverURL = 'http://127.0.0.1:8080/';
+//final String serverURL = 'http://127.0.0.1:8082/';
+//final String serverURL = 'https://dart2-test-dot-dart-services.appspot.com/';
 
 final Duration serviceCallTimeout = new Duration(seconds: 10);
 final Duration shortServiceCallTimeout = new Duration(seconds: 4);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,4 +401,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.57.0"
+  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.59.0"

--- a/web/index.html
+++ b/web/index.html
@@ -57,9 +57,9 @@
           <option value="74e990d984faad26dea0">Fibonacci</option>
           <option value="33706e19df021e52d98c">Hello World</option>
           <option value="9126d5d48ebabf5bf547">Hello World HTML</option>
-          <option value="72d83fe97bfc8e735607">Solar</option>
-          <option value="9e42aabfcc15c81a0406">Spirodraw</option>
-          <option value="9d2dd2ce17981ecacadd">Sunflower</option>
+          <option value="403698af1a71107edaface6006e5df7c">Solar</option>
+          <option value="6c7d620859100603e9acf351e1224a8c">Spirodraw</option>
+          <option value="49bde0c1ed780decc902f3d4d06d8f0c">Sunflower</option>
           <option value="479ecba5a56fd706b648">WebSockets</option>
         </select>
       </div>


### PR DESCRIPTION
This is now serving at https://dart2-test-dot-dart-pad.appspot.com/, with the serverURL set to ```https://dart2-test-dot-dart-services.appspot.com/``` instead of the default.

The changes to the samples are just the minimum to get them to pass analysis without deprecation warnings.