### PR TITLE
Print entire exception message to console

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -57,7 +57,7 @@ function dartPrint(message) {
     final String exceptionHandler = '''
 window.onerror = function(message, url, lineNumber) {
   parent.postMessage(
-    {'sender': 'frame', 'type': 'stderr', 'message': message.toString()}, '*');
+    {'sender': 'frame', 'type': 'stderr', 'message': message}, '*');
 };
 ''';
 


### PR DESCRIPTION
Fixes #737.  No idea why it does so, I would think this change would be a no-op.  But I discovered this worked while attempting to debug #737.

![screenshot from 2018-05-31 13-23-41](https://user-images.githubusercontent.com/14116827/40806283-db765d54-64d5-11e8-88a8-15fd3ea49e57.png)
