### PR TITLE
Display full error message from uncaught exceptions

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -55,9 +55,9 @@ function dartPrint(message) {
 ''';
 
     final String exceptionHandler = '''
-window.onerror = function(message, url, lineNumber) {
+window.onerror = function(message, url, lineNumber, columnNumber, errorObject) {
   parent.postMessage(
-    {'sender': 'frame', 'type': 'stderr', 'message': message}, '*');
+    {'sender': 'frame', 'type': 'stderr', 'message': message + errorObject}, '*');
 };
 ''';
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -54,21 +54,19 @@ function dartPrint(message) {
 }
 ''';
 
-    final String exceptionHandler = '''
-window.onerror = function(message, url, lineNumber, columnNumber, errorObject) {
-  out = '';
-  if (message.endsWith(errorObject.toString())) {
-    out = message;
-  } else {
-    out = message + errorObject;
+    final String dartMainRunner = '''
+function dartMainRunner(main, args) {
+  try {
+    main(args);
+  } catch(error) {
+    parent.postMessage(
+      {'sender': 'frame', 'type': 'stderr', 'message': "Uncaught exception:\\n" + error.message}, '*');
+    throw error;
   }
-
-  parent.postMessage(
-    {'sender': 'frame', 'type': 'stderr', 'message': out}, '*');
-};
+}
 ''';
 
-    return '${postMessagePrint}\n${exceptionHandler}\n${javaScript}';
+    return '${postMessagePrint}\n${dartMainRunner}\n${javaScript}';
   }
 
   Stream<String> get onStdout => _stdoutController.stream;

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -56,8 +56,15 @@ function dartPrint(message) {
 
     final String exceptionHandler = '''
 window.onerror = function(message, url, lineNumber, columnNumber, errorObject) {
+  out = '';
+  if (message.endsWith(errorObject.toString())) {
+    out = message;
+  } else {
+    out = message + errorObject;
+  }
+
   parent.postMessage(
-    {'sender': 'frame', 'type': 'stderr', 'message': message + errorObject}, '*');
+    {'sender': 'frame', 'type': 'stderr', 'message': out}, '*');
 };
 ''';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,4 +401,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.57.0"
+  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.59.0"


### PR DESCRIPTION
Fixes #737, hopefully for real this time.

In simplifying my fix I had accidentally removed the part that was essential because I had tested it on a bad example.   errorObject sometimes contains what's necessary to fully describe the error, and I've verified it with the case mentioned in #737 that's still valid in strong mode:

![screenshot from 2018-05-31 13-42-42](https://user-images.githubusercontent.com/14116827/40807310-cce99b0e-64d8-11e8-9a0d-fd5692d19829.png)

