### PR TITLE
Fix uncaught embedded exceptions on gist loading

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -98,11 +98,13 @@ class PlaygroundMobile {
     if (url.hasQuery) {
       String id = url.queryParameters['id'];
       if (isLegalGistId(id)) {
-        _showGist(id);
-        _storePreviousResult();
-        if (url.queryParameters['run'] == 'true') {
-          _handleRun();
-        }
+        _showGist(id).then((_) {
+          _storePreviousResult().then((_) {
+            if (url.queryParameters['run'] == 'true') {
+              _handleRun();
+            }
+          });
+        });
         return;
       }
     }
@@ -128,8 +130,9 @@ class PlaygroundMobile {
       return;
     }
 
-    _showGist(gistId, run: page == 'run');
-    _storePreviousResult();
+    _showGist(gistId, run: page == 'run').then((_) {
+      _storePreviousResult();
+    });
   }
 
   void registerMessageToast() {
@@ -322,8 +325,8 @@ class PlaygroundMobile {
     _clearOutput();
   }
 
-  void _showGist(String gistId, {bool run: false}) {
-    gistLoader.loadGist(gistId).then((Gist gist) {
+  Future<void> _showGist(String gistId, {bool run: false}) {
+    return gistLoader.loadGist(gistId).then((Gist gist) {
       _setGistDescription(gist.description);
       _setGistId(gist.id);
 
@@ -509,7 +512,6 @@ class PlaygroundMobile {
     Timer.run(() {
       editor.resize();
     });
-
     _router = new Router()
       ..root.addRoute(name: 'home', defaultRoute: true, enter: showHome)
       ..root.addRoute(name: 'gist', path: '/:gist', enter: showGist)
@@ -601,10 +603,10 @@ class PlaygroundMobile {
         _cachedCompile != null);
   }
 
-  void _storePreviousResult() {
+  Future<void> _storePreviousResult() {
     var input = new CompileRequest()..source = context.dartSource;
     _setLastRunCondition();
-    dartServices
+    return dartServices
         .compile(input)
         .timeout(longServiceCallTimeout)
         .then((CompileResponse response) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -401,4 +401,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.59.0"
+  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.63.0"


### PR DESCRIPTION
Partial fix for #791, at least restoring things to where they were before this cropped up.
@kwalrath 

This fixes errors of this form:

```
async_patch.dart:726 Uncaught Error: DetailedApiRequestError(status: 400, message: main.dart:
Error: No 'main' method found.

Error: Compilation failed.
)
    at Object.a (js_helper.dart:1759)
    at yj.dart.yj.$1 (clients.dart:881)
    at ww.fH (zone.dart:1381)
    at fP.md (future_impl.dart:129)
    at vA.$0 (future_impl.dart:633)
    at Object.ca (future_impl.dart:662)
    at F.aE (future_impl.dart:467)
    at Object.dh (stream_pipe.dart:63)
    at tE.dart.tE.$1 (stream.dart:1149)
    at ww.fI (zone.dart:1316)
```

They were caused by compilation/running not waiting on the asynchronous gist loading before executing.  While the code was always suspect, we might have accidentally not hit this because of implementation details in Dart, and that changed with 2.x.