### PR TITLE
Make dartpad work at runtime when built with dart 2.0 dart2js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: dart
 dart:
   - dev
-sudo: false
+sudo: required
+addons:
+  chrome: stable
 script: ./tool/travis.sh
 
 # Saucelabs setup.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,4 @@
 analyzer:
-  strong-mode: true
   exclude:
     - 'build/**'
     - 'doc/api/**'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,7 @@ analyzer:
     - 'doc/api/**'
     - 'lib/bower/**'
     - 'last_prod/**'
+    - 'third_party/pkg/**'
 
 linter:
   rules:

--- a/lib/services/dartservices.dart
+++ b/lib/services/dartservices.dart
@@ -796,10 +796,11 @@ class AnalysisResults {
     if (_json.containsKey("issues")) {
       issues = _json["issues"]
           .map((value) => new AnalysisIssue.fromJson(value))
+          .cast<AnalysisIssue>()
           .toList();
     }
     if (_json.containsKey("packageImports")) {
-      packageImports = _json["packageImports"];
+      packageImports = _json["packageImports"].cast<core.String>();
     }
   }
 
@@ -825,6 +826,7 @@ class CandidateFix {
     if (_json.containsKey("edits")) {
       edits = _json["edits"]
           .map((value) => new SourceEdit.fromJson(value))
+          .cast<SourceEdit>()
           .toList();
     }
     if (_json.containsKey("message")) {
@@ -973,7 +975,7 @@ class DocumentResponse {
 
   DocumentResponse.fromJson(core.Map _json) {
     if (_json.containsKey("info")) {
-      info = _json["info"];
+      info = new core.Map<core.String, core.String>.from(_json["info"]);
     }
   }
 
@@ -995,6 +997,7 @@ class FixesResponse {
     if (_json.containsKey("fixes")) {
       fixes = _json["fixes"]
           .map((value) => new ProblemAndFixes.fromJson(value))
+          .cast<ProblemAndFixes>()
           .toList();
     }
   }
@@ -1076,6 +1079,7 @@ class ProblemAndFixes {
     if (_json.containsKey("fixes")) {
       fixes = _json["fixes"]
           .map((value) => new CandidateFix.fromJson(value))
+          .cast<CandidateFix>()
           .toList();
     }
     if (_json.containsKey("length")) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,7 +277,7 @@ packages:
   route_hierarchical:
     dependency: "direct main"
     description:
-      path: "../route.dart"
+      path: "third_party/pkg/route.dart"
       relative: true
     source: path
     version: "0.7.1-dev"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.31.1"
+    version: "0.32.3"
   args:
     dependency: transitive
     description:
@@ -56,14 +56,14 @@ packages:
       name: codemirror
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1+5.13.4"
+    version: "0.4.2+5.13.4"
   collection:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.9"
+    version: "1.14.10"
   convert:
     dependency: transitive
     description:
@@ -93,12 +93,12 @@ packages:
     source: hosted
     version: "2.0.0"
   front_end:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0-alpha.9"
+    version: "0.1.3"
   git:
     dependency: "direct dev"
     description:
@@ -162,13 +162,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.2+1"
-  isolate:
-    dependency: transitive
-    description:
-      name: isolate
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0"
   js:
     dependency: transitive
     description:
@@ -176,13 +169,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.1"
+  json_rpc_2:
+    dependency: transitive
+    description:
+      name: json_rpc_2
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0-alpha.9"
+    version: "0.3.3"
   logging:
     dependency: "direct main"
     description:
@@ -203,7 +203,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2+1"
+    version: "0.12.3"
   meta:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
   route_hierarchical:
     dependency: "direct main"
     description:
-      name: route_hierarchical
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.7.0"
+      path: "../route.dart"
+      relative: true
+    source: path
+    version: "0.7.1-dev"
   shelf:
     dependency: transitive
     description:
@@ -364,7 +364,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.37"
+    version: "1.2.0"
   typed_data:
     dependency: transitive
     description:
@@ -379,6 +379,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0+4"
+  vm_service_client:
+    dependency: transitive
+    description:
+      name: vm_service_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.4+3"
   watcher:
     dependency: transitive
     description:
@@ -401,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.13"
 sdks:
-  dart: ">=2.0.0-dev.52.0 <=2.0.0-dev.63.0"
+  dart: ">=2.0.0-dev.67.0 <=2.0.0-dev.68.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+1"
+    version: "0.1.3"
   codemirror:
     dependency: "direct main"
     description:
@@ -77,7 +77,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.5"
   csslib:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.6"
   grinder:
     dependency: "direct dev"
     description:
@@ -133,21 +133,21 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.3+1"
   http:
     dependency: "direct main"
     description:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.3+16"
+    version: "0.11.3+17"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   http_parser:
     dependency: transitive
     description:
@@ -196,7 +196,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
@@ -217,7 +217,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6"
+    version: "0.9.6+1"
   multi_server_socket:
     dependency: transitive
     description:
@@ -231,7 +231,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.3"
   package_config:
     dependency: transitive
     description:
@@ -245,14 +245,14 @@ packages:
       name: package_resolver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.6.1"
   plugin:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.4"
+    version: "1.3.5"
   pub_semver:
     dependency: transitive
     description:
@@ -287,7 +287,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.3+2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -301,14 +301,14 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.7+1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.2+2"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -322,7 +322,7 @@ packages:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.5"
+    version: "0.10.6"
   source_span:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.6"
+    version: "1.6.7+1"
   string_scanner:
     dependency: transitive
     description:
@@ -392,20 +392,20 @@ packages:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+7"
+    version: "0.9.7+9"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.8"
   yaml:
     dependency: "direct dev"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.13"
+    version: "2.1.14"
 sdks:
   dart: ">=2.0.0-dev.67.0 <=2.0.0-dev.68.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,18 +3,21 @@ author: Dart Team <misc@dartlang.org>
 description: The UI client for a web based interactive Dart service.
 homepage: https://github.com/dart-lang/dart-pad
 environment:
-  sdk: '>=2.0.0-dev.17.0 <2.0.0'
+  sdk: '>=2.0.0-dev.67.0 <2.0.0'
 dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
-  codemirror: ^0.4.1
+  codemirror: '^0.4.2+5.13.4'
   haikunator: ^0.1.0
   http: '>=0.11.1 <0.12.0'
   logging: '>=0.9.0 <0.12.0'
   markdown: ^2.0.0
-  route_hierarchical: ^0.7.0
+  route_hierarchical:
+    path: ../route.dart/
 dev_dependencies:
+  collection: ^1.14.10
+  front_end: ^0.1.3
   dhttpd: any
   git: any
   grinder: ^0.8.0
-  test: ^0.12.0
+  test: ^1.2.0
   yaml: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   logging: '>=0.9.0 <0.12.0'
   markdown: ^2.0.0
   route_hierarchical:
-    path: ../route.dart/
+    path: third_party/pkg/route.dart/
 dev_dependencies:
   collection: ^1.14.10
   front_end: ^0.1.3

--- a/third_party/pkg/route.dart/.gitignore
+++ b/third_party/pkg/route.dart/.gitignore
@@ -1,0 +1,13 @@
+packages
+pubspec.lock
+.buildlog
+build/
+/node_modules/
+/test/out/
+/npm-debug.log
+.DS_Store
+dart-sdk
+dartium
+.packages
+.analysis_options
+.pub

--- a/third_party/pkg/route.dart/.gitignore
+++ b/third_party/pkg/route.dart/.gitignore
@@ -9,5 +9,4 @@ build/
 dart-sdk
 dartium
 .packages
-.analysis_options
 .pub

--- a/third_party/pkg/route.dart/.travis.yml
+++ b/third_party/pkg/route.dart/.travis.yml
@@ -1,0 +1,24 @@
+language: node_js
+node_js:
+  - 0.10
+env:
+  matrix:
+    - JOB=unit-stable
+    - JOB=unit-dev
+  global:
+    # Sauce Labs
+    - LOGS_DIR=/tmp/route-build/logs
+    - BROWSER_PROVIDER_READY_FILE=/tmp/sauce-connect-ready
+    - SAUCE_USERNAME=angular-ci
+    - SAUCE_ACCESS_KEY=9b988f434ff8-fbca-8aa4-4ae3-35442987
+
+before_install:
+  - export DISPLAY=:99.0
+
+before_script:
+  - ./scripts/travis/travis-setup.sh
+  - ./scripts/sauce/sauce_connect_setup.sh
+  - ./scripts/sauce/sauce_connect_block.sh
+
+script:
+  - ./scripts/travis/travis-build.sh

--- a/third_party/pkg/route.dart/AUTHORS
+++ b/third_party/pkg/route.dart/AUTHORS
@@ -1,0 +1,6 @@
+# Below is a list of people and organizations that have contributed
+# to the Dart project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Google Inc.

--- a/third_party/pkg/route.dart/CHANGELOG.md
+++ b/third_party/pkg/route.dart/CHANGELOG.md
@@ -1,0 +1,59 @@
+# v0.6.3
+
+## Breaking changes
+
+- UrlPattern has been removed. It was deprecated in v0.6.2.
+- package:unittest replaced by package:test
+- package:mock replaced by package:mockito
+
+## Fixes
+
+- Strong-mode analysis is clean (except some warnings in unit tests)
+
+# v0.6.2
+
+## Fixes
+
+- correctly include query parameters when using pushState [#95](https://github.com/angular/route.dart/issues/95)
+
+## Features
+
+- allow specifying route page title [#10](https://github.com/angular/route.dart/issues/10)
+
+
+# v0.6.1
+
+## Features
+
+- Added forceReload param to `Router.go` which forces reloading of already active routes.
+
+# v0.6.0
+
+## Features
+
+- Introduced `reload({startingFrom})` method which allows to force reload currently active routes.
+- UrlPattern now support paramerter values that contain slashes (`/foo/:bar*` which will fully match `/foo/bar/baz`)
+
+BREAKING CHANGE:
+The router no longer requires prefixing query param names with route name.
+By default all query param changes will trigger route reload, but you can provide
+a list of param patterns (via watchQueryParameters named param on addRoute) which
+will be used to match (prefix match) param names that trigger route reloading. 
+A short-hand for "I don't care about any parameters, never reload" is
+`watchQueryParameters: []`.
+
+
+# v0.5.0
+
+## Breaking changes
+
+- `UrlMatcher.urlParameterNames` has been changed from a method to a getter. The client code must be
+   updated accordingly:
+
+   Before:
+
+        var names = urlMatcher.urlParameterNames();
+
+   After:
+
+        var names = urlMatcher.urlParameterNames;

--- a/third_party/pkg/route.dart/LICENSE
+++ b/third_party/pkg/route.dart/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2012, the Dart project authors. All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/pkg/route.dart/PATENTS
+++ b/third_party/pkg/route.dart/PATENTS
@@ -1,0 +1,23 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Dart Project.
+
+Google hereby grants to you a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell,
+import, transfer, and otherwise run, modify and propagate the contents
+of this implementation of Dart, where such license applies only to
+those patent claims, both currently owned by Google and acquired in
+the future, licensable by Google that are necessarily infringed by
+this implementation of Dart. This grant does not include claims that
+would be infringed only as a consequence of further modification of
+this implementation. If you or your agent or exclusive licensee
+institute or order or agree to the institution of patent litigation
+against any entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that this implementation of Dart or any code
+incorporated within this implementation of Dart constitutes direct or
+contributory patent infringement, or inducement of patent
+infringement, then any patent rights granted to you under this License
+for this implementation of Dart shall terminate as of the date such
+litigation is filed.

--- a/third_party/pkg/route.dart/README.md
+++ b/third_party/pkg/route.dart/README.md
@@ -1,0 +1,149 @@
+Route
+=====
+
+Route is a client routing library for Dart that helps make building
+single-page web apps.
+
+Installation
+------------
+
+Add this package to your pubspec.yaml file:
+
+    dependencies:
+      route_hierarchical: any
+
+Then, run `pub install` to download and link in the package.
+
+UrlMatcher
+----------
+Route is built around `UrlMatcher`, an interface that defines URL template
+parsing, matching and reversing.
+
+
+UrlTemplate
+-----------
+The default implementation of the `UrlMatcher` is `UrlTemplate`. As an example,
+consider a blog with a home page and an article page. The article URL has the
+form /article/1234. It can matched by the following template:
+`/article/:articleId`.
+
+Router
+--------------
+
+Router is a stateful object that contains routes and can perform URL routing
+on those routes.
+
+The `Router` can listen to `Window.onPopState` (or fallback to
+Window.onHashChange in older browsers) events and invoke the correct
+handler so that the back button seamlessly works.
+
+Example (client.dart):
+
+```dart
+library client;
+
+import 'package:route_hierarchical/client.dart';
+
+main() {
+  var router = new Router();
+  router.root
+    ..addRoute(name: 'article', path: '/article/:articleId', enter: showArticle)
+    ..addRoute(name: 'home', defaultRoute: true, path: '/', enter: showHome);
+  router.listen();
+}
+
+void showHome(RouteEvent e) {
+  // nothing to parse from path, since there are no groups
+}
+
+void showArticle(RouteEvent e) {
+  var articleId = e.parameters['articleId'];
+  // show article page with loading indicator
+  // load article from server, then render article
+}
+```
+
+The client side router can let you define nested routes.
+
+```dart
+var router = new Router();
+router.root
+  ..addRoute(
+     name: 'usersList',
+     path: '/users',
+     defaultRoute: true,
+     enter: showUsersList)
+  ..addRoute(
+     name: 'user',
+     path: '/user/:userId',
+     mount: (router) =>
+       router
+         ..addRoute(
+             name: 'articleList',
+             path: '/acticles',
+             defaultRoute: true,
+             enter: showArticlesList)
+         ..addRoute(
+             name: 'article',
+             path: '/article/:articleId',
+             mount: (router) =>
+               router
+                 ..addRoute(
+                     name: 'view',
+                     path: '/view',
+                     defaultRoute: true,
+                     enter: viewArticle)
+                 ..addRoute(
+                     name: 'edit',
+                     path: '/edit',
+                     enter: editArticle)))
+```
+
+The mount parameter takes either a function that accepts an instance of a new
+child router as the only parameter, or an instance of an object that implements
+Routable interface.
+
+```dart
+typedef void MountFn(Router router);
+```
+
+or
+
+```dart
+abstract class Routable {
+  void configureRoute(Route router);
+}
+```
+
+In either case, the child router is instantiated by the parent router an
+injected into the mount point, at which point child router can be configured
+with new routes.
+
+Routing with hierarchical router: when the parent router performs a prefix
+match on the URL, it removes the matched part from the URL and invokes the
+child router with the remaining tail.
+
+For instance, with the above example lets consider this URL: `/user/jsmith/article/1234`.
+Route "user" will match `/user/jsmith` and invoke the child router with `/article/1234`.
+Route "article" will match `/article/1234` and invoke the child router with ``.
+Route "view" will be matched as the default route.
+The resulting route path will be: `user -> article -> view`, or simply `user.article.view`
+
+Named Routes in Hierarchical Routers
+------------------------------------
+
+```dart
+router.go('usersList');
+router.go('user.articles', {'userId': 'jsmith'});
+router.go('user.article.view', {
+  'userId': 'jsmith',
+  'articleId', 1234}
+);
+router.go('user.article.edit', {
+  'userId': 'jsmith',
+  'articleId', 1234}
+);
+```
+
+If "go" is invoked on child routers, the router can automatically reconstruct
+and generate the new URL from the state in the parent routers.

--- a/third_party/pkg/route.dart/codereview.settings
+++ b/third_party/pkg/route.dart/codereview.settings
@@ -1,0 +1,3 @@
+CODE_REVIEW_SERVER: https://chromiumcodereview.appspot.com/
+VIEW_VC: https://github.com/dart-lang/route/commit/
+CC_LIST: reviews@dartlang.org

--- a/third_party/pkg/route.dart/example/basic/example.dart
+++ b/third_party/pkg/route.dart/example/basic/example.dart
@@ -1,0 +1,37 @@
+library example;
+
+import 'dart:html';
+
+import 'package:logging/logging.dart';
+import 'package:route_hierarchical/client.dart';
+
+main() {
+  new Logger('')
+    ..level = Level.FINEST
+    ..onRecord.listen((r) => print('[${r.level}] ${r.message}'));
+
+  querySelector('#warning').remove();
+
+  var router = new Router(useFragment: true);
+
+  router.root
+    ..addRoute(name: 'one', defaultRoute: true, path: '/one', enter: showOne)
+    ..addRoute(name: 'two', path: '/two', enter: showTwo);
+
+  querySelector('#linkOne').attributes['href'] = router.url('one');
+  querySelector('#linkTwo').attributes['href'] = router.url('two');
+
+  router.listen();
+}
+
+void showOne(RouteEvent e) {
+  print("showOne");
+  querySelector('#one').classes.add('selected');
+  querySelector('#two').classes.remove('selected');
+}
+
+void showTwo(RouteEvent e) {
+  print("showTwo");
+  querySelector('#one').classes.remove('selected');
+  querySelector('#two').classes.add('selected');
+}

--- a/third_party/pkg/route.dart/example/basic/example.html
+++ b/third_party/pkg/route.dart/example/basic/example.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>example</title>
+    <style>
+      section {
+        display: none;
+        width: 600px;
+        height: 400px;
+        border: solid 1px #888;
+      }
+
+      section.selected {
+        display: block;
+      }
+
+      .warning {
+        color: red;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>route.dart demo</h1>
+    <p>This demo requires a server to be truly useful. Coming soon!</p>
+    <div id="warning">Dart is not running</div>
+
+    <nav>
+      <a href="#" id="linkOne" title="Section One">One</a>
+      <a href="#" id="linkTwo" title="Section Two">Two</a>
+    </nav>
+
+    <section id="one">
+      <h2>Section One</h2>
+    </section>
+    <section id="two">
+      <h2>Section Two</h2>
+    </section>
+
+    <script type="application/dart" src="example.dart"></script>
+    <script src="packages/browser/dart.js"></script>
+  </body>
+</html>

--- a/third_party/pkg/route.dart/karma.conf.js
+++ b/third_party/pkg/route.dart/karma.conf.js
@@ -1,0 +1,62 @@
+module.exports = function(config) {
+  config.set({
+    //logLevel: config.LOG_DEBUG,
+    basePath: '.',
+    frameworks: ['dart-unittest'],
+
+    // list of files / patterns to load in the browser
+    // all tests must be 'included', but all other libraries must be 'served' and
+    // optionally 'watched' only.
+    files: [
+      'test/*.dart',
+      {pattern: '**/*.dart', watched: true, included: false, served: true},
+      'packages/browser/dart.js',
+      'packages/browser/interop.js'
+    ],
+
+    autoWatch: false,
+
+    // If browser does not capture in given timeout [ms], kill it
+    captureTimeout: 120000,
+    // Time for dart2js to run on Travis... [ms]
+    browserNoActivityTimeout: 1500000,
+
+    plugins: [
+        'karma-dart',
+        'karma-chrome-launcher',
+        'karma-firefox-launcher',
+        'karma-script-launcher',
+        'karma-sauce-launcher',
+        'karma-junit-reporter'
+    ],
+
+
+    customLaunchers: {
+        'SL_Chrome': {
+            base: 'SauceLabs',
+            browserName: 'chrome',
+            version: '35'
+        },
+        'SL_Firefox': {
+            base: 'SauceLabs',
+            browserName: 'firefox',
+            version: '30'
+        }
+    },
+
+    junitReporter: {
+      outputFile: 'test/out/unit.xml',
+      suite: 'unit'
+    },
+
+    sauceLabs: {
+        testName: 'RouteDart',
+        tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER,
+        startConnect: false,
+        options:  {
+            'selenium-version': '2.41.0',
+            'max-duration': 2700
+        }
+    }
+  });
+};

--- a/third_party/pkg/route.dart/lib/click_handler.dart
+++ b/third_party/pkg/route.dart/lib/click_handler.dart
@@ -1,0 +1,55 @@
+library link_handler;
+
+import 'dart:html';
+
+import 'link_matcher.dart';
+import 'client.dart';
+
+typedef String _HashNormalizer(String s);
+
+/**
+ * WindowClickHandler can be used as a hook into [Router] to
+ * modify behavior right after user clicks on an element, and
+ * before the URL in the browser changes.
+ */
+typedef WindowClickHandler(Event e);
+
+/**
+ * This is default behavior used by [Router] to handle clicks on elements.
+ *
+ * The default behavior finds first anchor element. It then uses
+ * [RouteLinkMatcher] to decided if it should handle the link or not.
+ * See [RouterLinkMatcher] and [DefaultRouterLinkMatcher] for details
+ * on deciding if a link should be handled or not.
+ */
+class DefaultWindowClickHandler {
+  final RouterLinkMatcher _linkMatcher;
+  final Router _router;
+  final _HashNormalizer _normalizer;
+  final Window _window;
+  bool _useFragment;
+
+  DefaultWindowClickHandler(this._linkMatcher, this._router, this._useFragment,
+      this._window, this._normalizer);
+
+  void call(Event e) {
+    Element el = e.target;
+    while (el != null && el is! AnchorElement) {
+      el = el.parent;
+    }
+    if (el == null) return;
+    assert(el is AnchorElement);
+    AnchorElement anchor = el;
+    if (!_linkMatcher.matches(anchor)) {
+      return;
+    }
+    if (anchor.host == _window.location.host) {
+      e.preventDefault();
+      if (_useFragment) {
+        _router.gotoUrl(_normalizer(anchor.hash));
+      } else {
+        _router.gotoUrl('${anchor.pathname}${anchor.search}');
+      }
+    }
+  }
+}

--- a/third_party/pkg/route.dart/lib/client.dart
+++ b/third_party/pkg/route.dart/lib/client.dart
@@ -1,0 +1,960 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library route.client;
+
+import 'dart:async';
+import 'dart:html';
+import 'dart:math';
+
+import 'package:logging/logging.dart';
+
+import 'src/utils.dart';
+
+import 'link_matcher.dart';
+import 'click_handler.dart';
+import 'url_matcher.dart';
+export 'url_matcher.dart';
+import 'url_template.dart';
+
+part 'route_handle.dart';
+
+final _logger = new Logger('route');
+const _PATH_SEPARATOR = '.';
+
+typedef void RoutePreEnterEventHandler(RoutePreEnterEvent event);
+typedef void RouteEnterEventHandler(RouteEnterEvent event);
+typedef void RoutePreLeaveEventHandler(RoutePreLeaveEvent event);
+typedef void RouteLeaveEventHandler(RouteLeaveEvent event);
+
+/**
+ * [Route] represents a node in the route tree.
+ */
+abstract class Route {
+  /**
+   * Name of the route. Used when querying routes.
+   */
+  String get name;
+
+  /**
+   * A path fragment [UrlMatcher] for this route.
+   */
+  UrlMatcher get path;
+
+  /**
+   * Parent route in the route tree.
+   */
+  Route get parent;
+
+  /**
+   * Indicates whether this route is currently active. Root route is always
+   * active.
+   */
+  bool get isActive;
+
+  /**
+   * Returns parameters for the currently active route. If the route is not
+   * active the getter returns null.
+   */
+  Map get parameters;
+
+  /**
+   * Returns query parameters for the currently active route. If the route is
+   * not active the getter returns null.
+   */
+  Map get queryParameters;
+
+  /**
+   * Whether to trigger the leave event when only the parameters change.
+   */
+  bool get dontLeaveOnParamChanges;
+
+  /**
+   * Used to set page title when the route [isActive].
+   */
+  String get pageTitle;
+
+  /**
+   * Returns a stream of [RouteEnterEvent] events. The [RouteEnterEvent] event
+   * is fired when route has already been made active, but before subroutes
+   * are entered. The event starts at the root and propagates from parent to
+   * child routes.
+   */
+  @Deprecated("use [onEnter] instead.")
+  Stream<RouteEnterEvent> get onRoute;
+
+  /**
+   * Returns a stream of [RoutePreEnterEvent] events. The [RoutePreEnterEvent]
+   * event is fired when the route is matched during the routing, but before
+   * any previous routes were left, or any new routes were entered. The event
+   * starts at the root and propagates from parent to child routes.
+   *
+   * At this stage it's possible to veto entering of the route by calling
+   * [RoutePreEnterEvent.allowEnter] with a [Future] returns a boolean value
+   * indicating whether enter is permitted (true) or not (false).
+   */
+  Stream<RoutePreEnterEvent> get onPreEnter;
+
+  /**
+   * Returns a stream of [RoutePreLeaveEvent] events. The [RoutePreLeaveEvent]
+   * event is fired when the route is NOT matched during the routing, but before
+   * any routes are actually left, or any new routes were entered.
+   *
+   * At this stage it's possible to veto leaving of the route by calling
+   * [RoutePreLeaveEvent.allowLeave] with a [Future] returns a boolean value
+   * indicating whether enter is permitted (true) or not (false).
+   */
+  Stream<RoutePreLeaveEvent> get onPreLeave;
+
+  /**
+   * Returns a stream of [RouteLeaveEvent] events. The [RouteLeaveEvent]
+   * event is fired when the route is being left. The event starts at the leaf
+   * route and propagates from child to parent routes.
+   */
+  Stream<RouteLeaveEvent> get onLeave;
+
+  /**
+   * Returns a stream of [RouteEnterEvent] events. The [RouteEnterEvent] event
+   * is fired when route has already been made active, but before subroutes
+   * are entered.  The event starts at the root and propagates from parent
+   * to child routes.
+   */
+  Stream<RouteEnterEvent> get onEnter;
+
+  void addRoute(
+      {String name,
+      Pattern path,
+      bool defaultRoute: false,
+      RouteEnterEventHandler enter,
+      RoutePreEnterEventHandler preEnter,
+      RoutePreLeaveEventHandler preLeave,
+      RouteLeaveEventHandler leave,
+      mount,
+      dontLeaveOnParamChanges: false,
+      String pageTitle,
+      List<Pattern> watchQueryParameters});
+
+  /**
+   * Queries sub-routes using the [routePath] and returns the matching [Route].
+   *
+   * [routePath] is a dot-separated list of route names. Ex: foo.bar.baz, which
+   * means that current route should contain route named 'foo', the 'foo' route
+   * should contain route named 'bar', and so on.
+   *
+   * If no match is found then null is returned.
+   */
+  @Deprecated("use [findRoute] instead.")
+  Route getRoute(String routePath);
+
+  /**
+   * Queries sub-routes using the [routePath] and returns the matching [Route].
+   *
+   * [routePath] is a dot-separated list of route names. Ex: foo.bar.baz, which
+   * means that current route should contain route named 'foo', the 'foo' route
+   * should contain route named 'bar', and so on.
+   *
+   * If no match is found then null is returned.
+   */
+  Route findRoute(String routePath);
+
+  /**
+   * Create an return a new [RouteHandle] for this route.
+   */
+  RouteHandle newHandle();
+
+  String toString() => '[Route: $name]';
+}
+
+/**
+ * Route is a node in the tree of routes. The edge leading to the route is
+ * defined by path.
+ */
+class RouteImpl extends Route {
+  @override
+  final String name;
+  @override
+  final UrlMatcher path;
+  @override
+  final RouteImpl parent;
+  @override
+  final String pageTitle;
+
+  /// Child routes map route names to `Route` instances
+  final _routes = <String, RouteImpl>{};
+
+  final StreamController<RouteEnterEvent> _onEnterController;
+  final StreamController<RoutePreEnterEvent> _onPreEnterController;
+  final StreamController<RoutePreLeaveEvent> _onPreLeaveController;
+  final StreamController<RouteLeaveEvent> _onLeaveController;
+
+  final List<Pattern> _watchQueryParameters;
+
+  /// The default child route
+  RouteImpl _defaultRoute;
+
+  /// The currently active child route
+  RouteImpl _currentRoute;
+  RouteEvent _lastEvent;
+  @override
+  final bool dontLeaveOnParamChanges;
+
+  @override
+  @Deprecated("use [onEnter] instead.")
+  Stream<RouteEnterEvent> get onRoute => onEnter;
+  @override
+  Stream<RoutePreEnterEvent> get onPreEnter => _onPreEnterController.stream;
+  @override
+  Stream<RoutePreLeaveEvent> get onPreLeave => _onPreLeaveController.stream;
+  @override
+  Stream<RouteLeaveEvent> get onLeave => _onLeaveController.stream;
+  @override
+  Stream<RouteEnterEvent> get onEnter => _onEnterController.stream;
+
+  RouteImpl._new(
+      {this.name,
+      this.path,
+      this.parent,
+      this.dontLeaveOnParamChanges: false,
+      this.pageTitle,
+      List<Pattern> watchQueryParameters})
+      : _onEnterController =
+            new StreamController<RouteEnterEvent>.broadcast(sync: true),
+        _onPreEnterController =
+            new StreamController<RoutePreEnterEvent>.broadcast(sync: true),
+        _onPreLeaveController =
+            new StreamController<RoutePreLeaveEvent>.broadcast(sync: true),
+        _onLeaveController =
+            new StreamController<RouteLeaveEvent>.broadcast(sync: true),
+        _watchQueryParameters = watchQueryParameters;
+
+  @override
+  void addRoute(
+      {String name,
+      Pattern path,
+      bool defaultRoute: false,
+      RouteEnterEventHandler enter,
+      RoutePreEnterEventHandler preEnter,
+      RoutePreLeaveEventHandler preLeave,
+      RouteLeaveEventHandler leave,
+      mount,
+      dontLeaveOnParamChanges: false,
+      String pageTitle,
+      List<Pattern> watchQueryParameters}) {
+    if (name == null) {
+      throw new ArgumentError('name is required for all routes');
+    }
+    if (name.contains(_PATH_SEPARATOR)) {
+      throw new ArgumentError('name cannot contain dot.');
+    }
+    if (_routes.containsKey(name)) {
+      throw new ArgumentError('Route $name already exists');
+    }
+
+    var matcher = path is UrlMatcher ? path : new UrlTemplate(path.toString());
+
+    var route = new RouteImpl._new(
+        name: name,
+        path: matcher,
+        parent: this,
+        dontLeaveOnParamChanges: dontLeaveOnParamChanges,
+        pageTitle: pageTitle,
+        watchQueryParameters: watchQueryParameters);
+
+    route
+      ..onPreEnter.listen(preEnter)
+      ..onPreLeave.listen(preLeave)
+      ..onEnter.listen(enter)
+      ..onLeave.listen(leave);
+
+    if (mount != null) {
+      if (mount is Function) {
+        mount(route);
+      } else if (mount is Routable) {
+        mount.configureRoute(route);
+      }
+    }
+
+    if (defaultRoute) {
+      if (_defaultRoute != null) {
+        throw new StateError('Only one default route can be added.');
+      }
+      _defaultRoute = route;
+    }
+    _routes[name] = route;
+  }
+
+  @override
+  Route getRoute(String routePath) => findRoute(routePath);
+
+  @override
+  Route findRoute(String routePath) {
+    RouteImpl currentRoute = this;
+    List<String> subRouteNames = routePath.split(_PATH_SEPARATOR);
+    while (subRouteNames.isNotEmpty) {
+      var routeName = subRouteNames.removeAt(0);
+      currentRoute = currentRoute._routes[routeName];
+      if (currentRoute == null) {
+        _logger.warning('Invalid route name: $routeName $_routes');
+        return null;
+      }
+    }
+    return currentRoute;
+  }
+
+  String _getHead(String tail) {
+    for (RouteImpl route = this; route.parent != null; route = route.parent) {
+      var currentRoute = route.parent._currentRoute;
+      if (currentRoute == null) {
+        throw new StateError(
+            'Route ${route.parent.name} has no current route.');
+      }
+
+      tail = currentRoute._reverse(tail);
+    }
+    return tail;
+  }
+
+  String _getTailUrl(Route routeToGo, Map parameters) {
+    var tail = '';
+    for (RouteImpl route = routeToGo; route != this; route = route.parent) {
+      tail = route.path.reverse(
+          parameters: _joinParams(
+              parameters == null ? route.parameters : parameters,
+              route._lastEvent),
+          tail: tail);
+    }
+    return tail;
+  }
+
+  Map _joinParams(Map parameters, RouteEvent lastEvent) =>
+      lastEvent == null ? parameters : new Map.from(lastEvent.parameters)
+        ..addAll(parameters);
+
+  /**
+   * Returns a URL for this route. The tail (url generated by the child path)
+   * will be passes to the UrlMatcher to be properly appended in the
+   * right place.
+   */
+  String _reverse(String tail) =>
+      path.reverse(parameters: _lastEvent.parameters, tail: tail);
+
+  /**
+   * Create an return a new [RouteHandle] for this route.
+   */
+  @override
+  RouteHandle newHandle() {
+    _logger.finest('newHandle for $this');
+    return new RouteHandle._new(this);
+  }
+
+  /**
+   * Indicates whether this route is currently active. Root route is always
+   * active.
+   */
+  @override
+  bool get isActive =>
+      parent == null ? true : identical(parent._currentRoute, this);
+
+  /**
+   * Returns parameters for the currently active route. If the route is not
+   * active the getter returns null.
+   */
+  @override
+  Map get parameters {
+    if (isActive) {
+      return _lastEvent == null
+          ? const {}
+          : new Map.from(_lastEvent.parameters);
+    }
+    return null;
+  }
+
+  /**
+   * Returns parameters for the currently active route. If the route is not
+   * active the getter returns null.
+   */
+  @override
+  Map get queryParameters {
+    if (isActive) {
+      return _lastEvent == null
+          ? const {}
+          : new Map.from(_lastEvent.queryParameters);
+    }
+    return null;
+  }
+}
+
+/**
+ * Route enter or leave event.
+ */
+abstract class RouteEvent {
+  final String path;
+  final Map parameters;
+  final Map queryParameters;
+  final Route route;
+
+  RouteEvent(this.path, this.parameters, this.queryParameters, this.route);
+}
+
+class RoutePreEnterEvent extends RouteEvent {
+  final _allowEnterFutures = <Future<bool>>[];
+
+  RoutePreEnterEvent(path, parameters, queryParameters, route)
+      : super(path, parameters, queryParameters, route);
+
+  RoutePreEnterEvent._fromMatch(_Match m)
+      : this(m.urlMatch.tail, m.urlMatch.parameters, {}, m.route);
+
+  /**
+   * Can be called with a future which will complete with a boolean
+   * value allowing (true) or disallowing (false) the current navigation.
+   */
+  void allowEnter(Future<bool> allow) {
+    _allowEnterFutures.add(allow);
+  }
+}
+
+class RouteEnterEvent extends RouteEvent {
+  RouteEnterEvent(path, parameters, queryParameters, route)
+      : super(path, parameters, queryParameters, route);
+
+  RouteEnterEvent._fromMatch(_Match m)
+      : this(m.urlMatch.match, m.urlMatch.parameters, m.queryParameters,
+            m.route);
+}
+
+class RouteLeaveEvent extends RouteEvent {
+  RouteLeaveEvent(route) : super('', {}, {}, route);
+}
+
+class RoutePreLeaveEvent extends RouteEvent {
+  final _allowLeaveFutures = <Future<bool>>[];
+
+  RoutePreLeaveEvent(route) : super('', {}, {}, route);
+
+  /**
+   * Can be called with a future which will complete with a boolean
+   * value allowing (true) or disallowing (false) the current navigation.
+   */
+  void allowLeave(Future<bool> allow) {
+    _allowLeaveFutures.add(allow);
+  }
+}
+
+/**
+ * Event emitted when routing starts.
+ */
+class RouteStartEvent {
+  /**
+   * URI that was passed to [Router.route].
+   */
+  final String uri;
+
+  /**
+   * Future that completes to a boolean value of whether the routing was
+   * successful.
+   */
+  final Future<bool> completed;
+
+  RouteStartEvent._new(this.uri, this.completed);
+}
+
+abstract class Routable {
+  void configureRoute(Route router);
+}
+
+/**
+ * Stores a set of [UrlPattern] to [Handler] associations and provides methods
+ * for calling a handler for a URL path, listening to [Window] history events,
+ * and creating HTML event handlers that navigate to a URL.
+ */
+class Router {
+  final bool _useFragment;
+  final Window _window;
+  final Route root;
+  final _onRouteStart =
+      new StreamController<RouteStartEvent>.broadcast(sync: true);
+  final bool sortRoutes;
+  bool _listen = false;
+  WindowClickHandler _clickHandler;
+
+  /**
+   * [useFragment] determines whether this Router uses pure paths with
+   * [History.pushState] or paths + fragments and [Location.assign]. The default
+   * value is null which then determines the behavior based on
+   * [History.supportsState].
+   */
+  Router(
+      {bool useFragment,
+      Window windowImpl,
+      bool sortRoutes: true,
+      RouterLinkMatcher linkMatcher,
+      WindowClickHandler clickHandler})
+      : this._init(null,
+            useFragment: useFragment,
+            windowImpl: windowImpl,
+            sortRoutes: sortRoutes,
+            linkMatcher: linkMatcher,
+            clickHandler: clickHandler);
+
+  Router._init(Router parent,
+      {bool useFragment,
+      Window windowImpl,
+      this.sortRoutes,
+      RouterLinkMatcher linkMatcher,
+      WindowClickHandler clickHandler})
+      : _useFragment =
+            (useFragment == null) ? !History.supportsState : useFragment,
+        _window = (windowImpl == null) ? window : windowImpl,
+        root = new RouteImpl._new() {
+    if (clickHandler == null) {
+      if (linkMatcher == null) {
+        linkMatcher = new DefaultRouterLinkMatcher();
+      }
+      _clickHandler = new DefaultWindowClickHandler(
+          linkMatcher, this, _useFragment, _window, _normalizeHash);
+    } else {
+      _clickHandler = clickHandler;
+    }
+  }
+
+  /**
+   * A stream of route calls.
+   */
+  Stream<RouteStartEvent> get onRouteStart => _onRouteStart.stream;
+
+  /**
+   * Finds a matching [Route] added with [addRoute], parses the path
+   * and invokes the associated callback. Search for the matching route starts
+   * at [startingFrom] route or the root [Route] if not specified. By default
+   * the common path from [startingFrom] to the current active path and target
+   * path will be ignored (i.e. no leave or enter will be executed on them).
+   *
+   * This method does not perform any navigation, [go] should be used for that.
+   * This method is used to invoke a handler after some other code navigates the
+   * window, such as [listen].
+   *
+   * Setting [forceReload] to true (default false) will force the matched routes
+   * to reload, even if they are already active and none of the parameters
+   * changed.
+   */
+  Future<bool> route(String path,
+      {Route startingFrom, bool forceReload: false}) {
+    _logger.finest('route path=$path startingFrom=$startingFrom '
+        'forceReload=$forceReload');
+    var baseRoute;
+    List<Route> trimmedActivePath;
+    if (startingFrom == null) {
+      baseRoute = root;
+      trimmedActivePath = activePath;
+    } else {
+      baseRoute = _dehandle(startingFrom);
+      trimmedActivePath = activePath.sublist(activePath.indexOf(baseRoute) + 1);
+    }
+
+    var treePath = _matchingTreePath(path, baseRoute);
+    // Figure out the list of routes that will be leaved
+    var future =
+        _preLeave(path, treePath, trimmedActivePath, baseRoute, forceReload);
+    _onRouteStart.add(new RouteStartEvent._new(path, future));
+    return future;
+  }
+
+  /**
+   * Called before leaving the current route.
+   *
+   * If none of the preLeave listeners veto the leave, chain call [_preEnter].
+   *
+   * If at least one preLeave listeners veto the leave, returns a Future that
+   * will resolve to false. The current route will not change.
+   */
+  Future<bool> _preLeave(String path, List<_Match> treePath,
+      List<RouteImpl> activePath, RouteImpl baseRoute, bool forceReload) {
+    Iterable<RouteImpl> mustLeave = activePath;
+    var leaveBase = baseRoute;
+    for (var i = 0, ll = min(activePath.length, treePath.length); i < ll; i++) {
+      if (mustLeave.first == treePath[i].route &&
+          (treePath[i].route.dontLeaveOnParamChanges ||
+              !(forceReload ||
+                  _paramsChanged(treePath[i].route, treePath[i])))) {
+        mustLeave = mustLeave.skip(1);
+        leaveBase = leaveBase._currentRoute;
+      } else {
+        break;
+      }
+    }
+    // Reverse the list to ensure child is left before the parent.
+    mustLeave = mustLeave.toList().reversed;
+
+    var preLeaving = <Future<bool>>[];
+    mustLeave.forEach((toLeave) {
+      var event = new RoutePreLeaveEvent(toLeave);
+      toLeave._onPreLeaveController.add(event);
+      preLeaving.addAll(event._allowLeaveFutures);
+    });
+    return Future.wait(preLeaving).then<bool>((List<bool> results) {
+      if (!results.any((r) => r == false)) {
+        var leaveFn = () => _leave(mustLeave, leaveBase);
+        return _preEnter(
+            path, treePath, activePath, baseRoute, leaveFn, forceReload);
+      }
+      return new Future.value(false);
+    });
+  }
+
+  void _leave(Iterable<Route> mustLeave, Route leaveBase) {
+    mustLeave.forEach((toLeave) {
+      var event = new RouteLeaveEvent(toLeave);
+      (toLeave as dynamic)._onLeaveController.add(event);
+    });
+    if (!mustLeave.isEmpty) {
+      _unsetAllCurrentRoutesRecursively(leaveBase);
+    }
+  }
+
+  void _unsetAllCurrentRoutesRecursively(RouteImpl r) {
+    if (r._currentRoute != null) {
+      _unsetAllCurrentRoutesRecursively(r._currentRoute);
+      r._currentRoute = null;
+    }
+  }
+
+  Future<bool> _preEnter(
+      String path,
+      List<_Match> treePath,
+      List<Route> activePath,
+      RouteImpl baseRoute,
+      Function leaveFn,
+      bool forceReload) {
+    Iterable<_Match> toEnter = treePath;
+    var tail = path;
+    var enterBase = baseRoute;
+    for (var i = 0, ll = min(toEnter.length, activePath.length); i < ll; i++) {
+      if (toEnter.first.route == activePath[i] &&
+          !(forceReload || _paramsChanged(activePath[i], treePath[i]))) {
+        tail = treePath[i].urlMatch.tail;
+        toEnter = toEnter.skip(1);
+        enterBase = enterBase._currentRoute;
+      } else {
+        break;
+      }
+    }
+    if (toEnter.isEmpty) {
+      leaveFn();
+      return new Future.value(true);
+    }
+
+    var preEnterFutures = <Future<bool>>[];
+    toEnter.forEach((_Match matchedRoute) {
+      var preEnterEvent = new RoutePreEnterEvent._fromMatch(matchedRoute);
+      matchedRoute.route._onPreEnterController.add(preEnterEvent);
+      preEnterFutures.addAll(preEnterEvent._allowEnterFutures);
+    });
+    return Future.wait(preEnterFutures).then<bool>((List<bool> results) {
+      if (!results.any((v) => v == false)) {
+        leaveFn();
+        _enter(enterBase, toEnter, tail);
+        return new Future.value(true);
+      }
+      return new Future.value(false);
+    });
+  }
+
+  void _enter(RouteImpl startingFrom, Iterable<_Match> treePath, String path) {
+    var base = startingFrom;
+    treePath.forEach((_Match matchedRoute) {
+      var event = new RouteEnterEvent._fromMatch(matchedRoute);
+      base._currentRoute = matchedRoute.route;
+      base._currentRoute._lastEvent = event;
+      matchedRoute.route._onEnterController.add(event);
+      base = matchedRoute.route;
+    });
+  }
+
+  /// Returns the direct child routes of [baseRoute] matching the given [path]
+  List<RouteImpl> _matchingRoutes(String path, RouteImpl baseRoute) {
+    var routes = baseRoute._routes.values
+        .where((RouteImpl r) => r.path.match(path) != null)
+        .toList();
+
+    return sortRoutes
+        ? (routes..sort((r1, r2) => r1.path.compareTo(r2.path)))
+        : routes;
+  }
+
+  /// Returns the path as a list of [_Match]
+  List<_Match> _matchingTreePath(String path, RouteImpl baseRoute) {
+    final treePath = <_Match>[];
+    Route matchedRoute;
+    do {
+      matchedRoute = null;
+      List matchingRoutes = _matchingRoutes(path, baseRoute);
+      if (matchingRoutes.isNotEmpty) {
+        if (matchingRoutes.length > 1) {
+          _logger.fine("More than one route matches $path $matchingRoutes");
+        }
+        matchedRoute = matchingRoutes.first;
+      } else {
+        if (baseRoute._defaultRoute != null) {
+          matchedRoute = baseRoute._defaultRoute;
+        }
+      }
+      if (matchedRoute != null) {
+        var match = _getMatch(matchedRoute, path);
+        treePath.add(match);
+        baseRoute = matchedRoute;
+        path = match.urlMatch.tail;
+      }
+    } while (matchedRoute != null);
+    return treePath;
+  }
+
+  bool _paramsChanged(RouteImpl route, _Match match) {
+    var lastEvent = route._lastEvent;
+    return lastEvent == null ||
+        lastEvent.path != match.urlMatch.match ||
+        !mapsShallowEqual(lastEvent.parameters, match.urlMatch.parameters) ||
+        !mapsShallowEqual(
+            _filterQueryParams(
+                lastEvent.queryParameters, route._watchQueryParameters),
+            _filterQueryParams(
+                match.queryParameters, route._watchQueryParameters));
+  }
+
+  Map _filterQueryParams(
+      Map queryParameters, List<Pattern> watchQueryParameters) {
+    if (watchQueryParameters == null) {
+      return queryParameters;
+    }
+    Map result = {};
+    queryParameters.keys.forEach((key) {
+      if (watchQueryParameters
+          .any((pattern) => pattern.matchAsPrefix(key) != null)) {
+        result[key] = queryParameters[key];
+      }
+    });
+    return result;
+  }
+
+  Future<bool> reload({Route startingFrom}) {
+    var path = activePath;
+    RouteImpl baseRoute = startingFrom == null ? root : _dehandle(startingFrom);
+    if (baseRoute != root) {
+      path = path.skipWhile((r) => r != baseRoute).skip(1).toList();
+    }
+    String reloadPath = '';
+    for (int i = path.length - 1; i >= 0; i--) {
+      reloadPath = (path[i] as dynamic)._reverse(reloadPath);
+    }
+    reloadPath += _buildQuery(path.isEmpty ? {} : path.last.queryParameters);
+    return route(reloadPath, startingFrom: startingFrom, forceReload: true);
+  }
+
+  /// Navigates to a given relative route path, and parameters.
+  Future<bool> go(String routePath, Map parameters,
+      {Route startingFrom,
+      bool replace: false,
+      Map queryParameters,
+      bool forceReload: false}) {
+    RouteImpl baseRoute = startingFrom == null ? root : _dehandle(startingFrom);
+    var routeToGo = _findRoute(baseRoute, routePath);
+    var newTail = baseRoute._getTailUrl(routeToGo, parameters) +
+        _buildQuery(queryParameters);
+    String newUrl = baseRoute._getHead(newTail);
+    _logger.finest('go $newUrl');
+    return route(newTail, startingFrom: baseRoute, forceReload: forceReload)
+        .then((success) {
+      if (success) {
+        _go(newUrl, routeToGo.pageTitle, replace);
+      }
+      return success;
+    });
+  }
+
+  /// Returns an absolute URL for a given relative route path and parameters.
+  String url(String routePath,
+      {Route startingFrom, Map parameters, Map queryParameters}) {
+    var baseRoute = startingFrom == null ? root : _dehandle(startingFrom);
+    parameters = parameters == null ? {} : parameters;
+    var routeToGo = _findRoute(baseRoute, routePath);
+    var tail = (baseRoute as dynamic)._getTailUrl(routeToGo, parameters);
+    return (_useFragment ? '#' : '') +
+        (baseRoute as dynamic)._getHead(tail) +
+        _buildQuery(queryParameters);
+  }
+
+  /// Attempts to find [Route] for the specified [routePath] relative to the
+  /// [baseRoute]. If nothing is found throws a [StateError].
+  Route _findRoute(Route baseRoute, String routePath) {
+    var route = baseRoute.findRoute(routePath);
+    if (route == null) {
+      throw new StateError('Invalid route path: $routePath');
+    }
+    return route;
+  }
+
+  /// Build an query string from a parameter `Map`
+  String _buildQuery(Map queryParams) {
+    if (queryParams == null || queryParams.isEmpty) {
+      return '';
+    }
+    return '?' +
+        queryParams.keys
+            .map((key) => '$key=${Uri.encodeComponent(queryParams[key])}')
+            .join('&');
+  }
+
+  Route _dehandle(Route r) => r is RouteHandle ? r._getHost(r) : r;
+
+  _Match _getMatch(Route route, String path) {
+    var match = route.path.match(path);
+    // default route
+    if (match == null) {
+      return new _Match(route, new UrlMatch('', '', {}), {});
+    }
+    return new _Match(route, match, _parseQuery(route, path));
+  }
+
+  /// Parse the query string to a parameter `Map`
+  Map<String, String> _parseQuery(Route route, String path) {
+    var params = <String, String>{};
+    if (path.indexOf('?') == -1) return params;
+    var queryStr = path.substring(path.indexOf('?') + 1);
+    queryStr.split('&').forEach((String keyValPair) {
+      List<String> keyVal = _parseKeyVal(keyValPair);
+      var key = keyVal[0];
+      if (key.isNotEmpty) {
+        params[key] = Uri.decodeComponent(keyVal[1]);
+      }
+    });
+    return params;
+  }
+
+  /**
+   * Parse a key value pair (`"key=value"`) and returns a list of
+   * `["key", "value"]`.
+   */
+  List<String> _parseKeyVal(String kvPair) {
+    if (kvPair.isEmpty) {
+      return const ['', ''];
+    }
+    var splitPoint = kvPair.indexOf('=');
+
+    return (splitPoint == -1)
+        ? [kvPair, '']
+        : [kvPair.substring(0, splitPoint), kvPair.substring(splitPoint + 1)];
+  }
+
+  /**
+   * Listens for window history events and invokes the router. On older
+   * browsers the hashChange event is used instead.
+   */
+  void listen({bool ignoreClick: false, Element appRoot}) {
+    _logger.finest('listen ignoreClick=$ignoreClick');
+    if (_listen) {
+      throw new StateError('listen can only be called once');
+    }
+    _listen = true;
+    if (_useFragment) {
+      _window.onHashChange.listen((_) {
+        route(_normalizeHash(_window.location.hash)).then((allowed) {
+          // if not allowed, we need to restore the browser location
+          if (!allowed) {
+            _window.history.back();
+          }
+        });
+      });
+      route(_normalizeHash(_window.location.hash));
+    } else {
+      String getPath() =>
+          '${_window.location.pathname}${_window.location.search}'
+          '${_window.location.hash}';
+
+      _window.onPopState.listen((_) {
+        route(getPath()).then((allowed) {
+          // if not allowed, we need to restore the browser location
+          if (!allowed) {
+            _window.history.back();
+          }
+        });
+      });
+      route(getPath());
+    }
+    if (!ignoreClick) {
+      if (appRoot == null) {
+        appRoot = _window.document.documentElement;
+      }
+      _logger.finest('listen on win');
+      appRoot.onClick
+          .where((MouseEvent e) => !(e.ctrlKey || e.metaKey || e.shiftKey))
+          .listen(_clickHandler);
+    }
+  }
+
+  String _normalizeHash(String hash) => hash.isEmpty ? '' : hash.substring(1);
+
+  /**
+   * Navigates the browser to the path produced by [url] with [args] by calling
+   * [History.pushState], then invokes the handler associated with [url].
+   *
+   * On older browsers [Location.assign] is used instead with the fragment
+   * version of the UrlPattern.
+   */
+  Future<bool> gotoUrl(String url) => route(url).then((success) {
+        if (success) {
+          _go(url, null, false);
+        }
+      });
+
+  void _go(String path, String title, bool replace) {
+    if (_useFragment) {
+      if (replace) {
+        _window.location.replace('#$path');
+      } else {
+        _window.location.assign('#$path');
+      }
+    } else {
+      if (title == null) {
+        title = (_window.document as HtmlDocument).title;
+      }
+      if (replace) {
+        _window.history.replaceState(null, title, path);
+      } else {
+        _window.history.pushState(null, title, path);
+      }
+    }
+    if (title != null) {
+      (_window.document as HtmlDocument).title = title;
+    }
+  }
+
+  /**
+   * Returns the current active route path in the route tree.
+   * Excludes the root path.
+   */
+  List<Route> get activePath {
+    var res = <RouteImpl>[];
+    dynamic route = root;
+    while (route._currentRoute != null) {
+      route = route._currentRoute;
+      res.add(route);
+    }
+    return res;
+  }
+
+  /**
+   * A shortcut for router.root.findRoute().
+   */
+  Route findRoute(String routePath) => root.findRoute(routePath);
+}
+
+class _Match {
+  final RouteImpl route;
+  final UrlMatch urlMatch;
+  final Map queryParameters;
+
+  _Match(this.route, this.urlMatch, this.queryParameters);
+
+  String toString() => route.toString();
+}

--- a/third_party/pkg/route.dart/lib/link_matcher.dart
+++ b/third_party/pkg/route.dart/lib/link_matcher.dart
@@ -1,0 +1,22 @@
+library link_matcher;
+
+import 'dart:html';
+
+const _TARGETS = const ['_blank', '_parent', '_self', '_top'];
+
+/**
+ * RouterLinkMatcher is used to customize [Router] behavior by
+ * selecting which [AnchorElement]s to process.
+ */
+abstract class RouterLinkMatcher {
+  bool matches(AnchorElement link);
+}
+
+/**
+ * A [RouterLinkMatcher] that matches anchor elements which
+ * do not have have `_blank`, `_parent`, `_self` or `_top`
+ * set as target.
+ */
+class DefaultRouterLinkMatcher implements RouterLinkMatcher {
+  bool matches(AnchorElement link) => !_TARGETS.contains(link.target);
+}

--- a/third_party/pkg/route.dart/lib/route_handle.dart
+++ b/third_party/pkg/route.dart/lib/route_handle.dart
@@ -1,0 +1,150 @@
+part of route.client;
+
+/**
+ * A helper Router handle that scopes all route event subscriptions to it's
+ * instance and provides an convenience [discard] method.
+ */
+class RouteHandle implements Route {
+  Route _route;
+  final StreamController<RoutePreEnterEvent> _onPreEnterController;
+  final StreamController<RoutePreLeaveEvent> _onPreLeaveController;
+  final StreamController<RouteEnterEvent> _onEnterController;
+  final StreamController<RouteLeaveEvent> _onLeaveController;
+
+  @override
+  @Deprecated("use [onEnter] instead.")
+  Stream<RouteEnterEvent> get onRoute => onEnter;
+  @override
+  Stream<RoutePreEnterEvent> get onPreEnter => _onPreEnterController.stream;
+  @override
+  Stream<RoutePreLeaveEvent> get onPreLeave => _onPreLeaveController.stream;
+  @override
+  Stream<RouteEnterEvent> get onEnter => _onEnterController.stream;
+  @override
+  Stream<RouteLeaveEvent> get onLeave => _onLeaveController.stream;
+
+  StreamSubscription _onPreEnterSubscription;
+  StreamSubscription _onPreLeaveSubscription;
+  StreamSubscription _onEnterSubscription;
+  StreamSubscription _onLeaveSubscription;
+  List<RouteHandle> _childHandles = <RouteHandle>[];
+
+  RouteHandle._new(this._route)
+      : _onEnterController =
+            new StreamController<RouteEnterEvent>.broadcast(sync: true),
+        _onPreEnterController =
+            new StreamController<RoutePreEnterEvent>.broadcast(sync: true),
+        _onPreLeaveController =
+            new StreamController<RoutePreLeaveEvent>.broadcast(sync: true),
+        _onLeaveController =
+            new StreamController<RouteLeaveEvent>.broadcast(sync: true) {
+    _onEnterSubscription = _route.onEnter.listen(_onEnterController.add);
+    _onPreEnterSubscription =
+        _route.onPreEnter.listen(_onPreEnterController.add);
+    _onPreLeaveSubscription =
+        _route.onPreLeave.listen(_onPreLeaveController.add);
+    _onLeaveSubscription = _route.onLeave.listen(_onLeaveController.add);
+  }
+
+  /// discards this handle.
+  void discard() {
+    _logger.finest('discarding handle for $_route');
+    _onPreEnterSubscription.cancel();
+    _onEnterSubscription.cancel();
+    _onPreLeaveSubscription.cancel();
+    _onLeaveSubscription.cancel();
+    _onEnterController.close();
+    _onPreEnterController.close();
+    _onLeaveController.close();
+    _onPreLeaveController.close();
+    _childHandles
+      ..forEach((RouteHandle c) => c.discard())
+      ..clear();
+    _route = null;
+  }
+
+  /// Not supported. Overridden to throw an error.
+  @override
+  void addRoute(
+      {String name,
+      Pattern path,
+      bool defaultRoute: false,
+      RouteEnterEventHandler enter,
+      RoutePreEnterEventHandler preEnter,
+      RoutePreLeaveEventHandler preLeave,
+      RouteLeaveEventHandler leave,
+      mount,
+      dontLeaveOnParamChanges: false,
+      String pageTitle,
+      List<Pattern> watchQueryParameters}) {
+    throw new UnsupportedError('addRoute is not supported in handle');
+  }
+
+  @override
+  @Deprecated("use [findRoute] instead.")
+  Route getRoute(String routePath) => findRoute(routePath);
+
+  @override
+  Route findRoute(String routePath) {
+    Route r = _assertState(() => _getHost(_route).findRoute(routePath));
+    if (r == null) return null;
+    var handle = r.newHandle();
+    if (handle != null) _childHandles.add(handle);
+    return handle;
+  }
+
+  /**
+   * Create an return a new [RouteHandle] for this route.
+   */
+  @override
+  RouteHandle newHandle() {
+    _logger.finest('newHandle for $this');
+    return new RouteHandle._new(_getHost(_route));
+  }
+
+  Route _getHost(Route r) {
+    _assertState();
+    if (r == null) throw new StateError('Oops?!');
+    if ((r is Route) && (r is! RouteHandle)) return r;
+    RouteHandle rh = r;
+    return rh._getHost(rh._route);
+  }
+
+  dynamic _assertState([f()]) {
+    if (_route == null) {
+      throw new StateError('This route handle is already discarded.');
+    }
+    return f == null ? null : f();
+  }
+
+  /// See [Route.isActive]
+  @override
+  bool get isActive => _route.isActive;
+
+  /// See [Route.parameters]
+  @override
+  Map get parameters => _route.parameters;
+
+  /// See [Route.path]
+  @override
+  UrlMatcher get path => _route.path;
+
+  /// See [Route.name]
+  @override
+  String get name => _route.name;
+
+  /// See [Route.parent]
+  @override
+  Route get parent => _route.parent;
+
+  /// See [Route.dontLeaveOnParamChanges]
+  @override
+  bool get dontLeaveOnParamChanges => _route.dontLeaveOnParamChanges;
+
+  /// See [Route.title]
+  @override
+  String get pageTitle => _route.pageTitle;
+
+  @override
+  Map get queryParameters => _route.queryParameters;
+}

--- a/third_party/pkg/route.dart/lib/src/utils.dart
+++ b/third_party/pkg/route.dart/lib/src/utils.dart
@@ -1,0 +1,5 @@
+library route.utils;
+
+bool mapsShallowEqual(Map a, Map b) =>
+    a.length == b.length &&
+    a.keys.every((k) => b.containsKey(k) && a[k] == b[k]);

--- a/third_party/pkg/route.dart/lib/url_matcher.dart
+++ b/third_party/pkg/route.dart/lib/url_matcher.dart
@@ -1,0 +1,59 @@
+library url_matcher;
+
+import 'src/utils.dart';
+
+/**
+ * A reversible URL matcher interface.
+ */
+abstract class UrlMatcher extends Comparable<UrlMatcher> {
+  /**
+   * Attempts to match a given URL. If match is successful then returns an
+   * instance or [UrlMatch], otherwise returns [null].
+   */
+  UrlMatch match(String url);
+
+  /**
+   * Reverses (reconstructs) a URL from optionally provided parameters map
+   * and a tail.
+   */
+  String reverse({Map parameters, String tail});
+
+  /**
+   * Returns a list of named parameters in the URL.
+   */
+  List<String> get urlParameterNames;
+
+  /**
+   * Returns a value which is:
+   * * negative if this matcher should be tested before another.
+   * * zero if this matcher and another can be tested in no particular order.
+   * * positive if this matcher should be tested after another.
+   */
+  int compareTo(UrlMatcher other);
+}
+
+/**
+ * Object representing a successful URL match.
+ */
+class UrlMatch {
+  /// Matched section of the URL
+  final String match;
+
+  /// Remaining unmatched suffix
+  final String tail;
+
+  final Map parameters;
+
+  UrlMatch(this.match, this.tail, this.parameters);
+
+  bool operator ==(other) =>
+      other is UrlMatch &&
+      other.match == match &&
+      other.tail == tail &&
+      mapsShallowEqual(other.parameters, parameters);
+
+  int get hashCode =>
+      13 * match.hashCode + 101 * tail.hashCode + 199 * parameters.hashCode;
+
+  String toString() => '{$match, $tail, $parameters}';
+}

--- a/third_party/pkg/route.dart/lib/url_template.dart
+++ b/third_party/pkg/route.dart/lib/url_template.dart
@@ -1,0 +1,118 @@
+library url_template;
+
+import 'url_matcher.dart';
+
+final _specialChars = new RegExp(r'[\\()$^.+[\]{}|]');
+final _paramPattern = r'([^/?]+)';
+final _paramWithSlashesPattern = r'([^?]+)';
+
+/**
+ * A reversible URL template class that can match/parse and reverse URL
+ * templates like: /foo/:bar/baz
+ */
+class UrlTemplate implements UrlMatcher {
+  // Parameter names of the template ie  `['bar']` for `/foo/:bar/baz`
+  List<String> _fields;
+
+  // The compiled template
+  RegExp _pattern;
+
+  /**
+   * The template exploded as parts
+   * - even indexes contain text
+   * - odd indexes contain closures that return the parameter value
+   *
+   * `/foo/:bar/baz` produces:
+   * - [0] = `/foo/`
+   * - [1] = `(p) => p['bar']`
+   * - [2] = `/baz`
+   */
+  List _chunks;
+
+  String toString() => 'UrlTemplate($_pattern)';
+
+  int compareTo(UrlMatcher other) {
+    final String tmpParamPattern = '\t';
+    if (other is UrlTemplate) {
+      String thisPattern =
+          _pattern.pattern.replaceAll(_paramPattern, tmpParamPattern);
+      String otherPattern =
+          other._pattern.pattern.replaceAll(_paramPattern, tmpParamPattern);
+      List<String> thisPatternParts = thisPattern.split('/');
+      List<String> otherPatternParts = otherPattern.split('/');
+      if (thisPatternParts.length == otherPatternParts.length) {
+        for (int i = 0; i < thisPatternParts.length; i++) {
+          String thisPart = thisPatternParts[i];
+          String otherPart = otherPatternParts[i];
+          if (thisPart == tmpParamPattern && otherPart != tmpParamPattern) {
+            return 1;
+          } else if (thisPart != tmpParamPattern &&
+              otherPart == tmpParamPattern) {
+            return -1;
+          }
+        }
+        return otherPattern.compareTo(thisPattern);
+      } else {
+        return otherPatternParts.length - thisPatternParts.length;
+      }
+    } else {
+      return 0;
+    }
+  }
+
+  UrlTemplate(String template) {
+    _compileTemplate(template);
+  }
+
+  void _compileTemplate(String template) {
+    // Escape special characters
+    template = template.replaceAllMapped(_specialChars, (m) => r'\' + m[0]);
+    _fields = <String>[];
+    _chunks = [];
+    var exp = new RegExp(r':(\w+\*?)');
+    StringBuffer sb = new StringBuffer('^');
+    int start = 0;
+    exp.allMatches(template).forEach((Match m) {
+      var paramName = m[1];
+      var txt = template.substring(start, m.start);
+      _fields.add(paramName);
+      _chunks.add(txt);
+      _chunks.add((Map params) => params[paramName]);
+      sb.write(txt);
+      if (paramName.endsWith(r'*')) {
+        sb.write(_paramWithSlashesPattern);
+      } else {
+        sb.write(_paramPattern);
+      }
+      start = m.end;
+    });
+    if (start != template.length) {
+      var txt = template.substring(start, template.length);
+      sb.write(txt);
+      _chunks.add(txt);
+    }
+    _pattern = new RegExp(sb.toString());
+  }
+
+  UrlMatch match(String url) {
+    Match match = _pattern.firstMatch(url);
+    if (match == null) {
+      return null;
+    }
+    var parameters = new Map();
+    for (var i = 0; i < match.groupCount; i++) {
+      parameters[_fields[i]] = match[i + 1];
+    }
+    var tail = url.substring(match[0].length);
+    return new UrlMatch(match[0], tail, parameters);
+  }
+
+  String reverse({Map parameters, String tail: ''}) {
+    if (parameters == null) {
+      parameters = const {};
+    }
+    return _chunks.map((c) => c is Function ? c(parameters) : c).join() + tail;
+  }
+
+  List<String> get urlParameterNames => _fields;
+}

--- a/third_party/pkg/route.dart/package.json
+++ b/third_party/pkg/route.dart/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "route.dart",
+  "branchVersion": "0.5.*",
+  "cdnVersion": "0.4.15",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/angular/route.dart.git"
+  },
+  "devDependencies": {
+    "karma" : "~0.12.0",
+    "karma-dart" : "~0.2.6",
+    "karma-sauce-launcher": "^0.2.3",
+    "karma-script-launcher": "*",
+    "karma-chrome-launcher": "~0.1.3",
+    "karma-firefox-launcher": "*",
+    "karma-junit-reporter": "~0.2.1",
+    "jasmine-node": "*",
+    "qq": "*"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/angular/route.dart/blob/master/LICENSE"
+    }
+  ],
+  "dependencies": {}
+}

--- a/third_party/pkg/route.dart/pubspec.yaml
+++ b/third_party/pkg/route.dart/pubspec.yaml
@@ -1,0 +1,15 @@
+name: route_hierarchical
+version: 0.7.1-dev
+authors:
+- Justin Fagnani <justinfagnani@google.com>
+- Pavel Jbanov <pavelj@google.com>
+description: A client routing library for Dart, modified for Dart 2.
+homepage: https://github.com/angular/route.dart
+environment:
+  sdk: '>=2.0.0-dev.67.0 <2.0.0'
+dependencies:
+  logging: any
+dev_dependencies:
+  browser: any
+  mockito: ^2.2.3
+  test: any

--- a/third_party/pkg/route.dart/scripts/env.sh
+++ b/third_party/pkg/route.dart/scripts/env.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e -o pipefail
+
+PLATFORM="$(uname -s)"
+
+# Try to find the SDK alongside the dart command first.
+if [[ -z "$DART_SDK" ]]; then
+DART=$(which dart) || true
+if [[ -x "$DART" ]]; then
+  DART_SDK="${DART/dart-sdk\/*/dart-sdk}"
+  if [[ ! -e "$DART_SDK" ]]; then
+    unset DART DART_SDK
+  fi
+fi
+fi
+# Fallback: Assume it's alongside the current directory (e.g. Travis).
+if [[ -z "$DART_SDK" ]]; then
+DART_SDK="$(pwd)/dart-sdk"
+fi
+
+: "${DART:=$DART_SDK/bin/dart}"
+
+if [[ ! -x "$DART" ]]; then
+echo Unable to locate the dart binary / SDK. Exiting >&2
+exit 3
+fi
+
+DARTIUMROOT="$DART_SDK/../chromium"
+if [[ -e $DARTIUMROOT ]]; then
+  case "$PLATFORM" in
+    (Linux) export DARTIUM="$DARTIUMROOT/chrome" ;;
+    (Darwin) export DARTIUM="$DARTIUMROOT/Chromium.app/Contents/MacOS/Chromium" ;;
+    (*) echo Unsupported platform $PLATFORM.  Exiting ... >&2 ; exit 3 ;;
+  esac
+fi
+
+export DART_SDK
+export DART
+export PUB=${PUB:-"$DART_SDK/bin/pub"}
+export DARTANALYZER=${DARTANALYZER:-"$DART_SDK/bin/dartanalyzer"}
+export DARTIUM_BIN=${DARTIUM_BIN:-"$DARTIUM"}
+export PATH=$PATH:$DART_SDK/bin
+
+echo '*********'
+echo '** ENV **'
+echo '*********'
+echo DART_SDK=$DART_SDK
+echo DART=$DART
+echo PUB=$PUB
+echo DARTANALYZER=$DARTANALYZER
+echo DARTIUM_BIN=$DARTIUM_BIN
+echo PATH=$PATH
+$DART --version 2>&1

--- a/third_party/pkg/route.dart/scripts/sauce/sauce_connect_block.sh
+++ b/third_party/pkg/route.dart/scripts/sauce/sauce_connect_block.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Wait for Connect to be ready before exiting
+while [ ! -f $BROWSER_PROVIDER_READY_FILE ]; do
+  printf "."
+  sleep .5  #dart2js takes longer than the travis 10 min timeout to complete
+done

--- a/third_party/pkg/route.dart/scripts/sauce/sauce_connect_setup.sh
+++ b/third_party/pkg/route.dart/scripts/sauce/sauce_connect_setup.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Setup and start Sauce Connect for your TravisCI build
+# This script requires your .travis.yml to include the following two private env variables:
+# SAUCE_USERNAME
+# SAUCE_ACCESS_KEY
+# Follow the steps at https://saucelabs.com/opensource/travis to set that up.
+#
+# Curl and run this script as part of your .travis.yml before_script section:
+# before_script:
+#   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
+
+CONNECT_URL="https://saucelabs.com/downloads/sc-4.3-linux.tar.gz"
+CONNECT_DIR="/tmp/sauce-connect-$RANDOM"
+CONNECT_DOWNLOAD="sc-latest-linux.tar.gz"
+
+mkdir -p $LOGS_DIR
+CONNECT_LOG="$LOGS_DIR/sauce-connect"
+CONNECT_STDOUT="$LOGS_DIR/sauce-connect.stdout"
+CONNECT_STDERR="$LOGS_DIR/sauce-connect.stderr"
+
+# Get Connect and start it
+mkdir -p $CONNECT_DIR
+cd $CONNECT_DIR
+curl $CONNECT_URL -o $CONNECT_DOWNLOAD 2> /dev/null 1> /dev/null
+mkdir sauce-connect
+tar -x -f $CONNECT_DOWNLOAD --strip-components=1 -C sauce-connect > /dev/null
+rm $CONNECT_DOWNLOAD
+
+SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+
+ARGS=""
+
+# Set tunnel-id only on Travis, to make local testing easier.
+if [ ! -z "$TRAVIS_JOB_NUMBER" ]; then
+  ARGS="$ARGS --tunnel-identifier $TRAVIS_JOB_NUMBER"
+fi
+if [ ! -z "$BROWSER_PROVIDER_READY_FILE" ]; then
+  ARGS="$ARGS --readyfile $BROWSER_PROVIDER_READY_FILE"
+fi
+
+
+echo "Starting Sauce Connect in the background"
+
+sauce-connect/bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY $ARGS \
+    --logfile $CONNECT_LOG 2> $CONNECT_STDERR 1> $CONNECT_STDOUT &

--- a/third_party/pkg/route.dart/scripts/travis/travis-build.sh
+++ b/third_party/pkg/route.dart/scripts/travis/travis-build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+. ./scripts/env.sh
+
+dart -c test/url_template_test.dart
+dart -c test/url_pattern_test.dart
+
+export SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
+
+node "node_modules/karma/bin/karma" start karma.conf \
+  --reporters=junit,dots --port=8765 --runner-port=8766 \
+  --browsers=Dartium,SL_Chrome,SL_Firefox --single-run --no-colors
+

--- a/third_party/pkg/route.dart/scripts/travis/travis-setup.sh
+++ b/third_party/pkg/route.dart/scripts/travis/travis-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+sh -e /etc/init.d/xvfb start
+
+case $( uname -s ) in
+  Linux)
+    DART_SDK_ZIP=dartsdk-linux-x64-release.zip
+    DARTIUM_ZIP=dartium-linux-x64-release.zip
+    ;;
+  Darwin)
+    DART_SDK_ZIP=dartsdk-macos-x64-release.zip
+    DARTIUM_ZIP=dartium-macos-ia32-release.zip
+    ;;
+esac
+
+CHANNEL=`echo $JOB | cut -f 2 -d -`
+echo Fetch Dart channel: $CHANNEL
+
+echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP
+curl -L http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/sdk/$DART_SDK_ZIP > $DART_SDK_ZIP
+echo Fetched new dart version $(unzip -p $DART_SDK_ZIP dart-sdk/version)
+rm -rf dart-sdk
+unzip $DART_SDK_ZIP > /dev/null
+
+echo http://storage.googleapis.com/dart-archive/channels/$CHANNEL/raw/latest/dartium/$DARTIUM_ZIP
+curl -L http://storage.googleapis.com/dart-archive/channels/$CHANNEL/release/latest/dartium/$DARTIUM_ZIP > dartium.zip
+unzip dartium.zip > /dev/null
+rm -rf dartium
+rm dartium.zip
+mv dartium-* chromium
+
+echo =============================================================================
+. ./scripts/env.sh
+$DART --version
+$PUB install

--- a/third_party/pkg/route.dart/test/all_web_tests.dart
+++ b/third_party/pkg/route.dart/test/all_web_tests.dart
@@ -1,0 +1,13 @@
+import "click_handler_test.dart" as click_handler_test;
+import "client_test.dart" as client_test;
+import "link_matcher_test.dart" as link_matcher_test;
+import "url_template_test.dart" as url_template_test;
+
+/// Run tests from project root directory with the following command:
+/// pub run test -p "content-shell,dartium,chrome,safari" test/all_web_tests.dart
+main() {
+  click_handler_test.main();
+  client_test.main();
+  link_matcher_test.main();
+  url_template_test.main();
+}

--- a/third_party/pkg/route.dart/test/all_web_tests.html
+++ b/third_party/pkg/route.dart/test/all_web_tests.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<!--
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file.
+-->
+<html lang="en">
+  <head>
+    <title>client_test</title>
+    <link rel="x-dart-test" href="all_web_tests.dart">
+    <script src="packages/test/dart.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/third_party/pkg/route.dart/test/click_handler_test.dart
+++ b/third_party/pkg/route.dart/test/click_handler_test.dart
@@ -1,0 +1,137 @@
+library route.click_handler_test;
+
+import 'dart:html';
+import 'dart:async';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:route_hierarchical/click_handler.dart';
+import 'package:route_hierarchical/client.dart';
+import 'package:route_hierarchical/link_matcher.dart';
+
+import 'util/mocks.dart';
+
+main() {
+  group('DefaultWindowLinkHandler', () {
+    WindowClickHandler linkHandler;
+    MockRouter router;
+    MockWindow mockWindow;
+    Element root;
+    StreamController onHashChangeController;
+
+    setUp(() {
+      mockWindow = new MockWindow();
+      onHashChangeController = new StreamController<Event>();
+      when(mockWindow.location.host).thenReturn(window.location.host);
+      when(mockWindow.location.hash).thenReturn('');
+      when(mockWindow.onHashChange).thenReturn(onHashChangeController.stream);
+      router = new MockRouter();
+      root = new DivElement();
+      document.body.append(root);
+      linkHandler = new DefaultWindowClickHandler(
+          new DefaultRouterLinkMatcher(),
+          router,
+          true,
+          mockWindow,
+          (String hash) => hash.isEmpty ? '' : hash.substring(1));
+    });
+
+    tearDown(() {
+      resetMockitoState();
+      root.remove();
+    });
+
+    MouseEvent _createMockMouseEvent({String anchorTarget, String anchorHref}) {
+      AnchorElement anchor = new AnchorElement();
+      if (anchorHref != null) anchor.href = anchorHref;
+      if (anchorTarget != null) anchor.target = anchorTarget;
+
+      MockMouseEvent mockMouseEvent = new MockMouseEvent();
+      when(mockMouseEvent.target).thenReturn(anchor);
+      when(mockMouseEvent.path).thenReturn([anchor]);
+      return mockMouseEvent;
+    }
+
+    test('should process AnchorElements which have target set', () {
+      MockMouseEvent mockMouseEvent =
+          _createMockMouseEvent(anchorHref: '#test');
+      linkHandler(mockMouseEvent);
+      var result = verify(router.gotoUrl(typed<String>(captureAny)));
+      result.called(1);
+      expect(result.captured.first, "test");
+    });
+
+    test(
+        'should process AnchorElements which has target set to _blank, _self, _top or _parent',
+        () {
+      MockMouseEvent mockMouseEvent =
+          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_blank');
+      linkHandler(mockMouseEvent);
+
+      mockMouseEvent =
+          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_self');
+      linkHandler(mockMouseEvent);
+
+      mockMouseEvent =
+          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_top');
+      linkHandler(mockMouseEvent);
+
+      mockMouseEvent =
+          _createMockMouseEvent(anchorHref: '#test', anchorTarget: '_parent');
+      linkHandler(mockMouseEvent);
+
+      // We expect 0 calls to router.gotoUrl
+      verifyNever(router.gotoUrl(typed<String>(any)));
+    });
+
+    test('should process AnchorElements which has a child', () {
+      Element anchorChild = new DivElement();
+
+      AnchorElement anchor = new AnchorElement();
+      anchor.href = '#test';
+      anchor.append(anchorChild);
+
+      MockMouseEvent mockMouseEvent = new MockMouseEvent();
+      when(mockMouseEvent.target).thenReturn(anchorChild);
+      when(mockMouseEvent.path).thenReturn([anchorChild, anchor]);
+
+      linkHandler(mockMouseEvent);
+      var result = verify(router.gotoUrl(typed<String>(captureAny)));
+      result.called(1);
+      expect(result.captured.first, "test");
+    });
+
+    test('should be called if event triggerd on anchor element', () {
+      AnchorElement anchor = new AnchorElement();
+      anchor.href = '#test';
+      root.append(anchor);
+
+      var router = new Router(
+          useFragment: true,
+//          TODO Understand why adding the following line causes failure
+//          clickHandler: expectAsync((e) {}) as WindowClickHandler,
+          windowImpl: mockWindow);
+      router.listen(appRoot: root);
+      // Trigger handle method in linkHandler
+      anchor.dispatchEvent(new MouseEvent('click'));
+    });
+
+    test('should be called if event triggerd on child of an anchor element',
+        () {
+      Element anchorChild = new DivElement();
+      AnchorElement anchor = new AnchorElement();
+      anchor.href = '#test';
+      anchor.append(anchorChild);
+      root.append(anchor);
+
+      var router = new Router(
+          useFragment: true,
+//          TODO Understand why adding the following line causes failure
+//          clickHandler: expectAsync((e) {}) as WindowClickHandler,
+          windowImpl: mockWindow);
+      router.listen(appRoot: root);
+
+      // Trigger handle method in linkHandler
+      anchorChild.dispatchEvent(new MouseEvent('click'));
+    });
+  });
+}

--- a/third_party/pkg/route.dart/test/client_test.dart
+++ b/third_party/pkg/route.dart/test/client_test.dart
@@ -1,0 +1,1770 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library route.client_test;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:route_hierarchical/client.dart';
+
+import 'util/mocks.dart';
+
+main() {
+  test('paths are routed to routes added with addRoute', () {
+    var router = new Router();
+    router.root.addRoute(
+        name: 'foo',
+        path: '/foo',
+        enter: expectAsync1((RouteEvent e) {
+          expect(e.path, '/foo');
+          expect(router.root.findRoute('foo').isActive, isTrue);
+        }));
+    return router.route('/foo');
+  });
+
+  group('use a longer path first', () {
+    test('add a longer path first', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foobar',
+            path: '/foo/bar',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/foo/bar');
+              expect(router.root.findRoute('foobar').isActive, isTrue);
+            }))
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            enter: (e) => fail('should invoke /foo/bar'));
+      return router.route('/foo/bar');
+    });
+
+    test('add a longer path last', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            enter: (e) => fail('should invoke /foo/bar'))
+        ..addRoute(
+            name: 'foobar',
+            path: '/foo/bar',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/foo/bar');
+              expect(router.root.findRoute('foobar').isActive, isTrue);
+            }));
+      return router.route('/foo/bar');
+    });
+
+    test('add paths with a param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            enter: (e) => fail('should invoke /foo/bar'))
+        ..addRoute(
+            name: 'fooparam',
+            path: '/foo/:param',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/foo/bar');
+              expect(router.root.findRoute('fooparam').isActive, isTrue);
+            }));
+      return router.route('/foo/bar');
+    });
+
+    test('add paths with a parametalized parent', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'paramaddress',
+            path: '/:zzzzzz/address',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/foo/address');
+              expect(router.root.findRoute('paramaddress').isActive, isTrue);
+            }))
+        ..addRoute(
+            name: 'param_add',
+            path: '/:aaaaaa/add',
+            enter: (e) => fail('should invoke /foo/address'));
+      return router.route('/foo/address');
+    });
+
+    test('add paths with a first param and one without', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'fooparam',
+            path: '/:param/foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/bar/foo');
+              expect(router.root.findRoute('fooparam').isActive, isTrue);
+            }))
+        ..addRoute(
+            name: 'bar',
+            path: '/bar',
+            enter: (e) => fail('should enter fooparam'));
+      return router.route('/bar/foo');
+    });
+
+    test('add paths with a first param and one without 2', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'paramfoo',
+            path: '/:param/foo',
+            enter: (e) => fail('should enter barfoo'))
+        ..addRoute(
+            name: 'barfoo',
+            path: '/bar/foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/bar/foo');
+              expect(router.root.findRoute('barfoo').isActive, isTrue);
+            }));
+      return router.route('/bar/foo');
+    });
+
+    test('add paths with a second param and one without', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'bazparamfoo',
+            path: '/baz/:param/foo',
+            enter: (e) => fail('should enter bazbarfoo'))
+        ..addRoute(
+            name: 'bazbarfoo',
+            path: '/baz/bar/foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/baz/bar/foo');
+              expect(router.root.findRoute('bazbarfoo').isActive, isTrue);
+            }));
+      return router.route('/baz/bar/foo');
+    });
+
+    test('add paths with a first param and a second param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'parambarfoo',
+            path: '/:param/bar/foo',
+            enter: (e) => fail('should enter bazparamfoo'))
+        ..addRoute(
+            name: 'bazparamfoo',
+            path: '/baz/:param/foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/baz/bar/foo');
+              expect(router.root.findRoute('bazparamfoo').isActive, isTrue);
+            }));
+      return router.route('/baz/bar/foo');
+    });
+
+    test('add paths with two params and a param', () {
+      Router router = new Router();
+      router.root
+        ..addRoute(
+            name: 'param1param2foo',
+            path: '/:param1/:param2/foo',
+            enter: (e) => fail('should enter bazparamfoo'))
+        ..addRoute(
+            name: 'param1barfoo',
+            path: '/:param1/bar/foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, '/baz/bar/foo');
+              expect(router.root.findRoute('param1barfoo').isActive, isTrue);
+            }));
+      return router.route('/baz/bar/foo');
+    });
+  });
+
+  group('hierarchical routing', () {
+    void _testParentChild(Pattern parentPath, Pattern childPath,
+        String expectedParentPath, String expectedChildPath, String testPath) {
+      var router = new Router();
+      router.root.addRoute(
+          name: 'parent',
+          path: parentPath,
+          enter: expectAsync1((RouteEvent e) {
+            expect(e.path, expectedParentPath);
+            expect(e.route, isNotNull);
+            expect(e.route.name, 'parent');
+          }),
+          mount: (Route child) {
+            child.addRoute(
+                name: 'child',
+                path: childPath,
+                enter: expectAsync1((RouteEvent e) {
+                  expect(e.path, expectedChildPath);
+                }));
+          });
+      router.route(testPath);
+    }
+
+    test('child router with Strings', () {
+      _testParentChild('/foo', '/bar', '/foo', '/bar', '/foo/bar');
+    });
+  });
+
+  group('reload', () {
+    test('should not reload when no active path', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++);
+
+      return router.reload().then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        });
+      });
+    });
+
+    test('should reload currently active route', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+        'barLeave': 0,
+        'barEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            mount: (r) => r.addRoute(
+                name: 'bar',
+                path: '/:bar',
+                leave: (_) => counters['barLeave']++,
+                enter: (_) => counters['barEnter']++));
+
+      return router.route('/123').then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+          'barLeave': 0,
+          'barEnter': 0,
+        });
+        return router.reload().then((_) {
+          expect(counters, {
+            'fooLeave': 1,
+            'fooEnter': 2,
+            'barLeave': 0,
+            'barEnter': 0,
+          });
+          expect(router.findRoute('foo').parameters['foo'], '123');
+        });
+      });
+    });
+
+    test('should reload currently active route from startingFrom', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+        'barLeave': 0,
+        'barEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            mount: (r) => r.addRoute(
+                name: 'bar',
+                path: '/:bar',
+                leave: (_) => counters['barLeave']++,
+                enter: (_) => counters['barEnter']++));
+
+      return router.route('/123/321').then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+          'barLeave': 0,
+          'barEnter': 1,
+        });
+        return router.reload(startingFrom: router.findRoute('foo')).then((_) {
+          expect(counters, {
+            'fooLeave': 0,
+            'fooEnter': 1,
+            'barLeave': 1,
+            'barEnter': 2,
+          });
+          expect(router.findRoute('foo').parameters['foo'], '123');
+          expect(router.findRoute('foo.bar').parameters['bar'], '321');
+        });
+      });
+    });
+
+    test('should preserve param values on reload', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+        'barLeave': 0,
+        'barEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            mount: (r) => r.addRoute(
+                name: 'bar',
+                path: '/:bar',
+                leave: (_) => counters['barLeave']++,
+                enter: (_) => counters['barEnter']++));
+
+      return router.route('/123/321').then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+          'barLeave': 0,
+          'barEnter': 1,
+        });
+        return router.reload().then((_) {
+          expect(counters, {
+            'fooLeave': 1,
+            'fooEnter': 2,
+            'barLeave': 1,
+            'barEnter': 2,
+          });
+          expect(router.findRoute('foo').parameters['foo'], '123');
+          expect(router.findRoute('foo.bar').parameters['bar'], '321');
+        });
+      });
+    });
+
+    test('should preserve query param values on reload', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++);
+
+      return router.route('/123?foo=bar&blah=blah').then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+        });
+        expect(router.findRoute('foo').queryParameters, {
+          'foo': 'bar',
+          'blah': 'blah',
+        });
+        return router.reload().then((_) {
+          expect(router.findRoute('foo').queryParameters, {
+            'foo': 'bar',
+            'blah': 'blah',
+          });
+        });
+      });
+    });
+
+    test('should preserve query param values on reload from the middle', () {
+      var router = new Router();
+      var counters = {
+        'fooLeave': 0,
+        'fooEnter': 0,
+        'barLeave': 0,
+        'barEnter': 0,
+      };
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            mount: (r) => r.addRoute(
+                name: 'bar',
+                path: '/:bar',
+                leave: (_) => counters['barLeave']++,
+                enter: (_) => counters['barEnter']++));
+
+      return router.route('/123/321?foo=bar&blah=blah').then((_) {
+        expect(counters, {
+          'fooLeave': 0,
+          'fooEnter': 1,
+          'barLeave': 0,
+          'barEnter': 1,
+        });
+        expect(router.findRoute('foo').queryParameters, {
+          'foo': 'bar',
+          'blah': 'blah',
+        });
+        return router.reload(startingFrom: router.findRoute('foo')).then((_) {
+          expect(counters, {
+            'fooLeave': 0,
+            'fooEnter': 1,
+            'barLeave': 1,
+            'barEnter': 2,
+          });
+          expect(router.findRoute('foo').queryParameters, {
+            'foo': 'bar',
+            'blah': 'blah',
+          });
+          expect(router.findRoute('foo').parameters['foo'], '123');
+          expect(router.findRoute('foo.bar').parameters['bar'], '321');
+        });
+      });
+    });
+  });
+
+  group('leave', () {
+    test('should leave previous route and enter new', () {
+      var counters = <String, int>{
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0,
+        'bazPreEnter': 0,
+        'bazPreLeave': 0,
+        'bazEnter': 0,
+        'bazLeave': 0
+      };
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: '/foo',
+            name: 'foo',
+            preEnter: (_) => counters['fooPreEnter']++,
+            preLeave: (_) => counters['fooPreLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            leave: (_) => counters['fooLeave']++,
+            watchQueryParameters: [],
+            mount: (Route route) => route
+              ..addRoute(
+                  path: '/bar',
+                  name: 'bar',
+                  preEnter: (_) => counters['barPreEnter']++,
+                  preLeave: (_) => counters['barPreLeave']++,
+                  enter: (_) => counters['barEnter']++,
+                  leave: (_) => counters['barLeave']++)
+              ..addRoute(
+                  path: '/baz',
+                  name: 'baz',
+                  preEnter: (_) => counters['bazPreEnter']++,
+                  preLeave: (_) => counters['bazPreLeave']++,
+                  enter: (_) => counters['bazEnter']++,
+                  leave: (_) => counters['bazLeave']++,
+                  watchQueryParameters: ['baz.blah']));
+
+      expect(counters, {
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0,
+        'bazPreEnter': 0,
+        'bazPreLeave': 0,
+        'bazEnter': 0,
+        'bazLeave': 0
+      });
+      router
+          .route('/foo/bar')
+          .then(expectAsync1((_) {
+            expect(counters, {
+              'fooPreEnter': 1,
+              'fooPreLeave': 0,
+              'fooEnter': 1,
+              'fooLeave': 0,
+              'barPreEnter': 1,
+              'barPreLeave': 0,
+              'barEnter': 1,
+              'barLeave': 0,
+              'bazPreEnter': 0,
+              'bazPreLeave': 0,
+              'bazEnter': 0,
+              'bazLeave': 0
+            });
+          }))
+          .then(expectAsync1(
+              (_) => router.route('/foo/baz').then(expectAsync1((_) {
+                    expect(counters, {
+                      'fooPreEnter': 1,
+                      'fooPreLeave': 0,
+                      'fooEnter': 1,
+                      'fooLeave': 0,
+                      'barPreEnter': 1,
+                      'barPreLeave': 1,
+                      'barEnter': 1,
+                      'barLeave': 1,
+                      'bazPreEnter': 1,
+                      'bazPreLeave': 0,
+                      'bazEnter': 1,
+                      'bazLeave': 0
+                    });
+                  }))))
+          .then(expectAsync1((_) =>
+              router.route('/foo/baz?baz.blah=meme').then(expectAsync1((_) {
+                expect(counters, {
+                  'fooPreEnter': 1,
+                  'fooPreLeave': 0,
+                  'fooEnter': 1,
+                  'fooLeave': 0,
+                  'barPreEnter': 1,
+                  'barPreLeave': 1,
+                  'barEnter': 1,
+                  'barLeave': 1,
+                  'bazPreEnter': 2,
+                  'bazPreLeave': 1,
+                  'bazEnter': 2,
+                  'bazLeave': 1
+                });
+              }))));
+    });
+
+    test('should leave starting from child to parent', () {
+      var log = [];
+      void loggingLeaveHandler(RouteLeaveEvent r) {
+        log.add(r.route.name);
+      }
+
+      ;
+
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: '/foo',
+            name: 'foo',
+            leave: loggingLeaveHandler,
+            mount: (Route route) => route
+              ..addRoute(
+                  path: '/bar',
+                  name: 'bar',
+                  leave: loggingLeaveHandler,
+                  mount: (Route route) => route
+                    ..addRoute(
+                        path: '/baz',
+                        name: 'baz',
+                        leave: loggingLeaveHandler)));
+
+      router.route('/foo/bar/baz').then(expectAsync1((_) {
+        expect(log, []);
+
+        router.route('').then(expectAsync1((_) {
+          expect(log, ['baz', 'bar', 'foo']);
+        }));
+      }));
+    });
+
+    test('should leave active child route when routed to parent route only',
+        () {
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: '/foo',
+            name: 'foo',
+            mount: (Route route) => route..addRoute(path: '/bar', name: 'bar'));
+
+      return router.route('/foo/bar').then((_) {
+        expect(router.activePath.map((r) => r.name), ['foo', 'bar']);
+        return router.route('/foo').then((_) {
+          expect(router.activePath.map((r) => r.name), ['foo']);
+        });
+      });
+    });
+
+    void _testAllowLeave(bool allowLeave) {
+      var completer = new Completer<bool>();
+      bool barEntered = false;
+      bool bazEntered = false;
+
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (Route child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  enter: (RouteEnterEvent e) => barEntered = true,
+                  preLeave: (RoutePreLeaveEvent e) =>
+                      e.allowLeave(completer.future))
+              ..addRoute(
+                  name: 'baz',
+                  path: '/baz',
+                  enter: (RouteEnterEvent e) => bazEntered = true));
+
+      router.route('/foo/bar').then(expectAsync1((_) {
+        expect(barEntered, true);
+        expect(bazEntered, false);
+        router.route('/foo/baz').then(expectAsync1((_) {
+          expect(bazEntered, allowLeave);
+        }));
+        completer.complete(allowLeave);
+      }));
+    }
+
+    test('should allow navigation', () {
+      _testAllowLeave(true);
+    });
+
+    test('should veto navigation', () {
+      _testAllowLeave(false);
+    });
+  });
+
+  group('preEnter', () {
+    void _testAllowEnter(bool allowEnter) {
+      var completer = new Completer<bool>();
+      bool barEntered = false;
+
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (Route child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  enter: (RouteEnterEvent e) => barEntered = true,
+                  preEnter: (RoutePreEnterEvent e) =>
+                      e.allowEnter(completer.future)));
+
+      router.route('/foo/bar').then(expectAsync1((_) {
+        expect(barEntered, allowEnter);
+      }));
+      completer.complete(allowEnter);
+    }
+
+    test('should allow navigation', () {
+      _testAllowEnter(true);
+    });
+
+    test('should veto navigation', () {
+      _testAllowEnter(false);
+    });
+
+    test(
+        'should leave on parameters changes when dontLeaveOnParamChanges is false (default)',
+        () {
+      var counters = <String, int>{
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      };
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: r'/foo/:param',
+            name: 'foo',
+            preEnter: (_) => counters['fooPreEnter']++,
+            preLeave: (_) => counters['fooPreLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            leave: (_) => counters['fooLeave']++)
+        ..addRoute(
+            path: '/bar',
+            name: 'bar',
+            preEnter: (_) => counters['barPreEnter']++,
+            preLeave: (_) => counters['barPreLeave']++,
+            enter: (_) => counters['barEnter']++,
+            leave: (_) => counters['barLeave']++);
+
+      expect(counters, {
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      });
+
+      expect(router.findRoute('foo').dontLeaveOnParamChanges, false);
+
+      router.route('/foo/bar').then(expectAsync1((_) {
+        expect(counters, {
+          'fooPreEnter': 1, // +1
+          'fooPreLeave': 0,
+          'fooEnter': 1, // +1
+          'fooLeave': 0,
+          'barPreEnter': 0,
+          'barPreLeave': 0,
+          'barEnter': 0,
+          'barLeave': 0
+        });
+
+        router.route('/foo/bar').then(expectAsync1((_) {
+          expect(counters, {
+            'fooPreEnter': 1,
+            'fooPreLeave': 0,
+            'fooEnter': 1,
+            'fooLeave': 0,
+            'barPreEnter': 0,
+            'barPreLeave': 0,
+            'barEnter': 0,
+            'barLeave': 0
+          });
+
+          router.route('/foo/baz').then(expectAsync1((_) {
+            expect(counters, {
+              'fooPreEnter': 2, // +1
+              'fooPreLeave': 1, // +1
+              'fooEnter': 2, // +1
+              'fooLeave': 1, // +1
+              'barPreEnter': 0,
+              'barPreLeave': 0,
+              'barEnter': 0,
+              'barLeave': 0
+            });
+
+            router.route('/bar').then(expectAsync1((_) {
+              expect(counters, {
+                'fooPreEnter': 2,
+                'fooPreLeave': 2, // +1
+                'fooEnter': 2,
+                'fooLeave': 2, // +1
+                'barPreEnter': 1, // +1
+                'barPreLeave': 0,
+                'barEnter': 1, // +1
+                'barLeave': 0
+              });
+            }));
+          }));
+        }));
+      }));
+    });
+
+    test(
+        'should not leave on parameter changes when dontLeaveOnParamChanges is true',
+        () {
+      var counters = <String, int>{
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      };
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: r'/foo/:param',
+            name: 'foo',
+            preEnter: (_) => counters['fooPreEnter']++,
+            preLeave: (_) => counters['fooPreLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            leave: (_) => counters['fooLeave']++,
+            dontLeaveOnParamChanges: true)
+        ..addRoute(
+            path: '/bar',
+            name: 'bar',
+            preEnter: (_) => counters['barPreEnter']++,
+            preLeave: (_) => counters['barPreLeave']++,
+            enter: (_) => counters['barEnter']++,
+            leave: (_) => counters['barLeave']++);
+
+      expect(counters, {
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      });
+
+      router.route('/foo/bar').then(expectAsync1((_) {
+        expect(counters, {
+          'fooPreEnter': 1, // +1
+          'fooPreLeave': 0,
+          'fooEnter': 1, // +1
+          'fooLeave': 0,
+          'barPreEnter': 0,
+          'barPreLeave': 0,
+          'barEnter': 0,
+          'barLeave': 0
+        });
+
+        router.route('/foo/bar').then(expectAsync1((_) {
+          expect(counters, {
+            'fooPreEnter': 1,
+            'fooPreLeave': 0,
+            'fooEnter': 1,
+            'fooLeave': 0,
+            'barPreEnter': 0,
+            'barPreLeave': 0,
+            'barEnter': 0,
+            'barLeave': 0
+          });
+
+          router.route('/foo/baz').then(expectAsync1((_) {
+            expect(counters, {
+              'fooPreEnter': 2, // +1
+              'fooPreLeave': 0,
+              'fooEnter': 2, // +1
+              'fooLeave': 0,
+              'barPreEnter': 0,
+              'barPreLeave': 0,
+              'barEnter': 0,
+              'barLeave': 0
+            });
+
+            router.route('/bar').then(expectAsync1((_) {
+              expect(counters, {
+                'fooPreEnter': 2,
+                'fooPreLeave': 1, // +1
+                'fooEnter': 2,
+                'fooLeave': 1, // +1
+                'barPreEnter': 1, // +1
+                'barPreLeave': 0,
+                'barEnter': 1, // +1
+                'barLeave': 0
+              });
+            }));
+          }));
+        }));
+      }));
+    });
+
+    test('should not leave leaving when on preEnter fails', () {
+      var counters = <String, int>{
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      };
+      var router = new Router();
+      router.root
+        ..addRoute(
+            path: r'/foo',
+            name: 'foo',
+            preEnter: (_) => counters['fooPreEnter']++,
+            preLeave: (_) => counters['fooPreLeave']++,
+            enter: (_) => counters['fooEnter']++,
+            leave: (_) => counters['fooLeave']++)
+        ..addRoute(
+            path: '/bar',
+            name: 'bar',
+            preEnter: (RoutePreEnterEvent e) {
+              counters['barPreEnter']++;
+              e.allowEnter(new Future<bool>.value(false));
+            },
+            preLeave: (_) => counters['barPreLeave']++,
+            enter: (_) => counters['barEnter']++,
+            leave: (_) => counters['barLeave']++);
+
+      expect(counters, {
+        'fooPreEnter': 0,
+        'fooPreLeave': 0,
+        'fooEnter': 0,
+        'fooLeave': 0,
+        'barPreEnter': 0,
+        'barPreLeave': 0,
+        'barEnter': 0,
+        'barLeave': 0
+      });
+
+      router.route('/foo').then(expectAsync1((_) {
+        expect(counters, {
+          'fooPreEnter': 1, // +1
+          'fooPreLeave': 0,
+          'fooEnter': 1, // +1
+          'fooLeave': 0,
+          'barPreEnter': 0,
+          'barPreLeave': 0,
+          'barEnter': 0,
+          'barLeave': 0
+        });
+
+        router.route('/bar').then(expectAsync1((_) {
+          expect(counters, {
+            'fooPreEnter': 1,
+            'fooPreLeave': 1, // +1
+            'fooEnter': 1,
+            'fooLeave': 0, // can't leave
+            'barPreEnter': 1, // +1, enter but don't proceed
+            'barPreLeave': 0,
+            'barEnter': 0,
+            'barLeave': 0
+          });
+        }));
+      }));
+    });
+  });
+
+  group('Default route', () {
+    void _testHeadTail(String path, String expectFoo, String expectBar) {
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            defaultRoute: true,
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.path, expectFoo);
+            }),
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  defaultRoute: true,
+                  enter: expectAsync1(
+                      (RouteEvent e) => expect(e.path, expectBar))));
+
+      router.route(path);
+    }
+
+    test('should calculate head/tail of empty route', () {
+      _testHeadTail('', '', '');
+    });
+
+    test('should calculate head/tail of partial route', () {
+      _testHeadTail('/foo', '/foo', '');
+    });
+
+    test('should calculate head/tail of a route', () {
+      _testHeadTail('/foo/bar', '/foo', '/bar');
+    });
+
+    test('should calculate head/tail of an invalid parent route', () {
+      _testHeadTail('/garbage/bar', '', '');
+    });
+
+    test('should calculate head/tail of an invalid child route', () {
+      _testHeadTail('/foo/garbage', '/foo', '');
+    });
+
+    test('should follow default routes', () {
+      var counters = <String, int>{
+        'list_entered': 0,
+        'article_123_entered': 0,
+        'article_123_view_entered': 0,
+        'article_123_edit_entered': 0
+      };
+
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'articles',
+            path: '/articles',
+            defaultRoute: true,
+            enter: (_) => counters['list_entered']++)
+        ..addRoute(
+            name: 'article',
+            path: '/article/123',
+            enter: (_) => counters['article_123_entered']++,
+            mount: (Route child) => child
+              ..addRoute(
+                  name: 'viewArticles',
+                  path: '/view',
+                  defaultRoute: true,
+                  enter: (_) => counters['article_123_view_entered']++)
+              ..addRoute(
+                  name: 'editArticles',
+                  path: '/edit',
+                  enter: (_) => counters['article_123_edit_entered']++));
+
+      return router.route('').then((_) {
+        expect(counters, {
+          'list_entered': 1, // default to list
+          'article_123_entered': 0,
+          'article_123_view_entered': 0,
+          'article_123_edit_entered': 0
+        });
+        return router.route('/articles').then((_) {
+          expect(counters, {
+            'list_entered': 2,
+            'article_123_entered': 0,
+            'article_123_view_entered': 0,
+            'article_123_edit_entered': 0
+          });
+          return router.route('/article/123').then((_) {
+            expect(counters, {
+              'list_entered': 2,
+              'article_123_entered': 1,
+              'article_123_view_entered': 1, // default to view
+              'article_123_edit_entered': 0
+            });
+            return router.route('/article/123/view').then((_) {
+              expect(counters, {
+                'list_entered': 2,
+                'article_123_entered': 1,
+                'article_123_view_entered': 2,
+                'article_123_edit_entered': 0
+              });
+              return router.route('/article/123/edit').then((_) {
+                expect(counters, {
+                  'list_entered': 2,
+                  'article_123_entered': 1,
+                  'article_123_view_entered': 2,
+                  'article_123_edit_entered': 1
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
+  group('go', () {
+    tearDown(() {
+      resetMockitoState();
+    });
+
+    test('should use location.assign/.replace when useFragment=true', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(useFragment: true, windowImpl: mockWindow);
+      router.root.addRoute(name: 'articles', path: '/articles');
+
+      router.go('articles', {}).then(expectAsync1((_) {
+        var mockLocation = mockWindow.location;
+
+        var result = verify(mockLocation.assign(typed<String>(captureAny)));
+        result.called(1);
+        expect(result.captured.first, '#/articles');
+        verifyNever(mockLocation.replace(typed<String>(any)));
+
+        router.go('articles', {}, replace: true).then(expectAsync1((_) {
+          var result = verify(mockLocation.replace(typed<String>(captureAny)));
+          result.called(1);
+          expect(result.captured.first, '#/articles');
+          verifyNever(mockLocation.assign(typed<String>(any)));
+        }));
+      }));
+    });
+
+    test('should use history.push/.replaceState when useFragment=false', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(useFragment: false, windowImpl: mockWindow);
+      router.root.addRoute(name: 'articles', path: '/articles');
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+
+      router.go('articles', {}).then(expectAsync1((_) {
+        var mockHistory = mockWindow.history;
+
+        var result = verify(mockHistory.pushState(
+            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+        result.called(1);
+        expect(result.captured, [null, 'page title', '/articles']);
+        verifyNever(mockHistory.replaceState(
+            any, typed<String>(any), typed<String>(any)));
+
+        router.go('articles', {}, replace: true).then(expectAsync1((_) {
+          var result = verify(mockHistory.replaceState(captureAny,
+              typed<String>(captureAny), typed<String>(captureAny)));
+          result.called(1);
+          expect(result.captured, [null, 'page title', '/articles']);
+          verifyNever(mockHistory.pushState(
+              any, typed<String>(any), typed<String>(any)));
+        }));
+      }));
+    });
+
+    test('should encode query parameters in the URL', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(useFragment: false, windowImpl: mockWindow);
+      router.root.addRoute(name: 'articles', path: '/articles');
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+
+      var queryParams = {'foo': 'foo bar', 'bar': '%baz+aux'};
+      router
+          .go('articles', {}, queryParameters: queryParams)
+          .then(expectAsync1((_) {
+        var mockHistory = mockWindow.history;
+
+        var result = verify(mockHistory.pushState(
+            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+        result.called(1);
+        expect(result.captured,
+            [null, 'page title', '/articles?foo=foo%20bar&bar=%25baz%2Baux']);
+        verifyNever(mockHistory.replaceState(
+            any, typed<String>(any), typed<String>(any)));
+      }));
+    });
+
+    test('should work with hierarchical go', () {
+      var mockWindow = new MockWindow();
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'a',
+            path: '/:foo',
+            mount: (child) => child..addRoute(name: 'b', path: '/:bar'));
+
+      var routeA = router.root.findRoute('a');
+
+      router.go('a.b', {}).then(expectAsync1((_) {
+        var mockHistory = mockWindow.history;
+
+        var result = verify(mockHistory.pushState(
+            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+        result.called(1);
+        expect(result.captured, [null, 'page title', '/null/null']);
+
+        router.go('a.b', {'foo': 'aaaa', 'bar': 'bbbb'}).then(expectAsync1((_) {
+          var result = verify(mockHistory.pushState(captureAny,
+              typed<String>(captureAny), typed<String>(captureAny)));
+          result.called(1);
+          expect(result.captured, [null, 'page title', '/aaaa/bbbb']);
+
+          router
+              .go('b', {'bar': 'bbbb'}, startingFrom: routeA)
+              .then(expectAsync1((_) {
+            var result = verify(mockHistory.pushState(captureAny,
+                typed<String>(captureAny), typed<String>(captureAny)));
+            // Note: These were cumulative with mock but get reset with each
+            // call to mockito.verify(), so 3 became 1 here.
+            result.called(1);
+            expect(result.captured, [null, 'page title', '/aaaa/bbbb']);
+          }));
+        }));
+      }));
+    });
+
+    test('should attempt to reverse default routes', () {
+      var counters = <String, int>{'aEnter': 0, 'bEnter': 0};
+
+      var mockWindow = new MockWindow();
+
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'a',
+            defaultRoute: true,
+            path: '/:foo',
+            enter: (_) => counters['aEnter']++,
+            mount: (child) => child
+              ..addRoute(
+                  name: 'b',
+                  defaultRoute: true,
+                  path: '/:bar',
+                  enter: (_) => counters['bEnter']++));
+
+      expect(counters, {'aEnter': 0, 'bEnter': 0});
+
+      return router.route('').then((_) {
+        expect(counters, {'aEnter': 1, 'bEnter': 1});
+
+        var routeA = router.root.findRoute('a');
+        return router.go('b', {'bar': 'bbb'}, startingFrom: routeA).then((_) {
+          var mockHistory = mockWindow.history;
+
+          var result = verify(mockHistory.pushState(typed<String>(captureAny),
+              typed<String>(captureAny), typed<String>(captureAny)));
+          result.called(1);
+          expect(result.captured, [null, 'page title', '/null/bbb']);
+        });
+      });
+    });
+
+    test('should force reload already active routes', () {
+      var counters = <String, int>{'aEnter': 0, 'bEnter': 0};
+
+      var mockWindow = new MockWindow();
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'a',
+            path: '/foo',
+            enter: (_) => counters['aEnter']++,
+            mount: (child) => child
+              ..addRoute(
+                  name: 'b', path: '/bar', enter: (_) => counters['bEnter']++));
+
+      expect(counters, {'aEnter': 0, 'bEnter': 0});
+
+      return router.go('a.b', {}).then((_) {
+        expect(counters, {'aEnter': 1, 'bEnter': 1});
+        return router.go('a.b', {}).then((_) {
+          // didn't force reload, so should not change
+          expect(counters, {'aEnter': 1, 'bEnter': 1});
+          return router.go('a.b', {}, forceReload: true).then((_) {
+            expect(counters, {'aEnter': 2, 'bEnter': 2});
+          });
+        });
+      });
+    });
+
+    test('should update page title if the title property is set', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(useFragment: false, windowImpl: mockWindow);
+      router.root.addRoute(name: 'foo', path: '/foo', pageTitle: 'Foo');
+
+      router.go('foo', {}).then(expectAsync1((_) {
+        var mockHistory = mockWindow.history;
+        verify((mockWindow.document as HtmlDocument).title = typed<String>(any))
+            .called(1);
+        verify(mockHistory.pushState(null, 'Foo', '/foo')).called(1);
+      }));
+    });
+
+    test('should not change page title if the title property is not set', () {
+      var mockWindow = new MockWindow();
+      when((mockWindow.document as HtmlDocument).title)
+          .thenReturn('page title');
+      var router = new Router(useFragment: false, windowImpl: mockWindow);
+      router.root.addRoute(name: 'foo', path: '/foo');
+
+      router.go('foo', {}).then(expectAsync1((_) {
+        var mockHistory = mockWindow.history;
+        verify(mockHistory.pushState(null, 'page title', '/foo')).called(1);
+      }));
+    });
+  });
+
+  group('url', () {
+    test('should reconstruct url', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'a',
+            defaultRoute: true,
+            path: '/:foo',
+            mount: (child) =>
+                child..addRoute(name: 'b', defaultRoute: true, path: '/:bar'));
+
+      var routeA = router.root.findRoute('a');
+
+      return router.route('').then((_) {
+        expect(router.url('a.b'), '/null/null');
+        expect(router.url('a.b', parameters: {'foo': 'aaa'}), '/aaa/null');
+        expect(
+            router.url('b', parameters: {'bar': 'bbb'}, startingFrom: routeA),
+            '/null/bbb');
+
+        return router.route('/foo/bar').then((_) {
+          expect(router.url('a.b'), '/foo/bar');
+          expect(router.url('a.b', parameters: {'foo': 'aaa'}), '/aaa/bar');
+          expect(
+              router.url('b', parameters: {'bar': 'bbb'}, startingFrom: routeA),
+              '/foo/bbb');
+          expect(
+              router.url('b',
+                  parameters: {'foo': 'aaa', 'bar': 'bbb'},
+                  startingFrom: routeA),
+              '/foo/bbb');
+
+          expect(
+              router.url('b',
+                  parameters: {'bar': 'bbb'},
+                  queryParameters: {'param1': 'val1'},
+                  startingFrom: routeA),
+              '/foo/bbb?param1=val1');
+        });
+      });
+    });
+  });
+
+  group('findRoute', () {
+    test('should return correct routes', () {
+      Route routeFoo, routeBar, routeBaz, routeQux, routeAux;
+
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/:foo',
+            mount: (child) => routeFoo = child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/:bar',
+                  mount: (child) => routeBar = child
+                    ..addRoute(
+                        name: 'baz',
+                        path: '/:baz',
+                        mount: (child) => routeBaz = child))
+              ..addRoute(
+                  name: 'qux',
+                  path: '/:qux',
+                  mount: (child) => routeQux = child
+                    ..addRoute(
+                        name: 'aux',
+                        path: '/:aux',
+                        mount: (child) => routeAux = child)));
+
+      expect(router.root.findRoute('foo'), same(routeFoo));
+      expect(router.root.findRoute('foo.bar'), same(routeBar));
+      expect(routeFoo.findRoute('bar'), same(routeBar));
+      expect(router.root.findRoute('foo.bar.baz'), same(routeBaz));
+      expect(router.root.findRoute('foo.qux'), same(routeQux));
+      expect(router.root.findRoute('foo.qux.aux'), same(routeAux));
+      expect(routeQux.findRoute('aux'), same(routeAux));
+      expect(routeFoo.findRoute('qux.aux'), same(routeAux));
+
+      expect(router.root.findRoute('baz'), isNull);
+      expect(router.root.findRoute('foo.baz'), isNull);
+    });
+  });
+
+  group('route', () {
+    group('query params', () {
+      test('should parse query', () {
+        var router = new Router();
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/:foo',
+              enter: expectAsync1((RouteEvent e) {
+                expect(e.parameters, {
+                  'foo': '123',
+                });
+                expect(e.queryParameters, {'a': 'b', 'b': '', 'c': 'foo bar'});
+              }));
+
+        router.route('/123?a=b&b=&c=foo%20bar');
+      });
+
+      test('should not reload when unwatched query param changes', () {
+        var router = new Router();
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/:foo',
+              watchQueryParameters: ['bar'],
+              leave: (_) => counters['fooLeave']++,
+              enter: (_) => counters['fooEnter']++);
+
+        return router.route('/123').then((_) {
+          expect(counters, {
+            'fooLeave': 0,
+            'fooEnter': 1,
+          });
+          return router.route('/123?foo=bar').then((_) {
+            expect(counters, {
+              'fooLeave': 0,
+              'fooEnter': 1,
+            });
+          });
+        });
+      });
+
+      test('should reload when watched query param changes', () {
+        var router = new Router();
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/:foo',
+              watchQueryParameters: ['foo'],
+              leave: (_) => counters['fooLeave']++,
+              enter: (_) => counters['fooEnter']++);
+
+        return router.route('/123').then((_) {
+          expect(counters, {
+            'fooLeave': 0,
+            'fooEnter': 1,
+          });
+          return router.route('/123?foo=bar').then((_) {
+            expect(counters, {
+              'fooLeave': 1,
+              'fooEnter': 2,
+            });
+          });
+        });
+      });
+
+      test('should match pattern for watched query params', () {
+        var router = new Router();
+        var counters = {
+          'fooLeave': 0,
+          'fooEnter': 0,
+        };
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/:foo',
+              watchQueryParameters: [new RegExp(r'^foo$')],
+              leave: (_) => counters['fooLeave']++,
+              enter: (_) => counters['fooEnter']++);
+
+        return router.route('/123').then((_) {
+          expect(counters, {
+            'fooLeave': 0,
+            'fooEnter': 1,
+          });
+          return router.route('/123?foo=bar').then((_) {
+            expect(counters, {
+              'fooLeave': 1,
+              'fooEnter': 2,
+            });
+          });
+        });
+      });
+    });
+
+    group('isActive', () {
+      test('should currectly identify active/inactive routes', () {
+        var router = new Router();
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/foo',
+              mount: (child) => child
+                ..addRoute(
+                    name: 'bar',
+                    path: '/bar',
+                    mount: (child) => child
+                      ..addRoute(
+                          name: 'baz', path: '/baz', mount: (child) => child))
+                ..addRoute(
+                    name: 'qux',
+                    path: '/qux',
+                    mount: (child) => child
+                      ..addRoute(
+                          name: 'aux', path: '/aux', mount: (child) => child)));
+
+        expect(r(router, 'foo').isActive, false);
+        expect(r(router, 'foo.bar').isActive, false);
+        expect(r(router, 'foo.bar.baz').isActive, false);
+        expect(r(router, 'foo.qux').isActive, false);
+
+        return router.route('/foo').then((_) {
+          expect(r(router, 'foo').isActive, true);
+          expect(r(router, 'foo.bar').isActive, false);
+          expect(r(router, 'foo.bar.baz').isActive, false);
+          expect(r(router, 'foo.qux').isActive, false);
+
+          return router.route('/foo/qux').then((_) {
+            expect(r(router, 'foo').isActive, true);
+            expect(r(router, 'foo.bar').isActive, false);
+            expect(r(router, 'foo.bar.baz').isActive, false);
+            expect(r(router, 'foo.qux').isActive, true);
+
+            return router.route('/foo/bar/baz').then((_) {
+              expect(r(router, 'foo').isActive, true);
+              expect(r(router, 'foo.bar').isActive, true);
+              expect(r(router, 'foo.bar.baz').isActive, true);
+              expect(r(router, 'foo.qux').isActive, false);
+            });
+          });
+        });
+      });
+    });
+
+    group('parameters', () {
+      test('should return path parameters for routes', () {
+        var router = new Router();
+        router.root
+          ..addRoute(
+              name: 'foo',
+              path: '/:foo',
+              mount: (child) => child
+                ..addRoute(
+                    name: 'bar',
+                    path: '/:bar',
+                    mount: (child) => child
+                      ..addRoute(
+                          name: 'baz',
+                          path: '/:baz',
+                          mount: (child) => child)));
+
+        expect(r(router, 'foo').parameters, isNull);
+        expect(r(router, 'foo.bar').parameters, isNull);
+        expect(r(router, 'foo.bar.baz').parameters, isNull);
+
+        return router.route('/aaa').then((_) {
+          expect(r(router, 'foo').parameters, {'foo': 'aaa'});
+          expect(r(router, 'foo.bar').parameters, isNull);
+          expect(r(router, 'foo.bar.baz').parameters, isNull);
+
+          return router.route('/aaa/bbb').then((_) {
+            expect(r(router, 'foo').parameters, {'foo': 'aaa'});
+            expect(r(router, 'foo.bar').parameters, {'bar': 'bbb'});
+            expect(r(router, 'foo.bar.baz').parameters, isNull);
+
+            return router.route('/aaa/bbb/ccc').then((_) {
+              expect(r(router, 'foo').parameters, {'foo': 'aaa'});
+              expect(r(router, 'foo.bar').parameters, {'bar': 'bbb'});
+              expect(r(router, 'foo.bar.baz').parameters, {'baz': 'ccc'});
+            });
+          });
+        });
+      });
+    });
+  });
+
+  group('activePath', () {
+    test('should currectly identify active path', () {
+      var router = new Router();
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'baz', path: '/baz', mount: (child) => child))
+              ..addRoute(
+                  name: 'qux',
+                  path: '/qux',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'aux', path: '/aux', mount: (child) => child)));
+
+      var strPath =
+          (List<Route> path) => path.map((Route r) => r.name).join('.');
+
+      expect(strPath(router.activePath), '');
+
+      return router.route('/foo').then((_) {
+        expect(strPath(router.activePath), 'foo');
+
+        return router.route('/foo/qux').then((_) {
+          expect(strPath(router.activePath), 'foo.qux');
+
+          return router.route('/foo/bar/baz').then((_) {
+            expect(strPath(router.activePath), 'foo.bar.baz');
+          });
+        });
+      });
+    });
+
+    test('should currectly identify active path after relative go', () {
+      var mockWindow = new MockWindow();
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'baz', path: '/baz', mount: (child) => child))
+              ..addRoute(
+                  name: 'qux',
+                  path: '/qux',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'aux', path: '/aux', mount: (child) => child)));
+
+      var strPath =
+          (List<Route> path) => path.map((Route r) => r.name).join('.');
+
+      expect(strPath(router.activePath), '');
+
+      return router.route('/foo').then((_) {
+        expect(strPath(router.activePath), 'foo');
+
+        var foo = router.findRoute('foo');
+        return router.go('bar', {}, startingFrom: foo).then((_) {
+          expect(strPath(router.activePath), 'foo.bar');
+        });
+      });
+    });
+
+    test(
+        'should currectly identify active path after relative go from deeper active path',
+        () {
+      var mockWindow = new MockWindow();
+      var router = new Router(windowImpl: mockWindow);
+      router.root
+        ..addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'baz', path: '/baz', mount: (child) => child))
+              ..addRoute(
+                  name: 'qux',
+                  path: '/qux',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'aux', path: '/aux', mount: (child) => child)));
+
+      var strPath =
+          (List<Route> path) => path.map((Route r) => r.name).join('.');
+
+      expect(strPath(router.activePath), '');
+
+      return router.route('/foo/qux/aux').then((_) {
+        expect(strPath(router.activePath), 'foo.qux.aux');
+
+        var foo = router.findRoute('foo');
+        return router.go('bar', {}, startingFrom: foo).then((_) {
+          expect(strPath(router.activePath), 'foo.bar');
+        });
+      });
+    });
+  });
+
+  group('listen', () {
+    group('fragment', () {
+      test('shoud route current hash on listen', () {
+        var mockWindow = new MockWindow();
+        var mockHashChangeController = new StreamController<Event>(sync: true);
+
+        when(mockWindow.onHashChange)
+            .thenReturn(mockHashChangeController.stream);
+        when(mockWindow.location.hash).thenReturn('#/foo');
+        var router = new Router(useFragment: true, windowImpl: mockWindow);
+        router.root.addRoute(name: 'foo', path: '/foo');
+        router.onRouteStart.listen(expectAsync1((RouteStartEvent start) {
+          start.completed.then(expectAsync1((_) {
+            expect(router.findRoute('foo').isActive, isTrue);
+          }));
+        }, count: 1));
+        router.listen(ignoreClick: true);
+      });
+    });
+
+    group('pushState', () {
+      testInit(mockWindow, [count = 1]) {
+        when(mockWindow.location.hash).thenReturn('');
+        when(mockWindow.location.pathname).thenReturn('/hello');
+        when(mockWindow.location.search).thenReturn('?foo=bar&baz=bat');
+        var router = new Router(useFragment: false, windowImpl: mockWindow);
+        router.root.addRoute(name: 'hello', path: '/hello');
+        router.onRouteStart.listen(expectAsync1((RouteStartEvent start) {
+          start.completed.then(expectAsync1((_) {
+            expect(router.findRoute('hello').isActive, isTrue);
+            expect(router.findRoute('hello').queryParameters['baz'], 'bat');
+            expect(router.findRoute('hello').queryParameters['foo'], 'bar');
+          }));
+        }, count: count));
+        router.listen(ignoreClick: true);
+      }
+
+      test('should route current path on listen with pop', () {
+        var mockWindow = new MockWindow();
+        var mockPopStateController =
+            new StreamController<PopStateEvent>(sync: true);
+        when(mockWindow.onPopState).thenReturn(mockPopStateController.stream);
+        testInit(mockWindow, 2);
+        mockPopStateController.add(null);
+      });
+
+      test('shoud route current path on listen without pop', () {
+        var mockWindow = new MockWindow();
+        var mockPopStateController =
+            new StreamController<PopStateEvent>(sync: true);
+        when(mockWindow.onPopState).thenReturn(mockPopStateController.stream);
+        testInit(mockWindow);
+      });
+    });
+
+    group('links', () {
+      Element toRemove;
+
+      tearDown(() {
+        if (toRemove != null) {
+          toRemove.remove();
+          toRemove = null;
+        }
+      });
+
+      test('it should be called if event triggered on anchor element', () {
+        AnchorElement anchor = new AnchorElement();
+        anchor.href = '#test1';
+        document.body.append(toRemove = anchor);
+
+        var mockWindow = new MockWindow();
+        var mockHashChangeController = new StreamController<Event>(sync: true);
+
+        when(mockWindow.onHashChange)
+            .thenReturn(mockHashChangeController.stream);
+        when(mockWindow.location.hash).thenReturn('#/foo');
+        when(mockWindow.location.host).thenReturn(window.location.host);
+
+        var router = new Router(useFragment: true, windowImpl: mockWindow);
+        router.listen(appRoot: anchor);
+
+        router.onRouteStart.listen(expectAsync1((RouteStartEvent e) {
+          expect(e.uri, 'test1');
+        }, max: 2));
+
+        anchor.click();
+      });
+
+      test(
+          'it should be called if event triggered on child of an anchor element',
+          () {
+        Element anchorChild = new DivElement();
+        AnchorElement anchor = new AnchorElement();
+        anchor.href = '#test2';
+        anchor.append(anchorChild);
+        document.body.append(toRemove = anchor);
+
+        var mockWindow = new MockWindow();
+        var mockHashChangeController = new StreamController<Event>(sync: true);
+
+        when(mockWindow.onHashChange)
+            .thenReturn(mockHashChangeController.stream);
+        when(mockWindow.location.hash).thenReturn('#/foo');
+        when(mockWindow.location.host).thenReturn(window.location.host);
+
+        var router = new Router(useFragment: true, windowImpl: mockWindow);
+        router.listen(appRoot: anchor);
+
+        router.onRouteStart.listen(expectAsync1((RouteStartEvent e) {
+          expect(e.uri, 'test2');
+        }, max: 2));
+
+        anchorChild.click();
+      });
+    });
+  });
+}
+
+/// An alias for Router.root.findRoute(path)
+r(Router router, String path) => router.root.findRoute(path);

--- a/third_party/pkg/route.dart/test/link_matcher_test.dart
+++ b/third_party/pkg/route.dart/test/link_matcher_test.dart
@@ -1,0 +1,32 @@
+library route.link_matcher_test;
+
+import 'dart:html';
+import 'package:test/test.dart';
+import 'package:route_hierarchical/link_matcher.dart';
+
+main() {
+  group('DefaultRouterLinkMatcher', () {
+    RouterLinkMatcher linkMatcher = new DefaultRouterLinkMatcher();
+
+    test(
+        'should not match anchor element which has target set to _blank, _top, _parent or _self',
+        () {
+      AnchorElement anchor = new AnchorElement();
+
+      anchor.target = '_blank';
+      expect(linkMatcher.matches(anchor), isFalse);
+
+      anchor.target = '_top';
+      expect(linkMatcher.matches(anchor), isFalse);
+
+      anchor.target = '_parent';
+      expect(linkMatcher.matches(anchor), isFalse);
+
+      anchor.target = '_self';
+      expect(linkMatcher.matches(anchor), isFalse);
+
+      anchor.target = '';
+      expect(linkMatcher.matches(anchor), isTrue);
+    });
+  });
+}

--- a/third_party/pkg/route.dart/test/url_template_test.dart
+++ b/third_party/pkg/route.dart/test/url_template_test.dart
@@ -1,0 +1,102 @@
+library route.url_template_test;
+
+import 'package:test/test.dart';
+import 'package:route_hierarchical/url_template.dart';
+import 'package:route_hierarchical/url_matcher.dart';
+
+main() {
+  group('UrlTemplate', () {
+    test('should work with simple templates', () {
+      var tmpl = new UrlTemplate('/foo/bar:baz/aux');
+      expect(tmpl.match('/foo/bar123/aux'),
+          new UrlMatch('/foo/bar123/aux', '', {'baz': '123'}));
+
+      tmpl = new UrlTemplate('/foo/:bar');
+      expect(
+          tmpl.match('/foo/123'), new UrlMatch('/foo/123', '', {'bar': '123'}));
+
+      tmpl = new UrlTemplate('/:foo/bar');
+      expect(
+          tmpl.match('/123/bar'), new UrlMatch('/123/bar', '', {'foo': '123'}));
+
+      tmpl = new UrlTemplate('/user/:userId/article/:articleId/view');
+      UrlMatch params =
+          tmpl.match('/user/jsmith/article/1234/view/someotherstuff');
+      expect(
+          params,
+          new UrlMatch('/user/jsmith/article/1234/view', '/someotherstuff',
+              {'userId': 'jsmith', 'articleId': '1234'}));
+
+      params = tmpl.match('/user/jsmith/article/1234/edit');
+      expect(params, isNull);
+
+      tmpl = new UrlTemplate(r'/foo/:bar$123/aux');
+      expect(tmpl.match(r'/foo/123$123/aux'),
+          new UrlMatch(r'/foo/123$123/aux', '', {'bar': '123'}));
+    });
+
+    test('should work with special characters', () {
+      var tmpl = new UrlTemplate(r'\^\|+[]{}()');
+      expect(tmpl.match(r'\^\|+[]{}()'), new UrlMatch(r'\^\|+[]{}()', '', {}));
+
+      tmpl = new UrlTemplate(r'/:foo/^\|+[]{}()');
+      expect(tmpl.match(r'/123/^\|+[]{}()'),
+          new UrlMatch(r'/123/^\|+[]{}()', '', {'foo': '123'}));
+    });
+
+    test('should only match prefix', () {
+      var tmpl = new UrlTemplate(r'/foo');
+      expect(
+          tmpl.match(r'/foo/foo/bar'), new UrlMatch(r'/foo', '/foo/bar', {}));
+    });
+
+    test('should match without leading slashes', () {
+      var tmpl = new UrlTemplate(r'foo');
+      expect(tmpl.match(r'foo'), new UrlMatch(r'foo', '', {}));
+    });
+
+    test('should reverse', () {
+      var tmpl = new UrlTemplate('/:a/:b/:c');
+      expect(tmpl.reverse(), '/null/null/null');
+      expect(tmpl.reverse(parameters: {'a': 'foo', 'b': 'bar', 'c': 'baz'}),
+          '/foo/bar/baz');
+
+      tmpl = new UrlTemplate(':a/bar/baz');
+      expect(tmpl.reverse(), 'null/bar/baz');
+      expect(
+          tmpl.reverse(parameters: {
+            'a': '/foo',
+          }),
+          '/foo/bar/baz');
+
+      tmpl = new UrlTemplate('/foo/bar/:c');
+      expect(tmpl.reverse(), '/foo/bar/null');
+      expect(
+          tmpl.reverse(parameters: {
+            'c': 'baz',
+          }),
+          '/foo/bar/baz');
+
+      tmpl = new UrlTemplate('/foo/bar/:c');
+      expect(
+          tmpl.reverse(tail: '/tail', parameters: {
+            'c': 'baz',
+          }),
+          '/foo/bar/baz/tail');
+    });
+
+    test('should conditionally allow slashes in parameters', () {
+      var tmpl = new UrlTemplate('/foo/:bar');
+      expect(tmpl.match('/foo/123/456'),
+          new UrlMatch('/foo/123', '/456', {'bar': '123'}));
+
+      tmpl = new UrlTemplate('/foo/:bar*');
+      expect(tmpl.match('/foo/123/456'),
+          new UrlMatch('/foo/123/456', '', {'bar*': '123/456'}));
+
+      tmpl = new UrlTemplate('/foo/:bar*/baz');
+      expect(tmpl.match('/foo/123/456/baz'),
+          new UrlMatch('/foo/123/456/baz', '', {'bar*': '123/456'}));
+    });
+  });
+}

--- a/third_party/pkg/route.dart/test/util/mocks.dart
+++ b/third_party/pkg/route.dart/test/util/mocks.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library route.test_mocks;
+
+import 'dart:html';
+import 'package:mockito/mockito.dart';
+import 'package:route_hierarchical/client.dart';
+
+class MockWindow extends Mock implements Window {
+  final history = new MockHistory();
+  final location = new MockLocation();
+  final document = new MockDocument();
+}
+
+class MockHistory extends Mock implements History {}
+
+class MockLocation extends Mock implements Location {}
+
+class MockDocument extends Mock implements HtmlDocument {}
+
+class MockMouseEvent extends Mock implements MouseEvent {}
+
+class MockRouter extends Mock implements Router {}

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -14,10 +14,20 @@ import 'package:yaml/yaml.dart' as yaml;
 
 final FilePath _buildDir = new FilePath('build');
 final FilePath _webDir = new FilePath('web');
+final FilePath _pkgDir = new FilePath('third_party/pkg');
+final FilePath _routeDir = new FilePath('third_party/pkg/route.dart');
 
 Map get _env => Platform.environment;
 
 main(List<String> args) => grind(args);
+
+@Task('Copy the included route.dart package in.')
+updateRouteDart() {
+  run('rm', arguments: ['-rf', _routeDir.path]);
+  new Directory(_pkgDir.path).createSync(recursive: true);
+  run('git', arguments: ['clone', '--branch', 'dart2-route', '--depth=1', 'git@github.com:jcollins-g/route.dart.git', _routeDir.path]);
+  run('rm', workingDirectory: _routeDir.path, arguments: ['-rf', '.git']);
+}
 
 @Task()
 analyze() {
@@ -31,11 +41,16 @@ ddc() {
 }
 
 @Task()
-testCli() => new TestRunner().testAsync(platformSelector: 'vm');
+testCli() async => await new TestRunner().testAsync(platformSelector: 'vm');
 
 // This task require a frame buffer to run.
 @Task()
-testWeb() => new TestRunner().testAsync(platformSelector: 'chrome');
+testWeb() async {
+  await new TestRunner().testAsync(platformSelector: 'chrome');
+  log('Running route.dart tests...');
+  run('pub', arguments: ['get'], workingDirectory: _routeDir.path);
+  run('pub', arguments: ['run', 'test:test', '--platform=chrome'], workingDirectory: _routeDir.path);
+}
 
 @Task('Run bower')
 bower() => run('bower', arguments: ['install', '--force-latest']);

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -79,10 +79,11 @@ build() {
   copyPackageResources('codemirror', joinDir(buildDir, ['web']));
 
   // Compile main scripts.
+  // Debugging: minify: false, extraArgs: ['--enable-asserts']
   Dart2js.compile(joinFile(webDir, ['scripts', 'main.dart']),
-      outDir: joinDir(buildDir, ['web', 'scripts']), minify: false, extraArgs: ['--enable-asserts']);
+      outDir: joinDir(buildDir, ['web', 'scripts']), minify: true);
   Dart2js.compile(joinFile(webDir, ['scripts', 'embed.dart']),
-      outDir: joinDir(buildDir, ['web', 'scripts']), minify: false, extraArgs: ['--enable-asserts']);
+      outDir: joinDir(buildDir, ['web', 'scripts']), minify: true);
 
   FilePath mainFile = _buildDir.join('web', 'scripts/main.dart.js');
   log('${mainFile} compiled to ${_printSize(mainFile)}');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -65,9 +65,9 @@ build() {
 
   // Compile main scripts.
   Dart2js.compile(joinFile(webDir, ['scripts', 'main.dart']),
-      outDir: joinDir(buildDir, ['web', 'scripts']), minify: true);
+      outDir: joinDir(buildDir, ['web', 'scripts']), minify: false, extraArgs: ['--enable-asserts']);
   Dart2js.compile(joinFile(webDir, ['scripts', 'embed.dart']),
-      outDir: joinDir(buildDir, ['web', 'scripts']), minify: true);
+      outDir: joinDir(buildDir, ['web', 'scripts']), minify: false, extraArgs: ['--enable-asserts']);
 
   FilePath mainFile = _buildDir.join('web', 'scripts/main.dart.js');
   log('${mainFile} compiled to ${_printSize(mainFile)}');
@@ -111,11 +111,16 @@ void copyPackageResources(String packageName, Directory destDir) {
     int index = line.indexOf(':');
     String name = line.substring(0, index);
     String location = line.substring(index + 1);
-    if (name == packageName && location.startsWith('file:')) {
-      Uri uri = Uri.parse(location);
+    if (name == packageName) {
+      if (location.startsWith('file:')) {
+        Uri uri = Uri.parse(location);
 
-      copyDirectory(new Directory.fromUri(uri),
-          joinDir(destDir, ['packages', packageName]));
+        copyDirectory(new Directory.fromUri(uri),
+            joinDir(destDir, ['packages', packageName]));
+      } else {
+        copyDirectory(new Directory(location),
+            joinDir(destDir, ['pacakges', packageName]));
+      }
       return;
     }
   }

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -16,4 +16,4 @@ dart tool/grind.dart buildbot
 
 # Run the UI/web tests as well.
 # TODO: Our bot is flakey...
-#dart tool/grind.dart test-web
+dart tool/grind.dart test-web


### PR DESCRIPTION
Fixes #831, #832.

This includes changes to generated files because updating package:rpc to work with Dart 2.0 is not a small task.

I included a grind target to pull new versions of route.dart into third_party since that's discontinued.  You can see the branch differences here to the last published version:  https://github.com/dart-archive/route.dart/compare/master...jcollins-g:dart2-route?expand=1
