### PR TITLE
Make fix for #836 work on Safari

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -82,7 +82,7 @@ function dartMainRunner(main, args) {
 window.onerror = function(message, url, lineNumber, colno, error) {
   if (!_thrownDartMainRunner) {
     parent.postMessage(
-      {'sender': 'frame', 'type': 'stderr', 'message': message + "Error: " + error.message}, '*');
+      {'sender': 'frame', 'type': 'stderr', 'message': message + "Error: " + error}, '*');
   }
   _thrownDartMainRunner = false;
 };

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -408,4 +408,4 @@ packages:
     source: hosted
     version: "2.1.14"
 sdks:
-  dart: ">=2.0.0-dev.67.0 <=2.0.0-dev.68.0"
+  dart: ">=2.0.0-dev.67.0 <=2.0.0-dev.69.0"


### PR DESCRIPTION
The fix in PR #838 doesn't quite work on Safari because it doesn't provide `error.message`.

Safari console output:
```
[Error] TypeError: null is not an object (evaluating 'error.message')
	onerror (Script Element 1:21:84)
[Error] 
	assertHelper (Script Element 1:1235)
	call$0 (Script Element 1:2815)
	_microtaskLoop (Script Element 1:2126)
	(anonymous function) (Script Element 1:2132)
	call$1 (Script Element 1:2267)
	invokeClosure (Script Element 1:861)
	(anonymous function) (Script Element 1:877)
```

This fix makes Safari at least display something, if a little ugly, on internal errors like this without negatively impacting Chrome.

```
Script error.Error: null
```

