### PR TITLE
Move dartpad front-end to 2.0 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: dart
 dart:
   - dev
+  - stable
 sudo: required
 addons:
   chrome: stable

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,6 +8,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.6+1"
+  analysis_server_lib:
+    dependency: transitive
+    description:
+      name: analysis_server_lib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4+2"
   analyzer:
     dependency: transitive
     description:
@@ -176,6 +183,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.4+1"
+  dart2_constant:
+    dependency: transitive
+    description:
+      name: dart2_constant
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2+dart2"
   dart_style:
     dependency: transitive
     description:
@@ -235,10 +249,10 @@ packages:
   haikunator:
     dependency: "direct main"
     description:
-      name: haikunator
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.0"
+      path: "third_party/pkg/haikunatordart"
+      relative: true
+    source: path
+    version: "0.1.1"
   html:
     dependency: transitive
     description:
@@ -267,6 +281,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.7"
   io:
     dependency: transitive
     description:
@@ -413,7 +434,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0+1"
+    version: "0.29.0+2"
   route_hierarchical:
     dependency: "direct main"
     description:
@@ -519,6 +540,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  tuneup:
+    dependency: "direct dev"
+    description:
+      name: tuneup
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.6"
   typed_data:
     dependency: transitive
     description:
@@ -562,4 +590,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.67.0 <=2.0.0-dev.69.5"
+  dart: ">=2.0.0-dev.67.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,11 @@ environment:
 dependencies:
   _discoveryapis_commons: '>=0.1.0 <0.2.0'
   codemirror: '^0.4.2+5.13.4'
-  haikunator: ^0.1.0
+  # TODO(jcollins-g): return to haikunator pub package after it is
+  # published with https://github.com/Atrox/haikunatordart/pull/1
+  #haikunator: ^0.1.0
+  haikunator:
+    path: third_party/pkg/haikunatordart/
   http: '>=0.11.1 <0.12.0'
   logging: '>=0.9.0 <0.12.0'
   markdown: ^2.0.0
@@ -22,4 +26,5 @@ dev_dependencies:
   git: any
   grinder: ^0.8.0
   test: ^1.2.0
+  tuneup: any
   yaml: any

--- a/third_party/pkg/haikunatordart/.gitignore
+++ b/third_party/pkg/haikunatordart/.gitignore
@@ -1,0 +1,7 @@
+.buildlog
+.DS_Store
+.idea
+.pub/
+build/
+packages
+pubspec.lock

--- a/third_party/pkg/haikunatordart/.travis.yml
+++ b/third_party/pkg/haikunatordart/.travis.yml
@@ -1,0 +1,4 @@
+language: dart
+dart:
+  - stable
+  - dev

--- a/third_party/pkg/haikunatordart/CHANGELOG.md
+++ b/third_party/pkg/haikunatordart/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.1.1
+
+- Update dependencies for Dart 2.0.
+
+## 0.1.0
+
+- Initial version

--- a/third_party/pkg/haikunatordart/LICENSE
+++ b/third_party/pkg/haikunatordart/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2015, Atrox.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/pkg/haikunatordart/README.md
+++ b/third_party/pkg/haikunatordart/README.md
@@ -1,0 +1,80 @@
+# HaikunatorDART
+
+[![Build Status](https://img.shields.io/travis/Atrox/haikunatordart.svg?style=flat-square)](https://travis-ci.org/Atrox/haikunatordart)
+[![Latest Version](https://img.shields.io/pub/v/haikunator.svg?style=flat-square)](https://pub.dartlang.org/packages/haikunator)
+
+Generate Heroku-like random names to use in your dart applications.
+
+## Installation
+
+Add the following to your `pubspec.yaml` and run `pub get`:
+
+```yaml
+dependencies:
+  haikunator: any
+```
+
+## Usage
+
+Haikunator is pretty simple.
+
+```dart
+import 'package:haikunator/haikunator.dart';
+
+// default usage
+Haikunator.haikunate() // => "wispy-dust-1337"
+
+// custom length (default=4)
+Haikunator.haikunate(tokenLength: 6) // => "patient-king-887265"
+
+// use hex instead of numbers
+Haikunator.haikunate(tokenHex: true) // => "purple-breeze-98e1"
+
+// use custom chars instead of numbers/hex
+Haikunator.haikunate(tokenChars: "HAIKUNATE") // => "summer-atom-IHEA"
+
+// don't include a token
+Haikunator.haikunate(tokenLength: 0) // => "cold-wildflower"
+
+// use a different delimiter
+Haikunator.haikunate(delimiter: ".") // => "restless.sea.7976"
+
+// no token, space delimiter
+Haikunator.haikunate(tokenLength: 0, delimiter: " ") // => "delicate haze"
+
+// no token, empty delimiter
+Haikunator.haikunate(tokenLength: 0, delimiter: "") // => "billowingleaf"
+```
+
+## Options
+
+The following options are available:
+
+```dart
+Haikunator.haikunate(
+  delimiter: "-",
+  tokenLength: 4,
+  tokenHex: false,
+  tokenChars: "0123456789"
+);
+```
+*If ```tokenHex``` is true, it overrides any tokens specified in ```tokenChars```*
+
+## Contributing
+
+Everyone is encouraged to help improve this project. Here are a few ways you can help:
+
+- [Report bugs](https://github.com/Atrox/haikunatordart/issues)
+- Fix bugs and [submit pull requests](https://github.com/Atrox/haikunatordart/pulls)
+- Write, clarify, or fix documentation
+- Suggest or add new features
+
+## Other Languages
+
+Haikunator is also available in other languages. Check them out:
+
+- Node: https://github.com/Atrox/haikunatorjs
+- PHP: https://github.com/Atrox/haikunatorphp
+- Python: https://github.com/Atrox/haikunatorpy
+- Ruby: https://github.com/usmanbashir/haikunator
+- Go: https://github.com/yelinaung/go-haikunator

--- a/third_party/pkg/haikunatordart/example/haikunator.dart
+++ b/third_party/pkg/haikunatordart/example/haikunator.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2015, Atrox. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+library haikunator.example;
+
+import 'package:haikunator/haikunator.dart';
+
+main() {
+  // For more examples please take a view at the tests
+  print(Haikunator.haikunate(tokenChars: 'abc', delimiter: '+'));
+}

--- a/third_party/pkg/haikunatordart/lib/haikunator.dart
+++ b/third_party/pkg/haikunatordart/lib/haikunator.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2015, Atrox. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+/// The Haikunator library.
+///
+/// Generate Heroku-like random names to use in your dart applications.
+library haikunator;
+
+import 'dart:math' show Random;
+
+class Haikunator {
+  static final Random rndm = new Random();
+  static final adjectives = [
+    "autumn", "hidden", "bitter", "misty", "silent", "empty", "dry", "dark",
+    "summer", "icy", "delicate", "quiet", "white", "cool", "spring", "winter",
+    "patient", "twilight", "dawn", "crimson", "wispy", "weathered", "blue",
+    "billowing", "broken", "cold", "damp", "falling", "frosty", "green",
+    "long", "late", "lingering", "bold", "little", "morning", "muddy", "old",
+    "red", "rough", "still", "small", "sparkling", "throbbing", "shy",
+    "wandering", "withered", "wild", "black", "young", "holy", "solitary",
+    "fragrant", "aged", "snowy", "proud", "floral", "restless", "divine",
+    "polished", "ancient", "purple", "lively", "nameless", "lucky", "odd", "tiny",
+    "free", "dry", "yellow", "orange", "gentle", "tight", "super", "royal", "broad",
+    "steep", "flat", "square", "round", "mute", "noisy", "hushy", "raspy", "soft",
+    "shrill", "rapid", "sweet", "curly", "calm", "jolly", "fancy", "plain", "shinny"
+  ];
+  static final nouns = [
+    "waterfall", "river", "breeze", "moon", "rain", "wind", "sea", "morning",
+    "snow", "lake", "sunset", "pine", "shadow", "leaf", "dawn", "glitter",
+    "forest", "hill", "cloud", "meadow", "sun", "glade", "bird", "brook",
+    "butterfly", "bush", "dew", "dust", "field", "fire", "flower", "firefly",
+    "feather", "grass", "haze", "mountain", "night", "pond", "darkness",
+    "snowflake", "silence", "sound", "sky", "shape", "surf", "thunder",
+    "violet", "water", "wildflower", "wave", "water", "resonance", "sun",
+    "wood", "dream", "cherry", "tree", "fog", "frost", "voice", "paper",
+    "frog", "smoke", "star", "atom", "band", "bar", "base", "block", "boat",
+    "term", "credit", "art", "fashion", "truth", "disk", "math", "unit", "cell",
+    "scene", "heart", "recipe", "union", "limit", "bread", "toast", "bonus",
+    "lab", "mud", "mode", "poetry", "tooth", "hall", "king", "queen", "lion", "tiger",
+    "penguin", "kiwi", "cake", "mouse", "rice", "coke", "hola", "salad", "hat"
+  ];
+  
+  static String haikunate({String delimiter: "-", int tokenLength: 4, bool tokenHex: false, String tokenChars: "0123456789"}) {
+    String adjective, noun, token = "";
+    
+    if (tokenHex) tokenChars = "0123456789abcdef";
+    
+    adjective = adjectives[rndm.nextInt(adjectives.length)];
+    noun = nouns[rndm.nextInt(nouns.length)];
+    
+    for(var i = 0; i < tokenLength; i++) {
+      token += tokenChars[rndm.nextInt(tokenChars.length)];
+    }
+    
+    var sections = [adjective, noun, token];
+    sections.removeWhere((item) => item.isEmpty);
+    
+    return sections.join(delimiter);
+  }
+}

--- a/third_party/pkg/haikunatordart/pubspec.yaml
+++ b/third_party/pkg/haikunatordart/pubspec.yaml
@@ -1,0 +1,10 @@
+name: haikunator
+version: 0.1.1
+author: Atrox <mail@atrox.me>
+description: Generate Heroku-like random names to use in your dart applications.
+homepage: https://github.com/Atrox/haikunatordart
+documentation: https://github.com/Atrox/haikunatordart
+environment:
+  sdk: ">=2.0.0-dev.63.0 <=3.0.0"
+dev_dependencies:
+  test: any

--- a/third_party/pkg/haikunatordart/test/all_test.dart
+++ b/third_party/pkg/haikunatordart/test/all_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2015, Atrox. All rights reserved. Use of this source code
+// is governed by a BSD-style license that can be found in the LICENSE file.
+
+library Haikunator.test;
+
+import 'package:test/test.dart';
+import 'package:haikunator/haikunator.dart';
+
+main() {
+  group('testing haikunate', () {
+    test('should return 4 digits', () {
+      String haiku = Haikunator.haikunate();
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))(-)(\d{4})$'));
+    });
+    
+    test('should return 4 digits as hex', () {
+      String haiku = Haikunator.haikunate(tokenHex: true);
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))(-)(.{4})$'));
+    });
+
+    test('should return 9 digits', () {
+      String haiku = Haikunator.haikunate(tokenLength: 9);
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))(-)(\d{9})$'));
+    });
+    
+    test('should return 9 digits as hex', () {
+      String haiku = Haikunator.haikunate(tokenLength: 9, tokenHex: true);
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))(-)(.{9})$'));
+    });
+    
+    test('wont return the same name for subsequent calls', () {
+      expect(Haikunator.haikunate(),isNot(equals(Haikunator.haikunate())));
+    });
+    
+    test('drops the token if token range is 0', () {
+      String haiku = Haikunator.haikunate(tokenLength: 0);
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))$'));
+    });
+    
+    test('permits optional configuration of the delimiter', () {
+      String haiku = Haikunator.haikunate(delimiter: '.');
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(\.)((?:[a-z][a-z]+))(\.)(\d+)$'));
+    });
+    
+    test('drops the token if token range is 0 and delimiter is an empty space', () {
+      String haiku = Haikunator.haikunate(tokenLength: 0, delimiter: ' ');
+      expect(haiku, matches(r'((?:[a-z][a-z]+))( )((?:[a-z][a-z]+))$'));
+    });
+    
+    test('returns one single word if token and delimiter are dropped', () {
+      String haiku = Haikunator.haikunate(tokenLength: 0, delimiter: '');
+      expect(haiku, matches(r'((?:[a-z][a-z]+))$'));
+    });
+    
+    test('permits custom token chars', () {
+      String haiku = Haikunator.haikunate(tokenChars: 'A');
+      expect(haiku, matches(r'((?:[a-z][a-z]+))(-)((?:[a-z][a-z]+))(-)(AAAA)$'));
+    });
+  });
+}

--- a/third_party/pkg/route.dart/pubspec.yaml
+++ b/third_party/pkg/route.dart/pubspec.yaml
@@ -6,10 +6,9 @@ authors:
 description: A client routing library for Dart, modified for Dart 2.
 homepage: https://github.com/angular/route.dart
 environment:
-  sdk: '>=2.0.0-dev.67.0 <2.0.0'
+  sdk: '>=2.0.0-dev.67.0 <3.0.0'
 dependencies:
   logging: any
 dev_dependencies:
-  browser: any
-  mockito: ^2.2.3
+  mockito: ^3.0.0
   test: any

--- a/third_party/pkg/route.dart/test/click_handler_test.dart
+++ b/third_party/pkg/route.dart/test/click_handler_test.dart
@@ -23,7 +23,7 @@ main() {
       onHashChangeController = new StreamController<Event>();
       when(mockWindow.location.host).thenReturn(window.location.host);
       when(mockWindow.location.hash).thenReturn('');
-      when(mockWindow.onHashChange).thenReturn(onHashChangeController.stream);
+      when(mockWindow.onHashChange).thenAnswer((_) => onHashChangeController.stream);
       router = new MockRouter();
       root = new DivElement();
       document.body.append(root);
@@ -55,7 +55,7 @@ main() {
       MockMouseEvent mockMouseEvent =
           _createMockMouseEvent(anchorHref: '#test');
       linkHandler(mockMouseEvent);
-      var result = verify(router.gotoUrl(typed<String>(captureAny)));
+      var result = verify(router.gotoUrl(captureAny));
       result.called(1);
       expect(result.captured.first, "test");
     });
@@ -80,7 +80,7 @@ main() {
       linkHandler(mockMouseEvent);
 
       // We expect 0 calls to router.gotoUrl
-      verifyNever(router.gotoUrl(typed<String>(any)));
+      verifyNever(router.gotoUrl(any));
     });
 
     test('should process AnchorElements which has a child', () {
@@ -95,7 +95,7 @@ main() {
       when(mockMouseEvent.path).thenReturn([anchorChild, anchor]);
 
       linkHandler(mockMouseEvent);
-      var result = verify(router.gotoUrl(typed<String>(captureAny)));
+      var result = verify(router.gotoUrl(captureAny));
       result.called(1);
       expect(result.captured.first, "test");
     });

--- a/third_party/pkg/route.dart/test/client_test.dart
+++ b/third_party/pkg/route.dart/test/client_test.dart
@@ -1054,16 +1054,16 @@ main() {
       router.go('articles', {}).then(expectAsync1((_) {
         var mockLocation = mockWindow.location;
 
-        var result = verify(mockLocation.assign(typed<String>(captureAny)));
+        var result = verify(mockLocation.assign(captureAny));
         result.called(1);
         expect(result.captured.first, '#/articles');
-        verifyNever(mockLocation.replace(typed<String>(any)));
+        verifyNever(mockLocation.replace(any));
 
         router.go('articles', {}, replace: true).then(expectAsync1((_) {
-          var result = verify(mockLocation.replace(typed<String>(captureAny)));
+          var result = verify(mockLocation.replace(captureAny));
           result.called(1);
           expect(result.captured.first, '#/articles');
-          verifyNever(mockLocation.assign(typed<String>(any)));
+          verifyNever(mockLocation.assign(any));
         }));
       }));
     });
@@ -1079,19 +1079,19 @@ main() {
         var mockHistory = mockWindow.history;
 
         var result = verify(mockHistory.pushState(
-            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+            captureAny, captureAny, captureAny));
         result.called(1);
         expect(result.captured, [null, 'page title', '/articles']);
         verifyNever(mockHistory.replaceState(
-            any, typed<String>(any), typed<String>(any)));
+            any, any, any));
 
         router.go('articles', {}, replace: true).then(expectAsync1((_) {
           var result = verify(mockHistory.replaceState(captureAny,
-              typed<String>(captureAny), typed<String>(captureAny)));
+              captureAny, captureAny));
           result.called(1);
           expect(result.captured, [null, 'page title', '/articles']);
           verifyNever(mockHistory.pushState(
-              any, typed<String>(any), typed<String>(any)));
+              any, any, any));
         }));
       }));
     });
@@ -1110,12 +1110,12 @@ main() {
         var mockHistory = mockWindow.history;
 
         var result = verify(mockHistory.pushState(
-            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+            captureAny, captureAny, captureAny));
         result.called(1);
         expect(result.captured,
             [null, 'page title', '/articles?foo=foo%20bar&bar=%25baz%2Baux']);
         verifyNever(mockHistory.replaceState(
-            any, typed<String>(any), typed<String>(any)));
+            any, any, any));
       }));
     });
 
@@ -1136,13 +1136,13 @@ main() {
         var mockHistory = mockWindow.history;
 
         var result = verify(mockHistory.pushState(
-            captureAny, typed<String>(captureAny), typed<String>(captureAny)));
+            captureAny, captureAny, captureAny));
         result.called(1);
         expect(result.captured, [null, 'page title', '/null/null']);
 
         router.go('a.b', {'foo': 'aaaa', 'bar': 'bbbb'}).then(expectAsync1((_) {
           var result = verify(mockHistory.pushState(captureAny,
-              typed<String>(captureAny), typed<String>(captureAny)));
+              captureAny, captureAny));
           result.called(1);
           expect(result.captured, [null, 'page title', '/aaaa/bbbb']);
 
@@ -1150,7 +1150,7 @@ main() {
               .go('b', {'bar': 'bbbb'}, startingFrom: routeA)
               .then(expectAsync1((_) {
             var result = verify(mockHistory.pushState(captureAny,
-                typed<String>(captureAny), typed<String>(captureAny)));
+                captureAny, captureAny));
             // Note: These were cumulative with mock but get reset with each
             // call to mockito.verify(), so 3 became 1 here.
             result.called(1);
@@ -1190,8 +1190,8 @@ main() {
         return router.go('b', {'bar': 'bbb'}, startingFrom: routeA).then((_) {
           var mockHistory = mockWindow.history;
 
-          var result = verify(mockHistory.pushState(typed<String>(captureAny),
-              typed<String>(captureAny), typed<String>(captureAny)));
+          var result = verify(mockHistory.pushState(captureAny,
+              captureAny, captureAny));
           result.called(1);
           expect(result.captured, [null, 'page title', '/null/bbb']);
         });
@@ -1235,7 +1235,7 @@ main() {
 
       router.go('foo', {}).then(expectAsync1((_) {
         var mockHistory = mockWindow.history;
-        verify((mockWindow.document as HtmlDocument).title = typed<String>(any))
+        verify((mockWindow.document as HtmlDocument).title = any)
             .called(1);
         verify(mockHistory.pushState(null, 'Foo', '/foo')).called(1);
       }));
@@ -1655,7 +1655,7 @@ main() {
         var mockHashChangeController = new StreamController<Event>(sync: true);
 
         when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
+            .thenAnswer((_) => mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
         var router = new Router(useFragment: true, windowImpl: mockWindow);
         router.root.addRoute(name: 'foo', path: '/foo');
@@ -1689,7 +1689,7 @@ main() {
         var mockWindow = new MockWindow();
         var mockPopStateController =
             new StreamController<PopStateEvent>(sync: true);
-        when(mockWindow.onPopState).thenReturn(mockPopStateController.stream);
+        when(mockWindow.onPopState).thenAnswer((_) => mockPopStateController.stream);
         testInit(mockWindow, 2);
         mockPopStateController.add(null);
       });
@@ -1698,7 +1698,7 @@ main() {
         var mockWindow = new MockWindow();
         var mockPopStateController =
             new StreamController<PopStateEvent>(sync: true);
-        when(mockWindow.onPopState).thenReturn(mockPopStateController.stream);
+        when(mockWindow.onPopState).thenAnswer((_) => mockPopStateController.stream);
         testInit(mockWindow);
       });
     });
@@ -1722,7 +1722,7 @@ main() {
         var mockHashChangeController = new StreamController<Event>(sync: true);
 
         when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
+            .thenAnswer((_) => mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
         when(mockWindow.location.host).thenReturn(window.location.host);
 
@@ -1749,7 +1749,7 @@ main() {
         var mockHashChangeController = new StreamController<Event>(sync: true);
 
         when(mockWindow.onHashChange)
-            .thenReturn(mockHashChangeController.stream);
+            .thenAnswer((_) => mockHashChangeController.stream);
         when(mockWindow.location.hash).thenReturn('#/foo');
         when(mockWindow.location.host).thenReturn(window.location.host);
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -52,12 +52,6 @@ analyze() {
   new PubApp.local('tuneup')..run(['check']);
 }
 
-@Task('Analyze the source code with the ddc compiler')
-ddc() {
-  PubApp ddc = new PubApp.local('dev_compiler');
-  ddc.run(['web/scripts/main.dart']);
-}
-
 @Task()
 testCli() async => await new TestRunner().testAsync(platformSelector: 'vm');
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -16,14 +16,16 @@ final FilePath _buildDir = new FilePath('build');
 final FilePath _webDir = new FilePath('web');
 final FilePath _pkgDir = new FilePath('third_party/pkg');
 final FilePath _routeDir = new FilePath('third_party/pkg/route.dart');
+final FilePath _haikunatorDir = new FilePath('third_party/pkg/haikunatordart');
 
 Map get _env => Platform.environment;
 
 main(List<String> args) => grind(args);
 
-@Task('Copy the included route.dart package in.')
-updateRouteDart() {
+@Task('Copy the included route.dart/haikunator package in.')
+updateThirdParty() {
   run('rm', arguments: ['-rf', _routeDir.path]);
+  run('rm', arguments: ['-rf', _haikunatorDir.path]);
   new Directory(_pkgDir.path).createSync(recursive: true);
   run('git', arguments: [
     'clone',
@@ -33,17 +35,26 @@ updateRouteDart() {
     'git@github.com:jcollins-g/route.dart.git',
     _routeDir.path
   ]);
+  run('git', arguments: [
+    'clone',
+    '--branch',
+    'dart2-stable',
+    '--depth=1',
+    'git@github.com:jcollins-g/haikunatordart.git',
+    _haikunatorDir.path
+  ]);
   run('rm', workingDirectory: _routeDir.path, arguments: ['-rf', '.git']);
+  run('rm', workingDirectory: _haikunatorDir.path, arguments: ['-rf', '.git']);
 }
 
 @Task()
 analyze() {
-  new PubApp.global('tuneup')..run(['check']);
+  new PubApp.local('tuneup')..run(['check']);
 }
 
 @Task('Analyze the source code with the ddc compiler')
 ddc() {
-  PubApp ddc = new PubApp.global('dev_compiler');
+  PubApp ddc = new PubApp.local('dev_compiler');
   ddc.run(['web/scripts/main.dart']);
 }
 


### PR DESCRIPTION
This doesn't change the version used for compiling/analysis, just how we build the front-end.

Haikunator needs a change (Atrox/haikunatordart#1) but until that gets published, this PR will assimilate it into third_party.