### PR TITLE
Change privacy notices for DartPad

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -40,12 +40,8 @@ language and libraries. Source code entered into DartPad may be sent to servers
 running in Google Cloud Platform to be analyzed for errors/warnings, compiled 
 to JavaScript, and returned to the browser.
 <br><br>
-Source code entered into DartPad may be stored indefinitely, processed, and 
-aggregated in order to improve the user experience. For example, we may use 
-the source code to help offer better code completion suggestions.
-<br><br>
-Learn more about Google's
-<a href="http://www.google.com/policies/privacy/" target="policy">privacy policy</a>.
+Learn more about how DartPad stores your data in our
+<a href="https://www.dartlang.org/tools/dartpad/privacy">privacy notice</a>.
 We look forward to your
 <a href="https://github.com/dart-lang/dart-pad/issues" target="feedback">feedback</a>.
 <br><br>

--- a/web/index.html
+++ b/web/index.html
@@ -118,8 +118,8 @@
     <footer layout horizontal>
       <div id="keyboard-button" class="keyboard footer-item"></div>
       <div>
-        <a href="https://github.com/dart-lang/dart-pad/wiki/Privacy-Policy"
-            target="repo" class="footer-item">Privacy policy</a>
+        <a href="https://www.dartlang.org/tools/dartpad/privacy"
+            target="repo" class="footer-item">Privacy notice</a>
         <a href="https://github.com/dart-lang/dart-pad/issues"
             target="repo">Send feedback</a>
       </div>


### PR DESCRIPTION
Fixes #853.

Changes the references to the privacy policy to references to the privacy notice.

Screenshot including the "Privacy notice" in the bottom left, and revised about text:

![screenshot from 2018-09-28 15-47-38](https://user-images.githubusercontent.com/14116827/46236930-3cc51780-c336-11e8-86be-4838be485257.png)
