### PR TITLE
Update front-end dependencies for Dart 2.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -212,7 +212,7 @@ packages:
     source: hosted
     version: "0.10.8"
   front_end:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.32.4"
+    version: "0.33.0"
   archive:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.7+3"
+    version: "1.0.1"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -77,42 +77,42 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1+2"
+    version: "0.3.1+3"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.1+1"
+    version: "1.0.1"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1+1"
+    version: "0.2.2+6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.0"
+    version: "1.0.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "1.0.1"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.4+2"
   built_collection:
     dependency: transitive
     description:
@@ -196,7 +196,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   dhttpd:
     dependency: "direct dev"
     description:
@@ -217,7 +217,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.6"
   git:
     dependency: "direct dev"
     description:
@@ -308,7 +308,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -322,7 +322,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.6"
   logging:
     dependency: "direct main"
     description:
@@ -393,6 +393,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.2"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   plugin:
     dependency: transitive
     description:
@@ -448,7 +455,7 @@ packages:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.3+1"
+    version: "0.0.3+2"
   shelf:
     dependency: transitive
     description:
@@ -476,7 +483,7 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+3"
+    version: "0.2.2+4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -539,7 +546,14 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.4"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
   tuneup:
     dependency: "direct dev"
     description:
@@ -590,4 +604,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.0.0-dev.67.0 <3.0.0"
+  dart: ">=2.0.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,10 +21,9 @@ dev_dependencies:
   build_runner: any
   build_web_compilers: any
   collection: ^1.14.10
-  front_end: ^0.1.6
   dhttpd: any
   git: any
   grinder: ^0.8.0
-  test: ^1.2.0
+  test: ^1.3.4
   tuneup: any
   yaml: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
   build_runner: any
   build_web_compilers: any
   collection: ^1.14.10
-  front_end: ^0.1.3
+  front_end: ^0.1.6
   dhttpd: any
   git: any
   grinder: ^0.8.0

--- a/third_party/pkg/route.dart/pubspec.yaml
+++ b/third_party/pkg/route.dart/pubspec.yaml
@@ -10,5 +10,6 @@ environment:
 dependencies:
   logging: any
 dev_dependencies:
+  front_end: ^0.1.6
   mockito: ^3.0.0
-  test: any
+  test: ^1.3.4

--- a/third_party/pkg/route.dart/pubspec.yaml
+++ b/third_party/pkg/route.dart/pubspec.yaml
@@ -10,6 +10,5 @@ environment:
 dependencies:
   logging: any
 dev_dependencies:
-  front_end: ^0.1.6
   mockito: ^3.0.0
   test: ^1.3.4


### PR DESCRIPTION
Front-end piece of #861.

A simple dependencies change seems to be enough to keep DartPad's frontend building and working on 2.1.