### PR TITLE
Move contributing info to markdown from wiki and add triage priorities

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing to DartPad
+
+## How to change and add to Sample Gists
+
+1) Update the samples first in the dartpad_examples repository: https://github.com/dart-lang/dartpad_examples
+
+1) Create your own gist based on the existing samples.  Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,39 @@
 # Contributing to DartPad
+Want to contribute? Great! First, read this page (including the small print at the end).
+
+## Before you contribute
+Before we can use your code, you must sign the [Google Individual Contributor License Agreement](https://developers.google.com/open-source/cla/individual?csw=1) (CLA), which you can do online. The CLA is necessary mainly because you own the copyright to your changes, even after your contribution becomes part of our codebase, so we need your permission to use and distribute your code. We also need to be sure of various other things—for instance that you'll tell us if you know that your code infringes on other people's patents. You don't have to sign the CLA until after you've submitted your code for review and a member has approved it, but you must do it before we can put your code into our codebase.
+
+Before you start working on a larger contribution, you should get in touch with us first through the issue tracker with your idea so that we can help out and possibly guide you. Coordinating up front makes it much easier to avoid frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review. We use Github pull requests for this purpose.
+
+### File headers
+All files in the project must start with the following header.
+
+    // Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than the one above, the Software Grant and Corporate Contributor License Agreement.
 
 ## How to change and add to Sample Gists
 
 1) Update the samples first in the dartpad_examples repository: https://github.com/dart-lang/dartpad_examples
 
-1) Create your own gist based on the existing samples.  Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
-
+2) If you are updating an existing sample, create your own gist based on the existing samples.
+   Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
+   Fork the gist, if necessary, then update the contents with the new version from dartpad_examples.
+ 
+   Otherwise, use the same gist layout as the samples to make sure that DartPad recognizes it:
+     * `index.html` for the HTML snippet used to build the output page
+     * `styles.css` for the style sheet
+     * `main.dart` for the Dart code. 
+ 
+   You can test your gist after updating or creating it by appending the gist ID to the URL for
+   dartpad.
+ 
+3) Add or change sample Gist IDs to the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54),
+   and submit a PR for review.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,46 @@ that we used to build DartPad.
 Please file reports on the
 [GitHub Issue Tracker](https://github.com/dart-lang/dart-pad/issues).
 
+### Bug Triage Priorities
+
+Each issue in the tracker will be assigned a priority based on the impact to users when the
+issue appears and the number of users impacted (widespread or rare).
+
+Some examples of likely triage priorities:
+
+* P0
+  * Broken internal/external navigation links within DartPad
+  * JavaScript console errors indicating problems with DartPad functionality in many cases, widespread.
+  * App is down / not loading
+  * Interface bugs preventing all or almost all uses of the application
+  * Unable to compile or analyze valid Dart code (widespread and/or with error messages that aren't retryable)
+
+* P1
+  * Unable to compile or analyze valid Dart code in edge cases only, and/or retryable
+  * Incorrect or not up-to-date warning information for invalid Dart code (widespread)
+  * Interface bugs interfering with common uses of the application, widespread
+  * JavaScript console errors indicating problems with DartPad functionality
+    (edge cases / not widespread)
+  * Enhancements that have significant data around them indicating they are a big win
+  * User performance problem (e.g. app loading / run / analysis), widespread
+  
+* P2
+  * Incorrect or not up-to-date warning information for invalid Dart code (edge cases / not widespread)
+  * JavaScript errors not resulting in visible problems outside of the console (widespread)
+  * Interface bugs interfering with the use of the application in edge cases.
+  * User interface and display warts that are not significantly impacting functionality, widespread
+  * Enhancements that are agreed to be a good idea even if they don't have data around them indicating
+    they are a big win
+  * User performance problem (e.g. app loading / run analysis), edge cases / not widespread
+
+* P3
+  * Minor user interface warts not significantly impacting functionality, on edge cases only.
+  * JavaScript errors not resulting in visible problems outside of the console (edge cases)
+  * Enhancements that are speculative or where we are unsure of impacts/tradeoffs
+
 ## License and Contributing
 
 Contributions welcome! Please read this short
-[guide](https://github.com/dart-lang/dart-pad/wiki/Contributing) first. You
+[guide](https://github.com/dart-lang/dart-pad/blob/master/CONTRIBUTING.md) first. You
 can view our license
 [here](https://github.com/dart-lang/dart-pad/blob/master/LICENSE).


### PR DESCRIPTION
Enhance our contributing guide with how to update gists and add triage priorities for DartPad bugs.