### PR TITLE
add a hide/show web content checkbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Don’t commit the following directories created by pub.
 build/
 .buildlog

--- a/lib/elements/bind.dart
+++ b/lib/elements/bind.dart
@@ -57,7 +57,7 @@ abstract class PropertyOwner {
 }
 
 /// An instantiation of a binding from one element to another. [Binding]s can be
-/// cancelled, so changes are no longer propogated from the source to the
+/// cancelled, so changes are no longer propagated from the source to the
 /// target.
 abstract class Binding {
   /// Explicitly push the value from the source to the target. This might be a

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -231,6 +231,14 @@ class Gist {
     }
   }
 
+  bool hasWebContent() {
+    return files.any((GistFile file) {
+      final bool isWebFile =
+          file.name.endsWith('.html') || file.name.endsWith('.css');
+      return isWebFile && file.content.trim().isNotEmpty;
+    });
+  }
+
   Map toMap() {
     Map m = {};
     if (id != null) m['id'] = id;
@@ -270,6 +278,7 @@ class GistFile {
 
 abstract class GistController {
   Future createNewGist();
+
   Future shareAnon({String summary});
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -68,8 +68,8 @@
       <div class="view" flex three layout vertical>
         <div class="header" layout horizontal wrap>
           <li><a id="darttab" selected class="arrow_box"><span>Dart</span></a></li>
-          <li><a id="htmltab"><span>HTML</span></a></li>
-          <li><a id="csstab"><span>CSS</span></a></li>
+          <li><a id="htmltab" style="visibility: hidden;"><span>HTML</span></a></li>
+          <li><a id="csstab" style="visibility: hidden;"><span>CSS</span></a></li>
           <div flex></div>
           <div id="dartbusy" class="busylight"></div>
           <div>
@@ -96,7 +96,7 @@
           <div id="frame-overlay"></div>
           <div class="header" layout horizontal wrap>
             <div flex></div>
-            <li><a id="resulttab"><span>HTML Output</span></a></li>
+            <li><a id="resulttab" style="visibility: hidden;"><span>HTML Output</span></a></li>
             <li><a id="consoletab" selected last><span>Console</span></a></li>
             <div id="consolebusy" class="busylight"></div>
           </div>
@@ -125,6 +125,10 @@
             target="repo">Send feedback</a>
       </div>
       <div flex></div>
+
+      <input type="checkbox" id="show-web-content" class="footer-items">
+      <label for="show-web-content" class="footer-item">Show web content</label>
+
       <div id="dartpad_version"> </div>
     </footer>
   </body>

--- a/web/styles/index.css
+++ b/web/styles/index.css
@@ -79,12 +79,15 @@ input {
   resize: none;
   border: 1px solid #555;
   padding: 0.5em;
-  margin: 0 0 8px 0;
 }
 
 textarea, input {
   font-family: 'Roboto', sans-serif;
   font-size: 14px;
+}
+
+label {
+  user-select: none;
 }
 
 .sharingSummaryText {


### PR DESCRIPTION
Add a hide/show web content checkbox (fix https://github.com/dart-lang/dart-pad/issues/860).

- when a user visits DartPad for the first time, the Web-specific tabs are not displayed; they just see DART on the left and CONSOLE on the right (exception: if the URL is to a web-specific sample)
- show Web-specific tabs if a gist with web-content is loaded
- if a user navigates to a sample with web content (via shared URL or the samples drop-down) the Web-specific tabs are visible
- add a 'Web content' checkbox in the bottom toolbar
- unchecking the checkbox hides the UI again; if there is content in the HTML or CSS tabs (.trim().isEmpty) when unchecking the box, a user prompt is displayed
- when running a snippet, we check to see if the web content UI is displayed before trying to auto-switch to the 'html output' tab

@kevmoo @jcollins-g 

We can delay landing this until after Janice has rolled the site to 2.1 if we like.

<img width="166" alt="screen shot 2018-11-12 at 4 16 09 pm" src="https://user-images.githubusercontent.com/1269969/48382700-2204f300-e697-11e8-8c5d-c59992f2173c.png">

<img width="589" alt="screen shot 2018-11-12 at 4 16 14 pm" src="https://user-images.githubusercontent.com/1269969/48382707-27fad400-e697-11e8-9810-7e104e7f7711.png">

<img width="290" alt="screen shot 2018-11-12 at 4 16 37 pm" src="https://user-images.githubusercontent.com/1269969/48382712-2cbf8800-e697-11e8-929e-e9c1d811363d.png">

<img width="258" alt="screen shot 2018-11-12 at 4 16 41 pm" src="https://user-images.githubusercontent.com/1269969/48382718-31843c00-e697-11e8-848c-37915281548f.png">

<img width="346" alt="screen shot 2018-11-12 at 4 16 27 pm" src="https://user-images.githubusercontent.com/1269969/48382724-36e18680-e697-11e8-9d0b-cfe15b8ed3d0.png">

<img width="302" alt="screen shot 2018-11-12 at 4 16 31 pm" src="https://user-images.githubusercontent.com/1269969/48382734-3cd76780-e697-11e8-8f06-e7b8b1b806cd.png">
