### PR TITLE
Replace generated files (reverting lint changes) and exclude them

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,8 +3,10 @@ analyzer:
   exclude:
     - 'build/**'
     - 'doc/api/**'
-    - 'lib/bower/**'
     - 'last_prod/**'
+    - 'lib/bower/**'
+    - 'lib/services/_dartpadsupportservices.dart'
+    - 'lib/services/dartservices.dart'
     - 'third_party/pkg/**'
 
 linter:

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -100,7 +100,7 @@ class DartCompleter extends CodeCompleter {
                 return Completion(text,
                     displayString: displayString, type: deprecatedClass);
               } else {
-                int cursorPos = null;
+                int cursorPos;
 
                 if (completion.isMethod && completion.parameterCount > 0) {
                   cursorPos = text.indexOf('(') + 1;

--- a/lib/services/_dartpadsupportservices.dart
+++ b/lib/services/_dartpadsupportservices.dart
@@ -4,9 +4,9 @@
 
 library dart_services.P_dartpadsupportservices.v1;
 
+import 'dart:core' as core;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
-import 'dart:core' as core;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
 import 'package:http/http.dart' as http;
@@ -20,10 +20,10 @@ class P_dartpadsupportservicesApi {
   final commons.ApiRequester _requester;
 
   P_dartpadsupportservicesApi(http.Client client,
-      {core.String rootUrl = "/",
-      core.String servicePath = "api/_dartpadsupportservices/v1/"})
+      {core.String rootUrl: "/",
+      core.String servicePath: "api/_dartpadsupportservices/v1/"})
       : _requester =
-            commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
+            new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /// Store a gist dataset to be retrieved.
   ///
@@ -40,7 +40,7 @@ class P_dartpadsupportservicesApi {
   /// this method will complete with the same error.
   async.Future<UuidContainer> export(PadSaveObject request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -58,7 +58,7 @@ class P_dartpadsupportservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => UuidContainer.fromJson(data));
+    return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
   /// Request parameters:
@@ -72,7 +72,7 @@ class P_dartpadsupportservicesApi {
   /// this method will complete with the same error.
   async.Future<UuidContainer> getUnusedMappingId() {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -86,7 +86,7 @@ class P_dartpadsupportservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => UuidContainer.fromJson(data));
+    return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
   /// Retrieve a stored gist data set.
@@ -104,7 +104,7 @@ class P_dartpadsupportservicesApi {
   /// this method will complete with the same error.
   async.Future<PadSaveObject> pullExportContent(UuidContainer request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -122,7 +122,7 @@ class P_dartpadsupportservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => PadSaveObject.fromJson(data));
+    return _response.then((data) => new PadSaveObject.fromJson(data));
   }
 
   /// Request parameters:
@@ -138,7 +138,7 @@ class P_dartpadsupportservicesApi {
   /// this method will complete with the same error.
   async.Future<UuidContainer> retrieveGist({core.String id}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -156,7 +156,7 @@ class P_dartpadsupportservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => UuidContainer.fromJson(data));
+    return _response.then((data) => new UuidContainer.fromJson(data));
   }
 
   /// [request] - The metadata request object.
@@ -172,7 +172,7 @@ class P_dartpadsupportservicesApi {
   /// this method will complete with the same error.
   async.Future<UuidContainer> storeGist(GistToInternalIdMapping request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -190,7 +190,7 @@ class P_dartpadsupportservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => UuidContainer.fromJson(data));
+    return _response.then((data) => new UuidContainer.fromJson(data));
   }
 }
 
@@ -211,7 +211,7 @@ class GistToInternalIdMapping {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (gistId != null) {
       _json["gistId"] = gistId;
     }
@@ -247,7 +247,7 @@ class PadSaveObject {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (css != null) {
       _json["css"] = css;
     }
@@ -277,7 +277,7 @@ class UuidContainer {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (uuid != null) {
       _json["uuid"] = uuid;
     }

--- a/lib/services/dartservices.dart
+++ b/lib/services/dartservices.dart
@@ -4,9 +4,9 @@
 
 library dart_services.dartservices.v1;
 
+import 'dart:core' as core;
 import 'dart:async' as async;
 import 'dart:convert' as convert;
-import 'dart:core' as core;
 
 import 'package:_discoveryapis_commons/_discoveryapis_commons.dart' as commons;
 import 'package:http/http.dart' as http;
@@ -20,10 +20,10 @@ class DartservicesApi {
   final commons.ApiRequester _requester;
 
   DartservicesApi(http.Client client,
-      {core.String rootUrl = "/",
-      core.String servicePath = "api/dartservices/v1/"})
+      {core.String rootUrl: "/",
+      core.String servicePath: "api/dartservices/v1/"})
       : _requester =
-            commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
+            new commons.ApiRequester(client, rootUrl, servicePath, USER_AGENT);
 
   /// Analyze the given Dart source code and return any resulting analysis
   /// errors or warnings.
@@ -41,7 +41,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<AnalysisResults> analyze(SourceRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -59,7 +59,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => AnalysisResults.fromJson(data));
+    return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
   /// Request parameters:
@@ -75,7 +75,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<AnalysisResults> analyzeGet({core.String source}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -93,7 +93,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => AnalysisResults.fromJson(data));
+    return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
   /// Analyze the given Dart source code and return any resulting analysis
@@ -112,7 +112,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<AnalysisResults> analyzeMulti(SourcesRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -130,7 +130,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => AnalysisResults.fromJson(data));
+    return _response.then((data) => new AnalysisResults.fromJson(data));
   }
 
   /// Compile the given Dart source code and return the resulting JavaScript.
@@ -148,7 +148,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<CompileResponse> compile(CompileRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -166,7 +166,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CompileResponse.fromJson(data));
+    return _response.then((data) => new CompileResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -182,7 +182,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<CompileResponse> compileGet({core.String source}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -200,7 +200,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CompileResponse.fromJson(data));
+    return _response.then((data) => new CompileResponse.fromJson(data));
   }
 
   /// Get the valid code completion results for the given offset.
@@ -218,7 +218,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<CompleteResponse> complete(SourceRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -236,7 +236,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CompleteResponse.fromJson(data));
+    return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -255,7 +255,7 @@ class DartservicesApi {
   async.Future<CompleteResponse> completeGet(
       {core.String source, core.int offset}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -276,7 +276,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CompleteResponse.fromJson(data));
+    return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
   /// Get the valid code completion results for the given offset.
@@ -294,7 +294,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<CompleteResponse> completeMulti(SourcesRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -312,7 +312,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CompleteResponse.fromJson(data));
+    return _response.then((data) => new CompleteResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -328,7 +328,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<CounterResponse> counterGet({core.String name}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -346,7 +346,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => CounterResponse.fromJson(data));
+    return _response.then((data) => new CounterResponse.fromJson(data));
   }
 
   /// Return the relevant dartdoc information for the element at the given
@@ -365,7 +365,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<DocumentResponse> document(SourceRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -383,7 +383,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => DocumentResponse.fromJson(data));
+    return _response.then((data) => new DocumentResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -402,7 +402,7 @@ class DartservicesApi {
   async.Future<DocumentResponse> documentGet(
       {core.String source, core.int offset}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -423,7 +423,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => DocumentResponse.fromJson(data));
+    return _response.then((data) => new DocumentResponse.fromJson(data));
   }
 
   /// Get any quick fixes for the given source code location.
@@ -441,7 +441,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<FixesResponse> fixes(SourceRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -459,7 +459,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => FixesResponse.fromJson(data));
+    return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -477,7 +477,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<FixesResponse> fixesGet({core.String source, core.int offset}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -498,7 +498,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => FixesResponse.fromJson(data));
+    return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
   /// Get any quick fixes for the given source code location.
@@ -516,7 +516,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<FixesResponse> fixesMulti(SourcesRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -534,7 +534,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => FixesResponse.fromJson(data));
+    return _response.then((data) => new FixesResponse.fromJson(data));
   }
 
   /// Format the given Dart source code and return the results. If an offset is
@@ -554,7 +554,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<FormatResponse> format(SourceRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -572,7 +572,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => FormatResponse.fromJson(data));
+    return _response.then((data) => new FormatResponse.fromJson(data));
   }
 
   /// Request parameters:
@@ -591,7 +591,7 @@ class DartservicesApi {
   async.Future<FormatResponse> formatGet(
       {core.String source, core.int offset}) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -612,7 +612,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => FormatResponse.fromJson(data));
+    return _response.then((data) => new FormatResponse.fromJson(data));
   }
 
   /// Summarize the given Dart source code and return any resulting analysis
@@ -631,7 +631,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<SummaryText> summarize(SourcesRequest request) {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -649,7 +649,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => SummaryText.fromJson(data));
+    return _response.then((data) => new SummaryText.fromJson(data));
   }
 
   /// Return the current SDK version for DartServices.
@@ -665,7 +665,7 @@ class DartservicesApi {
   /// this method will complete with the same error.
   async.Future<VersionResponse> version() {
     var _url = null;
-    var _queryParams = core.Map<core.String, core.List<core.String>>();
+    var _queryParams = new core.Map<core.String, core.List<core.String>>();
     var _uploadMedia = null;
     var _uploadOptions = null;
     var _downloadOptions = commons.DownloadOptions.Metadata;
@@ -679,7 +679,7 @@ class DartservicesApi {
         uploadOptions: _uploadOptions,
         uploadMedia: _uploadMedia,
         downloadOptions: _downloadOptions);
-    return _response.then((data) => VersionResponse.fromJson(data));
+    return _response.then((data) => new VersionResponse.fromJson(data));
   }
 }
 
@@ -720,7 +720,7 @@ class AnalysisIssue {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (charLength != null) {
       _json["charLength"] = charLength;
     }
@@ -757,7 +757,7 @@ class AnalysisResults {
   AnalysisResults.fromJson(core.Map _json) {
     if (_json.containsKey("issues")) {
       issues = (_json["issues"] as core.List)
-          .map<AnalysisIssue>((value) => AnalysisIssue.fromJson(value))
+          .map<AnalysisIssue>((value) => new AnalysisIssue.fromJson(value))
           .toList();
     }
     if (_json.containsKey("packageImports")) {
@@ -768,7 +768,7 @@ class AnalysisResults {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (issues != null) {
       _json["issues"] = issues.map((value) => (value).toJson()).toList();
     }
@@ -788,7 +788,7 @@ class CandidateFix {
   CandidateFix.fromJson(core.Map _json) {
     if (_json.containsKey("edits")) {
       edits = (_json["edits"] as core.List)
-          .map<SourceEdit>((value) => SourceEdit.fromJson(value))
+          .map<SourceEdit>((value) => new SourceEdit.fromJson(value))
           .toList();
     }
     if (_json.containsKey("message")) {
@@ -798,7 +798,7 @@ class CandidateFix {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (edits != null) {
       _json["edits"] = edits.map((value) => (value).toJson()).toList();
     }
@@ -835,7 +835,7 @@ class CompileRequest {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (returnSourceMap != null) {
       _json["returnSourceMap"] = returnSourceMap;
     }
@@ -866,7 +866,7 @@ class CompileResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (result != null) {
       _json["result"] = result;
     }
@@ -905,7 +905,7 @@ class CompleteResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (completions != null) {
       _json["completions"] = completions;
     }
@@ -932,7 +932,7 @@ class CounterResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (count != null) {
       _json["count"] = count;
     }
@@ -953,7 +953,7 @@ class DocumentResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (info != null) {
       _json["info"] = info;
     }
@@ -969,14 +969,14 @@ class FixesResponse {
   FixesResponse.fromJson(core.Map _json) {
     if (_json.containsKey("fixes")) {
       fixes = (_json["fixes"] as core.List)
-          .map<ProblemAndFixes>((value) => ProblemAndFixes.fromJson(value))
+          .map<ProblemAndFixes>((value) => new ProblemAndFixes.fromJson(value))
           .toList();
     }
   }
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (fixes != null) {
       _json["fixes"] = fixes.map((value) => (value).toJson()).toList();
     }
@@ -1004,7 +1004,7 @@ class FormatResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (newString != null) {
       _json["newString"] = newString;
     }
@@ -1032,7 +1032,7 @@ class Location {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (offset != null) {
       _json["offset"] = offset;
     }
@@ -1054,7 +1054,7 @@ class ProblemAndFixes {
   ProblemAndFixes.fromJson(core.Map _json) {
     if (_json.containsKey("fixes")) {
       fixes = (_json["fixes"] as core.List)
-          .map<CandidateFix>((value) => CandidateFix.fromJson(value))
+          .map<CandidateFix>((value) => new CandidateFix.fromJson(value))
           .toList();
     }
     if (_json.containsKey("length")) {
@@ -1070,7 +1070,7 @@ class ProblemAndFixes {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (fixes != null) {
       _json["fixes"] = fixes.map((value) => (value).toJson()).toList();
     }
@@ -1108,7 +1108,7 @@ class SourceEdit {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (length != null) {
       _json["length"] = length;
     }
@@ -1148,7 +1148,7 @@ class SourceRequest {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (offset != null) {
       _json["offset"] = offset;
     }
@@ -1176,7 +1176,7 @@ class SourcesRequest {
 
   SourcesRequest.fromJson(core.Map _json) {
     if (_json.containsKey("location")) {
-      location = Location.fromJson(_json["location"]);
+      location = new Location.fromJson(_json["location"]);
     }
     if (_json.containsKey("sources")) {
       sources = (_json["sources"] as core.Map).cast<core.String, core.String>();
@@ -1188,7 +1188,7 @@ class SourcesRequest {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (location != null) {
       _json["location"] = (location).toJson();
     }
@@ -1215,7 +1215,7 @@ class SummaryText {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (text != null) {
       _json["text"] = text;
     }
@@ -1263,7 +1263,7 @@ class VersionResponse {
 
   core.Map<core.String, core.Object> toJson() {
     final core.Map<core.String, core.Object> _json =
-        core.Map<core.String, core.Object>();
+        new core.Map<core.String, core.Object>();
     if (appEngineVersion != null) {
       _json["appEngineVersion"] = appEngineVersion;
     }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,21 +21,21 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.33.0"
+    version: "0.34.2"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.7"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   async:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.15"
+    version: "0.1.16"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   build_cli_annotations:
     dependency: transitive
     description:
       name: build_cli_annotations
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   build_config:
     dependency: transitive
     description:
@@ -84,49 +84,56 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+6"
+    version: "0.2.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.3"
+  build_test:
+    dependency: "direct dev"
+    description:
+      name: build_test
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.10.5"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.4+2"
+    version: "1.0.0"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.3.0"
   charcode:
     dependency: transitive
     description:
@@ -154,7 +161,7 @@ packages:
       name: codemirror
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.5+5.41.0"
+    version: "0.4.7+5.41.0"
   collection:
     dependency: "direct dev"
     description:
@@ -168,7 +175,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.1"
   crypto:
     dependency: transitive
     description:
@@ -183,20 +190,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.14.6"
-  dart2_constant:
-    dependency: transitive
-    description:
-      name: dart2_constant
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2+dart2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.2"
   dhttpd:
     dependency: "direct dev"
     description:
@@ -210,14 +210,14 @@ packages:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.8"
+    version: "0.10.9"
   front_end:
     dependency: transitive
     description:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.6"
+    version: "0.1.9"
   git:
     dependency: "direct dev"
     description:
@@ -238,7 +238,7 @@ packages:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+1"
+    version: "0.2.0"
   grinder:
     dependency: "direct dev"
     description:
@@ -266,7 +266,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0"
+    version: "0.12.0+1"
   http_multi_server:
     dependency: transitive
     description:
@@ -322,7 +322,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.6"
+    version: "0.3.9"
   logging:
     dependency: "direct main"
     description:
@@ -350,7 +350,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.7"
   mime:
     dependency: transitive
     description:
@@ -399,7 +399,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   plugin:
     dependency: transitive
     description:
@@ -413,14 +413,14 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.4.0"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.4"
+    version: "0.11.0"
   pub_semver:
     dependency: transitive
     description:
@@ -434,14 +434,14 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.2+3"
+    version: "0.1.4"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.29.0+2"
+    version: "2.0.1"
   route_hierarchical:
     dependency: "direct main"
     description:
@@ -462,7 +462,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3+3"
+    version: "0.7.4"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -504,7 +504,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.2"
   stack_trace:
     dependency: transitive
     description:
@@ -539,14 +539,28 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.4"
+    version: "1.5.2"
+  test_api:
+    dependency: transitive
+    description:
+      name: test_api
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.2"
+  test_core:
+    dependency: transitive
+    description:
+      name: test_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   timing:
     dependency: transitive
     description:
@@ -560,7 +574,7 @@ packages:
       name: tuneup
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.6"
+    version: "0.3.6+1"
   typed_data:
     dependency: transitive
     description:
@@ -604,4 +618,4 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.1.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     path: third_party/pkg/route.dart/
 dev_dependencies:
   build_runner: any
+  build_test: any
   build_web_compilers: any
   collection: ^1.14.10
   dhttpd: any


### PR DESCRIPTION
I had missed in #869 that it modified generated files to support the new lints.  Replace the modified generated files with clean ones and exclude them from lint modifications, and support a new lint added in the latest dev build.