### PR TITLE
fix an issue in the embeddings UI

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -224,7 +224,12 @@ class PlaygroundMobile {
         // Sharing is currently disabled pending establishing OAuth2 configurations with Github.
         //_exportDialog.open();
         ga.sendEvent("embed", "export");
-        window.open("/${_gistId}", "_export");
+
+        if (_gistId == null) {
+          window.open("/", "_export");
+        } else {
+          window.open("/$_gistId", "_export");
+        }
       });
     }
   }

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -31,8 +31,8 @@
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/editing/editor_codemirror.css" rel="stylesheet" media="screen">
+    <script src="packages/codemirror/codemirror.js" defer></script>
 
-    <script src="scripts/codemirror.js" defer></script>
     <script src="scripts/embed.dart.js" defer></script>
     <script src="scripts/ga.js" defer></script>
     <script src="scripts/polymerpatch.js" defer></script>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -32,7 +32,8 @@
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/editing/editor_codemirror.css"
           rel="stylesheet" media="screen">
-    <script src="scripts/codemirror.js" defer></script>
+    <script src="packages/codemirror/codemirror.js" defer></script>
+
     <script src="scripts/embed.dart.js" defer></script>
     <script src="scripts/ga.js" defer></script>
     <script src="scripts/polymerpatch.js" defer></script>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -31,7 +31,8 @@
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/editing/editor_codemirror.css"
         rel="stylesheet" media="screen">
-    <script src="scripts/codemirror.js" defer></script>
+    <script src="packages/codemirror/codemirror.js" defer></script>
+
     <script src="scripts/embed.dart.js" defer></script>
     <script src="scripts/ga.js" defer></script>
     <script src="scripts/polymerpatch.js" defer></script>
@@ -40,7 +41,7 @@
   <body class="fullbleed vertical layout" unresolved>
     <div id="main" class="relative layout vertical">
       <paper-progress id="run-progress" class="bottom fit" hidden></paper-progress>
-      <dartpad-run-button></dartpad-run-button>
+      <dartpad-buttons></dartpad-buttons>
       <dartpad-editor id="topPanel" dart class="layout vertical"></dartpad-editor>
       <horizontal-splitter class="splitter" horizontal></horizontal-splitter>
       <dartpad-console id='bottomPanel' class="flex layout vertical"></dartpad-console>

--- a/web/index.html
+++ b/web/index.html
@@ -29,7 +29,7 @@
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/editing/editor_codemirror.css" rel="stylesheet" media="screen">
-    <script src="scripts/codemirror.js" defer></script>
+    <script src="packages/codemirror/codemirror.js" defer></script>
 
     <script defer src="scripts/main.dart.js"></script>
 


### PR DESCRIPTION
- in the embedding UI, if we don't have an active gist, when the user clicks the export button we'll redirect to `/null`; this instead directs to `/`
- when run with `pub global run webdev serve` (for local development), we weren't loading the correct script for codemirror
