### PR TITLE
simplify the code around embedding codemirror

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -10,14 +10,10 @@ import 'dart:math';
 
 abstract class EditorFactory {
   List<String> get modes;
+
   List<String> get themes;
 
-  bool get inited;
-  Future init();
-
   Editor createFromElement(html.Element element);
-
-  bool get supportsCompletionPositioning;
 
   void registerCompleter(String mode, CodeCompleter completer);
 }
@@ -33,35 +29,34 @@ abstract class Editor {
 
   Document get document;
 
-  /// Runs the command with the given name on the editor. Only implemented for
-  /// codemirror and comid; returns `null` for ace editor.
+  /// Runs the command with the given name on the editor.
   void execCommand(String name);
 
   void showCompletions({bool autoInvoked = false, bool onlyShowFixes = false});
 
-  /// Checks if the completion popup is displayed. Only implemented for
-  /// codemirror; returns `null` for ace editor and comid.
+  /// Checks if the completion popup is displayed.
   bool get completionActive;
 
   String get mode;
+
   set mode(String str);
 
   String get theme;
+
   set theme(String str);
 
   /// Returns the cursor coordinates in pixels. cursorCoords.x corresponds to
-  /// left and cursorCoords.y corresponds to top. Only implemented for
-  /// codemirror, returns `null` for ace editor and comid.
+  /// left and cursorCoords.y corresponds to top.
   Point getCursorCoords({Position position});
 
   bool get hasFocus;
 
   /// Fired when a mouse is clicked. You can preventDefault the event to signal
-  /// that the editor should do no further handling.  Only implemented for
-  /// codemirror, returns `null` for ace editor and comid.
+  /// that the editor should do no further handling.
   Stream<html.MouseEvent> get onMouseDown;
 
   void resize();
+
   void focus();
 
   void swapDocument(Document document);
@@ -76,6 +71,7 @@ abstract class Document {
   Document(this.editor);
 
   String get value;
+
   set value(String str);
 
   /// Update the value on behalf of a user action, performing
@@ -92,12 +88,15 @@ abstract class Document {
   String get mode;
 
   bool get isClean;
+
   void markClean();
 
   void setAnnotations(List<Annotation> annotations);
+
   void clearAnnotations() => setAnnotations([]);
 
   int indexFromPos(Position pos);
+
   Position posFromIndex(int index);
 
   void applyEdit(SourceEdit edit);
@@ -166,14 +165,12 @@ class Completion {
   /// An optional string that is displayed during auto-completion if specified.
   final String displayString;
 
-  /// The css class type for the completion. This may not be supported by all
-  /// completors.
+  /// The css class type for the completion.
   String type;
 
   /// The (optional) offset to display the cursor at after completion. This is
   /// relative to the insertion location, not the absolute position in the file.
-  /// This may be `null`, and cursor re-positioning may not be supported by all
-  /// completors. See [EditorFactory.supportsCompletionPositioning].
+  /// This can be `null`.
   final int cursorOffset;
 
   List<SourceEdit> quickFixes = [];

--- a/lib/editing/editor_codemirror.css
+++ b/lib/editing/editor_codemirror.css
@@ -2,9 +2,6 @@
 /* for details. All rights reserved. Use of this source code is governed by a */
 /* BSD-style license that can be found in the LICENSE file. */
 
-/*@import '../../../packages/codemirror/codemirror.css';
-@import '../../../packages/codemirror/addon/lint/lint.css';*/
-
 /* CodeMirror tweaks */
 
 #editpanel .CodeMirror {

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -22,40 +22,13 @@ export 'editor.dart';
 final CodeMirrorFactory codeMirrorFactory = CodeMirrorFactory._();
 
 class CodeMirrorFactory extends EditorFactory {
-  //static final String cssRef = 'packages/dart_pad/editing/editor_codemirror.css';
-  //static final String jsRef = 'packages/codemirror/codemirror.js';
-
   CodeMirrorFactory._();
 
   String get version => CodeMirror.version;
 
   List<String> get modes => CodeMirror.MODES;
+
   List<String> get themes => CodeMirror.THEMES;
-
-  bool get inited {
-    return true;
-//    List scripts = html.querySelectorAll('head script');
-//    return scripts.any((script) => script.src == jsRef);
-  }
-
-  Future init() {
-    List<Future> futures = [];
-    //html.Element head = html.querySelector('html head');
-
-//    // <link href="packages/dart_pad/editing/editor_codemirror.css"
-//    //   rel="stylesheet">
-//    html.LinkElement link = new html.LinkElement();
-//    link.rel = 'stylesheet';
-//    link.href = cssRef;
-//    futures.add(_appendNode(head, link));
-
-//    // <script src="packages/codemirror/codemirror.js"></script>
-//    html.ScriptElement script = new html.ScriptElement();
-//    script.src = jsRef;
-//    futures.add(_appendNode(head, script));
-
-    return Future.wait(futures);
-  }
 
   Editor createFromElement(html.Element element, {Map options}) {
     options ??= {
@@ -83,8 +56,6 @@ class CodeMirrorFactory extends EditorFactory {
     CodeMirror.addCommand('goLineLeft', _handleGoLineLeft);
     return _CodeMirrorEditor._(this, editor);
   }
-
-  bool get supportsCompletionPositioning => true;
 
   void registerCompleter(String mode, CodeCompleter completer) {
     Hints.registerHintsHelperAsync(mode, (CodeMirror editor,
@@ -223,9 +194,11 @@ class _CodeMirrorEditor extends Editor {
   }
 
   String get mode => cm.getMode();
+
   set mode(String str) => cm.setMode(str);
 
   String get theme => cm.getTheme();
+
   set theme(String str) => cm.setTheme(str);
 
   bool get hasFocus => cm.jsProxy['state']['focused'];
@@ -243,6 +216,7 @@ class _CodeMirrorEditor extends Editor {
   }
 
   void focus() => cm.focus();
+
   void resize() => cm.refresh();
 
   void swapDocument(Document document) {
@@ -262,7 +236,7 @@ class _CodeMirrorDocument extends Document {
   final List<html.DivElement> nodes = [];
 
   /// We use `_lastSetValue` here to avoid a change notification when we
-  /// programatically change the `value` field.
+  /// programmatically change the `value` field.
   String _lastSetValue;
 
   _CodeMirrorDocument._(_CodeMirrorEditor editor, this.doc) : super(editor);
@@ -275,8 +249,7 @@ class _CodeMirrorDocument extends Document {
     _lastSetValue = str;
     doc.setValue(str);
     doc.markClean();
-    // TODO: Switch over to non-JS interop when this method is exposed.
-    doc.jsProxy.callMethod('clearHistory');
+    doc.clearHistory();
   }
 
   void updateValue(String str) {
@@ -334,19 +307,6 @@ class _CodeMirrorDocument extends Document {
       // Create markers in the margin.
       if (lastLine == an.line) continue;
       lastLine = an.line;
-
-//      html.DivElement node = new html.DivElement();
-//      //node.style.position = 'absolute';
-//      node.text = an.message;
-//      node.style.backgroundColor = '#444';
-//      //node.style.height = '40px';
-//      //nodes.add(node);
-//      //(editor as _CodeMirrorEditor).cm.addWidget(_posToPos(an.start), node);
-//      widgets.add(
-//          (editor as _CodeMirrorEditor).cm.addLineWidget(an.line - 1, node));
-//
-////      cm.setGutterMarker(an.line - 1, _gutterId,
-////          _makeMarker(an.type, an.message, an.start, an.end));
     }
   }
 
@@ -361,34 +321,15 @@ class _CodeMirrorDocument extends Document {
   ed.Position _posFromPos(pos.Position position) =>
       ed.Position(position.line, position.ch);
 
-//  html.Element _makeMarker(String severity, String tooltip, ed.Position start,
-//      ed.Position end) {
-//    html.Element marker = new html.DivElement();
-//    marker.className = "CodeMirror-lint-marker-" + severity;
-//    if (tooltip != null) marker.title = tooltip;
-//    marker.onClick.listen((_) {
-//      doc.setSelection(new pos.Position(start.line, start.char),
-//          head: new pos.Position(end.line, end.char));
-//    });
-//    return marker;
-//  }
-
-  Stream get onChange => doc.onChange.where((_) {
-        if (value != _lastSetValue) {
-          _lastSetValue = null;
-          return true;
-        } else {
-          //_lastSetValue = null;
-          return false;
-        }
-      });
+  Stream get onChange {
+    return doc.onChange.where((_) {
+      if (value != _lastSetValue) {
+        _lastSetValue = null;
+        return true;
+      } else {
+        //_lastSetValue = null;
+        return false;
+      }
+    });
+  }
 }
-
-//Future _appendNode(html.Element parent, html.Element child) {
-//  Completer completer = new Completer();
-//  child.onLoad.listen((e) {
-//    completer.complete();
-//  });
-//  parent.nodes.add(child);
-//  return completer.future;
-//}

--- a/lib/modules/codemirror_module.dart
+++ b/lib/modules/codemirror_module.dart
@@ -11,13 +11,7 @@ import '../editing/editor_codemirror.dart';
 class CodeMirrorModule extends Module {
   static String get version => codeMirrorFactory.version;
 
-  Future init() {
+  Future init() async {
     deps[EditorFactory] = codeMirrorFactory;
-
-    if (!codeMirrorFactory.inited) {
-      return codeMirrorFactory.init();
-    } else {
-      return Future.value();
-    }
   }
 }


### PR DESCRIPTION
- simplify the code around embedding codemirror (remove some technical debt and commented out code from when we supported 2 variants of codemirror as well as ace)
