### PR TITLE
Add minify options and exclude unnecessary files from deploys

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,8 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        options:
+          dart2js_args:
+          - --minify
+          - --fast-startup

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -31,3 +31,4 @@ libraries:
 
 skip_files:
 - experimental/
+- packages/(?!(?:codemirror|dart-pad))


### PR DESCRIPTION
We lost the minify option with dart2js in #889.  Use it, and exclude most of the packages directory from deploys (reduces deployment size by 80%).