### PR TITLE
Basic scaffolding for new embed UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ web/scripts/codemirror.js
 
 last_prod/
 
-.idea
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ web/mdetect.py
 web/scripts/codemirror.js
 
 last_prod/
+
+.idea

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -63,6 +63,10 @@ class DElement {
     return child;
   }
 
+  void clearChildren() {
+    element.children.clear();
+  }
+
   Stream<Event> get onClick => element.onClick;
 
   void dispose() {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -1,16 +1,216 @@
-// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-NewEmbed get playground => _playground;
+import 'dart:async';
+import 'dart:convert';
+import 'dart:html' hide Document;
 
-NewEmbed _playground;
+import 'package:dart_pad/editing/editor.dart';
+import 'package:dart_pad/elements/elements.dart';
+import 'package:dart_pad/experimental/new_embed_editor.dart';
+import 'package:dart_pad/modules/dartservices_module.dart';
+import 'package:http/http.dart' as http;
+import 'package:dart_pad/core/modules.dart';
+
+import '../services/execution_iframe.dart';
+
+NewEmbed get newEmbed => _newEmbed;
+
+NewEmbed _newEmbed;
+
 void init() {
-  _playground = NewEmbed();
+  _newEmbed = NewEmbed();
 }
 
+final urlStr =
+    'https://dart-services.appspot.com/api/dartservices/v1/compile?alt=json';
+
+final String mainMethod = '''
+void main() {
+  if (addNumbers(2, 3) == 5) {
+    print('TEST SUCCESS');
+  } else {
+    print('TEST FAILURE');
+  } 
+}
+''';
+
+/// An embeddable DartPad UI that provides the ability to test the user's code
+/// snippet against a desired result.
 class NewEmbed {
+  LinkElement editorTabLink;
+  LinkElement testTabLink;
+  LinkElement consoleTabLink;
+  LinkElement testCodeLink;
+  LinkElement runCodeLink;
+
+  DivElement editorTab;
+  TextAreaElement editorTextArea;
+
+  DivElement testTab;
+  DivElement testView;
+
+  DivElement consoleTab;
+  DivElement consoleView;
+
+  ExecutionService executionSvc;
+  TabController tabController;
+
+  NewEmbedContext _context;
+
   NewEmbed() {
-    print('Created a NewEmbed.');
+    tabController = TabController();
+    for (String name in ['dart', 'html', 'css']) {
+      tabController.registerTab(
+          TabElement(querySelector('#${name}tab'), name: name, onSelect: () {
+        Element issuesElement = querySelector('#issues');
+        issuesElement.style.display = name == 'dart' ? 'block' : 'none';
+        _context.switchTo(name);
+      }));
+    }
+
+    testCodeLink = querySelector('#test-code');
+    runCodeLink = querySelector('#run-code');
+    editorTab = querySelector('#editor-tab');
+    editorTabLink = querySelector('#editor-tab a');
+    editorTextArea = querySelector('#editor');
+    testTab = querySelector('#test-tab');
+    testTabLink = querySelector('#test-tab a');
+    testView = querySelector('#test-view');
+    consoleTab = querySelector('#console-tab');
+    consoleTabLink = querySelector('#console-tab a');
+    consoleView = querySelector('#console-view');
+    executionSvc = ExecutionServiceIFrame(querySelector('#frame'));
+
+    editorTabLink.addEventListener('click', (e) {
+      editorTab.classes.add('tab-active');
+      editorTextArea.classes.remove('tabview-hidden');
+      testTab.classes.remove('tab-active');
+      testView.classes.add('tabview-hidden');
+      consoleTab.classes.remove('tab-active');
+      consoleView.classes.add('tabview-hidden');
+    });
+
+    editorTabLink.addEventListener('click', (e) {
+      editorTab.classes.add('tab-active');
+      editorTextArea.classes.remove('tabview-hidden');
+      testTab.classes.remove('tab-active');
+      testView.classes.add('tabview-hidden');
+      consoleTab.classes.remove('tab-active');
+      consoleView.classes.add('tabview-hidden');
+    });
+
+    editorTabLink.addEventListener('click', (e) {
+      editorTab.classes.add('tab-active');
+      editorTextArea.classes.remove('tabview-hidden');
+      testTab.classes.remove('tab-active');
+      testView.classes.add('tabview-hidden');
+      consoleTab.classes.remove('tab-active');
+      consoleView.classes.add('tabview-hidden');
+    });
+
+    executionSvc.onStderr.listen((msg) {
+      consoleView.text += 'ERROR: $msg\n';
+    });
+
+    executionSvc.onStdout.listen((msg) {
+      consoleView.text += '$msg\n';
+    });
+
+    testCodeLink.addEventListener('click', (e) async {
+      final code = _context.dartSource;
+      final markedUpCode = '$code\n$mainMethod';
+      final response =
+          await http.post(urlStr, body: json.encode({'source': markedUpCode}));
+      final compilationResult = json.decode(response.body);
+      await executionSvc.execute('', '', compilationResult['result']);
+    });
+
+    //_initModules();
+    //_initNewEmbed();
+  }
+
+  Future _initModules() {
+    ModuleManager modules = ModuleManager();
+
+    modules.register(DartServicesModule());
+
+    return modules.start();
+  }
+
+  void _initNewEmbed() {
+    _context = NewEmbedContext(
+        NewEmbedEditorFactory().createFromElement(editorTextArea));
+  }
+}
+
+class NewEmbedContext {
+  final NewEmbedEditor editor;
+
+  Document _dartDoc;
+
+  final _dartDirtyController = StreamController.broadcast();
+
+  final _dartReconcileController = StreamController.broadcast();
+
+  NewEmbedContext(this.editor) {
+    editor.mode = 'dart';
+
+    _dartDoc = editor.document;
+
+    _dartDoc.onChange.listen((_) => _dartDirtyController.add(null));
+
+    _createReconciler(_dartDoc, _dartReconcileController, 1250);
+  }
+
+  Document get dartDocument => _dartDoc;
+
+  String get dartSource => _dartDoc.value;
+
+  set dartSource(String value) {
+    _dartDoc.value = value;
+  }
+
+  String get activeMode => editor.mode;
+
+  //Stream<String> get onModeChange => _modeController.stream;
+
+  void switchTo(String name) {
+    String oldMode = activeMode;
+
+    if (name == 'dart') {
+      editor.swapDocument(_dartDoc);
+    }
+
+    editor.focus();
+  }
+
+  String get focusedEditor {
+    return 'dart';
+  }
+
+  Stream get onDartDirty => _dartDirtyController.stream;
+
+  Stream get onDartReconcile => _dartReconcileController.stream;
+
+  void markDartClean() => _dartDoc.markClean();
+
+  /// Restore the focus to the last focused editor.
+  void focus() => editor.focus();
+
+  void _createReconciler(Document doc, StreamController controller, int delay) {
+    Timer timer;
+    doc.onChange.listen((_) {
+      if (timer != null) timer.cancel();
+      timer = Timer(Duration(milliseconds: delay), () {
+        controller.add(null);
+      });
+    });
+  }
+
+  /// Return true if the current cursor position is in a whitespace char.
+  bool cursorPositionIsWhitespace() {
+    return false;
   }
 }

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -92,7 +92,7 @@ class NewEmbed {
     testCodeButton.addEventListener('click', (e) => _handleRun());
   }
 
-  // To be removed when gist-loading is integrated.
+  // TODO(RedBrogdon): Remove when gist-loading is integrated.
   final testMain = '''
 void main() {
   final str = stringify(2, 3); 
@@ -108,7 +108,7 @@ void main() {
 }
 ''';
 
-  // To be removed when gist-loading is integrated.
+  // TODO(RedBrogdon): Remove when gist-loading is integrated.
   final initialCode = '''
 String stringify(int x, int y) {
   // Return a formatted string here
@@ -125,10 +125,10 @@ String stringify(int x, int y) {
         .then((CompileResponse response) {
       executionSvc.execute('', '', response.result);
     }).catchError((e) {
-      // TODO
+      // TODO(RedBrogdon): Implement error handling / reporting
       print(e);
     }).whenComplete(() {
-      // TODO
+      // TODO(RedBrogdon): Implement compilation completion UI
     });
   }
 
@@ -232,7 +232,7 @@ class NewEmbedContext {
 
   /// Return true if the current cursor position is in a whitespace char.
   bool cursorPositionIsWhitespace() {
-    // TODO
+    // TODO(DomesticMouse): implement with CodeMirror integration
     return false;
   }
 }

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -125,10 +125,8 @@ String stringify(int x, int y) {
         .then((CompileResponse response) {
       executionSvc.execute('', '', response.result);
     }).catchError((e) {
-      // TODO(RedBrogdon): Implement error handling / reporting
+      // TODO(redbrogdon): Add logging and possibly output to UI.
       print(e);
-    }).whenComplete(() {
-      // TODO(RedBrogdon): Implement compilation completion UI
     });
   }
 

--- a/lib/experimental/new_embed_editor.dart
+++ b/lib/experimental/new_embed_editor.dart
@@ -1,0 +1,128 @@
+import 'dart:html' hide Document;
+
+import '../editing/editor.dart' hide Position;
+import '../editing/editor.dart' as ed show Position;
+
+class NewEmbedEditor extends Editor {
+  NewEmbedEditor(NewEmbedEditorFactory factory, this.textarea) : super(factory) {
+    _document = NewEmbedDocument(this, '');
+  }
+
+  final TextAreaElement textarea;
+
+  NewEmbedDocument _document;
+
+  @override
+  String mode;
+
+  @override
+  String theme;
+
+  @override
+  bool get completionActive => false;
+
+  @override
+  Document createDocument({String content, String mode}) {
+    return NewEmbedDocument(this, content);
+  }
+
+  @override
+  Document get document => _document;
+
+  @override
+  void execCommand(String name) {
+    // TODO: implement execCommand
+  }
+
+  @override
+  void focus() {
+    // TODO: implement focus
+  }
+
+  @override
+  Point<num> getCursorCoords({ed.Position position}) {
+    return Point<num>(0, 0);
+  }
+
+  @override
+  bool get hasFocus => true;
+
+  @override
+  Stream<MouseEvent> get onMouseDown => textarea.onMouseDown;
+
+  @override
+  void resize() {
+    // TODO: implement resize
+  }
+
+  @override
+  void showCompletions({bool autoInvoked = false, bool onlyShowFixes = false}) {
+  }
+
+  @override
+  void swapDocument(Document document) {
+    if (document is NewEmbedDocument) {
+      _document = _document;
+    }
+  }
+}
+
+class NewEmbedEditorFactory extends EditorFactory {
+  @override
+  Editor createFromElement(Element element) {
+    return NewEmbedEditor(this, element);
+  }
+
+  @override
+  List<String> get modes => ['dart'];
+
+  @override
+  void registerCompleter(String mode, CodeCompleter completer) {
+    // TODO: implement registerCompleter
+  }
+
+  @override
+  List<String> get themes => ['normal'];
+}
+
+class NewEmbedDocument extends Document {
+  NewEmbedDocument(NewEmbedEditor editor, this.doc) : super(editor);
+
+  NewEmbedEditor get parent => editor;
+
+  String doc;
+
+  String get value => doc;
+
+  set value(String str) {
+    doc = str;
+  }
+
+  void updateValue(String str) {
+    doc = str;
+  }
+
+  ed.Position get cursor => ed.Position(0, 0);
+
+  void select(ed.Position start, [ed.Position end]) {}
+
+  String get selection => '';
+
+  String get mode => parent.mode;
+
+  bool get isClean => false;
+
+  void markClean() => () {};
+
+  void applyEdit(SourceEdit edit) {}
+
+  void setAnnotations(List<Annotation> annotations) {}
+
+  int indexFromPos(ed.Position position) => 0;
+
+  ed.Position posFromIndex(int index) => null;
+
+  Stream get onChange {
+    return null;
+  }
+}

--- a/lib/experimental/new_embed_editor.dart
+++ b/lib/experimental/new_embed_editor.dart
@@ -1,11 +1,21 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
 import 'dart:html' hide Document;
 
 import '../editing/editor.dart' hide Position;
 import '../editing/editor.dart' as ed show Position;
 
 class NewEmbedEditor extends Editor {
-  NewEmbedEditor(NewEmbedEditorFactory factory, this.textarea) : super(factory) {
-    _document = NewEmbedDocument(this, '');
+  NewEmbedEditor(NewEmbedEditorFactory factory, this.textarea)
+      : super(factory) {
+    _document = NewEmbedDocument(this, textarea.value);
+
+    textarea.addEventListener('input', (e) {
+      _document.updateValue(textarea.value);
+    });
   }
 
   final TextAreaElement textarea;
@@ -13,7 +23,7 @@ class NewEmbedEditor extends Editor {
   NewEmbedDocument _document;
 
   @override
-  String mode;
+  String mode = 'dart';
 
   @override
   String theme;
@@ -22,12 +32,12 @@ class NewEmbedEditor extends Editor {
   bool get completionActive => false;
 
   @override
+  Document get document => _document;
+
+  @override
   Document createDocument({String content, String mode}) {
     return NewEmbedDocument(this, content);
   }
-
-  @override
-  Document get document => _document;
 
   @override
   void execCommand(String name) {
@@ -41,6 +51,7 @@ class NewEmbedEditor extends Editor {
 
   @override
   Point<num> getCursorCoords({ed.Position position}) {
+    // TODO: implement getCursorCoords
     return Point<num>(0, 0);
   }
 
@@ -56,8 +67,8 @@ class NewEmbedEditor extends Editor {
   }
 
   @override
-  void showCompletions({bool autoInvoked = false, bool onlyShowFixes = false}) {
-  }
+  void showCompletions(
+      {bool autoInvoked = false, bool onlyShowFixes = false}) {}
 
   @override
   void swapDocument(Document document) {
@@ -89,6 +100,8 @@ class NewEmbedDocument extends Document {
   NewEmbedDocument(NewEmbedEditor editor, this.doc) : super(editor);
 
   NewEmbedEditor get parent => editor;
+
+  final _changeController = StreamController<String>.broadcast();
 
   String doc;
 
@@ -122,7 +135,5 @@ class NewEmbedDocument extends Document {
 
   ed.Position posFromIndex(int index) => null;
 
-  Stream get onChange {
-    return null;
-  }
+  Stream get onChange => _changeController.stream;
 }

--- a/lib/experimental/new_embed_editor.dart
+++ b/lib/experimental/new_embed_editor.dart
@@ -41,17 +41,17 @@ class NewEmbedEditor extends Editor {
 
   @override
   void execCommand(String name) {
-    // TODO: implement execCommand
+    // TODO(redbrogdon): implement execCommand
   }
 
   @override
   void focus() {
-    // TODO: implement focus
+    // TODO(redbrogdon): implement focus
   }
 
   @override
   Point<num> getCursorCoords({ed.Position position}) {
-    // TODO: implement getCursorCoords
+    // TODO(redbrogdon): implement getCursorCoords
     return Point<num>(0, 0);
   }
 
@@ -63,7 +63,7 @@ class NewEmbedEditor extends Editor {
 
   @override
   void resize() {
-    // TODO: implement resize
+    // TODO(redbrogdon): implement resize
   }
 
   @override
@@ -89,7 +89,7 @@ class NewEmbedEditorFactory extends EditorFactory {
 
   @override
   void registerCompleter(String mode, CodeCompleter completer) {
-    // TODO: implement registerCompleter
+    // TODO(redbrogdon): implement registerCompleter
   }
 
   @override

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -4,8 +4,8 @@
 
 library dart_pad.common;
 
-final String serverURL = 'https://dart-services.appspot.com/';
-//final String serverURL = 'http://127.0.0.1:8082/';
+//final String serverURL = 'https://dart-services.appspot.com/';
+final String serverURL = 'http://127.0.0.1:8082/';
 //final String serverURL = 'https://dart2-test-dot-dart-services.appspot.com/';
 
 final Duration serviceCallTimeout = Duration(seconds: 10);
@@ -16,6 +16,10 @@ class StringTextProvider {
   final String _text;
   StringTextProvider(this._text);
   String getText() => _text;
+}
+
+class MyClass {
+  final myBool = false;
 }
 
 class Lines {

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -4,8 +4,8 @@
 
 library dart_pad.common;
 
-//final String serverURL = 'https://dart-services.appspot.com/';
-final String serverURL = 'http://127.0.0.1:8082/';
+final String serverURL = 'https://dart-services.appspot.com/';
+//final String serverURL = 'http://127.0.0.1:8082/';
 //final String serverURL = 'https://dart2-test-dot-dart-services.appspot.com/';
 
 final Duration serviceCallTimeout = Duration(seconds: 10);
@@ -14,9 +14,7 @@ final Duration longServiceCallTimeout = Duration(seconds: 20);
 
 class StringTextProvider {
   final String _text;
-
   StringTextProvider(this._text);
-
   String getText() => _text;
 }
 

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -14,12 +14,10 @@ final Duration longServiceCallTimeout = Duration(seconds: 20);
 
 class StringTextProvider {
   final String _text;
-  StringTextProvider(this._text);
-  String getText() => _text;
-}
 
-class MyClass {
-  final myBool = false;
+  StringTextProvider(this._text);
+
+  String getText() => _text;
 }
 
 class Lines {

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -6,6 +6,12 @@ library execution;
 
 import 'dart:async';
 
+class TestResult {
+  const TestResult(this.success, this.message);
+  final bool success;
+  final String message;
+}
+
 abstract class ExecutionService {
   Future execute(String html, String css, String javaScript);
 
@@ -18,4 +24,11 @@ abstract class ExecutionService {
 
   Stream<String> get onStdout;
   Stream<String> get onStderr;
+  Stream<TestResult> get testResults;
+
+  /// This method should be added to any Dart code that needs to report a test
+  /// result while executing via this service. It calls `print` with a specially
+  /// constructed string, which is caught by the `dartPrint` method and routed
+  /// to [testResults] rather than the [onStdout] stream.
+  String get testResultDecoration;
 }

--- a/test/experimental/new_embed_test.dart
+++ b/test/experimental/new_embed_test.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+import 'dart:html';
+
+import 'package:dart_pad/experimental/new_embed.dart' as new_embed;
+import 'package:test/test.dart';
+
+void main() {
+  group('new_embed', () {
+    setUp(() => new_embed.init());
+
+    test('Editor tab is selected at init', () {
+      final editorTab = querySelector('#editor-tab');
+      expect(editorTab.attributes.keys, contains('selected'));
+    });
+
+    test('Console tab is not selected at init', () {
+      final consoleTab = querySelector('#console-tab');
+      expect(consoleTab.attributes.keys, isNot(contains('selected')));
+    });
+
+    test('Console tab is selected when clicked.', () {
+      final consoleTab = querySelector('#console-tab');
+      consoleTab.dispatchEvent(Event('click'));
+
+      expect(consoleTab.attributes.keys, contains('selected'));
+    });
+
+    test('Editor tab is not selected when console tab is clicked', () {
+      final consoleTab = querySelector('#console-tab');
+      consoleTab.dispatchEvent(Event('click'));
+
+      final editorTab = querySelector('#editor-tab');
+      expect(editorTab.attributes.keys, isNot(contains('selected')));
+    });
+
+    test('Test tab is not selected at init', () {
+      final testTab = querySelector('#test-tab');
+      expect(testTab.attributes.keys, isNot(contains('selected')));
+    });
+
+    test('Test tab is selected when clicked.', () {
+      final testTab = querySelector('#test-tab');
+      testTab.dispatchEvent(Event('click'));
+
+      expect(testTab.attributes.keys, contains('selected'));
+    });
+
+    test('Editor tab is not selected when test tab is clicked', () {
+      final testTab = querySelector('#test-tab');
+      testTab.dispatchEvent(Event('click'));
+
+      final editorTab = querySelector('#editor-tab');
+      expect(editorTab.attributes.keys, isNot(contains('selected')));
+    });
+  });
+}

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved. Use of this source code is governed by a
+BSD-style license that can be found in the LICENSE file. -->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="shortcut icon" href="/dart-64.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <title>DartPad</title>
+
+    <link rel="stylesheet" type="text/css" href="new_embed.css">
+
+    <!-- Test package stuff -->
+    <link rel="x-dart-test" href="new_embed_test.dart">
+    <script src="packages/test/dart.js"></script>
+
+<body>
+<header>
+    <div class="tab" selected id="editor-tab">
+        <a href="#">Editor</a>
+    </div>
+    <div class="tab" id="test-tab">
+        <a href="#">Test</a>
+    </div>
+    <div class="tab" id="console-tab">
+        <a href="#">Console</a>
+    </div>
+    <div id="head-space"></div>
+    <div class="button" id="test-code">Test</div>
+    <div class="button" id="run-code">Run</div>
+</header>
+
+<section id="tab-container">
+    <textarea class="tabview" id="editor" selected></textarea>
+    <div class="tabview" id="test-view"></div>
+    <div class="tabview" id="console-view"></div>
+</section>
+
+<iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
+</iframe>
+</body>
+</html>

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -91,8 +91,7 @@ serveCustomBackend() {
 
 @Task('Build the `web/index.html` entrypoint')
 build() {
-//  PubApp.local('build_runner').run(['build', '-r', '-o', 'web:build']);
-  PubApp.local('build_runner').run(['build', '-o', 'web:build']);
+  PubApp.local('build_runner').run(['build', '-r', '-o', 'web:build']);
 
   FilePath mainFile = _buildDir.join('scripts/main.dart.js');
   log('${mainFile} compiled to ${_printSize(mainFile)}');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -91,7 +91,8 @@ serveCustomBackend() {
 
 @Task('Build the `web/index.html` entrypoint')
 build() {
-  PubApp.local('build_runner').run(['build', '-r', '-o', 'web:build']);
+//  PubApp.local('build_runner').run(['build', '-r', '-o', 'web:build']);
+  PubApp.local('build_runner').run(['build', '-o', 'web:build']);
 
   FilePath mainFile = _buildDir.join('scripts/main.dart.js');
   log('${mainFile} compiled to ${_printSize(mainFile)}');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -16,6 +16,7 @@ final FilePath _buildDir = FilePath('build');
 final FilePath _pkgDir = FilePath('third_party/pkg');
 final FilePath _routeDir = FilePath('third_party/pkg/route.dart');
 final FilePath _haikunatorDir = FilePath('third_party/pkg/haikunatordart');
+final FilePath _experimentalTestDir = FilePath('test/experimental');
 
 Map get _env => Platform.environment;
 
@@ -65,6 +66,15 @@ testWeb() async {
       workingDirectory: _routeDir.path);
 }
 
+// This task also requires a frame buffer to run.
+@Task()
+testExperimental() async {
+  await TestRunner().testAsync(
+    files: _experimentalTestDir.path,
+    platformSelector: 'chrome',
+  );
+}
+
 @Task('Serve locally on port 8000')
 @Depends(build)
 serve() {
@@ -72,6 +82,7 @@ serve() {
 }
 
 const String backendVariable = 'DARTPAD_BACKEND';
+
 @Task(
     'Serve locally on port 8000 and use backend from ${backendVariable} environment variable')
 @Depends(build)
@@ -222,7 +233,7 @@ coverage() {
 }
 
 @DefaultTask()
-@Depends(analyze, testCli, testWeb, coverage, build)
+@Depends(analyze, testCli, testWeb, testExperimental, coverage, build)
 void buildbot() => null;
 
 @Task('Prepare the app for deployment')

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -19,28 +19,28 @@ BSD-style license that can be found in the LICENSE file. -->
 </head>
 
 <body>
-    <header>
-        <div class="tab tab-active" id="editor-tab">
-            <a href="#">Editor</a>
-        </div>
-        <div class="tab" id="test-tab">
-            <a href="#">Test</a>
-        </div>
-        <div class="tab" id="console-tab">
-            <a href="#">Console</a>
-        </div>
-        <div id="head-space"></div>
-        <div class="button" id="test-code"><a href="#">Test</a></div>
-        <div class="button" id="run-code"><a href="#">Run</a></div>
-    </header>
+<header>
+    <div class="tab" selected id="editor-tab">
+        <a href="#">Editor</a>
+    </div>
+    <div class="tab" id="test-tab">
+        <a href="#">Test</a>
+    </div>
+    <div class="tab" id="console-tab">
+        <a href="#">Console</a>
+    </div>
+    <div id="head-space"></div>
+    <div class="button" id="test-code">Test</div>
+    <div class="button" id="run-code">Run</div>
+</header>
 
-    <section id="tab-container">
-        <textarea id="editor"></textarea>
-        <div id="test-view" class=tabview-hidden"></div>
-        <div id="console-view" class=tabview-hidden"></div>
-    </section>
+<section id="tab-container">
+    <textarea class="tabview" id="editor" selected></textarea>
+    <div class="tabview" id="test-view"></div>
+    <div class="tabview" id="console-view"></div>
+</section>
 
-    <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
-    </iframe>
+<iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
+</iframe>
 </body>
 </html>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -14,16 +14,33 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <title>DartPad</title>
 
-<script defer src="new_embed.dart.js"></script>
+    <link rel="stylesheet" type="text/css" href="new_embed.css">
+    <script defer src="new_embed.dart.js"></script>
 </head>
 
 <body>
-    <header layout horizontal>
-        <div class="header-title">DartPad</div>
+    <header>
+        <div class="tab tab-active" id="editor-tab">
+            <a href="#">Editor</a>
+        </div>
+        <div class="tab" id="test-tab">
+            <a href="#">Test</a>
+        </div>
+        <div class="tab" id="console-tab">
+            <a href="#">Console</a>
+        </div>
+        <div id="head-space"></div>
+        <div class="button" id="test-code"><a href="#">Test</a></div>
+        <div class="button" id="run-code"><a href="#">Run</a></div>
     </header>
 
-    <section>
-        <div class="view"></div>
+    <section id="tab-container">
+        <textarea id="editor"></textarea>
+        <div id="test-view" class=tabview-hidden"></div>
+        <div id="console-view" class=tabview-hidden"></div>
     </section>
+
+    <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
+    </iframe>
 </body>
 </html>

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -32,6 +32,7 @@ header {
 }
 
 .tab {
+  cursor: pointer;
   margin-right: 10px;
   padding: 5px;
   background-color: #008;
@@ -41,11 +42,11 @@ header {
   color: #888;
 }
 
-.tab-active {
+.tab[selected] {
   background-color: #44b;
 }
 
-.tab-active a {
+.tab[selected] a {
   color: #fff;
 }
 
@@ -54,24 +55,19 @@ header {
 }
 
 .button {
+  cursor: pointer;
   padding: 5px;
   background-color: #080;
-}
-
-.button a {
   color: #888;
 }
 
 .button:hover {
   background-color: #4b4;
-}
-
-.button:hover a {
   color: #fff;
 }
 
-#run-button {
-  display: none
+#run-code {
+  display: none;
 }
 
 #tab-container {
@@ -80,8 +76,12 @@ header {
   flex-direction: row;
 }
 
-.tabview-hidden {
+.tabview {
   display: none;
+}
+
+.tabview[selected] {
+  display: block;
 }
 
 #editor {
@@ -90,6 +90,8 @@ header {
 
 #test-view {
   flex-grow: 1;
+  font-size: 8pt;
+  line-height: 12pt;
 }
 
 #console-view {
@@ -98,4 +100,13 @@ header {
 
 #frame {
   display: none;
+}
+
+.console-message {
+  padding: 5px;
+}
+
+.console-error {
+  padding: 5px;
+  color: #800;
 }

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -1,0 +1,101 @@
+/* Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file */
+/* for details. All rights reserved. Use of this source code is governed by a */
+/* BSD-style license that can be found in the LICENSE file. */
+
+body {
+  margin: 0;
+  padding: 0;
+
+  background-color: #fff;
+  color: #111;
+
+  display: flex;
+  flex-direction: column;
+
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+
+  position: absolute;
+
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+
+  overflow: hidden;
+}
+
+header {
+  display: flex;
+  flex-direction: row;
+}
+
+.tab {
+  margin-right: 10px;
+  padding: 5px;
+  background-color: #008;
+}
+
+.tab a {
+  color: #888;
+}
+
+.tab-active {
+  background-color: #44b;
+}
+
+.tab-active a {
+  color: #fff;
+}
+
+#head-space {
+    flex-grow: 1;
+}
+
+.button {
+  padding: 5px;
+  background-color: #080;
+}
+
+.button a {
+  color: #888;
+}
+
+.button:hover {
+  background-color: #4b4;
+}
+
+.button:hover a {
+  color: #fff;
+}
+
+#run-button {
+  display: none
+}
+
+#tab-container {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: row;
+}
+
+.tabview-hidden {
+  display: none;
+}
+
+#editor {
+  flex-grow: 1;
+}
+
+#test-view {
+  flex-grow: 1;
+}
+
+#console-view {
+  flex-grow: 1;
+}
+
+#frame {
+  display: none;
+}

--- a/web/experimental/new_embed.dart
+++ b/web/experimental/new_embed.dart
@@ -3,12 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_pad/experimental/new_embed.dart' as new_embed;
-import 'package:logging/logging.dart';
 
 void main() {
-  print('main() in web script');
-
-  Logger.root.onRecord.listen(print);
-
   new_embed.init();
 }

--- a/web/experimental/new_embed.dart
+++ b/web/experimental/new_embed.dart
@@ -3,7 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dart_pad/experimental/new_embed.dart' as new_embed;
+import 'package:logging/logging.dart';
 
 void main() {
   new_embed.init();
+
+  Logger.root.onRecord.listen(print);
 }

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<!-- Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+<!-- Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
      for details. All rights reserved. Use of this source code is governed by a
      BSD-style license that can be found in the LICENSE file. -->
 

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -35,7 +35,6 @@
       .code {
         font-family: monospace;
       }
-
     </style>
 </head>
 
@@ -43,53 +42,52 @@
 <div class="container">
     <div class="row">
         <div class="col-md-2"></div>
-        < class="col-md-8">
-
-        <h2>Dart Cheat Sheet Codelab</h2>
-        <p>
-            Dart is designed to be easy to learn for coders coming from other languages, but it
-            also has a few unique features that will be new to people learning it for the first
-            time. This short codelab will walk you through the most important ones, and can be a
-            handy place to return for a refresher as you grow your Dart skills.
-        </p>
-        <p>
-            In addition to explanations and examples, the codelab includes embedded editors with
-            partially completed code snippets. You can use these editors to test your knowledge
-            by completing the code and clicking the "test" button.
-        </p>
-        <h3>String interpolation</h3>
-        <p>
-            Dart offers string interpolation to simplify formatting variables and expressions
-            as strings:You can put the value of an expression inside a string by using
-            <span class="code">${expression}</span>. If the expression is an identifier, you can
-            skip the <span class="code">{}</span>.
-        </p>
-        <p>
-            Some examples:
-        </p>
-        <ul>
-            <li>
-                <span class="code">'${3 + 2}'</span> becomes <span class="code">'5'</span>
-            </li>
-            <li>
-                <span class="code">'${"word".toUpperCase()}'</span> becomes
-                <span class="code">'WORD'</span>
-            </li>
-            <li>
-                <span class="code">'$myObject'</span> becomes the value of
-                <span class="code">myObject.toString()</span>
-            </li>
-        </ul>
-        <br/>
-        <h4>Code example</h4>
-        <p>
-            The following function takes two integers as parameters. Add code to make it return
-            a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
-        </p>
-        <iframe short src="embed-new.html"></iframe>
+        <div class="col-md-8">
+            <h2>Dart Cheat Sheet Codelab</h2>
+            <p>
+                Dart is designed to be easy to learn for coders coming from other languages, but it
+                also has a few unique features that will be new to people learning it for the first
+                time. This short codelab will walk you through the most important ones, and can be a
+                handy place to return for a refresher as you grow your Dart skills.
+            </p>
+            <p>
+                In addition to explanations and examples, the codelab includes embedded editors with
+                partially completed code snippets. You can use these editors to test your knowledge
+                by completing the code and clicking the "test" button.
+            </p>
+            <h3>String interpolation</h3>
+            <p>
+                Dart offers string interpolation to simplify formatting variables and expressions
+                as strings. You can put the value of an expression inside a string by using
+                <span class="code">${expression}</span>. If the expression is an identifier, you can
+                skip the <span class="code">{}</span>.
+            </p>
+            <p>
+                Some examples:
+            </p>
+            <ul>
+                <li>
+                    <span class="code">'${3 + 2}'</span> becomes <span class="code">'5'</span>
+                </li>
+                <li>
+                    <span class="code">'${"word".toUpperCase()}'</span> becomes
+                    <span class="code">'WORD'</span>
+                </li>
+                <li>
+                    <span class="code">'$myObject'</span> becomes the value of
+                    <span class="code">myObject.toString()</span>
+                </li>
+            </ul>
+            <h4>Code example</h4>
+            <p>
+                The following function takes two integers as parameters. Add code to make it return
+                a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
+            </p>
+            <iframe short src="embed-new.html"></iframe>
+        </div>
+        <div class="col-md-2"></div>
     </div>
 </div>
-<div class="col-md-2"></div>
-</div>
+
 </body>
 </html>

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<!-- Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+<!-- Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
      for details. All rights reserved. Use of this source code is governed by a
      BSD-style license that can be found in the LICENSE file. -->
 
@@ -58,4 +58,11 @@
     <div class="col-md-2"></div>
 </div>
 </body>
+<script>
+    function changeOptions(){
+      var select = document.getElementById("choosePad");
+      var url = 'embed-dart.html?id='+select.options[select.selectedIndex].value;
+      document.getElementById("embed-dart").src = url;
+    }
+  </script>
 </html>

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -31,6 +31,10 @@
         margin-bottom: 8px;
         float: right;
       }
+
+      .code {
+        font-family: monospace;
+      }
     </style>
 </head>
 
@@ -38,31 +42,53 @@
 <div class="container">
     <div class="row">
         <div class="col-md-2"></div>
-        <div class="col-md-8">
-            <h2>Embeddings Demo</h2>
+        < class="col-md-8">
+
+            <h2>Dart Cheat Sheet Codelab</h2>
             <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-                tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-                veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-                commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-                velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                cupidatat non proident, sunt in culpa qui officia deserunt mollit anim
-                id est laborum.
+                Dart is designed to be easy to learn for coders coming from other languages, but it
+                also has a few unique features that will be new to people learning it for the first
+                time. This short codelab will walk you through the most important ones, and can be a
+                handy place to return for a refresher as you grow your Dart skills.
+            </p>
+            <p>
+                In addition to explanations and examples, the codelab includes embedded editors with
+                partially completed code snippets. You can use these editors to test your knowledge
+                by completing the code and clicking the "test" button.
+            </p>
+            <h3>String interpolation</h3>
+            <p>
+                Dart offers string interpolation to simplify formatting variables and expressions
+                as strings:You can put the value of an expression inside a string by using
+                <span class="code">${expression}</span>. If the expression is an identifier, you can
+                skip the <span class="code">{}</span>.
+            </p>
+            <p>
+                Some examples:
+            </p>
+            <ul>
+                <li>
+                    <span class="code">'${3 + 2}'</span> becomes <span class="code">'5'</span>
+                </li>
+                <li>
+                    <span class="code">'${"word".toUpperCase()}'</span> becomes
+                    <span class="code">'WORD'</span>
+                </li>
+                <li>
+                    <span class="code">'$myObject'</span> becomes the value of
+                    <span class="code">myObject.toString()</span>
+                </li>
+            </ul>
+            <br />
+            <h4>Code example</h4>
+            <p>
+                The following function takes two integers as parameters. Add code to make it return
+                a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
             </p>
             <iframe short src="embed-new.html"></iframe>
-            <p></p>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-                tempor incididunt ut labore et dolore magna aliqua.</p>
         </div>
     </div>
     <div class="col-md-2"></div>
 </div>
 </body>
-<script>
-    function changeOptions(){
-      var select = document.getElementById("choosePad");
-      var url = 'embed-dart.html?id='+select.options[select.selectedIndex].value;
-      document.getElementById("embed-dart").src = url;
-    }
-  </script>
 </html>

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -35,6 +35,7 @@
       .code {
         font-family: monospace;
       }
+
     </style>
 </head>
 
@@ -44,51 +45,51 @@
         <div class="col-md-2"></div>
         < class="col-md-8">
 
-            <h2>Dart Cheat Sheet Codelab</h2>
-            <p>
-                Dart is designed to be easy to learn for coders coming from other languages, but it
-                also has a few unique features that will be new to people learning it for the first
-                time. This short codelab will walk you through the most important ones, and can be a
-                handy place to return for a refresher as you grow your Dart skills.
-            </p>
-            <p>
-                In addition to explanations and examples, the codelab includes embedded editors with
-                partially completed code snippets. You can use these editors to test your knowledge
-                by completing the code and clicking the "test" button.
-            </p>
-            <h3>String interpolation</h3>
-            <p>
-                Dart offers string interpolation to simplify formatting variables and expressions
-                as strings:You can put the value of an expression inside a string by using
-                <span class="code">${expression}</span>. If the expression is an identifier, you can
-                skip the <span class="code">{}</span>.
-            </p>
-            <p>
-                Some examples:
-            </p>
-            <ul>
-                <li>
-                    <span class="code">'${3 + 2}'</span> becomes <span class="code">'5'</span>
-                </li>
-                <li>
-                    <span class="code">'${"word".toUpperCase()}'</span> becomes
-                    <span class="code">'WORD'</span>
-                </li>
-                <li>
-                    <span class="code">'$myObject'</span> becomes the value of
-                    <span class="code">myObject.toString()</span>
-                </li>
-            </ul>
-            <br />
-            <h4>Code example</h4>
-            <p>
-                The following function takes two integers as parameters. Add code to make it return
-                a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
-            </p>
-            <iframe short src="embed-new.html"></iframe>
-        </div>
+        <h2>Dart Cheat Sheet Codelab</h2>
+        <p>
+            Dart is designed to be easy to learn for coders coming from other languages, but it
+            also has a few unique features that will be new to people learning it for the first
+            time. This short codelab will walk you through the most important ones, and can be a
+            handy place to return for a refresher as you grow your Dart skills.
+        </p>
+        <p>
+            In addition to explanations and examples, the codelab includes embedded editors with
+            partially completed code snippets. You can use these editors to test your knowledge
+            by completing the code and clicking the "test" button.
+        </p>
+        <h3>String interpolation</h3>
+        <p>
+            Dart offers string interpolation to simplify formatting variables and expressions
+            as strings:You can put the value of an expression inside a string by using
+            <span class="code">${expression}</span>. If the expression is an identifier, you can
+            skip the <span class="code">{}</span>.
+        </p>
+        <p>
+            Some examples:
+        </p>
+        <ul>
+            <li>
+                <span class="code">'${3 + 2}'</span> becomes <span class="code">'5'</span>
+            </li>
+            <li>
+                <span class="code">'${"word".toUpperCase()}'</span> becomes
+                <span class="code">'WORD'</span>
+            </li>
+            <li>
+                <span class="code">'$myObject'</span> becomes the value of
+                <span class="code">myObject.toString()</span>
+            </li>
+        </ul>
+        <br/>
+        <h4>Code example</h4>
+        <p>
+            The following function takes two integers as parameters. Add code to make it return
+            a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
+        </p>
+        <iframe short src="embed-new.html"></iframe>
     </div>
-    <div class="col-md-2"></div>
+</div>
+<div class="col-md-2"></div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Fixes #910.

Includes enough HTML, dart, and CSS for the new embed UI to run a code snippet, test the result, and report success or failure. Some of this code (values for the test, for instance) will be pulled out once gist integration is improved. Some other bits of code are stubbed out and will be modified in subsequent PRs.

Feel free to critique anything you want, though. 😄 