### PR TITLE
Prepare for 2.2.0

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -61,7 +61,6 @@ linter:
   - prefer_typing_uninitialized_variables
   - recursive_getters
   - slash_for_doc_comments
-  #- super_goes_last
   - test_types_in_equals
   - throw_in_finally
   - type_init_formals

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -61,7 +61,7 @@ linter:
   - prefer_typing_uninitialized_variables
   - recursive_getters
   - slash_for_doc_comments
-  - super_goes_last
+  #- super_goes_last
   - test_types_in_equals
   - throw_in_finally
   - type_init_formals


### PR DESCRIPTION
Removes an obsolete lint that causes the pre-deploy checks to fail with a lint warning on analysis_options.yaml.