### PR TITLE
Makes test methods as well as code snippets editable

### DIFF
--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -38,7 +38,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <section id="tab-container">
     <textarea class="tabview" id="editor" selected></textarea>
-    <div class="tabview" id="test-view"></div>
+    <textarea class="tabview" id="test-view"></textarea>
     <div class="tabview" id="console-view"></div>
 </section>
 

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -37,7 +37,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <section id="tab-container">
     <textarea class="tabview" id="editor" selected></textarea>
-    <div class="tabview" id="test-view"></div>
+    <textarea class="tabview" id="test-view"></textarea>
     <div class="tabview" id="console-view"></div>
 </section>
 


### PR DESCRIPTION
This is a temporary change that will allow anyone who needs to play with both a code snippet and a test method (e.g. @kwalrath working on a codelab) to edit both from within the new embed UI rather than by manually editing the dart-pad source.

When @domesticmouse begins incorporating CodeMirror, we'll need to decide whether to use a single editor and just swap the source around (as the Playground UI does now) or maintain two separate editors. In either case, this code will end up being heavily modified in the process.