### PR TITLE
Adds polymerpatch to new embed, removes old onmessage hook

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -166,36 +166,5 @@ window.onerror = function(message, url, lineNumber, colno, error) {
         _stdoutController.add(data['message']);
       }
     });
-
-    window.onMessage.listen((MessageEvent event) {
-      Map data;
-
-      try {
-        // TODO: This throws in Safari and FireFox with the polymer polyfills active.
-        if (event.data is! Map) return;
-        data = event.data;
-        if (data['sender'] != 'frame') return;
-      } catch (e) {
-        print('${e}');
-
-        return;
-      }
-
-      String type = data['type'];
-
-      if (type == 'testResult') {
-        final result = TestResult(data['success'] == true, data['message']);
-        _testResultsController.add(result);
-      } else if (type == 'stderr') {
-        // Ignore any exceptions before the iframe has completed initialization.
-        if (_readyCompleter.isCompleted) {
-          _stderrController.add(data['message']);
-        }
-      } else if (type == 'ready' && !_readyCompleter.isCompleted) {
-        _readyCompleter.complete();
-      } else {
-        _stdoutController.add(data['message']);
-      }
-    });
   }
 }

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -16,6 +16,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <link rel="stylesheet" type="text/css" href="new_embed.css">
     <script defer src="new_embed.dart.js"></script>
+    <script defer src="../scripts/polymerpatch.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This completely removes the window.onMessage assignment that had been commented out for previous releases, and adds polymerpatch.js (used by the playground UI to wire up its execution iframe listener) to the new embed UI.