### PR TITLE
Restyles new embed UI using Primer.css and Octicons

### DIFF
--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -14,6 +14,7 @@ class DElement {
   final Element element;
 
   DElement(this.element);
+
   DElement.tag(String tag, {String classes}) : element = Element.tag(tag) {
     if (classes != null) {
       element.classes.add(classes);
@@ -36,6 +37,8 @@ class DElement {
   void toggleClass(String name, bool value) {
     value ? element.classes.add(name) : element.classes.remove(name);
   }
+
+  bool hasClass(String name) => element.classes.contains(name);
 
   String get text => element.text;
 
@@ -104,6 +107,7 @@ class DButton extends DElement {
   ButtonElement get belement => element;
 
   bool get disabled => belement.disabled;
+
   set disabled(bool value) {
     belement.disabled = value;
   }
@@ -138,12 +142,14 @@ class DSplitter extends DElement {
   }
 
   bool get horizontal => hasAttr('horizontal');
+
   set horizontal(bool value) {
     clearAttr(value ? 'vertical' : 'horizontal');
     setAttr(value ? 'horizontal' : 'vertical');
   }
 
   bool get vertical => hasAttr('vertical');
+
   set vertical(bool value) {
     clearAttr(value ? 'horizontal' : 'vertical');
     setAttr(value ? 'vertical' : 'horizontal');
@@ -351,6 +357,7 @@ class DOverlay extends DElement {
   DOverlay(Element element) : super(element);
 
   bool get visible => element.classes.contains('visible');
+
   set visible(bool value) {
     element.classes.toggle('visible', value);
   }

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -33,6 +33,10 @@ class DElement {
 
   String clearAttr(String name) => element.attributes.remove(name);
 
+  void toggleClass(String name, bool value) {
+    value ? element.classes.add(name) : element.classes.remove(name);
+  }
+
   String get text => element.text;
 
   set text(String value) {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -229,23 +229,32 @@ class TestResultLabel {
 class ExecuteCodeButton {
   /// This constructor will throw if the provided element has no child with a
   /// CSS class that begins with "octicon-".
-  ExecuteCodeButton(this.element, VoidCallback onClick) {
-    final iconElement = element.children.firstWhere(Octicon.elementIsOcticon);
+  ExecuteCodeButton(AnchorElement anchorElement, VoidCallback onClick)
+      : assert(anchorElement != null),
+        assert(onClick != null) {
+    final iconElement =
+        anchorElement.children.firstWhere(Octicon.elementIsOcticon);
     _icon = Octicon(iconElement);
-    element.addEventListener('click', (e) => onClick());
+    _element = DElement(anchorElement);
+    _element.onClick.listen((e) => onClick());
   }
 
-  static const readyIconName = 'chevron-right';
+  static const readyIconName = 'triangle-right';
   static const waitingIconName = 'sync';
+  static const disabledClassName = 'disabled';
 
-  final AnchorElement element;
+  DElement _element;
 
   Octicon _icon;
 
-  bool get ready => _icon.iconName == readyIconName;
+  // Both the icon and the disabled attribute are set at the same time, so
+  // checking one should be as good as checking both.
+  bool get ready => !_element.hasClass(disabledClassName);
 
-  set ready(bool value) =>
-      _icon.iconName = value ? readyIconName : waitingIconName;
+  set ready(bool value) {
+    _element.toggleClass(disabledClassName, !value);
+    _icon.iconName = value ? readyIconName : waitingIconName;
+  }
 }
 
 class Octicon {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -379,6 +379,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.4"
+  octicons_css:
+    dependency: "direct main"
+    description:
+      name: octicons_css
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1"
   package_config:
     dependency: transitive
     description:
@@ -421,6 +428,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  primer_css:
+    dependency: "direct main"
+    description:
+      name: primer_css
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1"
   protobuf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   http: '>=0.11.1 <0.13.0'
   logging: '>=0.9.0 <0.12.0'
   markdown: ^2.0.0
+  octicons_css: ^0.0.1
+  primer_css: ^0.0.1
   route_hierarchical:
     path: third_party/pkg/route.dart/
 dev_dependencies:

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -14,35 +14,49 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <title>DartPad</title>
 
+    <link href='https://fonts.googleapis.com/css?family=Roboto'
+          rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'
+          rel='stylesheet' type='text/css'>
+
+    <link rel="stylesheet" type="text/css" href="../packages/octicons_css/octicons_4.4.0.css">
+    <link rel="stylesheet" type="text/css" href="../packages/primer_css/primer_11.0.0.css">
+
     <link rel="stylesheet" type="text/css" href="new_embed.css">
 
     <!-- Test package stuff -->
     <link rel="x-dart-test" href="new_embed_test.dart">
     <script src="packages/test/dart.js"></script>
 
-<body>
-<header>
-    <div class="tab" selected id="editor-tab">
-        <a href="#">Editor</a>
-    </div>
-    <div class="tab" id="test-tab">
-        <a href="#">Test</a>
-    </div>
-    <div class="tab" id="console-tab">
-        <a href="#">Console</a>
-    </div>
-    <div id="head-space"></div>
-    <div class="button" id="test-code">Test</div>
-    <div class="button" id="run-code">Run</div>
-</header>
+    <script defer src="../scripts/polymerpatch.js"></script>
+</head>
 
-<section id="tab-container">
-    <textarea class="tabview" id="editor" selected></textarea>
-    <textarea class="tabview" id="test-view"></textarea>
-    <div class="tabview" id="console-view"></div>
+<body class="d-flex flex-column">
+
+<nav class="UnderlineNav px-2">
+    <div class="UnderlineNav-body">
+        <a id="editor-tab" href="#" class="UnderlineNav-item selected" selected>Your code</a>
+        <a id="test-tab" href="#" class="UnderlineNav-item">Test</a>
+        <a id="console-tab" href="#" class="UnderlineNav-item">Console</a>
+    </div>
+    <div class="UnderlineNav-actions">
+        <div id="test-result" class="tabnav-extra pr-3"></div>
+        <a id="execute" class="btn btn-primary">
+            <div class="octicon medium-octicon octicon-chevron-right"></div>
+            Check code
+        </a>
+    </div>
+</nav>
+
+<section id="tab-container" class="flex-auto d-flex flex-column p-1">
+    <textarea class="tabview flex-auto" id="editor" selected spellcheck="false"></textarea>
+    <textarea class="tabview flex-auto" id="test-view" spellcheck="false"></textarea>
+    <div class="tabview flex-auto" id="console-view"></div>
 </section>
 
 <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
 </iframe>
+
 </body>
+
 </html>

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -42,7 +42,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <div class="UnderlineNav-actions">
         <div id="test-result" class="tabnav-extra pr-3"></div>
         <a id="execute" class="btn btn-primary">
-            <div class="octicon medium-octicon octicon-chevron-right"></div>
+            <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code
         </a>
     </div>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -14,34 +14,46 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <title>DartPad</title>
 
+    <link href='https://fonts.googleapis.com/css?family=Roboto'
+          rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'
+          rel='stylesheet' type='text/css'>
+
+    <link rel="stylesheet" type="text/css" href="../packages/octicons_css/octicons_4.4.0.css">
+    <link rel="stylesheet" type="text/css" href="../packages/primer_css/primer_11.0.0.css">
+
     <link rel="stylesheet" type="text/css" href="new_embed.css">
+
     <script defer src="new_embed.dart.js"></script>
     <script defer src="../scripts/polymerpatch.js"></script>
 </head>
 
-<body>
-<header>
-    <div class="tab" selected id="editor-tab">
-        <a href="#">Editor</a>
-    </div>
-    <div class="tab" id="test-tab">
-        <a href="#">Test</a>
-    </div>
-    <div class="tab" id="console-tab">
-        <a href="#">Console</a>
-    </div>
-    <div id="head-space"></div>
-    <div class="button" id="test-code">Test</div>
-    <div class="button" id="run-code">Run</div>
-</header>
+<body class="d-flex flex-column">
 
-<section id="tab-container">
-    <textarea class="tabview" id="editor" selected></textarea>
-    <textarea class="tabview" id="test-view"></textarea>
-    <div class="tabview" id="console-view"></div>
+<nav class="UnderlineNav px-2">
+    <div class="UnderlineNav-body">
+        <a id="editor-tab" href="#" class="UnderlineNav-item selected" selected>Your code</a>
+        <a id="test-tab" href="#" class="UnderlineNav-item">Test</a>
+        <a id="console-tab" href="#" class="UnderlineNav-item">Console</a>
+    </div>
+    <div class="UnderlineNav-actions">
+        <div id="test-result" class="tabnav-extra pr-3"></div>
+        <a id="execute" class="btn btn-primary">
+            <div class="octicon medium-octicon octicon-chevron-right"></div>
+            Check code
+        </a>
+    </div>
+</nav>
+
+<section id="tab-container" class="flex-auto d-flex flex-column p-1">
+    <textarea class="tabview flex-auto" id="editor" selected spellcheck="false"></textarea>
+    <textarea class="tabview flex-auto" id="test-view" spellcheck="false"></textarea>
+    <div class="tabview flex-auto" id="console-view"></div>
 </section>
 
 <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
 </iframe>
+
 </body>
+
 </html>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -39,7 +39,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <div class="UnderlineNav-actions">
         <div id="test-result" class="tabnav-extra pr-3"></div>
         <a id="execute" class="btn btn-primary">
-            <div class="octicon medium-octicon octicon-chevron-right"></div>
+            <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code
         </a>
     </div>

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -3,15 +3,6 @@
 /* BSD-style license that can be found in the LICENSE file. */
 
 body {
-  margin: 0;
-  padding: 0;
-
-  background-color: #fff;
-  color: #111;
-
-  display: flex;
-  flex-direction: column;
-
   top: 0;
   bottom: 0;
   left: 0;
@@ -19,61 +10,7 @@ body {
 
   position: absolute;
 
-  font-family: 'Roboto', sans-serif;
-  font-size: 14px;
-  line-height: 20px;
-
   overflow: hidden;
-}
-
-header {
-  display: flex;
-  flex-direction: row;
-}
-
-.tab {
-  cursor: pointer;
-  margin-right: 10px;
-  padding: 5px;
-  background-color: #008;
-}
-
-.tab a {
-  color: #888;
-}
-
-.tab[selected] {
-  background-color: #44b;
-}
-
-.tab[selected] a {
-  color: #fff;
-}
-
-#head-space {
-    flex-grow: 1;
-}
-
-.button {
-  cursor: pointer;
-  padding: 5px;
-  background-color: #080;
-  color: #888;
-}
-
-.button:hover {
-  background-color: #4b4;
-  color: #fff;
-}
-
-#run-code {
-  display: none;
-}
-
-#tab-container {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: row;
 }
 
 .tabview {
@@ -84,29 +21,17 @@ header {
   display: block;
 }
 
-#editor {
-  flex-grow: 1;
-}
-
-#test-view {
-  flex-grow: 1;
-  font-size: 8pt;
-  line-height: 12pt;
-}
-
-#console-view {
-  flex-grow: 1;
-}
-
 #frame {
   display: none;
 }
 
-.console-message {
-  padding: 5px;
+textarea {
+  border: none;
+  resize: none;
+  font-family: 'Inconsolata', monospace;
+  font-size: 12pt;
 }
 
-.console-error {
-  padding: 5px;
-  color: #800;
+.medium-octicon {
+  font-size: 19px;
 }

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -83,7 +83,7 @@
                 The following function takes two integers as parameters. Add code to make it return
                 a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
             </p>
-            <iframe short src="embed-new.html"></iframe>
+            <iframe src="embed-new.html"></iframe>
         </div>
         <div class="col-md-2"></div>
     </div>


### PR DESCRIPTION
Fixes #906 by adding Primer.css and Octicons, then reworking the existing code to take advantage of them. The new embed now looks like this:

![image](https://user-images.githubusercontent.com/969662/53669000-7b833480-3c2a-11e9-8cb6-920818e85f42.png)

It still has some rough edges and will need a number of new additions for error messages, docs and so forth, but this is a solid start.