### PR TITLE
Adds basic gist loading, updates the demo page to include six total examples

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:html' hide Document;
 
+import 'package:dart_pad/sharing/gists.dart';
+
 import '../core/dependencies.dart';
 import '../core/modules.dart';
 import '../editing/editor.dart';
@@ -66,10 +68,6 @@ class NewEmbed {
       querySelector('#test-view'),
     );
 
-    // These two will ultimately be loaded from GitHub.
-    testTabView.testMethod = initialTest;
-    editorTextArea.value = initialCode;
-
     executionSvc = ExecutionServiceIFrame(querySelector('#frame'));
     executionSvc.onStderr.listen((err) => consoleTabView.appendError(err));
     executionSvc.onStdout.listen((msg) => consoleTabView.appendMessage(msg));
@@ -90,32 +88,27 @@ class NewEmbed {
   }
 
   void _initNewEmbed() {
+    deps[GistLoader] = GistLoader.defaultFilters();
+
     context = NewEmbedContext(
         NewEmbedEditorFactory().createFromElement(editorTextArea), testTabView);
+
+    Uri url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery &&
+        url.queryParameters['id'] != null &&
+        isLegalGistId(url.queryParameters['id'])) {
+      _loadAndShowGist(url.queryParameters['id']);
+    }
   }
 
-  // TODO(RedBrogdon): Remove when gist-loading is integrated.
-  final initialTest = '''
-void main() {
-  final str = stringify(2, 3); 
-  if (str == '2 3') {
-    _result(true, 'Test passed. Great job!');
-  } else if (str == '23') {
-    _result(false, 'Test failed. It looks like you forgot the space!');
-  } else if (str == null) {
-    _result(false, 'Test failed. Did you forget to return a value?');
-  } else {
-    _result(false, 'That\\'s not quite right. Keep trying!');
+  Future<void> _loadAndShowGist(String id) async {
+    final GistLoader loader = deps[GistLoader];
+    final gist = await loader.loadGist(id);
+    print(gist.getFile('main.dart')?.content);
+    context.dartSource = gist.getFile('main.dart')?.content;
+    context.testMethod = gist.getFile('test.dart')?.content;
   }
-}
-''';
-
-  // TODO(RedBrogdon): Remove when gist-loading is integrated.
-  final initialCode = '''
-String stringify(int x, int y) {
-  // Return a formatted string here
-}
-''';
 
   void _handleExecute() {
     executeButton.ready = false;
@@ -286,6 +279,10 @@ class NewEmbedContext {
 
   String get testMethod => testView.testMethod;
 
+  set testMethod(String value) {
+    testView.testMethod = value;
+  }
+
   final _dartDirtyController = StreamController.broadcast();
 
   final _dartReconcileController = StreamController.broadcast();
@@ -301,7 +298,7 @@ class NewEmbedContext {
   String get dartSource => _dartDoc.value;
 
   set dartSource(String value) {
-    _dartDoc.value = value;
+    editor.setContent(value);
   }
 
   String get activeMode => editor.mode;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -105,9 +105,8 @@ class NewEmbed {
   Future<void> _loadAndShowGist(String id) async {
     final GistLoader loader = deps[GistLoader];
     final gist = await loader.loadGist(id);
-    print(gist.getFile('main.dart')?.content);
-    context.dartSource = gist.getFile('main.dart')?.content;
-    context.testMethod = gist.getFile('test.dart')?.content;
+    context.dartSource = gist.getFile('main.dart')?.content ?? '';
+    context.testMethod = gist.getFile('test.dart')?.content ?? '';
   }
 
   void _handleExecute() {

--- a/lib/experimental/new_embed_editor.dart
+++ b/lib/experimental/new_embed_editor.dart
@@ -34,6 +34,13 @@ class NewEmbedEditor extends Editor {
   @override
   Document get document => _document;
 
+  // TODO(brettmorgan): This is a temporary means to set the textarea contents
+  // and needs to be removed during the CodeMirror integration.
+  void setContent(String content) {
+    textarea.value = content;
+    _document.updateValue(content);
+  }
+
   @override
   Document createDocument({String content, String mode}) {
     return NewEmbedDocument(this, content);

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -83,7 +83,7 @@
                 The following function takes two integers as parameters. Add code to make it return
                 a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
             </p>
-            <iframe src="embed-new.html"></iframe>
+            <iframe src="embed-new.html?id=a082c5c4de47de521fef8a3c14aa0a9e"></iframe>
         </div>
         <div class="col-md-2"></div>
     </div>

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -84,10 +84,54 @@
                 a string containing both numbers separated by a space (e.g. 2 and 3 become '2 3').
             </p>
             <iframe src="embed-new.html?id=a082c5c4de47de521fef8a3c14aa0a9e"></iframe>
+            <h3>Additional test case</h3>
+            <p>
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+            </p>
+            <iframe src="embed-new.html?id=083b133262c0872859ca81dabe44ca0b"></iframe>
+            <h3>Additional test case</h3>
+            <p>
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+            </p>
+            <iframe src="embed-new.html?id=ed561e99ff358b98b9a659ea70fca7fa"></iframe>
+            <h3>Additional test case</h3>
+            <p>
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+            </p>
+            <iframe src="embed-new.html?id=dbf158166830de38a1c4726991782872"></iframe>
+            <h3>Additional test case</h3>
+            <p>
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+            </p>
+            <iframe src="embed-new.html?id=f712a462e7d28df61f41711a7c571ed3"></iframe>
+            <h3>Additional test case</h3>
+            <p>
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+                This is some text about the additional test case. This is some text about the additional test case.
+            </p>
+            <iframe src="embed-new.html?id=c4e7bb3bf83a2d25fa9a2f9305f9016c"></iframe>
         </div>
         <div class="col-md-2"></div>
     </div>
 </div>
-
 </body>
 </html>


### PR DESCRIPTION
I've added some basic gist-loading functionality to the new embed, and updated the embeddings demo to show its use with six different gist files. Each one works as a rudimentary test.

This is mostly just wiring up existing gist-related code already in use by the playground. It does not do any local storage of modified gists, or anything related to saving them back to GitHub.

Fixes #909.