### PR TITLE
Adding line numbers to experimental

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -60,7 +60,7 @@ abstract class Editor {
   void focus();
 
   /// Whether to show line numbers to the left of the editor.
-  bool lineNumbers;
+  bool showLineNumbers;
 
   /// Whether the editor is in read only mode.
   bool readOnly;

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -59,9 +59,11 @@ abstract class Editor {
 
   void focus();
 
-  bool get readOnly;
+  /// Whether to show line numbers to the left of the editor.
+  bool lineNumbers;
 
-  set readOnly(bool ro);
+  /// Whether the editor is in read only mode.
+  bool readOnly;
 
   void swapDocument(Document document);
 

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -245,6 +245,12 @@ class _CodeMirrorEditor extends Editor {
   set readOnly(bool ro) => cm.setReadOnly(ro);
 
   @override
+  bool get lineNumbers => cm.getLineNumbers();
+
+  @override
+  set lineNumbers(bool ln) => cm.setLineNumbers(ln);
+
+  @override
   void swapDocument(Document document) {
     _document = document;
     cm.swapDoc(_document.doc);

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -245,10 +245,10 @@ class _CodeMirrorEditor extends Editor {
   set readOnly(bool ro) => cm.setReadOnly(ro);
 
   @override
-  bool get lineNumbers => cm.getLineNumbers();
+  bool get showLineNumbers => cm.getLineNumbers();
 
   @override
-  set lineNumbers(bool ln) => cm.setLineNumbers(ln);
+  set showLineNumbers(bool ln) => cm.setLineNumbers(ln);
 
   @override
   void swapDocument(Document document) {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -167,7 +167,7 @@ class EditorTabView extends TabView {
     // Make sure the theme's css is included in /web/experimental/embed-new.html
     _editor.theme = 'elegant';
     _editor.mode = 'dart';
-    _editor.lineNumbers = true;
+    _editor.showLineNumbers = true;
   }
 
   final Editor _editor;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -167,6 +167,7 @@ class EditorTabView extends TabView {
     // Make sure the theme's css is included in /web/experimental/embed-new.html
     _editor.theme = 'elegant';
     _editor.mode = 'dart';
+    _editor.lineNumbers = true;
   }
 
   final Editor _editor;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -203,7 +203,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   dhttpd:
     dependency: "direct dev"
     description:
@@ -546,7 +546,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.16"
+    version: "0.0.16+1"
   string_scanner:
     dependency: transitive
     description:


### PR DESCRIPTION
I'm wondering if this is something that is useful for referring to specific lines in the surrounding text.

![line-numbers-dart-pad](https://user-images.githubusercontent.com/30503/54316372-a90dac00-4634-11e9-981d-afa1fbc03c59.png)
