### PR TITLE
Adds popup display of analysis and test results

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -83,6 +83,7 @@ class NewEmbed {
           ..theme = 'elegant'
           ..mode = 'dart'
           ..showLineNumbers = true;
+
     userCodeEditor.document.onChange.listen(_performAnalysis);
 
     testEditor = editorFactory.createFromElement(querySelector('#test-editor'))

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -31,12 +31,14 @@ void init() {
 /// snippet against a desired result.
 class NewEmbed {
   ExecuteCodeButton executeButton;
-  TestResultLabel testResultLabel;
 
   TabController tabController;
   TabView editorTabView;
   TabView testTabView;
   ConsoleTabView consoleTabView;
+
+  FlashBox testResultBox;
+  FlashBox analysisResultBox;
 
   ExecutionService executionSvc;
 
@@ -74,9 +76,11 @@ class NewEmbed {
       );
     }
 
-    testResultLabel = TestResultLabel(querySelector('#test-result'));
     executeButton =
         ExecuteCodeButton(querySelector('#execute'), _handleExecute);
+
+    testResultBox = FlashBox(querySelector('#test-result-box'));
+    analysisResultBox = FlashBox(querySelector('#analysis-result-box'));
 
     userCodeEditor =
         editorFactory.createFromElement(querySelector('#user-code-editor'))
@@ -91,11 +95,9 @@ class NewEmbed {
       ..mode = 'dart'
       ..showLineNumbers = true;
 
-    editorTabView = TabView(
-      DElement(querySelector('#user-code-view')));
+    editorTabView = TabView(DElement(querySelector('#user-code-view')));
 
-    testTabView = TabView(
-      DElement(querySelector('#test-view')));
+    testTabView = TabView(DElement(querySelector('#test-view')));
 
     consoleTabView = ConsoleTabView(DElement(querySelector('#console-view')));
 
@@ -103,7 +105,14 @@ class NewEmbed {
     executionSvc.onStderr.listen((err) => consoleTabView.appendError(err));
     executionSvc.onStdout.listen((msg) => consoleTabView.appendMessage(msg));
     executionSvc.testResults.listen((result) {
-      testResultLabel.setResult(result);
+      if (result.success) {
+        executeButton.executionState = ExecutionState.testSuccess;
+      }
+
+      testResultBox.showStrings(
+        result.messages.isNotEmpty ? result.messages : ['Test passed!'],
+        result.success ? FlashBoxStyle.success : FlashBoxStyle.warn,
+      );
     });
 
     _initModules().then((_) => _initNewEmbed());
@@ -140,10 +149,14 @@ class NewEmbed {
   }
 
   void _handleExecute() {
-    executeButton.ready = false;
+    executeButton.executionState = ExecutionState.executing;
+    testResultBox.hide();
+
     final fullCode =
         '${context.dartSource}\n${context.testMethod}\n${executionSvc.testResultDecoration}';
+
     var input = CompileRequest()..source = fullCode;
+
     deps[DartservicesApi]
         .compile(input)
         .timeout(longServiceCallTimeout)
@@ -153,66 +166,32 @@ class NewEmbed {
         // TODO(redbrogdon): Add logging and possibly output to UI.
         .catchError(print)
         .whenComplete(() {
-          executeButton.ready = true;
+          executeButton.executionState = ExecutionState.ready;
         });
   }
 
   void _displayIssues(List<AnalysisIssue> issues) {
-    Element issuesElement = querySelector('#issues');
+    final elements = <DivElement>[];
 
-    // Detect when hiding; don't remove the content until hidden.
-    bool isHiding = issuesElement.children.isNotEmpty && issues.isEmpty;
+    for (AnalysisIssue issue in issues) {
+      elements.add(
+        DivElement()
+          ..children.add(
+            AnchorElement()
+              ..text = '${issue.kind.toUpperCase()} - ${issue.message}'
+              ..classes = ['link-message', 'text-red']
+              ..onClick.listen((event) {
+                _jumpTo(issue.line, issue.charStart, issue.charLength,
+                    focus: true);
+              }),
+          ),
+      );
+    }
 
-    if (isHiding) {
-      issuesElement.classes.toggle('showing', issues.isNotEmpty);
-
-      StreamSubscription sub;
-      sub = issuesElement.onTransitionEnd.listen((_) {
-        issuesElement.children.clear();
-        sub.cancel();
-      });
+    if (elements.isNotEmpty) {
+      analysisResultBox.showElements(elements, FlashBoxStyle.error);
     } else {
-      issuesElement.children.clear();
-
-      issues.sort((a, b) => a.charStart - b.charStart);
-
-      // Create an item for each issue.
-      for (AnalysisIssue issue in issues) {
-        DivElement e = DivElement();
-        e.classes.add('issue');
-        e.attributes['layout'] = '';
-        e.attributes['horizontal'] = '';
-        issuesElement.children.add(e);
-        e.onClick.listen((_) {
-          _jumpTo(issue.line, issue.charStart, issue.charLength, focus: true);
-        });
-
-        SpanElement typeSpan = SpanElement();
-        typeSpan.classes.addAll([issue.kind, 'issuelabel']);
-        typeSpan.text = issue.kind;
-        e.children.add(typeSpan);
-
-        SpanElement messageSpan = SpanElement();
-        messageSpan.classes.add('message');
-        messageSpan.attributes['flex'] = '';
-        messageSpan.text = issue.message;
-        e.children.add(messageSpan);
-        if (issue.hasFixes) {
-          e.classes.add('hasFix');
-          e.onClick.listen((e) {
-            // This is a bit of a hack to make sure quick fixes popup
-            // is only shown if the wrench is clicked,
-            // and not if the text or label is clicked.
-            if ((e.target as Element).className == 'issue hasFix') {
-              // codemiror only shows completions if there is no selected text
-              _jumpTo(issue.line, issue.charStart, 0, focus: true);
-              userCodeEditor.showCompletions(onlyShowFixes: true);
-            }
-          });
-        }
-      }
-
-      issuesElement.classes.toggle('showing', issues.isNotEmpty);
+      analysisResultBox.hide();
     }
   }
 
@@ -344,10 +323,16 @@ class TestResultLabel {
   }
 }
 
+enum ExecutionState {
+  ready,
+  executing,
+  testSuccess,
+}
+
 class ExecuteCodeButton {
   /// This constructor will throw if the provided element has no child with a
   /// CSS class that begins with "octicon-".
-  ExecuteCodeButton(AnchorElement anchorElement, VoidCallback onClick)
+  ExecuteCodeButton(ButtonElement anchorElement, VoidCallback onClick)
       : assert(anchorElement != null),
         assert(onClick != null) {
     final iconElement =
@@ -357,21 +342,21 @@ class ExecuteCodeButton {
     _element.onClick.listen((e) => onClick());
   }
 
-  static const readyIconName = 'triangle-right';
-  static const waitingIconName = 'sync';
+  static const iconNames = <ExecutionState, String>{
+    ExecutionState.ready: 'triangle-right',
+    ExecutionState.executing: 'sync',
+    ExecutionState.testSuccess: 'check',
+  };
+
   static const disabledClassName = 'disabled';
 
   DElement _element;
 
   Octicon _icon;
 
-  // Both the icon and the disabled attribute are set at the same time, so
-  // checking one should be as good as checking both.
-  bool get ready => !_element.hasClass(disabledClassName);
-
-  set ready(bool value) {
-    _element.toggleClass(disabledClassName, !value);
-    _icon.iconName = value ? readyIconName : waitingIconName;
+  set executionState(ExecutionState state) {
+    _element.toggleClass(disabledClassName, state == ExecutionState.executing);
+    _icon.iconName = iconNames[state];
   }
 }
 
@@ -394,6 +379,60 @@ class Octicon {
 
   static bool elementIsOcticon(Element el) =>
       el.classes.any((s) => s.startsWith(prefix));
+}
+
+enum FlashBoxStyle {
+  warn,
+  error,
+  success,
+}
+
+class FlashBox {
+  /// This constructor will throw if [div] does not have a child with the
+  /// flash-close class and a child with the message-container class.
+  FlashBox(DivElement div) {
+    _element = DElement(div);
+    _messageContainer = DElement(div.querySelector('.message-container'));
+
+    final closeLink = DElement(div.querySelector('.flash-close'));
+    closeLink.onClick.listen((event) {
+      hide();
+    });
+  }
+
+  static const classNamesForStyles = <FlashBoxStyle, String>{
+    FlashBoxStyle.warn: 'flash-warn',
+    FlashBoxStyle.error: 'flash-error',
+    FlashBoxStyle.success: 'flash-success',
+  };
+
+  DElement _element;
+
+  DElement _messageContainer;
+
+  void showStrings(List<String> messages, [FlashBoxStyle style]) {
+    showElements(messages.map((m) => DivElement()..text = m).toList(), style);
+  }
+
+  void showElements(List<Element> elements, [FlashBoxStyle style]) {
+    _element.clearAttr('hidden');
+    _element.element.classes
+        .removeWhere((s) => classNamesForStyles.values.contains(s));
+
+    if (style != null) {
+      _element.toggleClass(classNamesForStyles[style], true);
+    }
+
+    _messageContainer.clearChildren();
+
+    for (final element in elements) {
+      _messageContainer.add(element);
+    }
+  }
+
+  void hide() {
+    _element.setAttr('hidden');
+  }
 }
 
 class NewEmbedContext {

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -49,11 +49,10 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
-        <div id="test-result" class="tabnav-extra pr-3"></div>
-        <a id="execute" class="btn btn-primary">
+        <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code
-        </a>
+        </button>
     </div>
 </nav>
 
@@ -66,6 +65,17 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
     <div id="console-view" class="tabview flex-auto" hidden></div>
 </section>
+
+<div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
+    <div id="analysis-result-box" class="flash flash-error" hidden>
+        <button class="flash-close">close</button>
+        <div class="message-container"></div>
+    </div>
+    <div id="test-result-box" class="flash flash-warn" hidden>
+        <button class="flash-close">close</button>
+        <div class="message-container"></div>
+    </div>
+</div>
 
 <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
 </iframe>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -64,6 +64,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <div id="console-view" class="tabview flex-auto" hidden></div>
 </section>
 
+<div class="position-fixed right-0 bottom-0 bg-gray-light border p-2">
+    <div>Issue #1</div>
+    <div>Issue #1</div>
+    <div>Issue #1</div>
+</div>
+
 <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
 </iframe>
 

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -46,11 +46,10 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
-        <div id="test-result" class="tabnav-extra pr-3"></div>
-        <a id="execute" class="btn btn-primary">
+        <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code
-        </a>
+        </button>
     </div>
 </nav>
 
@@ -64,10 +63,15 @@ BSD-style license that can be found in the LICENSE file. -->
     <div id="console-view" class="tabview flex-auto" hidden></div>
 </section>
 
-<div class="position-fixed right-0 bottom-0 bg-gray-light border p-2">
-    <div>Issue #1</div>
-    <div>Issue #1</div>
-    <div>Issue #1</div>
+<div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
+    <div id="analysis-result-box" class="flash flash-error" hidden>
+        <button class="flash-close">close</button>
+        <div class="message-container"></div>
+    </div>
+    <div id="test-result-box" class="flash flash-warn" hidden>
+        <button class="flash-close">close</button>
+        <div class="message-container"></div>
+    </div>
 </div>
 
 <iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -28,6 +28,18 @@ textarea {
   font-size: 19px;
 }
 
+/*
+  This rule adds space between the flashes in the flash container, if more
+  than one is displayed.
+*/
+#flash-container > div + div {
+  margin-top: 8px;
+}
+
+.link-message {
+  cursor: pointer;
+}
+
 /* Code annotations */
 .squiggle-error {
   border-bottom: 2px solid #F7977A;


### PR DESCRIPTION
This adds popups (Primer.css flash boxes) to display analysis and test results. Both can be closed via "close" link in the top right, and clicking on analysis messages will jump to the corresponding code in the editor, similar to what the playground UI already does.

The test result label has been removed from the top navigation bar, and the button that triggers code execution now displays a checkmark if the most recent execution resulted in a passed test.

Shot of the analysis and test results:

![image](https://user-images.githubusercontent.com/969662/55295661-7f8aa980-53c4-11e9-97b5-4d5caecb61e5.png)
