### PR TITLE
Prints properly formatted compile exceptions to console

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -164,8 +164,10 @@ class NewEmbed {
         .then((CompileResponse response) {
           executionSvc.execute('', '', response.result);
         })
-        // TODO(redbrogdon): Add logging and possibly output to UI.
-        .catchError(print)
+        .catchError((e) {
+          consoleTabView.appendError('Error compiling to JavaScript:\n$e');
+          tabController.selectTab('console');
+        })
         .whenComplete(() {
           executeButton.executionState = ExecutionState.ready;
         });

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -29,6 +29,7 @@ body {
   font-size: 16px;
   overflow-y: auto;
   height: 100%;
+  white-space: pre-wrap;
 }
 
 


### PR DESCRIPTION
Compile-time exceptions are now printed to the console, and focus is sent there as soon as one arrives. There may be a more elegant way to surface these, but this approach should work at least for the short term.