### PR TITLE
Adds a "reload this gist button"

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -31,6 +31,7 @@ void init() {
 /// snippet against a desired result.
 class NewEmbed {
   ExecuteCodeButton executeButton;
+  ButtonElement reloadGistButton;
 
   TabController tabController;
   TabView editorTabView;
@@ -79,6 +80,13 @@ class NewEmbed {
     executeButton =
         ExecuteCodeButton(querySelector('#execute'), _handleExecute);
 
+    reloadGistButton = querySelector('#reload-gist');
+    if (gistId.isNotEmpty) {
+      reloadGistButton.onClick.listen((e) => _loadAndShowGist(gistId));
+    } else {
+      reloadGistButton.setAttribute('disabled', 'true');
+    }
+
     testResultBox = FlashBox(querySelector('#test-result-box'));
     analysisResultBox = FlashBox(querySelector('#analysis-result-box'));
 
@@ -118,6 +126,18 @@ class NewEmbed {
     _initModules().then((_) => _initNewEmbed());
   }
 
+  String get gistId {
+    Uri url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery &&
+        url.queryParameters['id'] != null &&
+        isLegalGistId(url.queryParameters['id'])) {
+      return url.queryParameters['id'];
+    }
+
+    return '';
+  }
+
   Future<void> _initModules() async {
     ModuleManager modules = ModuleManager();
 
@@ -132,12 +152,8 @@ class NewEmbed {
 
     context = NewEmbedContext(userCodeEditor, testEditor);
 
-    Uri url = Uri.parse(window.location.toString());
-
-    if (url.hasQuery &&
-        url.queryParameters['id'] != null &&
-        isLegalGistId(url.queryParameters['id'])) {
-      _loadAndShowGist(url.queryParameters['id']);
+    if (gistId.isNotEmpty) {
+      _loadAndShowGist(gistId);
     }
   }
 

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -49,6 +49,10 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
+        <button id="reload-gist" class="btn">
+            <div class="octicon medium-octicon octicon-cloud-download"></div>
+            Reset code
+        </button>
         <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code
@@ -83,3 +87,4 @@ BSD-style license that can be found in the LICENSE file. -->
 </body>
 
 </html>
+

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -46,6 +46,10 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
+        <button id="reload-gist" class="btn">
+            <div class="octicon medium-octicon octicon-cloud-download"></div>
+            Reset code
+        </button>
         <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Check code


### PR DESCRIPTION
A new button next to the one for "execute code." When clicked, it will reload the code and test from the gist referenced in the dartpad query string into the editors, allowing someone to reset their progress and start over.

![image](https://user-images.githubusercontent.com/969662/55359224-2f741b80-5486-11e9-8c50-00ef8e3ca5bd.png)
