### PR TITLE
Updates analyzer message UI to display message counts instead of full text

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -233,37 +233,39 @@ class NewEmbed {
   }
 
   void _displayIssues(List<AnalysisIssue> issues) {
-    final elements = <DivElement>[];
+    int errorCount = 0;
+    int infoCount = 0;
 
     for (AnalysisIssue issue in issues) {
-      elements.add(
-        DivElement()
-          ..children.add(
-            AnchorElement()
-              ..text = '${issue.kind.toUpperCase()} - ${issue.message}'
-              ..classes = ['link-message', 'text-red']
-              ..onClick.listen((event) {
-                _jumpTo(issue.line, issue.charStart, issue.charLength,
-                    focus: true);
-              }),
-          ),
-      );
+      if (issue.kind == 'error') {
+        errorCount++;
+      } else if (issue.kind == 'info') {
+        infoCount++;
+      }
     }
 
-    if (elements.isNotEmpty) {
-      analysisResultBox.showElements(elements, FlashBoxStyle.error);
-    } else {
+    if (errorCount == 0 && infoCount == 0) {
       analysisResultBox.hide();
+    } else {
+      String message;
+      FlashBoxStyle style;
+
+      if (errorCount > 0 && infoCount > 0) {
+        message = 'Analyzer found $errorCount error${errorCount > 1 ? 's' : ''}'
+            ' and $infoCount warning${infoCount > 1 ? 's' : ''}.';
+        style = FlashBoxStyle.error;
+      } else if (errorCount > 0) {
+        message =
+            'Analyzer found $errorCount error${errorCount > 1 ? 's' : ''}.';
+        style = FlashBoxStyle.error;
+      } else {
+        message =
+            'Analyzer found $infoCount warning${infoCount > 1 ? 's' : ''}.';
+        style = FlashBoxStyle.warn;
+      }
+
+      analysisResultBox.showStrings([message], style);
     }
-  }
-
-  void _jumpTo(int line, int charStart, int charLength, {bool focus = false}) {
-    Document doc = userCodeEditor.document;
-
-    doc.select(
-        doc.posFromIndex(charStart), doc.posFromIndex(charStart + charLength));
-
-    if (focus) userCodeEditor.focus();
   }
 
   /// Perform static analysis of the source code.

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -234,25 +234,25 @@ class NewEmbed {
 
   void _displayIssues(List<AnalysisIssue> issues) {
     int errorCount = 0;
-    int infoCount = 0;
+    int otherCount = 0;
 
     for (AnalysisIssue issue in issues) {
       if (issue.kind == 'error') {
         errorCount++;
-      } else if (issue.kind == 'info') {
-        infoCount++;
+      } else if (issue.kind == 'info' || issue.kind == 'warning') {
+        otherCount++;
       }
     }
 
-    if (errorCount == 0 && infoCount == 0) {
+    if (errorCount == 0 && otherCount == 0) {
       analysisResultBox.hide();
     } else {
       String message;
       FlashBoxStyle style;
 
-      if (errorCount > 0 && infoCount > 0) {
+      if (errorCount > 0 && otherCount > 0) {
         message = 'Analyzer found $errorCount error${errorCount > 1 ? 's' : ''}'
-            ' and $infoCount warning${infoCount > 1 ? 's' : ''}.';
+            ' and $otherCount other issue${otherCount > 1 ? 's' : ''}.';
         style = FlashBoxStyle.error;
       } else if (errorCount > 0) {
         message =
@@ -260,7 +260,7 @@ class NewEmbed {
         style = FlashBoxStyle.error;
       } else {
         message =
-            'Analyzer found $infoCount warning${infoCount > 1 ? 's' : ''}.';
+            'Analyzer found $otherCount issue${otherCount > 1 ? 's' : ''}';
         style = FlashBoxStyle.warn;
       }
 

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -74,11 +74,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
     <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">close</button>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
         <div class="message-container"></div>
     </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">close</button>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
         <div class="message-container"></div>
     </div>
 </div>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -74,11 +74,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
     <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">close</button>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
         <div class="message-container"></div>
     </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">close</button>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
         <div class="message-container"></div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #984 and partially addresses #976.

This PR changes the "close" label to close analyzer and test results to be an "X" icon from Octicons. It also changes the way analyzer issues are displayed. Rather than spitting them all out in full text, possibly covering half the editor, it summarizes them instead:

![image](https://user-images.githubusercontent.com/969662/55760535-39ab9200-5a11-11e9-8c23-667d4bdf6905.png)

Users can still mouseover the squiggles in the editor to get the full error messages as tooltips. We may want to look into writing a codemirror plugin to display real tooltips.

