### PR TITLE
Added unread counter to console tab button.

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -341,7 +341,7 @@ class Counter {
 
   void increment() {
     _itemCount++;
-    element.text = _itemCount.toString();
+    element.text = '$_itemCount';
     element.attributes.remove('hidden');
   }
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -38,6 +38,8 @@ class NewEmbed {
   TabView testTabView;
   ConsoleTabView consoleTabView;
 
+  Counter unreadConsoleCounter;
+
   FlashBox testResultBox;
   FlashBox analysisResultBox;
 
@@ -67,15 +69,18 @@ class NewEmbed {
           if (name == 'editor') {
             userCodeEditor.resize();
             userCodeEditor.focus();
-          }
-
-          if (name == 'test') {
+          } else if (name == 'test') {
             testEditor.resize();
             testEditor.focus();
+          } else {
+            // Must be the console tab.
+            unreadConsoleCounter.clear();
           }
         }),
       );
     }
+
+    unreadConsoleCounter = Counter(querySelector('#unread-console-counter'));
 
     executeButton =
         ExecuteCodeButton(querySelector('#execute'), _handleExecute);
@@ -110,8 +115,21 @@ class NewEmbed {
     consoleTabView = ConsoleTabView(DElement(querySelector('#console-view')));
 
     executionSvc = ExecutionServiceIFrame(querySelector('#frame'));
-    executionSvc.onStderr.listen((err) => consoleTabView.appendError(err));
-    executionSvc.onStdout.listen((msg) => consoleTabView.appendMessage(msg));
+
+    executionSvc.onStderr.listen((err) {
+      if (tabController.selectedTab.name != 'console') {
+        unreadConsoleCounter.increment();
+      }
+      consoleTabView.appendError(err);
+    });
+
+    executionSvc.onStdout.listen((msg) {
+      if (tabController.selectedTab.name != 'console') {
+        unreadConsoleCounter.increment();
+      }
+      consoleTabView.appendMessage(msg);
+    });
+
     executionSvc.testResults.listen((result) {
       if (result.success) {
         executeButton.executionState = ExecutionState.testSuccess;
@@ -178,15 +196,13 @@ class NewEmbed {
         .compile(input)
         .timeout(longServiceCallTimeout)
         .then((CompileResponse response) {
-          executionSvc.execute('', '', response.result);
-        })
-        .catchError((e) {
-          consoleTabView.appendError('Error compiling to JavaScript:\n$e');
-          tabController.selectTab('console');
-        })
-        .whenComplete(() {
-          executeButton.executionState = ExecutionState.ready;
-        });
+      executionSvc.execute('', '', response.result);
+    }).catchError((e) {
+      consoleTabView.appendError('Error compiling to JavaScript:\n$e');
+      tabController.selectTab('console');
+    }).whenComplete(() {
+      executeButton.executionState = ExecutionState.ready;
+    });
   }
 
   void _displayIssues(List<AnalysisIssue> issues) {
@@ -316,27 +332,22 @@ class ConsoleTabView extends TabView {
   }
 }
 
-/// A line of text next to the [ExecuteButton] that reports test result messages
-/// in red or green.
-class TestResultLabel {
-  TestResultLabel(this.element);
+class Counter {
+  Counter(this.element);
 
-  final DivElement element;
+  final SpanElement element;
 
-  void setResult(TestResult result) {
-    if (result.messages.isEmpty) {
-      element.text = result.success ? 'Test passed!' : 'Test failed.';
-    } else {
-      element.text = result.messages.first;
-    }
+  int _itemCount = 0;
 
-    if (result.success) {
-      element.classes.add('text-green');
-      element.classes.remove('text-red');
-    } else {
-      element.classes.remove('text-green');
-      element.classes.add('text-red');
-    }
+  void increment() {
+    _itemCount++;
+    element.text = _itemCount.toString();
+    element.attributes.remove('hidden');
+  }
+
+  void clear() {
+    _itemCount = 0;
+    element.setAttribute('hidden', 'true');
   }
 }
 

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -45,7 +45,10 @@ BSD-style license that can be found in the LICENSE file. -->
         <div class="BtnGroup mr-2">
             <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
             <button id="test-tab" class="btn BtnGroup-item" type="button">Test</button>
-            <button id="console-tab" class="btn BtnGroup-item" type="button">Console</button>
+            <button id="console-tab" class="btn BtnGroup-item" type="button">
+                Console
+                <span id="unread-console-counter" class="Counter" hidden></span>
+            </button>
         </div>
     </div>
     <div class="UnderlineNav-actions">
@@ -87,4 +90,3 @@ BSD-style license that can be found in the LICENSE file. -->
 </body>
 
 </html>
-

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -42,7 +42,10 @@ BSD-style license that can be found in the LICENSE file. -->
         <div class="BtnGroup mr-2">
             <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
             <button id="test-tab" class="btn BtnGroup-item" type="button">Test</button>
-            <button id="console-tab" class="btn BtnGroup-item" type="button">Console</button>
+            <button id="console-tab" class="btn BtnGroup-item" type="button">
+                Console
+                <span id="unread-console-counter" class="Counter" hidden></span>
+            </button>
         </div>
     </div>
     <div class="UnderlineNav-actions">


### PR DESCRIPTION
Addresses one of Devon's later comments in #978 by adding a Primer.css "counter" to the console tab button. It's incremented when a new message or error is added to the console, and cleared/hidden when the user switches to that view. If they're already on it when a new message arrives, the counter is left in its hidden state.