### PR TITLE
misc updates and changes to the embedded UI

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -66,56 +66,54 @@ class DartCompleter extends CodeCompleter {
         String replacementString = editor.document.value
             .substring(replaceOffset, replaceOffset + replaceLength);
 
-        List<AnalysisCompletion> analysisCompletions =
+        Iterable<AnalysisCompletion> responses =
             response.completions.map((Map completion) {
           return AnalysisCompletion(replaceOffset, replaceLength, completion);
-        }).toList();
+        });
 
-        List<Completion> completions = analysisCompletions
-            .map((completion) {
-              // TODO: Move to using a LabelProvider; decouple the data and rendering.
-              String displayString = completion.isMethod
-                  ? '${completion.text}${completion.parameters}'
-                  : completion.text;
-              if (completion.isMethod && completion.returnType != null) {
-                displayString += ' → ${completion.returnType}';
-              }
+        Iterable<Completion> completions = responses.map((completion) {
+          // TODO: Move to using a LabelProvider; decouple the data and rendering.
+          String displayString = completion.isMethod
+              ? '${completion.text}${completion.parameters}'
+              : completion.text;
+          if (completion.isMethod && completion.returnType != null) {
+            displayString += ' → ${completion.returnType}';
+          }
 
-              // Filter unmatching completions.
-              // TODO: This is temporary; tracking issue here:
-              // https://github.com/dart-lang/dart-services/issues/87.
-              if (replacementString.isNotEmpty) {
-                if (!completion.matchesCompletionFragment(replacementString)) {
-                  return null;
-                }
-              }
+          // Filter unmatching completions.
+          // TODO: This is temporary; tracking issue here:
+          // https://github.com/dart-lang/dart-services/issues/87.
+          if (replacementString.isNotEmpty) {
+            if (!completion.matchesCompletionFragment(replacementString)) {
+              return null;
+            }
+          }
 
-              String text = completion.text;
+          String text = completion.text;
 
-              if (completion.isMethod) text += '()';
+          if (completion.isMethod) text += '()';
 
-              String deprecatedClass =
-                  completion.isDeprecated ? ' deprecated' : '';
+          String deprecatedClass = completion.isDeprecated ? ' deprecated' : '';
 
-              if (completion.type == null) {
-                return Completion(text,
-                    displayString: displayString, type: deprecatedClass);
-              } else {
-                int cursorPos;
+          if (completion.type == null) {
+            return Completion(text,
+                displayString: displayString, type: deprecatedClass);
+          } else {
+            int cursorPos;
 
-                if (completion.isMethod && completion.parameterCount > 0) {
-                  cursorPos = text.indexOf('(') + 1;
-                }
+            if (completion.isMethod && completion.parameterCount > 0) {
+              cursorPos = text.indexOf('(') + 1;
+            }
 
-                return Completion(text,
-                    displayString: displayString,
-                    type:
-                        'type-${completion.type.toLowerCase()}$deprecatedClass',
-                    cursorOffset: cursorPos);
-              }
-            })
-            .where((x) => x != null)
-            .toList();
+            return Completion(
+              text,
+              displayString: displayString,
+              type: 'type-${completion.type.toLowerCase()}$deprecatedClass',
+              cursorOffset: cursorPos,
+            );
+          }
+        });
+        completions = completions.where((x) => x != null).toList();
 
         List<Completion> filterCompletions = List.from(completions);
 

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -242,7 +242,7 @@ class _CodeMirrorEditor extends Editor {
   bool get readOnly => cm.getReadOnly();
 
   @override
-  set readOnly(bool ro) => cm.setReadOnly(ro);
+  set readOnly(bool ro) => cm.setReadOnly(ro, true);
 
   @override
   bool get showLineNumbers => cm.getLineNumbers();

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -356,9 +356,13 @@ class NewEmbed {
 
       formatButton.disabled = false;
 
-      if (originalSource != result.newString) {
-        userCodeEditor.document.updateValue(result.newString);
-        _performAnalysis();
+      // Check that the user hasn't edited the source since the format request.
+      if (originalSource == userCodeEditor.document.value) {
+        // And, check that the format request did modify the source code.
+        if (originalSource != result.newString) {
+          userCodeEditor.document.updateValue(result.newString);
+          _performAnalysis();
+        }
       }
     } catch (e) {
       formatButton.disabled = false;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -117,7 +117,9 @@ class NewEmbed {
     testEditor = editorFactory.createFromElement(querySelector('#test-editor'))
       ..theme = 'elegant'
       ..mode = 'dart'
-      ..readOnly = true
+      // TODO(devoncarew): We should make this read-only after initial beta
+      // testing.
+      //..readOnly = true
       ..showLineNumbers = true;
 
     editorTabView = TabView(DElement(querySelector('#user-code-view')));
@@ -294,8 +296,7 @@ class NewEmbed {
       // Create a synthesis of the user code and other code to analyze.
       final fullSource = '$userSource\n'
           '${context.testMethod}\n'
-          '${executionSvc.testResultDecoration}\n'
-          'var resultFunction = _result;\n';
+          '${executionSvc.testResultDecoration}\n';
       final sourceRequest = SourceRequest()..source = fullSource;
       final lines = Lines(sourceRequest.source);
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -7,6 +7,7 @@ import 'dart:html' hide Document;
 
 import 'package:dart_pad/sharing/gists.dart';
 
+import '../completion.dart';
 import '../core/dependencies.dart';
 import '../core/modules.dart';
 import '../dart_pad.dart';
@@ -33,6 +34,7 @@ void init() {
 class NewEmbed {
   DisableableButton executeButton;
   DisableableButton reloadGistButton;
+  DisableableButton formatButton;
 
   DElement navBarElement;
   TabController tabController;
@@ -49,14 +51,14 @@ class NewEmbed {
 
   EditorFactory editorFactory = codeMirrorFactory;
 
-  Editor testEditor;
   Editor userCodeEditor;
+  Editor testEditor;
 
   NewEmbedContext context;
 
-  final _debounceTimer = DelayedTimer(
-    minDelay: Duration(milliseconds: 100),
-    maxDelay: Duration(milliseconds: 500),
+  final DelayedTimer _debounceTimer = DelayedTimer(
+    minDelay: Duration(milliseconds: 1000),
+    maxDelay: Duration(milliseconds: 5000),
   );
 
   NewEmbed() {
@@ -97,6 +99,11 @@ class NewEmbed {
 
     reloadGistButton.disabled = gistId.isEmpty;
 
+    formatButton = DisableableButton(
+      querySelector('#format-code'),
+      _performFormat,
+    );
+
     testResultBox = FlashBox(querySelector('#test-result-box'));
     analysisResultBox = FlashBox(querySelector('#analysis-result-box'));
 
@@ -105,12 +112,12 @@ class NewEmbed {
           ..theme = 'elegant'
           ..mode = 'dart'
           ..showLineNumbers = true;
-
     userCodeEditor.document.onChange.listen(_performAnalysis);
 
     testEditor = editorFactory.createFromElement(querySelector('#test-editor'))
       ..theme = 'elegant'
       ..mode = 'dart'
+      ..readOnly = true
       ..showLineNumbers = true;
 
     editorTabView = TabView(DElement(querySelector('#user-code-view')));
@@ -171,13 +178,25 @@ class NewEmbed {
 
     context = NewEmbedContext(userCodeEditor, testEditor);
 
+    editorFactory.registerCompleter(
+        'dart', DartCompleter(dartServices, userCodeEditor.document));
+    keys.bind(['ctrl-space', 'macctrl-space'], () {
+      if (userCodeEditor.hasFocus) {
+        userCodeEditor.showCompletions();
+      }
+    }, 'Completion');
+    document.onKeyUp.listen(_handleAutoCompletion);
+
     if (supportsFlutterWeb) {
       // Make the web output area visible.
       querySelector('#web-output').removeAttribute('hidden');
+
+      // Shrink the code editing area.
+      querySelector('#user-code-editor').classes.add('web-output-showing');
     }
 
     if (gistId.isNotEmpty) {
-      _loadAndShowGist(gistId);
+      _loadAndShowGist(gistId, analyze: false);
     }
   }
 
@@ -187,21 +206,25 @@ class NewEmbed {
     navBarElement.toggleClass('busy', value);
     executeButton.disabled = value;
     userCodeEditor.readOnly = value;
-    testEditor.readOnly = value;
     reloadGistButton.disabled = value || gistId.isEmpty;
   }
 
-  Future<void> _loadAndShowGist(String id) async {
+  Future<void> _loadAndShowGist(String id, {bool analyze = true}) async {
     editorIsBusy = true;
     final GistLoader loader = deps[GistLoader];
     final gist = await loader.loadGist(id);
     context.dartSource = gist.getFile('main.dart')?.content ?? '';
     context.testMethod = gist.getFile('test.dart')?.content ?? '';
     editorIsBusy = false;
+
+    if (analyze) {
+      _performAnalysis();
+    }
   }
 
   void _handleExecute() {
     editorIsBusy = true;
+    analysisResultBox.hide();
     testResultBox.hide();
     consoleTabView.clear();
 
@@ -245,60 +268,50 @@ class NewEmbed {
   }
 
   void _displayIssues(List<AnalysisIssue> issues) {
-    int errorCount = 0;
-    int otherCount = 0;
+    analysisResultBox.hide();
+    testResultBox.hide();
 
-    for (AnalysisIssue issue in issues) {
-      if (issue.kind == 'error') {
-        errorCount++;
-      } else if (issue.kind == 'info' || issue.kind == 'warning') {
-        otherCount++;
-      }
+    if (issues.isEmpty) {
+      return;
     }
 
-    if (errorCount == 0 && otherCount == 0) {
-      analysisResultBox.hide();
-    } else {
-      String message;
-      FlashBoxStyle style;
-
-      if (errorCount > 0 && otherCount > 0) {
-        message = 'Analyzer found $errorCount error${errorCount > 1 ? 's' : ''}'
-            ' and $otherCount other issue${otherCount > 1 ? 's' : ''}.';
-        style = FlashBoxStyle.error;
-      } else if (errorCount > 0) {
-        message =
-            'Analyzer found $errorCount error${errorCount > 1 ? 's' : ''}.';
-        style = FlashBoxStyle.error;
-      } else {
-        message =
-            'Analyzer found $otherCount issue${otherCount > 1 ? 's' : ''}';
-        style = FlashBoxStyle.warn;
+    List<String> messages = issues.map((AnalysisIssue issue) {
+      String message = issue.message;
+      if (message.endsWith('.')) {
+        message = message.substring(0, message.length - 1);
       }
+      return '$message - line ${issue.line}';
+    }).toList();
 
-      analysisResultBox.showStrings([message], style);
-    }
+    analysisResultBox.showStrings(messages, FlashBoxStyle.warn);
   }
 
   /// Perform static analysis of the source code.
-  void _performAnalysis(_) async {
+  void _performAnalysis([_]) {
     _debounceTimer.invoke(() {
       final dartServices = deps[DartservicesApi] as DartservicesApi;
-      final input = SourceRequest()..source = userCodeEditor.document.value;
-      final lines = Lines(input.source);
-      final request = dartServices.analyze(input).timeout(serviceCallTimeout);
+      final userSource = context.dartSource;
+      // Create a synthesis of the user code and other code to analyze.
+      final fullSource = '$userSource\n'
+          '${context.testMethod}\n'
+          '${executionSvc.testResultDecoration}\n'
+          'var resultFunction = _result;\n';
+      final sourceRequest = SourceRequest()..source = fullSource;
+      final lines = Lines(sourceRequest.source);
 
-      request.then((AnalysisResults result) {
+      dartServices
+          .analyze(sourceRequest)
+          .timeout(serviceCallTimeout)
+          .then((AnalysisResults result) {
         // Discard if the document has been mutated since we requested analysis.
-        if (input.source != userCodeEditor.document.value) return false;
+        if (userSource != context.dartSource) return;
 
         _displayIssues(result.issues);
 
-        userCodeEditor.document
-            .setAnnotations(result.issues.map((AnalysisIssue issue) {
-          final startLine = lines.getLineForOffset(issue.charStart);
-          final endLine =
-              lines.getLineForOffset(issue.charStart + issue.charLength);
+        Iterable<Annotation> issues = result.issues.map((AnalysisIssue issue) {
+          final charStart = issue.charStart;
+          final startLine = lines.getLineForOffset(charStart);
+          final endLine = lines.getLineForOffset(charStart + issue.charLength);
 
           return Annotation(
             issue.kind,
@@ -306,18 +319,57 @@ class NewEmbed {
             issue.line,
             start: Position(
               startLine,
-              issue.charStart - lines.offsetForLine(startLine),
+              charStart - lines.offsetForLine(startLine),
             ),
             end: Position(
               endLine,
-              issue.charStart +
-                  issue.charLength -
-                  lines.offsetForLine(startLine),
+              charStart + issue.charLength - lines.offsetForLine(startLine),
             ),
           );
-        }).toList());
+        });
+
+        userCodeEditor.document.setAnnotations(issues.toList());
+      }).catchError((e) {
+        if (e is! TimeoutException) {
+          final String message = e is ApiRequestError ? e.message : '$e';
+
+          _displayIssues([
+            AnalysisIssue()
+              ..kind = 'error'
+              ..line = 1
+              ..message = message
+          ]);
+          userCodeEditor.document.setAnnotations([]);
+        }
       });
     });
+  }
+
+  void _performFormat() async {
+    String originalSource = userCodeEditor.document.value;
+    SourceRequest input = SourceRequest()..source = originalSource;
+
+    try {
+      formatButton.disabled = true;
+      FormatResponse result =
+          await dartServices.format(input).timeout(serviceCallTimeout);
+
+      formatButton.disabled = false;
+
+      if (originalSource != result.newString) {
+        userCodeEditor.document.updateValue(result.newString);
+        _performAnalysis();
+      }
+    } catch (e) {
+      formatButton.disabled = false;
+      print(e);
+    }
+  }
+
+  void _handleAutoCompletion(KeyboardEvent e) {
+    if (userCodeEditor.hasFocus && e.keyCode == KeyCode.PERIOD) {
+      userCodeEditor.showCompletions(autoInvoked: true);
+    }
   }
 
   bool get supportsFlutterWeb {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -919,9 +919,9 @@ class Playground implements GistContainer, GistController {
         if (issue.hasFixes) {
           e.classes.add('hasFix');
           e.onClick.listen((e) {
-            // This is a bit of a hack to make sure quick fixes popup
-            // is only shown if the wrench is clicked,
-            // and not if the text or label is clicked.
+            // This is a bit of a hack to make sure quick fixes popup is only
+            // shown if the wrench is clicked, and not if the text or label is
+            // clicked.
             if ((e.target as Element).className == 'issue hasFix') {
               // codemiror only shows completions if there is no selected text
               _jumpTo(issue.line, issue.charStart, 0, focus: true);

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -134,7 +134,7 @@ window.onerror = function(message, url, lineNumber, colno, error) {
       requireConfig = '''
 require.config({
   "baseUrl": "$modulesBaseUrl",
-  waitSeconds: 60
+  "waitSeconds": 60
 });
 ''';
     }

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -71,7 +71,11 @@ void _result(bool success, [List<String> messages]) {
   final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
 
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
-}''';
+}
+
+// Ensure we have at least one use of `_result`.
+var resultFunction = _result;
+''';
 
   String _decorateJavaScript(String javaScript, {String modulesBaseUrl}) {
     final String postMessagePrint = '''

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -133,7 +133,8 @@ window.onerror = function(message, url, lineNumber, colno, error) {
     if (modulesBaseUrl != null) {
       requireConfig = '''
 require.config({
-  "baseUrl": "$modulesBaseUrl"
+  "baseUrl": "$modulesBaseUrl",
+  waitSeconds: 60
 });
 ''';
     }

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -44,20 +44,21 @@ BSD-style license that can be found in the LICENSE file. -->
     <div class="UnderlineNav-body">
         <div class="BtnGroup mr-2">
             <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
-            <button id="test-tab" class="btn BtnGroup-item" type="button">Test</button>
+            <button id="test-tab" class="btn BtnGroup-item" type="button">Test code</button>
             <button id="console-tab" class="btn BtnGroup-item" type="button">
-                Console
+                Output
                 <span id="unread-console-counter" class="Counter" hidden></span>
             </button>
         </div>
     </div>
     <div class="UnderlineNav-actions">
+        <button id="format-code" class="btn">Format</button>
         <button id="reload-gist" class="btn">
-            Reset code
+            Reset
         </button>
         <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
-            Check code
+            Run
         </button>
     </div>
 </nav>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -38,22 +38,21 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <nav id="navbar" class="UnderlineNav p-2">
     <div class="UnderlineNav-body">
-        <div class="BtnGroup mr-2">
+        <div class="BtnGroup">
             <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
-            <button id="test-tab" class="btn BtnGroup-item" type="button">Test</button>
+            <button id="test-tab" class="btn BtnGroup-item" type="button">Test code</button>
             <button id="console-tab" class="btn BtnGroup-item" type="button">
-                Console
+                Output
                 <span id="unread-console-counter" class="Counter" hidden></span>
             </button>
         </div>
     </div>
     <div class="UnderlineNav-actions">
-        <button id="reload-gist" class="btn">
-            Reset code
-        </button>
+        <button id="format-code" class="btn">Format</button>
+        <button id="reload-gist" class="btn mr-2">Reset</button>
         <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
-            Check code
+            Run
         </button>
     </div>
 </nav>
@@ -66,13 +65,13 @@ BSD-style license that can be found in the LICENSE file. -->
             </iframe>
         </div>
     </div>
-    <div id="test-view" class="flex-auto d-flex flex-column" spellcheck="false" hidden>
+    <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
         <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
     </div>
     <div id="console-view" class="tabview flex-auto p-2" hidden></div>
 </section>
 
-<div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
+<div id="flash-container" class="position-fixed right-2 bottom-2">
     <div id="analysis-result-box" class="flash flash-error" hidden>
         <button class="flash-close">
             <div class="octicon octicon-x"></div>

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -42,12 +42,27 @@ body {
   than one is displayed.
 */
 
-#flash-container {
-  z-index: 100;
-}
-
 #flash-container > div + div {
   margin-top: 8px;
+}
+
+.flash {
+  border-radius: 0.25em;
+}
+
+#flash-container {
+  width: 380px;
+  z-index: 10;
+}
+
+.message-container {
+  padding-right: 22px;
+  max-height: 120px;
+  overflow-y: scroll;
+}
+
+.message-container div+div {
+  padding-top: 8px;
 }
 
 .link-message {
@@ -80,6 +95,10 @@ body {
 #web-output {
   width: 260px;
   border-left: 1px solid #e1e4e8;
+}
+
+#user-code-editor.web-output-showing {
+  width: calc(100% - 260px);
 }
 
 .no-overflow {


### PR DESCRIPTION
misc updates and changes to the embedded UI:

- implement code completion
- add a 'format' button
- rename some of the existing buttons (`Test` ==> `Test code`, `Console` ==> `Output`, `Check code` ==> `Run`, `Reset code` ==> `Reset`)
- adjust the in-line error dialog; it now shows all the errors, not a count summary, has a max height, and supports scrolling within the dialog if necessary
- clear more toasts (the execution one one analysis results, and vice versa)
- adjust the analysis timings so we don't request analysis while the user is in the middle of typing
- make the test tab read-only
- ensure we analyze the same code we're compiling (otherwise we get unused imports warnings)
- fix a layout issue when the user had long source lines

<img width="469" alt="Screen Shot 2019-04-12 at 2 28 52 PM" src="https://user-images.githubusercontent.com/1269969/56099865-af0edb00-5ec7-11e9-91a8-cdf5a4f36f6d.png">

<img width="768" alt="Screen Shot 2019-04-12 at 5 59 13 PM" src="https://user-images.githubusercontent.com/1269969/56099866-b6ce7f80-5ec7-11e9-8165-01409f5e69e9.png">
