### PR TITLE
Adds the ability to show hints via popup flash

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -227,7 +227,6 @@ class NewEmbed {
     context.dartSource = gist.getFile('main.dart')?.content ?? '';
     context.testMethod = gist.getFile('test.dart')?.content ?? '';
     context.hint = gist.getFile('hint.txt')?.content ?? '';
-    showHintButton.disabled = context.hint.isEmpty;
     editorIsBusy = false;
 
     if (analyze) {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -35,6 +35,7 @@ class NewEmbed {
   DisableableButton executeButton;
   DisableableButton reloadGistButton;
   DisableableButton formatButton;
+  DisableableButton showHintButton;
 
   DElement navBarElement;
   TabController tabController;
@@ -46,6 +47,7 @@ class NewEmbed {
 
   FlashBox testResultBox;
   FlashBox analysisResultBox;
+  FlashBox hintBox;
 
   ExecutionService executionSvc;
 
@@ -99,6 +101,10 @@ class NewEmbed {
 
     reloadGistButton.disabled = gistId.isEmpty;
 
+    showHintButton = DisableableButton(querySelector('#show-hint'), () {
+      hintBox.showStrings([context.hint]);
+    });
+
     formatButton = DisableableButton(
       querySelector('#format-code'),
       _performFormat,
@@ -106,6 +112,7 @@ class NewEmbed {
 
     testResultBox = FlashBox(querySelector('#test-result-box'));
     analysisResultBox = FlashBox(querySelector('#analysis-result-box'));
+    hintBox = FlashBox(querySelector('#hint-box'));
 
     userCodeEditor =
         editorFactory.createFromElement(querySelector('#user-code-editor'))
@@ -206,9 +213,11 @@ class NewEmbed {
   /// too busy to handle code changes, execute/reset requests, etc.
   set editorIsBusy(bool value) {
     navBarElement.toggleClass('busy', value);
-    executeButton.disabled = value;
     userCodeEditor.readOnly = value;
+    executeButton.disabled = value;
+    formatButton.disabled = value;
     reloadGistButton.disabled = value || gistId.isEmpty;
+    showHintButton.disabled = value || context.hint.isEmpty;
   }
 
   Future<void> _loadAndShowGist(String id, {bool analyze = true}) async {
@@ -217,6 +226,8 @@ class NewEmbed {
     final gist = await loader.loadGist(id);
     context.dartSource = gist.getFile('main.dart')?.content ?? '';
     context.testMethod = gist.getFile('test.dart')?.content ?? '';
+    context.hint = gist.getFile('hint.txt')?.content ?? '';
+    showHintButton.disabled = context.hint.isEmpty;
     editorIsBusy = false;
 
     if (analyze) {
@@ -228,6 +239,7 @@ class NewEmbed {
     editorIsBusy = true;
     analysisResultBox.hide();
     testResultBox.hide();
+    hintBox.hide();
     consoleTabView.clear();
 
     final fullCode = '${context.dartSource}\n${context.testMethod}\n'
@@ -272,6 +284,7 @@ class NewEmbed {
   void _displayIssues(List<AnalysisIssue> issues) {
     analysisResultBox.hide();
     testResultBox.hide();
+    hintBox.hide();
 
     if (issues.isEmpty) {
       return;
@@ -550,6 +563,8 @@ class NewEmbedContext {
   final Editor testEditor;
 
   Document _dartDoc;
+
+  String hint = '';
 
   String get testMethod => testEditor.document.value;
 

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -42,7 +42,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <nav id="navbar" class="UnderlineNav p-2">
     <div class="UnderlineNav-body">
-        <div class="BtnGroup mr-2">
+        <div class="BtnGroup">
             <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
             <button id="test-tab" class="btn BtnGroup-item" type="button">Test code</button>
             <button id="console-tab" class="btn BtnGroup-item" type="button">
@@ -52,10 +52,9 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
+        <button id="show-hint" class="btn disabled">Hint</button>
         <button id="format-code" class="btn">Format</button>
-        <button id="reload-gist" class="btn">
-            Reset
-        </button>
+        <button id="reload-gist" class="btn mr-2">Reset</button>
         <button id="execute" class="btn btn-primary">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Run
@@ -63,17 +62,21 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
 </nav>
 
-<section id="tab-container" class="flex-auto d-flex flex-column">
-    <div id="user-code-view" class="flex-auto d-flex flex-column">
+<section id="tab-container" class="flex-auto d-flex flex-column no-overflow">
+    <div id="user-code-view" class="flex-auto d-flex flex-row no-overflow">
         <div id="user-code-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
+        <div id="web-output" class="p-1 d-flex" hidden>
+            <iframe id="frame" sandbox="allow-scripts" class="flex-auto" src="../scripts/frame.html">
+            </iframe>
+        </div>
     </div>
-    <div id="test-view" class="flex-auto d-flex flex-column" spellcheck="false" hidden>
+    <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
         <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
     </div>
     <div id="console-view" class="tabview flex-auto p-2" hidden></div>
 </section>
 
-<div id="flash-container" class="position-fixed right-2 bottom-2 col-6">
+<div id="flash-container" class="position-fixed right-2 bottom-2">
     <div id="analysis-result-box" class="flash flash-error" hidden>
         <button class="flash-close">
             <div class="octicon octicon-x"></div>
@@ -86,10 +89,13 @@ BSD-style license that can be found in the LICENSE file. -->
         </button>
         <div class="message-container"></div>
     </div>
+    <div id="hint-box" class="flash" hidden>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
+        <div class="message-container"></div>
+    </div>
 </div>
-
-<iframe id="frame" sandbox="allow-scripts" flex src="../scripts/frame.html">
-</iframe>
 
 </body>
 

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -48,6 +48,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div class="UnderlineNav-actions">
+        <button id="show-hint" class="btn disabled">Hint</button>
         <button id="format-code" class="btn">Format</button>
         <button id="reload-gist" class="btn mr-2">Reset</button>
         <button id="execute" class="btn btn-primary">
@@ -79,6 +80,12 @@ BSD-style license that can be found in the LICENSE file. -->
         <div class="message-container"></div>
     </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
+        <button class="flash-close">
+            <div class="octicon octicon-x"></div>
+        </button>
+        <div class="message-container"></div>
+    </div>
+    <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
             <div class="octicon octicon-x"></div>
         </button>


### PR DESCRIPTION
Hint feature for UXR (@galeyang).

Adds a `hint` field to the DartPad context, which is populated from a `hint.txt` file when a gist is loaded. If `hint` is non-empty, a "show hint" button is enabled next to the reset button. Pressing it causes a flash message containing the hint to appear.

This PR will conflict with @devoncarew's giant UI update PR, which should be merged first. I'll update this one afterward. It's ready for review now, though.

Reader poll: If the hint is already displayed, should clicking the show hint button again close the popup?