### PR TITLE
disable autoCloseBrackets for the embedded UI

### DIFF
--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -37,6 +37,10 @@ abstract class Editor {
   /// Checks if the completion popup is displayed.
   bool get completionActive;
 
+  bool get autoCloseBrackets;
+
+  set autoCloseBrackets(bool value);
+
   String get mode;
 
   set mode(String str);

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -45,8 +45,8 @@ class CodeMirrorFactory extends EditorFactory {
       'lineWrapping': true,
       'indentUnit': 2,
       'cursorHeight': 0.85,
-      // Increase the number of lines that are rendered above and before
-      // what's visible.
+      // Increase the number of lines that are rendered above and before what's
+      // visible.
       'viewportMargin': 100,
       //'gutters': [_gutterId],
       'extraKeys': {'Cmd-/': 'toggleComment', 'Ctrl-/': 'toggleComment'},
@@ -202,6 +202,12 @@ class _CodeMirrorEditor extends Editor {
       return cm.jsProxy['state']['completionActive']['widget'] != null;
     }
   }
+
+  @override
+  bool get autoCloseBrackets => cm.getOption('autoCloseBrackets');
+
+  @override
+  set autoCloseBrackets(bool value) => cm.setOption('autoCloseBrackets', value);
 
   @override
   String get mode => cm.getMode();

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -120,6 +120,7 @@ class NewEmbed {
           ..mode = 'dart'
           ..showLineNumbers = true;
     userCodeEditor.document.onChange.listen(_performAnalysis);
+    userCodeEditor.autoCloseBrackets = false;
 
     testEditor = editorFactory.createFromElement(querySelector('#test-editor'))
       ..theme = 'elegant'


### PR DESCRIPTION
- disable autoCloseBrackets for the embedded UI

This setting (auto-adding a closing `')'`) doesn't work well for Flutter code.

We could also just disable this completely in dartpad.