### PR TITLE
hide messages scrollbar

### DIFF
--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -73,19 +73,19 @@ BSD-style license that can be found in the LICENSE file. -->
         <button class="flash-close">
             <div class="octicon octicon-x"></div>
         </button>
-        <div class="message-container"></div>
+        <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
             <div class="octicon octicon-x"></div>
         </button>
-        <div class="message-container"></div>
+        <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
             <div class="octicon octicon-x"></div>
         </button>
-        <div class="message-container"></div>
+        <div class="message-container custom-scrollbar"></div>
     </div>
 </div>
 

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -91,7 +91,20 @@ body {
 .message-container {
   padding-right: 22px;
   max-height: 120px;
-  overflow-y: scroll;
+  overflow-y: auto;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  -webkit-appearance: none;
+  width: 9px;
+  height: 9px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  background-color: #888;
+  box-shadow: 0 0 1px rgba(255,255,255, 1);
+  opacity: 0.5;
 }
 
 .message-container div+div {


### PR DESCRIPTION
a scrollbar was appearing for messages:

![image](https://user-images.githubusercontent.com/1145719/56321905-892e4400-611c-11e9-8975-4c97dbe0b75e.png)

This hides the scrollbar in WebKit. We might want to improve the way we are displaying these though.