### PR TITLE
small adjustment to the tab UI

### DIFF
--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -9,7 +9,6 @@ final String serverURL = 'https://dart-services.appspot.com/';
 //final String serverURL = 'https://dart2-test-dot-dart-services.appspot.com/';
 
 final Duration serviceCallTimeout = Duration(seconds: 10);
-final Duration shortServiceCallTimeout = Duration(seconds: 4);
 final Duration longServiceCallTimeout = Duration(seconds: 60);
 
 class StringTextProvider {

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -39,11 +39,19 @@ body {
   flex-wrap: wrap-reverse;
 }
 
+#navbar .tabnav-tabs {
+  padding-left: 12px;
+}
+
 .nav-buttons {
   padding: 4px 4px 4px 4px;
   display: flex;
   flex-direction: row;
   align-items: center;
+}
+
+.tabnav-tab {
+  line-height: 18px;
 }
 
 .tabnav-tab:focus {


### PR DESCRIPTION
- make a small adjustment to the new tab UI so that the left tab border doesn't align with the editor line number border
- (unrelated, delete an unused top-level variable)

the UI before:

<img width="316" alt="Screen Shot 2019-04-19 at 7 14 11 PM" src="https://user-images.githubusercontent.com/1269969/56450230-259d4580-62d9-11e9-9da9-fa0196082fe8.png">

and after:

<img width="327" alt="Screen Shot 2019-04-19 at 7 13 32 PM" src="https://user-images.githubusercontent.com/1269969/56450232-2afa9000-62d9-11e9-93db-d4406022f5a7.png">

@johnpryan 