### PR TITLE
add "show solution" link to hints

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -184,9 +184,6 @@ class NewEmbed {
       );
     });
 
-    // set enabled/disabled state of various buttons
-    editorIsBusy = false;
-
     _initModules().then((_) => _initNewEmbed());
   }
 
@@ -236,6 +233,9 @@ class NewEmbed {
     if (gistId.isNotEmpty) {
       _loadAndShowGist(gistId, analyze: false);
     }
+
+    // set enabled/disabled state of various buttons
+    editorIsBusy = false;
   }
 
   /// Toggles the state of several UI components based on whether the editor is

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -111,8 +111,8 @@ class NewEmbed {
     reloadGistButton.disabled = gistId.isEmpty;
 
     showHintButton = DisableableButton(querySelector('#show-hint'), () {
-      var showSolutionButton = ButtonElement()
-        ..classes.add('link-button')
+      var showSolutionButton = AnchorElement()
+        ..style.cursor = 'pointer'
         ..text = 'Show solution';
       showSolutionButton.onClick.listen((_) {
         solutionTab.clearAttr('hidden');
@@ -184,6 +184,9 @@ class NewEmbed {
       );
     });
 
+    // set enabled/disabled state of various buttons
+    editorIsBusy = false;
+
     _initModules().then((_) => _initNewEmbed());
   }
 
@@ -243,8 +246,9 @@ class NewEmbed {
     executeButton.disabled = value;
     formatButton.disabled = value;
     reloadGistButton.disabled = value || gistId.isEmpty;
-    showHintButton.disabled =
-        value || (context.hint.isEmpty && context.solution.isEmpty);
+    var hasHintOrSolution =
+        context.hint.isNotEmpty || context.solution.isNotEmpty;
+    showHintButton.disabled = value || !hasHintOrSolution;
   }
 
   Future<void> _loadAndShowGist(String id, {bool analyze = true}) async {
@@ -510,6 +514,7 @@ class DisableableButton {
   static const disabledClassName = 'disabled';
 
   DElement _element;
+
   bool _disabled = false;
 
   bool get disabled => _disabled;
@@ -603,7 +608,7 @@ class NewEmbedContext {
 
   String hint = '';
 
-  String _solution;
+  String _solution = '';
 
   String get testMethod => testEditor.document.value;
 

--- a/test/experimental/new_embed_test.dart
+++ b/test/experimental/new_embed_test.dart
@@ -15,11 +15,13 @@ void main() {
     test('Editor tab is selected at init', () {
       final editorTab = querySelector('#editor-tab');
       expect(editorTab.attributes.keys, contains('selected'));
+      expect(editorTab.classes, contains('selected'));
     });
 
     test('Console tab is not selected at init', () {
       final consoleTab = querySelector('#console-tab');
       expect(consoleTab.attributes.keys, isNot(contains('selected')));
+      expect(consoleTab.classes, isNot(contains('selected')));
     });
 
     test('Console tab is selected when clicked.', () {
@@ -27,6 +29,7 @@ void main() {
       consoleTab.dispatchEvent(Event('click'));
 
       expect(consoleTab.attributes.keys, contains('selected'));
+      expect(consoleTab.classes, contains('selected'));
     });
 
     test('Editor tab is not selected when console tab is clicked', () {
@@ -35,11 +38,13 @@ void main() {
 
       final editorTab = querySelector('#editor-tab');
       expect(editorTab.attributes.keys, isNot(contains('selected')));
+      expect(editorTab.classes, isNot(contains('selected')));
     });
 
     test('Test tab is not selected at init', () {
       final testTab = querySelector('#test-tab');
       expect(testTab.attributes.keys, isNot(contains('selected')));
+      expect(testTab.classes, isNot(contains('selected')));
     });
 
     test('Test tab is selected when clicked.', () {
@@ -47,6 +52,7 @@ void main() {
       testTab.dispatchEvent(Event('click'));
 
       expect(testTab.attributes.keys, contains('selected'));
+      expect(testTab.classes, contains('selected'));
     });
 
     test('Editor tab is not selected when test tab is clicked', () {
@@ -55,6 +61,7 @@ void main() {
 
       final editorTab = querySelector('#editor-tab');
       expect(editorTab.attributes.keys, isNot(contains('selected')));
+      expect(editorTab.classes, isNot(contains('selected')));
     });
   });
 }

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -39,29 +39,26 @@ BSD-style license that can be found in the LICENSE file. -->
 </head>
 
 <body class="d-flex flex-column">
-
-<nav id="navbar" class="UnderlineNav p-2">
-    <div class="UnderlineNav-body">
-        <div class="BtnGroup">
-            <button id="editor-tab" class="btn BtnGroup-item selected" selected type="button">Your code</button>
-            <button id="test-tab" class="btn BtnGroup-item" type="button">Test code</button>
-            <button id="console-tab" class="btn BtnGroup-item" type="button">
-                Output
-                <span id="unread-console-counter" class="Counter" hidden></span>
-            </button>
-        </div>
-    </div>
-    <div class="UnderlineNav-actions">
-        <button id="show-hint" class="btn disabled">Hint</button>
-        <button id="format-code" class="btn">Format</button>
+<div id="navbar" class="tabnav dp-tabs">
+    <nav class="tabnav-tabs">
+        <button id="editor-tab" class="tabnav-tab selected" selected>Your code</button>
+        <button id="solution-tab" class="tabnav-tab" hidden>Solution</button>
+        <button id="test-tab" class="tabnav-tab">Test code</button>
+        <button id="console-tab" class="tabnav-tab">
+            Output
+            <span id="unread-console-counter" class="Counter" hidden></span>
+        </button>
+    </nav>
+    <div class="nav-buttons">
+        <button id="show-hint" class="btn mr-1">Hint</button>
+        <button id="format-code" class="btn mr-2">Format</button>
         <button id="reload-gist" class="btn mr-2">Reset</button>
-        <button id="execute" class="btn btn-primary">
+        <button id="execute" class="btn btn-primary float-right">
             <div class="octicon medium-octicon octicon-triangle-right"></div>
             Run
         </button>
     </div>
-</nav>
-
+</div>
 <section id="tab-container" class="flex-auto d-flex flex-column no-overflow">
     <div id="user-code-view" class="flex-auto d-flex flex-row no-overflow">
         <div id="user-code-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
@@ -69,6 +66,9 @@ BSD-style license that can be found in the LICENSE file. -->
             <iframe id="frame" sandbox="allow-scripts" class="flex-auto" src="../scripts/frame.html">
             </iframe>
         </div>
+    </div>
+    <div id="solution-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+        <div id="solution-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
     </div>
     <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
         <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -38,6 +38,7 @@ BSD-style license that can be found in the LICENSE file. -->
 <div id="navbar" class="tabnav dp-tabs">
     <nav class="tabnav-tabs">
         <button id="editor-tab" class="tabnav-tab selected">Your code</button>
+        <button id="solution-tab" class="tabnav-tab" hidden>Solution</button>
         <button id="test-tab" class="tabnav-tab">Test code</button>
         <button id="console-tab" class="tabnav-tab">
             Output
@@ -61,6 +62,9 @@ BSD-style license that can be found in the LICENSE file. -->
             <iframe id="frame" sandbox="allow-scripts" class="flex-auto" src="../scripts/frame.html">
             </iframe>
         </div>
+    </div>
+    <div id="solution-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+        <div id="solution-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
     </div>
     <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
         <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -102,6 +102,19 @@ body {
   cursor: pointer;
 }
 
+.link-button {
+  background:none!important;
+  color:inherit;
+  border:none;
+  padding:0;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.link-button:focus {
+  outline: 0;
+}
+
 /* Code annotations */
 
 .squiggle-error {

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -102,19 +102,6 @@ body {
   cursor: pointer;
 }
 
-.link-button {
-  background:none!important;
-  color:inherit;
-  border:none;
-  padding:0;
-  font: inherit;
-  text-decoration: underline;
-}
-
-.link-button:focus {
-  outline: 0;
-}
-
 /* Code annotations */
 
 .squiggle-error {


### PR DESCRIPTION
This adds a link-style button to hints. When there is a solution but no hint, the hint button is still enabled.

tested with the following scenarios:

- [no solution, no hint](https://gist.github.com/johnpryan/4c92731867b1a95bf57bea3ae6af51a7)
- [no hint](https://gist.github.com/johnpryan/8ce64d00ee74daa97b012f076cfe6164)
- [complete example (solution and hint)](https://gist.github.com/johnpryan/0a5a230dba4f382ed23627edf24ed40d)

closes #1023