### PR TITLE
re-add selected attribute to editor-tab

### DIFF
--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -37,7 +37,7 @@ BSD-style license that can be found in the LICENSE file. -->
 <body class="d-flex flex-column">
 <div id="navbar" class="tabnav dp-tabs">
     <nav class="tabnav-tabs">
-        <button id="editor-tab" class="tabnav-tab selected">Your code</button>
+        <button id="editor-tab" class="tabnav-tab selected" selected>Your code</button>
         <button id="solution-tab" class="tabnav-tab" hidden>Solution</button>
         <button id="test-tab" class="tabnav-tab">Test code</button>
         <button id="console-tab" class="tabnav-tab">


### PR DESCRIPTION
caused an exception to be thrown when the editor tries to determine the selected tab