### PR TITLE
Clears the output tab on new execution.

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -287,6 +287,7 @@ class NewEmbed {
     testResultBox.hide();
     hintBox.hide();
     consoleTabView.clear();
+    unreadConsoleCounter.clear();
 
     final fullCode = '${context.dartSource}\n${context.testMethod}\n'
         '${executionSvc.testResultDecoration}';


### PR DESCRIPTION
This was in the code previously and ended up getting removed somehow (I assume as an oversight, though folks are free to correct me).