### PR TITLE
Add a footer with a toggle for analysis issues

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -66,6 +66,10 @@ class NewEmbed {
 
   Splitter splitter;
 
+  DElement issuesMessage;
+  DElement issuesToggle;
+  bool _issuesHidden = true;
+
   final DelayedTimer _debounceTimer = DelayedTimer(
     minDelay: Duration(milliseconds: 1000),
     maxDelay: Duration(milliseconds: 5000),
@@ -188,6 +192,23 @@ class NewEmbed {
         result.success ? FlashBoxStyle.success : FlashBoxStyle.warn,
       );
     });
+
+    // Hide analysis issues until the user clicks the toggle
+    analysisResultBox.hide();
+
+    issuesMessage = DElement(querySelector('#issues-message'));
+    issuesToggle = DElement(querySelector('#issues-toggle'))
+      ..onClick.listen((_) {
+        if (_issuesHidden) {
+          analysisResultBox.show();
+          issuesToggle.text = 'hide';
+          _issuesHidden = false;
+        } else {
+          analysisResultBox.hide();
+          issuesToggle.text = 'show';
+          _issuesHidden = true;
+        }
+      });
 
     _initModules().then((_) => _initNewEmbed());
   }
@@ -334,8 +355,11 @@ class NewEmbed {
     hintBox.hide();
 
     if (issues.isEmpty) {
+      issuesMessage.text = 'no issues';
       return;
     }
+
+    issuesMessage.text = '${issues.length} issues';
 
     List<String> messages = issues.map((AnalysisIssue issue) {
       String message = issue.message;
@@ -595,7 +619,6 @@ class FlashBox {
   }
 
   void showElements(List<Element> elements, [FlashBoxStyle style]) {
-    _element.clearAttr('hidden');
     _element.element.classes
         .removeWhere((s) => classNamesForStyles.values.contains(s));
 
@@ -612,6 +635,10 @@ class FlashBox {
 
   void hide() {
     _element.setAttr('hidden');
+  }
+
+  void show() {
+    _element.clearAttr('hidden');
   }
 }
 

--- a/web/experimental/embed-new.html
+++ b/web/experimental/embed-new.html
@@ -72,6 +72,13 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
     <div id="console-view" class="tabview flex-auto p-2" hidden></div>
 </section>
+<footer flex layout horizontal class="footer">
+    <div class="issues-container">
+        <div id="issues-message">no issues</div>
+        <span class="issues-spacer"></span>
+        <a id="issues-toggle" class="issues-btn">show</a>
+    </div>
+</footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-2">
     <div id="analysis-result-box" class="flash flash-error" hidden>

--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -84,6 +84,7 @@ body {
 #flash-container {
   width: 380px;
   z-index: 10;
+    margin-bottom: 18px;
 }
 
 .message-container {
@@ -171,4 +172,33 @@ body {
   width: 100%;
   border-top: 1px solid #d0d5d9;
   border-bottom: 1px solid #d0d5d9;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  border-top: 1px solid #d0d5d9;
+  background-color: #f7f7f7;
+  padding: 0 12px 0 12px;
+}
+
+#issues-message {
+  cursor: default;
+  color: #586069;
+}
+
+#issues-toggle {
+  cursor: pointer;
+}
+
+.issues-spacer {
+  width: 12px;
+}
+
+.issues-container {
+  display: flex;
+  flex-direction: row;
 }


### PR DESCRIPTION
This removes the 'clearAttr' call in showElements() so that when the
issues are hidden, they stay hidden the next time showElements() is
called.

<img width="878" alt="Screen Shot 2019-04-25 at 1 02 00 PM" src="https://user-images.githubusercontent.com/1145719/56764791-6cb48c00-675a-11e9-87d4-f14a23316b11.png">
<img width="878" alt="Screen Shot 2019-04-25 at 1 01 57 PM" src="https://user-images.githubusercontent.com/1145719/56764792-6cb48c00-675a-11e9-99ed-94eba96297bb.png">


closes #976