### PR TITLE
Add default "test failed" message

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -178,12 +178,11 @@ class NewEmbed {
     });
 
     executionSvc.testResults.listen((result) {
-      if (result.messages.isEmpty &&
-          result.success == false) {
-        result.messages.add('Test failed!');
+      if (result.messages.isEmpty) {
+        result.messages.add(result.success ? 'Test passed!' : 'Test failed.');
       }
       testResultBox.showStrings(
-        result.messages.isNotEmpty ? result.messages : ['Test passed!'],
+        result.messages,
         result.success ? FlashBoxStyle.success : FlashBoxStyle.warn,
       );
     });

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -178,6 +178,10 @@ class NewEmbed {
     });
 
     executionSvc.testResults.listen((result) {
+      if (result.messages.isEmpty &&
+          result.success == false) {
+        result.messages.add('Test failed!');
+      }
       testResultBox.showStrings(
         result.messages.isNotEmpty ? result.messages : ['Test passed!'],
         result.success ? FlashBoxStyle.success : FlashBoxStyle.warn,

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -69,6 +69,7 @@ class ExecutionServiceIFrame implements ExecutionService {
 void _result(bool success, [List<String> messages]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
   final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
+  
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -69,7 +69,6 @@ class ExecutionServiceIFrame implements ExecutionService {
 void _result(bool success, [List<String> messages]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
   final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
-  
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -69,7 +69,7 @@ class ExecutionServiceIFrame implements ExecutionService {
 void _result(bool success, [List<String> messages]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
   final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
-
+  
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -69,7 +69,7 @@ class ExecutionServiceIFrame implements ExecutionService {
 void _result(bool success, [List<String> messages]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
   final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
-  
+
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 


### PR DESCRIPTION
Handles case where user passes `_result(false, messages)` and `messages` is empty. 
Before:
![before](https://user-images.githubusercontent.com/5550175/56770973-32eb8180-676a-11e9-96b5-c320424cb30d.png)

After:
![after](https://user-images.githubusercontent.com/5550175/56770984-38e16280-676a-11e9-8f9c-5694d6d991f0.png)

