### PR TITLE
add 'split' query parameter for setting split percentage

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -243,7 +243,7 @@ class NewEmbed {
         horizontal: true,
         gutterSize: defaultSplitterWidth,
         // set initial sizes (in percentages)
-        sizes: [70, 30],
+        sizes: [initialSplitPercent, (100 - initialSplitPercent)],
         // set the minimum sizes (in pixels)
         minSize: [100, 100],
       );
@@ -443,8 +443,13 @@ class NewEmbed {
   }
 
   bool get supportsFlutterWeb {
-    Uri url = Uri.parse(window.location.toString());
+    var url = Uri.parse(window.location.toString());
     return url.queryParameters['fw'] == 'true';
+  }
+
+  int get initialSplitPercent {
+    var url = Uri.parse(window.location.toString());
+    return int.tryParse(url.queryParameters['split']) ?? 70;
   }
 }
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -444,12 +444,12 @@ class NewEmbed {
   }
 
   bool get supportsFlutterWeb {
-    var url = Uri.parse(window.location.toString());
+    final url = Uri.parse(window.location.toString());
     return url.queryParameters['fw'] == 'true';
   }
 
   int get initialSplitPercent {
-    var url = Uri.parse(window.location.toString());
+    final url = Uri.parse(window.location.toString());
     var s = int.tryParse(url.queryParameters['split']) ?? 70;
 
     // keep the split within the range [5, 95]

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:html' hide Document;
+import 'dart:math' as math;
 
 import 'package:split/split.dart';
 
@@ -449,7 +450,12 @@ class NewEmbed {
 
   int get initialSplitPercent {
     var url = Uri.parse(window.location.toString());
-    return int.tryParse(url.queryParameters['split']) ?? 70;
+    var s = int.tryParse(url.queryParameters['split']) ?? 70;
+
+    // keep the split within the range [5, 95]
+    s = math.min(s, 95);
+    s = math.max(s, 5);
+    return s;
   }
 }
 


### PR DESCRIPTION
For example, split=25 will allow 25% for code and 75% for web output

closes #1037