### PR TITLE
address an issue parsing the split query param

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:html' hide Document;
-import 'dart:math' as math;
 
 import 'package:split/split.dart';
 
@@ -449,13 +448,14 @@ class NewEmbed {
   }
 
   int get initialSplitPercent {
+    final defaultPercentage = 70;
     final url = Uri.parse(window.location.toString());
-    var s = int.tryParse(url.queryParameters['split']) ?? 70;
+    var split =
+        int.tryParse(url.queryParameters['split'] ?? '$defaultPercentage') ??
+            defaultPercentage;
 
     // keep the split within the range [5, 95]
-    s = math.min(s, 95);
-    s = math.max(s, 5);
-    return s;
+    return split.clamp(5, 95);
   }
 }
 
@@ -555,6 +555,7 @@ class DisableableButton {
   bool _disabled = false;
 
   bool get disabled => _disabled;
+
   set disabled(bool value) {
     _disabled = value;
     _element.toggleClass(disabledClassName, value);
@@ -658,6 +659,7 @@ class NewEmbedContext {
   }
 
   String get solution => _solution;
+
   set solution(String value) {
     _solution = value;
     solutionEditor.document.value = value;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -450,9 +450,9 @@ class NewEmbed {
   int get initialSplitPercent {
     final defaultPercentage = 70;
     final url = Uri.parse(window.location.toString());
-    var split =
-        int.tryParse(url.queryParameters['split'] ?? '$defaultPercentage') ??
-            defaultPercentage;
+    final split = url.queryParameters.containsKey('split')
+        ? (int.tryParse(url.queryParameters['split']) ?? defaultPercentage)
+        : defaultPercentage;
 
     // keep the split within the range [5, 95]
     return split.clamp(5, 95);


### PR DESCRIPTION
- address an issue parsing the `split` query param

```
dart_sdk.js:5844 Uncaught (in promise) Error: Invalid argument: null
    at Object.dart.throw (dart_sdk.js:4556)
    at Object.dart.argumentError (dart_sdk.js:4487)
    at Function.parseInt (dart_sdk.js:15665)
    at Function.tryParse (dart_sdk.js:10163)
    at experimental__new_embed.NewEmbed.new.get initialSplitPercent [as initialSplitPercent] (new_embed.dart:453)
    at experimental__new_embed.NewEmbed.new.[_initNewEmbed] (new_embed.dart:247)
    at new_embed.dart:196
```
