### PR TITLE
use grey color when there's no web output

### DIFF
--- a/web/experimental/new_embed.css
+++ b/web/experimental/new_embed.css
@@ -153,6 +153,9 @@ body {
   overflow-y: hidden;
 }
 
+#web-output {
+  background-color: rgb(250, 250, 250);
+}
 
 /* Splitter */
 


### PR DESCRIPTION
This gives a nicer looking color when there's no web output. (A blank white page can make it look like something is wrong)

![Screen Shot 2019-05-02 at 3 08 29 PM](https://user-images.githubusercontent.com/1145719/57110125-4a87b480-6cec-11e9-9449-ffba03aa6e42.png)

This is somewhat related to https://github.com/dart-lang/dart-pad/issues/981