### PR TITLE
Use markdown language identifiers in inject script

### DIFF
--- a/lib/experimental/inject_embed.dart
+++ b/lib/experimental/inject_embed.dart
@@ -15,13 +15,13 @@ Logger _logger = Logger('dartpad-embed');
 var iframeSrc =
     'https://dartpad.dartlang.org/experimental/embed-new.html?fw=true';
 
-/// Replaces all code snippets marked with the 'dartpad-embed' class with an
+/// Replaces all code snippets marked with the 'run-dartpad' class with an
 /// instance of DartPad.
 void main() {
   _logger.onRecord.listen(logToJsConsole);
-  var hosts = querySelectorAll('.dartpad-embed');
-  for (var host in hosts) {
-    _injectEmbed(host);
+  var snippets = querySelectorAll('.run-dartpad');
+  for (var snippet in snippets) {
+    _injectEmbed(snippet);
   }
 }
 
@@ -29,30 +29,31 @@ void main() {
 ///
 /// Code snippets are assumed to be a div containing `pre` and `code` tags:
 ///
-/// <div class="dartpad-embed">
-///   <pre>
-///     <code>
-///       void main() => print("Hello, World!");
-///     </code>
-///   </pre>
-/// </div>
-void _injectEmbed(DivElement host) {
-  if (host.children.length != 1) {
+/// <pre>
+///   <code class="run-dartpad langauge-run-dartpad">
+///     void main() => print("Hello, World!");
+///   </code>
+/// </pre>
+void _injectEmbed(Element snippet) {
+  var preElement = snippet.parent;
+  if (preElement is! PreElement) {
     _logUnexpectedHtml();
     return;
   }
 
-  var preElement = host.children.first;
   if (preElement.children.length != 1) {
     _logUnexpectedHtml();
     return;
   }
 
-  var codeElement = preElement.children.first;
-  var code = HtmlUnescape().convert(codeElement.innerHtml);
+  var code = HtmlUnescape().convert(snippet.innerHtml);
   if (code.isEmpty) {
     return;
   }
+
+  var hostIndex = preElement.parent.children.indexOf(preElement);
+  var host = DivElement();
+  preElement.parent.children[hostIndex] = host;
 
   InjectedEmbed(host, code);
 }
@@ -86,12 +87,11 @@ class InjectedEmbed {
 
 void _logUnexpectedHtml() {
   var message = '''Incorrect HTML for "dartpad-embed". Please use this format:
-<div class="dartpad-embed">
-  <pre>
-    <code>
-      [code here]
-    </code>
-  </pre>
-</div>''';
+<pre>
+  <code class="run-dartpad">
+    [code here]
+  </code>
+</pre>
+''';
   _logger.warning(message);
 }

--- a/test/experimental/inject_embed_test.html
+++ b/test/experimental/inject_embed_test.html
@@ -38,13 +38,9 @@
 <body>
     <h4>Hello, World!</h4>
     <p>Below is a 'Hello, World!' app.</p>
-    <div class="dartpad-embed">
-        <pre>
-            <code>foo</code>
-        </pre>
-    </div>
-    <div class="dartpad-embed">
-        <code>foo</code>
-    </div>
+    <pre>
+        <code class="run-dartpad langauge-run-dartpad">foo</code>
+    </pre>
+    <code class="run-dartpad language-run-dartpad">foo</code>
 </body>
 </html>

--- a/web/experimental/new_embeddings_with_code_tags.html
+++ b/web/experimental/new_embeddings_with_code_tags.html
@@ -41,9 +41,8 @@
             <p>
                 Below is a 'Hello, World!' app.
             </p>
-            <div class="dartpad-embed">
-                <pre>
-                    <code>
+            <pre>
+                <code class="run-dartpad language-run-dartpad">
 import 'package:flutter_web/material.dart';
 import 'package:flutter_web_test/flutter_web_test.dart';
 import 'package:flutter_web_ui/ui.dart' as ui;
@@ -73,9 +72,8 @@ class _MyAppState extends State {
     );
   }
 }
-                    </code>
-                </pre>
-            </div>
+                </code>
+            </pre>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Kotlin uses a markdown language identifier 'run-kotlin'. This switches the inject_embed.dart script to use a similar class 'run-dartpad'. This method doesn't require wrapping code blocks in a dartpad-specific div.

The markdown could be:

````markdown
Example code:

```run-dartpad
void main() => print("Hello, World");
```
````

which converts to:

```html
<p>Example code:</p>

<pre><code class="run-dartpad language-run-dartpad">void main() =&gt; print("Hello, World");
</code></pre>
```