### PR TITLE
Add ability to inject multiple file types

### DIFF
--- a/lib/experimental/inject_embed.dart
+++ b/lib/experimental/inject_embed.dart
@@ -19,30 +19,34 @@ var iframePrefix = 'https://dartpad.dev/experimental/';
 /// instance of DartPad.
 void main() {
   _logger.onRecord.listen(logToJsConsole);
-  var snippets = querySelectorAll('.run-dartpad');
+  var snippets = querySelectorAll('code');
   for (var snippet in snippets) {
-    var options = List<String>.from(snippet.classes)
-        ..removeWhere((c) => c == 'run-dartpad' || c == 'language-run-dartpad');
-    _injectEmbed(snippet, options);
+    if (snippet.classes.isEmpty) {
+      continue;
+    }
+
+    var className = snippet.classes.first;
+    var parser = LanguageStringParser(className);
+    if (!parser.isValid) {
+      continue;
+    }
+
+    _injectEmbed(snippet, parser.options);
   }
 }
 
-String iframeSrc(List<String> options) {
+String iframeSrc(Map<String, String> options) {
   String theme;
-  if (options.contains('theme-dark')) {
-    theme = 'dark';
+  if (options.containsKey('theme')) {
+    theme = options['theme'];
   } else {
     theme = 'light';
   }
 
   String mode;
-  if (options.contains('mode-flutter')) {
-    mode = 'flutter';
-  } else if (options.contains('mode-html')) {
-    mode = 'html';
-  } else if (options.contains('mode-inline')) {
-    mode = 'inline';
-  } else if (options.contains('mode-dart')) {
+  if (options.containsKey('mode')) {
+    mode = options['mode'];
+  } else {
     mode = 'dart';
   }
 
@@ -58,7 +62,7 @@ String iframeSrc(List<String> options) {
 ///     void main() => print("Hello, World!");
 ///   </code>
 /// </pre>
-void _injectEmbed(Element snippet, List<String> options) {
+void _injectEmbed(Element snippet, Map<String, String> options) {
   var preElement = snippet.parent;
   if (preElement is! PreElement) {
     _logUnexpectedHtml();
@@ -88,7 +92,7 @@ Map<String, String> _parseFiles(String snippet) {
 class InjectedEmbed {
   final DivElement host;
   final Map<String, String> files;
-  final List<String> options;
+  final Map<String, String> options;
 
   InjectedEmbed(this.host, this.files, this.options) {
     _init();

--- a/lib/experimental/inject_parser.dart
+++ b/lib/experimental/inject_parser.dart
@@ -1,0 +1,71 @@
+/// Parses a snippet into multiple file types separated by
+/// `{% begin <filename> %}` and `{% end <filename> %}` markers
+class InjectParser {
+  final String input;
+  RegExp _beginExp = RegExp(r'{% begin ([a-z.]*) %}');
+  RegExp _endExp = RegExp(r'{% end ([a-z.]*) %}');
+  int _currentLine;
+  String _currentFile;
+  Map<String, String> _tokens = {};
+  InjectParser(this.input);
+
+  /// Returns filenames and contents that were parsed from the input
+  Map<String, String> read() {
+    var lines = input.split('\n');
+    for (var i = 0; i < lines.length; i++) {
+      _currentLine = i;
+      _readLine(lines[i]);
+    }
+
+    if (_tokens.isEmpty) {
+      return {"main.dart": input.trim()};
+    }
+
+    return _tokens;
+  }
+
+  void _readLine(String line) {
+    if (_beginExp.hasMatch(line)) {
+      if (_currentFile == null) {
+        _currentFile = _beginExp.firstMatch(line).group(1);
+      } else {
+        _error('$_currentLine: unexpected begin');
+      }
+    } else if (_endExp.hasMatch(line)) {
+      if (_currentFile == null) {
+        _error('$_currentLine: unexpected end');
+      } else {
+        var match = _endExp.firstMatch(line).group(1);
+        if (match != _currentFile) {
+          _error('$_currentLine: end statement did not match begin statement');
+        } else {
+          // add newline
+          _addLine('', _currentFile);
+          _currentFile = null;
+        }
+      }
+    } else if (_currentFile != null) {
+      _addLine(line, _currentFile);
+    }
+  }
+
+  void _addLine(String line, String file) {
+    if (_tokens[_currentFile] == null) {
+      _tokens[_currentFile] = line;
+    } else {
+      _tokens[_currentFile] += '\n$line';
+    }
+  }
+
+  void _error(String message) {
+    var errorMessage =
+        'error parsing DartPad scripts on line $_currentLine: $message';
+    throw new DartPadInjectException(errorMessage);
+  }
+}
+
+class DartPadInjectException implements Exception {
+  final String message;
+  DartPadInjectException(this.message);
+  String toString() => '$message';
+}

--- a/lib/experimental/inject_parser.dart
+++ b/lib/experimental/inject_parser.dart
@@ -31,7 +31,7 @@ class InjectParser {
   void _readLine(String line) {
     if (_beginExp.hasMatch(line)) {
       if (_currentFile == null) {
-        _currentFile = _beginExp.firstMatch(line).group(1);
+        _currentFile = _beginExp.firstMatch(line)[1];
       } else {
         _error('$_currentLine: unexpected begin');
       }
@@ -39,7 +39,7 @@ class InjectParser {
       if (_currentFile == null) {
         _error('$_currentLine: unexpected end');
       } else {
-        var match = _endExp.firstMatch(line).group(1);
+        var match = _endExp.firstMatch(line)[1];
         if (match != _currentFile) {
           _error('$_currentLine: end statement did not match begin statement');
         } else {
@@ -72,4 +72,34 @@ class DartPadInjectException implements Exception {
   final String message;
   DartPadInjectException(this.message);
   String toString() => '$message';
+}
+
+/// Parses the dartpad CSS class names to extract
+class LanguageStringParser {
+  final String input;
+  final RegExp _validExp = RegExp(r'[a-z-]*run-dartpad(:?[a-z-]*)+');
+  final RegExp _optionsExp = RegExp(r':([a-z]*)-([a-z]*)');
+
+  LanguageStringParser(this.input);
+
+  bool get isValid {
+    return _validExp.hasMatch(input);
+  }
+
+  Map<String, String> get options {
+    var opts = <String, String>{};
+    if (!isValid) {
+      return opts;
+    }
+
+    var matches = _optionsExp.allMatches(input);
+    for (var match in matches) {
+      if (match.groupCount != 2) {
+        continue;
+      }
+      opts[match[1]] = match[2];
+    }
+
+    return opts;
+  }
 }

--- a/lib/experimental/inject_parser.dart
+++ b/lib/experimental/inject_parser.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// Parses a snippet into multiple file types separated by
 /// `{% begin <filename> %}` and `{% end <filename> %}` markers
 class InjectParser {

--- a/lib/experimental/inject_parser.dart
+++ b/lib/experimental/inject_parser.dart
@@ -6,8 +6,8 @@
 /// `{% begin <filename> %}` and `{% end <filename> %}` markers
 class InjectParser {
   final String input;
-  RegExp _beginExp = RegExp(r'{% begin ([a-z.]*) %}');
-  RegExp _endExp = RegExp(r'{% end ([a-z.]*) %}');
+  RegExp _beginExp = RegExp(r'{\$ begin ([a-z.]*) \$}');
+  RegExp _endExp = RegExp(r'{\$ end ([a-z.]*) \$}');
   int _currentLine;
   String _currentFile;
   Map<String, String> _tokens = {};

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -99,7 +99,7 @@ class NewEmbed {
     executeButton.disabled = value;
     formatButton.disabled = value;
     reloadGistButton.disabled = value || gistId.isEmpty;
-    showHintButton.disabled = value;
+    showHintButton?.disabled = value;
   }
 
   NewEmbed(this.options) {
@@ -303,7 +303,11 @@ class NewEmbed {
 
       if (type == 'sourceCode') {
         var sourceCode = data['sourceCode'];
-        userCodeEditor.document.value = sourceCode;
+        userCodeEditor.document.value = sourceCode['main.dart'] ?? '';
+        solutionEditor.document.value = sourceCode['solution.dart'] ?? '';
+        testEditor.document.value = sourceCode['test.dart'] ?? '';
+        htmlEditor.document.value = sourceCode['index.html'] ?? '';
+        cssEditor.document.value = sourceCode['styles.css'] ?? '';
       }
     });
   }

--- a/test/experimental/inject_parser_test.dart
+++ b/test/experimental/inject_parser_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:dart_pad/experimental/inject_parser.dart';
 import 'package:test/test.dart';
 

--- a/test/experimental/inject_parser_test.dart
+++ b/test/experimental/inject_parser_test.dart
@@ -26,6 +26,21 @@ main() {
       expect(files['main.dart'], equals("main() => print('Hello, World!');"));
     });
   });
+
+  group('LanguageStringParser', () {
+    test('recognizes run-dartpad class names', () {
+      expect(LanguageStringParser('run-dartpad').isValid, isTrue);
+      expect(LanguageStringParser('language-run-dartpad').isValid, isTrue);
+      expect(LanguageStringParser('run-flutterpad').isValid, isFalse);
+    });
+
+    test('supports options ', () {
+      var options = LanguageStringParser('run-dartpad:mode-html:theme-dark').options;
+      expect(options, isNotEmpty);
+      expect(options['mode'], equals('html'));
+      expect(options['theme'], equals('dark'));
+    });
+  });
 }
 
 String _codelab = '''

--- a/test/experimental/inject_parser_test.dart
+++ b/test/experimental/inject_parser_test.dart
@@ -43,28 +43,28 @@ main() {
   });
 }
 
-String _codelab = '''
-{% begin main.dart %}
+String _codelab = r'''
+{$ begin main.dart $}
 String message = 'Hello, World!';
-{% end main.dart %}
+{$ end main.dart $}
 
-{% begin solution.dart %}
+{$ begin solution.dart $}
 String message = 'delete your code';
-{% end solution.dart %}
+{$ end solution.dart $}
 
-{% begin test.dart %}
+{$ begin test.dart $}
 main() => print(message);
-{% end test.dart %}
+{$ end test.dart $}
 ''';
 
-String _invalidCodelab = '''
-{% begin main.dart %}
+String _invalidCodelab = r'''
+{$ begin main.dart $}
 String message = 'Hello, World!';
-{% end main.dart %}
+{$ end main.dart $}
 
-{% begin solution.dart %}
+{$ begin solution.dart $}
 String message = 'delete your code';
-{% begin main.dart %}
+{$ begin main.dart $}
 ''';
 
 String _normalSnippet = '''

--- a/test/experimental/inject_parser_test.dart
+++ b/test/experimental/inject_parser_test.dart
@@ -1,0 +1,53 @@
+import 'package:dart_pad/experimental/inject_parser.dart';
+import 'package:test/test.dart';
+
+main() {
+  group('InjectParser', () {
+    test('can parse files', () {
+      var parser = InjectParser(_codelab);
+      var files = parser.read();
+      expect(files, isNotEmpty);
+      expect(files['main.dart'], "String message = 'Hello, World!';\n");
+      expect(files['solution.dart'], "String message = 'delete your code';\n");
+      expect(files['test.dart'], "main() => print(message);\n");
+    });
+
+    test('throws with invalid input', () {
+      expect(InjectParser(_invalidCodelab).read,
+          throwsA(TypeMatcher<DartPadInjectException>()));
+    });
+
+    test('can parse normal snippets', () {
+      var files = InjectParser(_normalSnippet).read();
+      expect(files['main.dart'], equals("main() => print('Hello, World!');"));
+    });
+  });
+}
+
+String _codelab = '''
+{% begin main.dart %}
+String message = 'Hello, World!';
+{% end main.dart %}
+
+{% begin solution.dart %}
+String message = 'delete your code';
+{% end solution.dart %}
+
+{% begin test.dart %}
+main() => print(message);
+{% end test.dart %}
+''';
+
+String _invalidCodelab = '''
+{% begin main.dart %}
+String message = 'Hello, World!';
+{% end main.dart %}
+
+{% begin solution.dart %}
+String message = 'delete your code';
+{% begin main.dart %}
+''';
+
+String _normalSnippet = '''
+main() => print('Hello, World!');
+''';

--- a/web/experimental/new_embeddings_with_code_tags.html
+++ b/web/experimental/new_embeddings_with_code_tags.html
@@ -26,7 +26,7 @@
 
         iframe {
             width: 100%;
-            height: 700px;
+            height: 600px;
             margin-bottom: 40px;
             margin-top: 40px;
         }
@@ -38,7 +38,7 @@
     <div class="col-md-10">
         <p>mode-flutter, theme-light</p>
         <pre>
-            <code class="run-dartpad language-run-dartpad theme-light mode-flutter">
+            <code class="language-run-dartpad:theme-light:mode-flutter">
 import 'package:flutter_web/material.dart';
 import 'package:flutter_web_test/flutter_web_test.dart';
 import 'package:flutter_web_ui/ui.dart' as ui;
@@ -73,7 +73,7 @@ class _MyAppState extends State {
 
         <p>mode-flutter, theme-dark</p>
         <pre>
-            <code class="run-dartpad language-run-dartpad theme-dark mode-flutter">
+            <code class="language-run-dartpad:theme-dark:mode-flutter">
 import 'package:flutter_web/material.dart';
 import 'package:flutter_web_test/flutter_web_test.dart';
 import 'package:flutter_web_ui/ui.dart' as ui;
@@ -111,7 +111,7 @@ class _MyAppState extends State {
 
         <p>mode-dart</p>
         <pre>
-            <code class="run-dartpad language-run-dartpad mode-dart">
+            <code class="language-run-dartpad:mode-dart">
 {% begin main.dart %}
 String message = 'Hello, World!';
 {% end main.dart %}
@@ -128,7 +128,7 @@ main() => print(message);
 
         <p>mode-html</p>
         <pre>
-            <code class="run-dartpad language-run-dartpad mode-html">
+            <code class="language-run-dartpad:mode-html">
 {% begin main.dart %}
 void main() {
   print("hello, world!");
@@ -152,7 +152,7 @@ p {
         </pre>
         <p>mode-inline</p>
         <pre>
-            <code class="run-dartpad language-run-dartpad mode-inline">
+            <code class="language-run-dartpad:mode-inline">
 void main() {
   print("hello, world!");
 }

--- a/web/experimental/new_embeddings_with_code_tags.html
+++ b/web/experimental/new_embeddings_with_code_tags.html
@@ -92,6 +92,9 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State {
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: new ThemeData(
+        brightness: Brightness.dark,
+      ),
       home: Scaffold(
         appBar: AppBar(),
         body: Center(

--- a/web/experimental/new_embeddings_with_code_tags.html
+++ b/web/experimental/new_embeddings_with_code_tags.html
@@ -112,42 +112,38 @@ class _MyAppState extends State {
         <p>mode-dart</p>
         <pre>
             <code class="language-run-dartpad:mode-dart">
-{% begin main.dart %}
+{$ begin main.dart $}
 String message = 'Hello, World!';
-{% end main.dart %}
+{$ end main.dart $}
 
-{% begin solution.dart %}
+{$ begin solution.dart $}
 String message = 'delete your code';
-{% end solution.dart %}
+{$ end solution.dart $}
 
-{% begin test.dart %}
+{$ begin test.dart $}
 main() => print(message);
-{% end test.dart %}
+{$ end test.dart $}
             </code>
         </pre>
 
         <p>mode-html</p>
         <pre>
             <code class="language-run-dartpad:mode-html">
-{% begin main.dart %}
+{$ begin main.dart $}
 void main() {
   print("hello, world!");
 }
-{% end main.dart %}
+{$ end main.dart $}
 
-
-
-{% begin index.html %}
+{$ begin index.html $}
 <p>I'm a paragraph!</p>
-{% end index.html %}
+{$ end index.html $}
 
-
-
-{% begin styles.css %}
+{$ begin styles.css $}
 p {
   font-family: monospace;
 }
-{% end styles.css %}
+{$ end styles.css $}
             </code>
         </pre>
         <p>mode-inline</p>

--- a/web/experimental/new_embeddings_with_code_tags.html
+++ b/web/experimental/new_embeddings_with_code_tags.html
@@ -109,18 +109,42 @@ class _MyAppState extends State {
         <p>mode-dart</p>
         <pre>
             <code class="run-dartpad language-run-dartpad mode-dart">
-void main() {
-  print("hello, world!");
-}
+{% begin main.dart %}
+String message = 'Hello, World!';
+{% end main.dart %}
+
+{% begin solution.dart %}
+String message = 'delete your code';
+{% end solution.dart %}
+
+{% begin test.dart %}
+main() => print(message);
+{% end test.dart %}
             </code>
         </pre>
 
         <p>mode-html</p>
         <pre>
             <code class="run-dartpad language-run-dartpad mode-html">
+{% begin main.dart %}
 void main() {
   print("hello, world!");
 }
+{% end main.dart %}
+
+
+
+{% begin index.html %}
+<p>I'm a paragraph!</p>
+{% end index.html %}
+
+
+
+{% begin styles.css %}
+p {
+  font-family: monospace;
+}
+{% end styles.css %}
             </code>
         </pre>
         <p>mode-inline</p>


### PR DESCRIPTION
this includes #1111 but it might be possible to rebase onto master if we need it sooner

This parses markdown input and injects the different code regions into the corresponding editor. The currently supported filenames / editors are:

- main.dart
- solution.dart
- test.dart
- index.html
- styles.css

other file types will be parsed but new_embed.dart won't use them.

An example markdown snippet could be:  
````
my code snippet:

```run-dartpad mode-dart theme-dark
{$ begin main.dart $}
String message = 'Hello, World!';
{$ end main.dart $}

{$ begin solution.dart $}
String message = 'delete your code';
{$ end solution.dart $}

{$ begin test.dart $}
main() => print(message);
{ $end test.dart $}
```