### PR TITLE
don't set frame background-color

### DIFF
--- a/web/scripts/frame.html
+++ b/web/scripts/frame.html
@@ -10,7 +10,6 @@
     <title></title>
     <style>
         body {
-            background-color: white;
             font-size: 12pt;
             margin: 0;
             padding: 0;

--- a/web/scripts/frame_dark.html
+++ b/web/scripts/frame_dark.html
@@ -10,7 +10,6 @@
     <title></title>
     <style>
         body {
-            background-color: #1b1e22;
             font-size: 12pt;
             margin: 0;
             padding: 0;


### PR DESCRIPTION
This was causing the current editor to show an ugly white background over the dark theme.