### PR TITLE
Hide test code checkbox

### DIFF
--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -380,6 +380,8 @@ class DContentEditable extends DElement {
 }
 
 class DInput extends DElement {
+  DInput(InputElement element) : super(element);
+
   DInput.input({String type}) : super(InputElement(type: type));
 
   InputElement get inputElement => element;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -62,7 +62,6 @@ class NewEmbed {
   DElement morePopover;
   DInput showTestCodeCheckbox;
   bool _showTestCode = false;
-  bool _popoverHidden = true;
 
   Counter unreadConsoleCounter;
 
@@ -186,8 +185,8 @@ class NewEmbed {
 
     morePopover = DElement(querySelector('#more-popover'));
     menuButton = DisableableButton(querySelector('#menu-button'), () {
-      _popoverHidden = !_popoverHidden;
-      morePopover.toggleAttr('hidden', _popoverHidden);
+      morePopover.toggleAttr(
+          'hidden', !(morePopover.getAttr('hidden') == 'true'));
     });
 
     formatButton = DisableableButton(
@@ -430,7 +429,8 @@ class NewEmbed {
     context.testMethod = gist.getFile('test.dart')?.content ?? '';
     context.solution = gist.getFile('solution.dart')?.content ?? '';
     context.hint = gist.getFile('hint.txt')?.content ?? '';
-    tabController.setTabVisibility('test', context.testMethod.isNotEmpty && _showTestCode);
+    tabController.setTabVisibility(
+        'test', context.testMethod.isNotEmpty && _showTestCode);
     showHintButton?.hidden = context.hint.isEmpty && context.testMethod.isEmpty;
     editorIsBusy = false;
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -48,6 +48,7 @@ class NewEmbed {
   DisableableButton reloadGistButton;
   DisableableButton formatButton;
   DisableableButton showHintButton;
+  DisableableButton moreButton;
 
   DElement navBarElement;
   NewEmbedTabController tabController;
@@ -57,6 +58,11 @@ class NewEmbed {
   TabView htmlTabView;
   TabView cssTabView;
   DElement solutionTab;
+
+  DElement morePopover;
+  DInput showTestCodeCheckbox;
+  bool _showTestCode = false;
+  bool _popoverHidden = true;
 
   Counter unreadConsoleCounter;
 
@@ -170,6 +176,19 @@ class NewEmbed {
         hintBox.showElements([hintElement, showSolutionButton]);
       });
     }
+
+    tabController.setTabVisibility('test', false);
+    showTestCodeCheckbox = DInput(querySelector('#show-test-checkbox'));
+    showTestCodeCheckbox.onClick.listen((e) {
+      _showTestCode = !_showTestCode;
+      tabController.setTabVisibility('test', _showTestCode);
+    });
+
+    morePopover = DElement(querySelector('#more-popover'));
+    moreButton = DisableableButton(querySelector('#more-button'), () {
+      _popoverHidden = !_popoverHidden;
+      morePopover.toggleAttr('hidden', _popoverHidden);
+    });
 
     formatButton = DisableableButton(
       querySelector('#format-code'),
@@ -411,7 +430,7 @@ class NewEmbed {
     context.testMethod = gist.getFile('test.dart')?.content ?? '';
     context.solution = gist.getFile('solution.dart')?.content ?? '';
     context.hint = gist.getFile('hint.txt')?.content ?? '';
-    tabController.setTabVisibility('test', context.testMethod.isNotEmpty);
+    tabController.setTabVisibility('test', context.testMethod.isNotEmpty && _showTestCode);
     showHintButton?.hidden = context.hint.isEmpty && context.testMethod.isEmpty;
     editorIsBusy = false;
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -48,7 +48,7 @@ class NewEmbed {
   DisableableButton reloadGistButton;
   DisableableButton formatButton;
   DisableableButton showHintButton;
-  DisableableButton moreButton;
+  DisableableButton menuButton;
 
   DElement navBarElement;
   NewEmbedTabController tabController;
@@ -185,7 +185,7 @@ class NewEmbed {
     });
 
     morePopover = DElement(querySelector('#more-popover'));
-    moreButton = DisableableButton(querySelector('#more-button'), () {
+    menuButton = DisableableButton(querySelector('#menu-button'), () {
       _popoverHidden = !_popoverHidden;
       morePopover.toggleAttr('hidden', _popoverHidden);
     });

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -185,8 +185,8 @@ class NewEmbed {
 
     morePopover = DElement(querySelector('#more-popover'));
     menuButton = DisableableButton(querySelector('#menu-button'), () {
-      morePopover.toggleAttr(
-          'hidden', !(morePopover.getAttr('hidden') == 'true'));
+      var popoverHidden = morePopover.hasAttr('hidden');
+      morePopover.toggleAttr('hidden', !popoverHidden);
     });
 
     formatButton = DisableableButton(

--- a/lib/experimental/scss/colors.scss
+++ b/lib/experimental/scss/colors.scss
@@ -27,6 +27,7 @@ $dark-issue-label-color: white;
 
 // V2 Colors
 $button-color: #168AFD;
+$secondary-color: #676767;
 $grey-1: #1c2834;
 $grey-2: #27323A;
 $grey-3: #12202F;

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -98,7 +98,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="more-popover" class="Popover right-0 position-absolute" hidden>
                 <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
                     <div class="d-flex flex-row flex-items-center">

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -97,6 +97,30 @@ BSD-style license that can be found in the LICENSE file. -->
             <i class="material-icons mdc-button__icon">play_arrow</i>
             Run
         </button>
+        <div class="position-relative text-right pr-2">
+            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <div id="more-popover" class="Popover right-0 position-absolute" hidden>
+                <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
+                    <div class="d-flex flex-row flex-items-center">
+                        <div class="mdc-checkbox">
+                            <input type="checkbox"
+                                   class="mdc-checkbox__native-control"
+                                   id="show-test-checkbox"/>
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark"
+                                     viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path"
+                                          fill="none"
+                                          d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                        </div>
+                        <label for="show-test-checkbox">Show Test Code</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <section id="tab-container">
@@ -133,7 +157,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <footer flex layout horizontal class="footer">
     <div id="issues-message"></div>
-    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--raised" hidden></button>
+    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -77,7 +77,7 @@ BSD-style license that can be found in the LICENSE file. -->
                         </button>
                         <button id="test-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0">
                              <span class="mdc-tab__content">
-                                 <span class="mdc-tab__text-label">Test code</span>
+                                 <span class="mdc-tab__text-label">Tests</span>
                             </span>
                             <span class="mdc-tab-indicator mdc-tab-indicator">
                                  <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -116,7 +116,7 @@ BSD-style license that can be found in the LICENSE file. -->
                                 <div class="mdc-checkbox__mixedmark"></div>
                             </div>
                         </div>
-                        <label for="show-test-checkbox">Show Test Code</label>
+                        <label for="show-test-checkbox">Show tests</label>
                     </div>
                 </div>
             </div>

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -92,6 +92,30 @@ BSD-style license that can be found in the LICENSE file. -->
             <i class="material-icons mdc-button__icon">play_arrow</i>
             Run
         </button>
+        <div class="position-relative text-right pr-2">
+            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <div id="more-popover" class="Popover right-0 position-absolute" hidden>
+                <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
+                    <div class="d-flex flex-row flex-items-center">
+                        <div class="mdc-checkbox">
+                            <input type="checkbox"
+                                   class="mdc-checkbox__native-control"
+                                   id="show-test-checkbox"/>
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark"
+                                     viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path"
+                                          fill="none"
+                                          d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                        </div>
+                        <label for="show-test-checkbox">Show Test Code</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <section id="tab-container">
@@ -119,7 +143,7 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 <footer flex layout horizontal class="footer">
     <div id="issues-message"></div>
-    <button id="issues-toggle" class="btn btn-sm" hidden></button>
+    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -93,7 +93,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="more-popover" class="Popover right-0 position-absolute" hidden>
                 <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
                     <div class="d-flex flex-row flex-items-center">

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -72,7 +72,7 @@ BSD-style license that can be found in the LICENSE file. -->
                         </button>
                         <button id="test-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0">
                              <span class="mdc-tab__content">
-                                 <span class="mdc-tab__text-label">Test code</span>
+                                 <span class="mdc-tab__text-label">Tests</span>
                             </span>
                             <span class="mdc-tab-indicator mdc-tab-indicator">
                                  <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -111,7 +111,7 @@ BSD-style license that can be found in the LICENSE file. -->
                                 <div class="mdc-checkbox__mixedmark"></div>
                             </div>
                         </div>
-                        <label for="show-test-checkbox">Show Test Code</label>
+                        <label for="show-test-checkbox">Show tests</label>
                     </div>
                 </div>
             </div>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -94,7 +94,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="more-popover" class="Popover right-0 position-absolute" hidden>
                 <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
                     <div class="d-flex flex-row flex-items-center">

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -73,7 +73,7 @@ BSD-style license that can be found in the LICENSE file. -->
                         </button>
                         <button id="test-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0">
                              <span class="mdc-tab__content">
-                                 <span class="mdc-tab__text-label">Test code</span>
+                                 <span class="mdc-tab__text-label">Tests</span>
                             </span>
                             <span class="mdc-tab-indicator mdc-tab-indicator">
                                  <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -112,7 +112,7 @@ BSD-style license that can be found in the LICENSE file. -->
                                 <div class="mdc-checkbox__mixedmark"></div>
                             </div>
                         </div>
-                        <label for="show-test-checkbox">Show Test Code</label>
+                        <label for="show-test-checkbox">Show tests</label>
                     </div>
                 </div>
             </div>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -93,6 +93,30 @@ BSD-style license that can be found in the LICENSE file. -->
             <i class="material-icons mdc-button__icon">play_arrow</i>
             Run
         </button>
+        <div class="position-relative text-right pr-2">
+            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <div id="more-popover" class="Popover right-0 position-absolute" hidden>
+                <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
+                    <div class="d-flex flex-row flex-items-center">
+                        <div class="mdc-checkbox">
+                            <input type="checkbox"
+                                   class="mdc-checkbox__native-control"
+                                   id="show-test-checkbox"/>
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark"
+                                     viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path"
+                                          fill="none"
+                                          d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                        </div>
+                        <label for="show-test-checkbox">Show Test Code</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <section id="tab-container">
@@ -129,7 +153,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <footer flex layout horizontal class="footer">
     <div id="issues-message"></div>
-    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--raised" hidden></button>
+    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -94,7 +94,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="more-popover" class="Popover right-0 position-absolute" hidden>
                 <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
                     <div class="d-flex flex-row flex-items-center">

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -112,7 +112,7 @@ BSD-style license that can be found in the LICENSE file. -->
                                 <div class="mdc-checkbox__mixedmark"></div>
                             </div>
                         </div>
-                        <label for="show-test-checkbox">Show Test Code</label>
+                        <label for="show-test-checkbox">Show tests</label>
                     </div>
                 </div>
             </div>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -93,6 +93,30 @@ BSD-style license that can be found in the LICENSE file. -->
             <i class="material-icons mdc-button__icon">play_arrow</i>
             Run
         </button>
+        <div class="position-relative text-right pr-2">
+            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <div id="more-popover" class="Popover right-0 position-absolute" hidden>
+                <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
+                    <div class="d-flex flex-row flex-items-center">
+                        <div class="mdc-checkbox">
+                            <input type="checkbox"
+                                   class="mdc-checkbox__native-control"
+                                   id="show-test-checkbox"/>
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark"
+                                     viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path"
+                                          fill="none"
+                                          d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                        </div>
+                        <label for="show-test-checkbox">Show Test Code</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -130,7 +154,7 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <footer flex layout horizontal class="footer">
     <div id="issues-message"></div>
-    <button id="issues-toggle" class="btn btn-sm" hidden></button>
+    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -92,6 +92,30 @@ BSD-style license that can be found in the LICENSE file. -->
             <i class="material-icons mdc-button__icon">play_arrow</i>
             Run
         </button>
+        <div class="position-relative text-right pr-2">
+            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <div id="more-popover" class="Popover right-0 position-absolute" hidden>
+                <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
+                    <div class="d-flex flex-row flex-items-center">
+                        <div class="mdc-checkbox">
+                            <input type="checkbox"
+                                   class="mdc-checkbox__native-control"
+                                   id="show-test-checkbox"/>
+                            <div class="mdc-checkbox__background">
+                                <svg class="mdc-checkbox__checkmark"
+                                     viewBox="0 0 24 24">
+                                    <path class="mdc-checkbox__checkmark-path"
+                                          fill="none"
+                                          d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
+                                </svg>
+                                <div class="mdc-checkbox__mixedmark"></div>
+                            </div>
+                        </div>
+                        <label for="show-test-checkbox">Show Test Code</label>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <section id="tab-container" class="flex-column">
@@ -119,7 +143,7 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 <footer flex layout horizontal class="footer">
     <div id="issues-message"></div>
-    <button id="issues-toggle" class="btn btn-sm" hidden></button>
+    <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -93,7 +93,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="more-button" class="mdc-icon-button material-icons">more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="more-popover" class="Popover right-0 position-absolute" hidden>
                 <div class="Popover-message Popover-message--top-right text-left p-4 mt-2 Box box-shadow-large">
                     <div class="d-flex flex-row flex-items-center">

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -72,7 +72,7 @@ BSD-style license that can be found in the LICENSE file. -->
                         </button>
                         <button id="test-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0">
                              <span class="mdc-tab__content">
-                                 <span class="mdc-tab__text-label">Test code</span>
+                                 <span class="mdc-tab__text-label">Tests</span>
                             </span>
                             <span class="mdc-tab-indicator mdc-tab-indicator">
                                  <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
@@ -111,7 +111,7 @@ BSD-style license that can be found in the LICENSE file. -->
                                 <div class="mdc-checkbox__mixedmark"></div>
                             </div>
                         </div>
-                        <label for="show-test-checkbox">Show Test Code</label>
+                        <label for="show-test-checkbox">Show tests</label>
                     </div>
                 </div>
             </div>

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -15,6 +15,7 @@ body {
 
   // Material Design theme
   --mdc-theme-primary: #168AFD;
+  --mdc-theme-secondary: #676767;
 }
 
 .medium-octicon {
@@ -38,10 +39,14 @@ body {
 }
 
 .nav-buttons {
-  padding: 4px 4px 4px 4px;
+  padding: 0 0 4px 0;
   display: flex;
   flex-direction: row;
   align-items: center;
+  > * {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
 }
 
 .tabnav-tab {
@@ -302,6 +307,16 @@ body {
 .issue .message {
   padding-left: 5px;
   line-height: 20px;
+}
+
+// Primer
+.Popover-message {
+  padding: 8px !important;
+}
+
+// Material Design
+#more-button {
+  color: $secondary-color;
 }
 
 // Misc

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -315,7 +315,7 @@ body {
 }
 
 // Material Design
-#more-button {
+#menu-button {
   color: $secondary-color;
 }
 


### PR DESCRIPTION
fixes #1085 
fixes #1024 

this uses the Primer version of the dropdown, not the material-components-web dropdown. the material-components-web dropdown requires javascript + npm. I looked into using https://github.com/jifalops/mdc_web but ran into some [Sass issues](https://github.com/dart-league/sass_builder/pull/47)

![Screen Shot 2019-07-02 at 5 01 08 PM](https://user-images.githubusercontent.com/1145719/60554068-01071600-9ceb-11e9-8747-a96611adcec0.png)

fyi @galeyang 

