### PR TITLE
add overflow-x: scroll to console output container

### DIFF
--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -218,7 +218,9 @@ body {
 #editor-and-console-container {
   display: flex;
   flex-direction: column;
+  overflow-x: scroll;
 }
+
 #editor-container {
   flex: 1;
   overflow: auto;


### PR DESCRIPTION
prevents large amounts of console output from blocking the split.js gutter

This can be reproduced by going to https://dartpad.dev/experimental/embed-new-flutter.html?id=5a59d93119dc5b6eb1725235fde137cf, running, and expanding the console