### PR TITLE
allow console for flutter layout to be larger

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -1062,7 +1062,7 @@ class ConsoleExpandController extends ConsoleController {
       horizontal: false,
       gutterSize: defaultSplitterWidth,
       sizes: [60, 40],
-      minSize: [200, 32],
+      minSize: [32, 32],
     );
   }
 }


### PR DESCRIPTION
Changes the minimum size of the editor area from 200 to 32 to allow
more space for the console

fixes #1164