### PR TITLE
Adds message for gist-related failures

### DIFF
--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -325,10 +325,8 @@ class PlaygroundMobile {
   }
 
   Future<void> _showGist(String gistId, {bool run = false}) async {
-    Gist gist;
-
     try {
-      gist = await gistLoader.loadGist(gistId);
+      final gist = await gistLoader.loadGist(gistId);
       _setGistDescription(gist.description);
       _setGistId(gist.id);
 

--- a/lib/embed/embed.dart
+++ b/lib/embed/embed.dart
@@ -324,13 +324,16 @@ class PlaygroundMobile {
     _clearOutput();
   }
 
-  Future<void> _showGist(String gistId, {bool run = false}) {
-    return gistLoader.loadGist(gistId).then((Gist gist) {
+  Future<void> _showGist(String gistId, {bool run = false}) async {
+    Gist gist;
+
+    try {
+      gist = await gistLoader.loadGist(gistId);
       _setGistDescription(gist.description);
       _setGistId(gist.id);
 
       GistFile dart =
-          chooseGistFile(gist, ['main.dart'], (f) => f.endsWith('.dart'));
+      chooseGistFile(gist, ['main.dart'], (f) => f.endsWith('.dart'));
       GistFile html = chooseGistFile(gist, ['index.html', 'body.html']);
       GistFile css = chooseGistFile(gist, ['styles.css', 'style.css']);
 
@@ -345,10 +348,10 @@ class PlaygroundMobile {
       if (url.hasQuery && url.queryParameters['line'] != null) {
         _jumpToLine(int.parse(url.queryParameters['line']));
       }
-    }).catchError((e) {
+    } catch (e) {
       print('Error loading gist $gistId.\n$e');
       _showError('Error Loading Gist', '$gistId - $e');
-    });
+    }
   }
 
   Future _initModules() {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -126,7 +126,7 @@ class NewEmbed {
 
     var tabNames = ['editor', 'solution', 'test'];
     if (options.mode == NewEmbedMode.html) {
-      tabNames = ['editor', 'html', 'css'];
+      tabNames = ['editor', 'html', 'css', 'solution', 'test'];
     }
 
     for (var name in tabNames) {
@@ -451,7 +451,7 @@ class NewEmbed {
       tabController.setTabVisibility(
           'test', context.testMethod.isNotEmpty && _showTestCode);
       showHintButton?.hidden = context.hint.isEmpty;
-      solutionTab.toggleAttr('hidden', context.solution.isEmpty);
+      solutionTab?.toggleAttr('hidden', context.solution.isEmpty);
       editorIsBusy = false;
 
       if (analyze) {
@@ -467,7 +467,7 @@ class NewEmbed {
       context.hint = '';
       tabController.setTabVisibility('test', false);
       showHintButton?.hidden = true;
-      solutionTab.toggleAttr('hidden', true);
+      solutionTab?.toggleAttr('hidden', true);
       editorIsBusy = false;
 
       if (ex.failureType == GistLoaderFailureType.gistDoesNotExist) {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -493,6 +493,13 @@ class NewEmbed {
       return;
     }
 
+    if (context.dartSource.isEmpty) {
+      dialog.showOk('No code to execute!',
+          'Try entering some Dart code into the "Dart" tab, then click this '
+          'button again to run it.');
+      return;
+    }
+
     ga?.sendEvent('execution', 'initiated');
 
     editorIsBusy = true;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -458,7 +458,7 @@ class NewEmbed {
         _performAnalysis();
       }
     } on GistLoaderException catch (ex) {
-      // No gist was loaded, so the editors need to be cleared out.
+      // No gist was loaded, so clear the editors.
       context.dartSource = '';
       context.htmlSource = '';
       context.cssSource = '';
@@ -471,8 +471,8 @@ class NewEmbed {
       editorIsBusy = false;
 
       if (ex.failureType == GistLoaderFailureType.gistDoesNotExist) {
-        await dialog.showOk('Error loading gist', 'No gist was found matching '
-            ' the ID provided ($gistId).');
+        await dialog.showOk('Error loading gist',
+            'No gist was found matching the ID provided ($gistId).');
       } else if (ex.failureType == GistLoaderFailureType.rateLimitExceeded) {
         await dialog.showOk('Error loading gist', 'GitHub\'s rate limit for '
             'API requests has been exceeded. This is typically caused by '
@@ -494,7 +494,7 @@ class NewEmbed {
     }
 
     if (context.dartSource.isEmpty) {
-      dialog.showOk('No code to execute!',
+      dialog.showOk('No code to execute',
           'Try entering some Dart code into the "Dart" tab, then click this '
           'button again to run it.');
       return;
@@ -1152,17 +1152,23 @@ class Dialog {
   Future<DialogResult> showYesNo(String title, String htmlMessage,
       {String yesText = "Yes", String noText = "No"}) {
     return _setUpAndDisplay(
-        title, htmlMessage, yesText, noText, DialogResult.yes, DialogResult.no);
+      title,
+      htmlMessage,
+      noText,
+      yesText,
+      DialogResult.no,
+      DialogResult.yes,
+    );
   }
 
   Future<DialogResult> showOk(String title, String htmlMessage) {
     return _setUpAndDisplay(
       title,
       htmlMessage,
-      "OK",
       '',
-      DialogResult.ok,
+      "OK",
       DialogResult.cancel,
+      DialogResult.ok,
       false,
     );
   }
@@ -1171,10 +1177,10 @@ class Dialog {
     return _setUpAndDisplay(
       title,
       htmlMessage,
-      'OK',
       'Cancel',
-      DialogResult.ok,
+      'OK',
       DialogResult.cancel,
+      DialogResult.ok,
     );
   }
 
@@ -1185,33 +1191,33 @@ class Dialog {
       String rightButtonText,
       DialogResult leftButtonResult,
       DialogResult rightButtonResult,
-      [bool showRightButton = true]) {
+      [bool showLeftButton = true]) {
     _title.text = title;
     _content.setInnerHtml(htmlMessage, validator: PermissiveNodeValidator());
-    _leftButton.text = leftButtonText;
+    _rightButton.text = rightButtonText;
 
     final completer = Completer<DialogResult>();
-    StreamSubscription rightSub;
+    StreamSubscription leftSub;
 
-    if (showRightButton) {
-      _rightButton.removeAttribute('hidden');
-      _rightButton.text = rightButtonText;
-      rightSub = _rightButton.onClick.listen((_) {
-        completer.complete(rightButtonResult);
+    if (showLeftButton) {
+      _leftButton.text = leftButtonText;
+      _leftButton.removeAttribute('hidden');
+      leftSub = _leftButton.onClick.listen((_) {
+        completer.complete(leftButtonResult);
       });
     } else {
-      _rightButton.setAttribute('hidden', 'true');
+      _leftButton.setAttribute('hidden', 'true');
     }
 
-    final leftSub = _leftButton.onClick.listen((_) {
-      completer.complete(leftButtonResult);
+    final rightSub = _rightButton.onClick.listen((_) {
+      completer.complete(rightButtonResult);
     });
 
     _mdcDialog.open();
 
     return completer.future.then((v) {
-      leftSub.cancel();
-      rightSub?.cancel();
+      leftSub?.cancel();
+      rightSub.cancel();
       _mdcDialog.close();
       return v;
     });

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -439,21 +439,52 @@ class NewEmbed {
     editorIsBusy = true;
 
     final GistLoader loader = deps[GistLoader];
-    final gist = await loader.loadGist(id);
-    context.dartSource = gist.getFile('main.dart')?.content ?? '';
-    context.htmlSource = gist.getFile('index.html')?.content ?? '';
-    context.cssSource = gist.getFile('styles.css')?.content ?? '';
-    context.testMethod = gist.getFile('test.dart')?.content ?? '';
-    context.solution = gist.getFile('solution.dart')?.content ?? '';
-    context.hint = gist.getFile('hint.txt')?.content ?? '';
-    tabController.setTabVisibility(
-        'test', context.testMethod.isNotEmpty && _showTestCode);
-    showHintButton?.hidden = context.hint.isEmpty;
-    solutionTab.toggleAttr('hidden', context.solution.isEmpty);
-    editorIsBusy = false;
 
-    if (analyze) {
-      _performAnalysis();
+    try {
+      final gist = await loader.loadGist(id);
+      context.dartSource = gist.getFile('main.dart')?.content ?? '';
+      context.htmlSource = gist.getFile('index.html')?.content ?? '';
+      context.cssSource = gist.getFile('styles.css')?.content ?? '';
+      context.testMethod = gist.getFile('test.dart')?.content ?? '';
+      context.solution = gist.getFile('solution.dart')?.content ?? '';
+      context.hint = gist.getFile('hint.txt')?.content ?? '';
+      tabController.setTabVisibility(
+          'test', context.testMethod.isNotEmpty && _showTestCode);
+      showHintButton?.hidden = context.hint.isEmpty;
+      solutionTab.toggleAttr('hidden', context.solution.isEmpty);
+      editorIsBusy = false;
+
+      if (analyze) {
+        _performAnalysis();
+      }
+    } on GistLoaderException catch (ex) {
+      // No gist was loaded, so the editors need to be cleared out.
+      context.dartSource = '';
+      context.htmlSource = '';
+      context.cssSource = '';
+      context.testMethod = '';
+      context.solution = '';
+      context.hint = '';
+      tabController.setTabVisibility('test', false);
+      showHintButton?.hidden = true;
+      solutionTab.toggleAttr('hidden', true);
+      editorIsBusy = false;
+
+      if (ex.failureType == GistLoaderFailureType.gistDoesNotExist) {
+        await dialog.showOk('Error loading gist', 'No gist was found matching '
+            ' the ID provided ($gistId).');
+      } else if (ex.failureType == GistLoaderFailureType.rateLimitExceeded) {
+        await dialog.showOk('Error loading gist', 'GitHub\'s rate limit for '
+            'API requests has been exceeded. This is typically caused by '
+            'repeatedly loading a single page that has many DartPad embeds or '
+            'when many users are accessing DartPad (and therefore GitHub\'s '
+            'API server) from a single, shared IP address. Quotas are '
+            'typically renewed within an hour, so the best course of action is '
+            'to try back later.');
+      } else {
+        await dialog.showOk('Error loading gist', 'An error occurred while '
+            'loading Gist ID $gistId.');
+      }
     }
   }
 
@@ -688,7 +719,7 @@ class NewEmbedTabController extends TabController {
   Future selectTab(String tabName) async {
     // Show a confirmation dialog if the solution tab is tapped
     if (tabName == 'solution' && !_userHasSeenSolution) {
-      var result = await _dialog.show(
+      var result = await _dialog.showYesNo(
         'Show solution?',
         'If you just want a hint, click <span style="font-weight:bold">Cancel'
             '</span> and then <span style="font-weight:bold">Hint</span>.',
@@ -1093,43 +1124,88 @@ class ConsoleExpandController extends ConsoleController {
 enum DialogResult {
   yes,
   no,
+  ok,
+  cancel,
 }
 
 class Dialog {
   final MDCDialog _mdcDialog;
-  final Element _yesButton;
-  final Element _noButton;
+  final Element _leftButton;
+  final Element _rightButton;
   final Element _title;
   final Element _content;
 
   Dialog()
       : _mdcDialog = MDCDialog(querySelector('.mdc-dialog')),
-        _yesButton = querySelector('#dialog-yes'),
-        _noButton = querySelector('#dialog-no'),
+        _leftButton = querySelector('#dialog-left-button'),
+        _rightButton = querySelector('#dialog-right-button'),
         _title = querySelector('#my-dialog-title'),
         _content = querySelector('#my-dialog-content');
 
-  Future<DialogResult> show(String title, String htmlMessage,
+  Future<DialogResult> showYesNo(String title, String htmlMessage,
       {String yesText = "Yes", String noText = "No"}) {
+    return _setUpAndDisplay(
+        title, htmlMessage, yesText, noText, DialogResult.yes, DialogResult.no);
+  }
+
+  Future<DialogResult> showOk(String title, String htmlMessage) {
+    return _setUpAndDisplay(
+      title,
+      htmlMessage,
+      "OK",
+      '',
+      DialogResult.ok,
+      DialogResult.cancel,
+      false,
+    );
+  }
+
+  Future<DialogResult> showOkCancel(String title, String htmlMessage) {
+    return _setUpAndDisplay(
+      title,
+      htmlMessage,
+      'OK',
+      'Cancel',
+      DialogResult.ok,
+      DialogResult.cancel,
+    );
+  }
+
+  Future<DialogResult> _setUpAndDisplay(
+      String title,
+      String htmlMessage,
+      String leftButtonText,
+      String rightButtonText,
+      DialogResult leftButtonResult,
+      DialogResult rightButtonResult,
+      [bool showRightButton = true]) {
     _title.text = title;
     _content.setInnerHtml(htmlMessage, validator: PermissiveNodeValidator());
+    _leftButton.text = leftButtonText;
 
-    _yesButton.text = yesText;
-    _noButton.text = noText;
+    final completer = Completer<DialogResult>();
+    StreamSubscription rightSub;
+
+    if (showRightButton) {
+      _rightButton.removeAttribute('hidden');
+      _rightButton.text = rightButtonText;
+      rightSub = _rightButton.onClick.listen((_) {
+        completer.complete(rightButtonResult);
+      });
+    } else {
+      _rightButton.setAttribute('hidden', 'true');
+    }
+
+    final leftSub = _leftButton.onClick.listen((_) {
+      completer.complete(leftButtonResult);
+    });
+
     _mdcDialog.open();
 
-    var completer = Completer<DialogResult>();
-
-    var sub1 = _yesButton.onClick.listen((_) {
-      completer.complete(DialogResult.yes);
-    });
-    var sub2 = _noButton.onClick.listen((_) {
-      completer.complete(DialogResult.no);
-    });
-
     return completer.future.then((v) {
-      sub1.cancel();
-      sub2.cancel();
+      leftSub.cancel();
+      rightSub?.cancel();
+      _mdcDialog.close();
       return v;
     });
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -229,7 +229,15 @@ class Playground implements GistContainer, GistController {
     } else if (url.hasQuery && url.queryParameters['source'] != null) {
       UuidContainer gistId = await dartSupportServices.retrieveGist(
           id: url.queryParameters['source']);
-      Gist backing = await gistLoader.loadGist(gistId.uuid);
+      Gist backing;
+
+      try {
+        backing = await gistLoader.loadGist(gistId.uuid);
+      } catch (ex) {
+        print(ex);
+        backing = Gist();
+      }
+
       editableGist.setBackingGist(backing);
       await router.go('gist', {'gist': backing.id});
     } else if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
@@ -728,8 +736,7 @@ class Playground implements GistContainer, GistController {
   /// Perform static analysis of the source code. Return whether the code
   /// analyzed cleanly (had no errors or warnings).
   Future<bool> _performAnalysis() {
-    SourceRequest input = SourceRequest()
-      ..source = _context.dartSource;
+    SourceRequest input = SourceRequest()..source = _context.dartSource;
 
     Lines lines = Lines(input.source);
 

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -175,10 +175,10 @@ BSD-style license that can be found in the LICENSE file. -->
             <h2 class="mdc-dialog__title" id="my-dialog-title"></h2>
             <div class="mdc-dialog__content" id="my-dialog-content"></div>
             <footer class="mdc-dialog__actions">
-                <button type="button" id="dialog-no" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">
+                <button type="button" id="dialog-left-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">No</span>
                 </button>
-                <button type="button" id="dialog-yes" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">
+                <button type="button" id="dialog-right-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Yes</span>
                 </button>
             </footer>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -184,10 +184,10 @@ BSD-style license that can be found in the LICENSE file. -->
             <h2 class="mdc-dialog__title" id="my-dialog-title"></h2>
             <div class="mdc-dialog__content" id="my-dialog-content"></div>
             <footer class="mdc-dialog__actions">
-                <button type="button" id="dialog-no" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">
+                <button type="button" id="dialog-left-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">No</span>
                 </button>
-                <button type="button" id="dialog-yes" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">
+                <button type="button" id="dialog-right-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Yes</span>
                 </button>
             </footer>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -146,6 +146,12 @@ BSD-style license that can be found in the LICENSE file. -->
             <div id="css-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
                 <div id="css-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
+            <div id="solution-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+                <div id="solution-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
+            </div>
+            <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+                <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
+            </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
             <div class="console-output-header">

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -185,10 +185,10 @@ BSD-style license that can be found in the LICENSE file. -->
             <h2 class="mdc-dialog__title" id="my-dialog-title"></h2>
             <div class="mdc-dialog__content" id="my-dialog-content"></div>
             <footer class="mdc-dialog__actions">
-                <button type="button" id="dialog-no" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">
+                <button type="button" id="dialog-left-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">No</span>
                 </button>
-                <button type="button" id="dialog-yes" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">
+                <button type="button" id="dialog-right-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Yes</span>
                 </button>
             </footer>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -87,6 +87,24 @@ BSD-style license that can be found in the LICENSE file. -->
                              </span>
                             <span class="mdc-tab__ripple"></span>
                         </button>
+                        <button id="solution-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0" hidden>
+                             <span class="mdc-tab__content">
+                                 <span class="mdc-tab__text-label">Solution</span>
+                             </span>
+                            <span class="mdc-tab-indicator mdc-tab-indicator">
+                                 <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
+                             </span>
+                            <span class="mdc-tab__ripple"></span>
+                        </button>
+                        <button id="test-tab" class="mdc-tab mdc-tab" role="tab" tabindex="0">
+                             <span class="mdc-tab__content">
+                                 <span class="mdc-tab__text-label">Tests</span>
+                            </span>
+                            <span class="mdc-tab-indicator mdc-tab-indicator">
+                                 <span class="mdc-tab-indicator__content mdc-tab-indicator__content--underline"></span>
+                             </span>
+                            <span class="mdc-tab__ripple"></span>
+                        </button>
                     </div>
                 </div>
             </div>

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -175,10 +175,10 @@ BSD-style license that can be found in the LICENSE file. -->
             <h2 class="mdc-dialog__title" id="my-dialog-title"></h2>
             <div class="mdc-dialog__content" id="my-dialog-content"></div>
             <footer class="mdc-dialog__actions">
-                <button type="button" id="dialog-no" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="no">
+                <button type="button" id="dialog-left-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">No</span>
                 </button>
-                <button type="button" id="dialog-yes" class="mdc-button mdc-dialog__button" data-mdc-dialog-action="yes">
+                <button type="button" id="dialog-right-button" class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Yes</span>
                 </button>
             </footer>


### PR DESCRIPTION
This change:

* Updates the gist-loading code to return specific exceptions rather than empty gists when it fails. 
* Adds code to the new embed to display an MDC dialog informing the user of failures when a gist can't be found or they've been rate-limited by GitHub.
* Updates the playground and old embed to the new loading API.
* Prevents users from executing when there's no code in the editor and tells them why.
* Fixes a pre-existing bug in the HTML layout caused by its lack of Test and Solution tabs.

Testing was done manually via the new and old embedding demo pages as well as the home page.