### PR TITLE
Use codemirror simple scrollbars to avoid issues with macOS

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -31,6 +31,26 @@ NewEmbed get newEmbed => _newEmbed;
 
 NewEmbed _newEmbed;
 
+var codeMirrorOptions = {
+  'continueComments': {'continueLineComment': false},
+  'autofocus': false,
+  'autoCloseBrackets': true,
+  'matchBrackets': true,
+  'tabSize': 2,
+  'lineWrapping': true,
+  'indentUnit': 2,
+  'cursorHeight': 0.85,
+  'viewportMargin': 100,
+  'extraKeys': {
+    'Cmd-/': 'toggleComment',
+    'Ctrl-/': 'toggleComment',
+    'Tab': 'insertSoftTab'
+  },
+  'hintOptions': {'completeSingle': false},
+  'theme': 'zenburn',
+  'scrollbarStyle': 'simple',
+};
+
 void init(NewEmbedOptions options) {
   _newEmbed = NewEmbed(options);
 }
@@ -74,7 +94,7 @@ class NewEmbed {
 
   ExecutionService executionSvc;
 
-  EditorFactory editorFactory = codeMirrorFactory;
+  CodeMirrorFactory editorFactory = codeMirrorFactory;
 
   Editor userCodeEditor;
   Editor testEditor;
@@ -213,15 +233,17 @@ class NewEmbed {
     hintBox = FlashBox(querySelector('#hint-box'));
     var editorTheme = isDarkMode ? 'darkpad' : 'dartpad';
 
-    userCodeEditor =
-        editorFactory.createFromElement(querySelector('#user-code-editor'))
-          ..theme = editorTheme
-          ..mode = 'dart'
-          ..showLineNumbers = true;
+    userCodeEditor = editorFactory.createFromElement(
+        querySelector('#user-code-editor'),
+        options: codeMirrorOptions)
+      ..theme = editorTheme
+      ..mode = 'dart'
+      ..showLineNumbers = true;
     userCodeEditor.document.onChange.listen(_performAnalysis);
     userCodeEditor.autoCloseBrackets = false;
 
-    testEditor = editorFactory.createFromElement(querySelector('#test-editor'))
+    testEditor = editorFactory.createFromElement(querySelector('#test-editor'),
+        options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'dart'
       // TODO(devoncarew): We should make this read-only after initial beta
@@ -229,19 +251,22 @@ class NewEmbed {
       //..readOnly = true
       ..showLineNumbers = true;
 
-    solutionEditor =
-        editorFactory.createFromElement(querySelector('#solution-editor'))
-          ..theme = editorTheme
-          ..mode = 'dart'
-          ..showLineNumbers = true;
+    solutionEditor = editorFactory.createFromElement(
+        querySelector('#solution-editor'),
+        options: codeMirrorOptions)
+      ..theme = editorTheme
+      ..mode = 'dart'
+      ..showLineNumbers = true;
 
-    htmlEditor = editorFactory.createFromElement(querySelector('#html-editor'))
+    htmlEditor = editorFactory.createFromElement(querySelector('#html-editor'),
+        options: codeMirrorOptions)
       ..theme = editorTheme
       // TODO(ryjohn): why doesn't editorFactory.modes have html?
       ..mode = 'xml'
       ..showLineNumbers = true;
 
-    cssEditor = editorFactory.createFromElement(querySelector('#css-editor'))
+    cssEditor = editorFactory.createFromElement(querySelector('#css-editor'),
+        options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'css'
       ..showLineNumbers = true;
@@ -480,16 +505,20 @@ class NewEmbed {
         await dialog.showOk('Error loading gist',
             'No gist was found matching the ID provided ($gistId).');
       } else if (ex.failureType == GistLoaderFailureType.rateLimitExceeded) {
-        await dialog.showOk('Error loading gist', 'GitHub\'s rate limit for '
-            'API requests has been exceeded. This is typically caused by '
-            'repeatedly loading a single page that has many DartPad embeds or '
-            'when many users are accessing DartPad (and therefore GitHub\'s '
-            'API server) from a single, shared IP address. Quotas are '
-            'typically renewed within an hour, so the best course of action is '
-            'to try back later.');
+        await dialog.showOk(
+            'Error loading gist',
+            'GitHub\'s rate limit for '
+                'API requests has been exceeded. This is typically caused by '
+                'repeatedly loading a single page that has many DartPad embeds or '
+                'when many users are accessing DartPad (and therefore GitHub\'s '
+                'API server) from a single, shared IP address. Quotas are '
+                'typically renewed within an hour, so the best course of action is '
+                'to try back later.');
       } else {
-        await dialog.showOk('Error loading gist', 'An error occurred while '
-            'loading Gist ID $gistId.');
+        await dialog.showOk(
+            'Error loading gist',
+            'An error occurred while '
+                'loading Gist ID $gistId.');
       }
     }
   }
@@ -500,9 +529,10 @@ class NewEmbed {
     }
 
     if (context.dartSource.isEmpty) {
-      dialog.showOk('No code to execute',
+      dialog.showOk(
+          'No code to execute',
           'Try entering some Dart code into the "Dart" tab, then click this '
-          'button again to run it.');
+              'button again to run it.');
       return;
     }
 

--- a/lib/experimental/scss/colors.scss
+++ b/lib/experimental/scss/colors.scss
@@ -54,7 +54,7 @@ $dark-orange-2: darken(desaturate(#ff9b00, 20%), 5%);
 $dark-editor-text: darken(desaturate(#ffffff, 20%), 5%);
 $dark-comment: darken(desaturate(#909cce, 20%), 5%);
 $dark-line-count: darken(desaturate(#414c58, 20%), 5%);
-$dark-gutter-line-number-color: darken(desaturate(#485561, 20%), 5%);
+$dark-gutter-line-number-color: $dark-text-color;
 $dark-selection-color: lighten($dark-code-background-color, 10%);
 
 $light-green: #007a27;

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -25,10 +25,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
+    <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
     <script src="../packages/split/split.min.js" defer></script>
 
     <script defer src="new_embed_flutter.dart.js"></script>

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -122,13 +122,13 @@ BSD-style license that can be found in the LICENSE file. -->
 <section id="tab-container">
     <div id="editor-and-console-container">
         <div id="editor-container">
-            <div id="user-code-view" class="flex-auto d-flex flex-row no-overflow">
+            <div id="user-code-view" class="flex-auto d-flex flex-column no-overflow">
                 <div id="user-code-editor" spellcheck="false"></div>
             </div>
-            <div id="solution-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+            <div id="solution-view" class="flex-auto d-flex flex-column no-overflow" spellcheck="false" hidden>
                 <div id="solution-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
-            <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
+            <div id="test-view" class="flex-auto d-flex flex-column no-overflow" spellcheck="false" hidden>
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
         </div>

--- a/web/experimental/cm-scrollbars.scss
+++ b/web/experimental/cm-scrollbars.scss
@@ -1,0 +1,72 @@
+@import 'package:dart_pad/experimental/scss/colors';
+
+.CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div {
+  position: absolute;
+  background: $scrollbar-color;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  border-radius: 4px;
+}
+
+.CodeMirror-simplescroll-horizontal, .CodeMirror-simplescroll-vertical {
+  position: absolute;
+  z-index: 6;
+}
+
+.CodeMirror-simplescroll-horizontal {
+  bottom: 0;
+  left: 0;
+  height: 9px;
+}
+
+.CodeMirror-simplescroll-horizontal div {
+  bottom: 0;
+  height: 100%;
+}
+
+.CodeMirror-simplescroll-vertical {
+  right: 0;
+  top: 0;
+  width: 9px;
+}
+
+.CodeMirror-simplescroll-vertical div {
+  right: 0;
+  width: 100%;
+}
+
+.CodeMirror-overlayscroll .CodeMirror-scrollbar-filler, .CodeMirror-overlayscroll .CodeMirror-gutter-filler {
+  display: none;
+}
+
+.CodeMirror-overlayscroll-horizontal div, .CodeMirror-overlayscroll-vertical div {
+  position: absolute;
+  border-radius: 3px;
+}
+
+.CodeMirror-overlayscroll-horizontal, .CodeMirror-overlayscroll-vertical {
+  position: absolute;
+  z-index: 6;
+}
+
+.CodeMirror-overlayscroll-horizontal {
+  bottom: 0;
+  left: 0;
+  height: 6px;
+}
+
+.CodeMirror-overlayscroll-horizontal div {
+  bottom: 0;
+  height: 100%;
+}
+
+.CodeMirror-overlayscroll-vertical {
+  right: 0;
+  top: 0;
+  width: 6px;
+}
+
+.CodeMirror-overlayscroll-vertical div {
+  right: 0;
+  width: 100%;
+}

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -25,10 +25,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
+    <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
     <script src="../packages/split/split.min.js" defer></script>
 
     <script defer src="new_embed_dart.dart.js"></script>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -25,10 +25,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
+    <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
     <script src="../packages/split/split.min.js" defer></script>
 
     <script defer src="new_embed_flutter.dart.js"></script>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -25,10 +25,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
+    <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
     <script src="../packages/split/split.min.js" defer></script>
 
     <script defer src="new_embed_html.dart.js"></script>

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -25,10 +25,12 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
+    <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
     <script src="../packages/split/split.min.js" defer></script>
 
     <script defer src="new_embed_inline.dart.js"></script>

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -51,8 +51,9 @@ body {
 
 // Code Editor
 
-#user-code-editor {
+#user-code-editor, #solution-editor, #test-editor, #html-editor, #solution-editor {
   flex: 1;
+  width: 100%;
 }
 
 .CodeMirror-hints {
@@ -121,8 +122,6 @@ body {
 .custom-scrollbar::-webkit-scrollbar-thumb {
   border-radius: 4px;
   background-color: $scrollbar-color;
-  box-shadow: 0 0 1px $light-code-background-color;
-  opacity: 0.5;
 }
 
 .message-container div+div {
@@ -226,7 +225,7 @@ body {
 
 #editor-container {
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
 }
 
 #tab-container {


### PR DESCRIPTION
macOS has a setting in Preferences -> General -> "Show scrollbars" that can produce unexpected behavior whether or not a mouse is attached.

This uses CodeMirror's simple scrollbar add-on to avoid this altogether.

fixes #1186 