### PR TITLE
hide hint button when app starts

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -204,7 +204,7 @@ class NewEmbed {
         tabController.selectTab('solution', force: true);
       });
       hintBox.showElements([hintElement, showSolutionButton]);
-    });
+    })..hidden = true;
 
     tabController.setTabVisibility('test', false);
     showTestCodeCheckmark = DElement(querySelector('#show-test-checkmark'));


### PR DESCRIPTION
If there's a gist or code injection, setContextSources will display the button.