### PR TITLE
Add experimental playground for Flutter redesign

### DIFF
--- a/lib/experimental/new_playground.dart
+++ b/lib/experimental/new_playground.dart
@@ -1,0 +1,1147 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library playground;
+
+import 'dart:async';
+import 'dart:html' hide Document;
+
+import 'package:logging/logging.dart';
+import 'package:route_hierarchical/client.dart';
+
+import '../completion.dart';
+import '../context.dart';
+import '../core/dependencies.dart';
+import '../core/keys.dart';
+import '../core/modules.dart';
+import '../dart_pad.dart';
+import '../dialogs.dart';
+import '../documentation.dart';
+import '../editing/editor.dart';
+import '../elements/bind.dart';
+import '../elements/elements.dart';
+import '../modules/codemirror_module.dart';
+import '../modules/dart_pad_module.dart';
+import '../modules/dartservices_module.dart';
+import '../services/_dartpadsupportservices.dart';
+import '../services/common.dart';
+import '../services/dartservices.dart';
+import '../services/execution_iframe.dart';
+import '../sharing/gists.dart';
+import '../sharing/mutable_gist.dart';
+import '../src/ga.dart';
+import '../src/util.dart';
+
+Playground get playground => _playground;
+
+Playground _playground;
+
+final Logger _logger = Logger('dartpad');
+
+/// Controls whether we request compilation using dart2js or DDC.
+const bool _useDDC = false;
+
+void init() {
+  _playground = Playground();
+}
+
+class Playground implements GistContainer, GistController {
+  DivElement get _editpanel => querySelector('#editpanel');
+
+  DivElement get _outputpanel => querySelector('#output');
+
+  IFrameElement get _frame => querySelector('#frame');
+
+  bool get _isCompletionActive => editor.completionActive;
+
+  DivElement get _docPanel => querySelector('#documentation');
+
+  DButton runButton;
+  DButton formatButton;
+  DOverlay overlay;
+  DBusyLight busyLight;
+  DBusyLight consoleBusyLight;
+  Editor editor;
+  PlaygroundContext _context;
+  Future _analysisRequest;
+  MutableGist editableGist = MutableGist(Gist());
+  final _gistStorage = GistStorage();
+  DContentEditable titleEditable;
+
+  TabController sourceTabController;
+  TabController outputTabController;
+  SharingDialog sharingDialog;
+  KeysDialog settings;
+
+  // We store the last returned shared gist; it's used to update the url.
+  Gist _overrideNextRouteGist;
+  DocHandler docHandler;
+
+  String _mappingId;
+
+  Playground() {
+    sourceTabController = TabController();
+    for (String name in ['dart', 'html', 'css']) {
+      sourceTabController.registerTab(
+          TabElement(querySelector('#${name}tab'), name: name, onSelect: () {
+            Element issuesElement = querySelector('#issues');
+            issuesElement.style.display = name == 'dart' ? 'block' : 'none';
+            ga.sendEvent('edit', name);
+            _context.switchTo(name);
+          }));
+    }
+
+    overlay = DOverlay(querySelector('#frame-overlay'));
+
+    sharingDialog = SharingDialog(this, this);
+
+    DButton newButton = DButton(querySelector('#newbutton'));
+    OkCancelDialog newDialog = OkCancelDialog(
+        'Create New Pad', 'Discard changes to the current pad?', createNewGist,
+        okText: 'Discard');
+    newButton.onClick.listen((_) {
+      newDialog.show();
+    });
+
+    DButton resetButton = DButton(querySelector('#resetbutton'));
+    OkCancelDialog resetDialog = OkCancelDialog(
+        'Reset Pad', 'Discard changes to the current pad?', _resetGists,
+        okText: 'Discard', cancelText: 'Cancel');
+    resetButton.onClick.listen((_) {
+      resetDialog.show();
+    });
+
+    editableGist.onDirtyChanged.listen((val) {
+      resetButton.disabled = !val;
+    });
+
+    DButton shareButton = DButton(querySelector('#sharebutton'));
+
+    shareButton.onClick.listen((Event e) => window.open(
+        'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
+        '_sharing'));
+
+    // Sharing is currently disabled pending establishing OAuth2 configurations with Github.
+    // shareButton.onClick.listen((Event e) => _createSummary()
+    //    .then((GistSummary summary) => sharingDialog.showWithSummary(summary)));
+
+    formatButton = DButton(querySelector('#formatbutton'));
+    formatButton.onClick.listen((Event e) => _format());
+
+    runButton = DButton(querySelector('#runbutton'));
+    runButton.onClick.listen((e) {
+      _handleRun();
+
+      // On a mobile device, focusing the editing area causes the keyboard to
+      // pop up when the user hits the run button.
+      if (!isMobile()) _context.focus();
+    });
+
+    // Listen for the keyboard button.
+    querySelector('#keyboard-button').onClick.listen((_) => settings.show());
+
+    busyLight = DBusyLight(querySelector('#dartbusy'));
+    consoleBusyLight = DBusyLight(querySelector('#consolebusy'));
+
+    // Update the title on changes.
+    titleEditable = DContentEditable(querySelector('header .header-gist-name'));
+    bind(titleEditable.onChanged, editableGist.property('description'));
+    bind(editableGist.property('description'), titleEditable.textProperty);
+    editableGist.onDirtyChanged.listen((val) {
+      titleEditable.element.classes.toggle('dirty', val);
+    });
+
+    // If there was a change, and the gist is dirty, write the gist's contents
+    // to storage.
+    debounceStream(mutableGist.onChanged, Duration(milliseconds: 100))
+        .listen((_) {
+      if (mutableGist.dirty) {
+        _gistStorage.setStoredGist(mutableGist.createGist());
+      }
+    });
+
+    SelectElement select = querySelector('#samples');
+    select.onChange.listen((_) => _handleSelectChanged(select));
+
+    // Show the about box on title clicks.
+    querySelector('div.header-title').onClick.listen((e) {
+      e.preventDefault();
+      _showAboutBox();
+    });
+
+    // Show the about box on version text clicks.
+    querySelector('#dartpad_version').onClick.listen((e) {
+      e.preventDefault();
+      _showAboutBox();
+    });
+
+    _initModules().then((_) {
+      _initPlayground();
+    });
+  }
+
+  void _showAboutBox() {
+    dartServices
+        .version()
+        .timeout(Duration(seconds: 2))
+        .then((VersionResponse ver) {
+      print('Dart SDK version ${ver.sdkVersion} (${ver.sdkVersionFull})');
+      print('CodeMirror: ${CodeMirrorModule.version}');
+      AboutDialog(ver.sdkVersionFull)..show();
+    }).catchError((e) {
+      AboutDialog()..show();
+    });
+  }
+
+  void _resetGists() {
+    _gistStorage.clearStoredGist();
+    editableGist.reset();
+    // Delay to give time for the model change event to propagate through
+    // to the editor component (which is where `_performAnalysis()` pulls
+    // the Dart source from).
+    Timer.run(_performAnalysis);
+    _clearOutput();
+  }
+
+  Future showHome(RouteEnterEvent event) async {
+    // Don't auto-run if we're re-loading some unsaved edits; the gist might
+    // have halting issues (#384).
+    bool loadedFromSaved = false;
+    Uri url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery &&
+        url.queryParameters['id'] != null &&
+        isLegalGistId(url.queryParameters['id'])) {
+      _showGist(url.queryParameters['id']);
+    } else if (url.hasQuery && url.queryParameters['export'] != null) {
+      UuidContainer requestId = UuidContainer()
+        ..uuid = url.queryParameters['export'];
+      Future<PadSaveObject> exportPad =
+      dartSupportServices.pullExportContent(requestId);
+      await exportPad.then((pad) {
+        Gist blankGist = createSampleGist();
+        blankGist.getFile('main.dart').content = pad.dart;
+        blankGist.getFile('index.html').content = pad.html;
+        blankGist.getFile('styles.css').content = pad.css;
+        editableGist.setBackingGist(blankGist);
+      });
+    } else if (url.hasQuery && url.queryParameters['source'] != null) {
+      UuidContainer gistId = await dartSupportServices.retrieveGist(
+          id: url.queryParameters['source']);
+      Gist backing;
+
+      try {
+        backing = await gistLoader.loadGist(gistId.uuid);
+      } catch (ex) {
+        print(ex);
+        backing = Gist();
+      }
+
+      editableGist.setBackingGist(backing);
+      await router.go('gist', {'gist': backing.id});
+    } else if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
+      loadedFromSaved = true;
+
+      Gist blankGist = Gist();
+      editableGist.setBackingGist(blankGist);
+
+      Gist storedGist = _gistStorage.getStoredGist();
+      editableGist.description = storedGist.description;
+      for (GistFile file in storedGist.files) {
+        editableGist.getGistFile(file.name).content = file.content;
+      }
+    } else {
+      editableGist.setBackingGist(createSampleGist());
+    }
+
+    _clearOutput();
+    // We delay this because of the latency in populating the editors from the
+    // gist data.
+    Timer.run(_autoSwitchSourceTab);
+
+    // Analyze and run it.
+    Timer.run(() {
+      _performAnalysis().then((bool result) {
+        // Only auto-run if the static analysis comes back clean.
+        if (result && !loadedFromSaved) _handleRun();
+        if (url.hasQuery && url.queryParameters['line'] != null) {
+          _jumpToLine(int.parse(url.queryParameters['line']));
+        }
+      }).catchError((e) => null);
+    });
+  }
+
+  void showGist(RouteEnterEvent event) {
+    String gistId = event.parameters['gist'];
+
+    _clearOutput();
+
+    if (!isLegalGistId(gistId)) {
+      showHome(event);
+      return;
+    }
+
+    _showGist(gistId);
+  }
+
+  // GistContainer interface
+  @override
+  MutableGist get mutableGist => editableGist;
+
+  @override
+  void overrideNextRoute(Gist gist) {
+    _overrideNextRouteGist = gist;
+  }
+
+  @override
+  Future createNewGist() {
+    _gistStorage.clearStoredGist();
+
+    if (ga != null) ga.sendEvent('main', 'new');
+
+    DToast.showMessage('New pad created');
+    router.go('gist', {'gist': ''}, forceReload: true);
+
+    return Future.value();
+  }
+
+  @override
+  Future shareAnon({String summary = ''}) {
+    return gistLoader
+        .createAnon(mutableGist.createGist(summary: summary))
+        .then((Gist newGist) {
+      editableGist.setBackingGist(newGist);
+      overrideNextRoute(newGist);
+      router.go('gist', {'gist': newGist.id});
+      var toast = DToast('Created ${newGist.id}')
+        ..show()
+        ..hide();
+      toast.element
+        ..style.cursor = 'pointer'
+        ..onClick.listen((e) => window.open(
+            'https://gist.github.com/anonymous/${newGist.id}', '_blank'));
+      GistToInternalIdMapping mapping = GistToInternalIdMapping()
+        ..gistId = newGist.id
+        ..internalId = _mappingId;
+      dartSupportServices.storeGist(mapping);
+    }).catchError((e) {
+      String message = 'Error saving gist: $e';
+      DToast.showMessage(message);
+      ga.sendException('GistLoader.createAnon: failed to create gist');
+    });
+  }
+
+  void _showGist(String gistId) {
+    // Don't auto-run if we're re-loading some unsaved edits; the gist might
+    // have halting issues (#384).
+    bool loadedFromSaved = false;
+
+    // When sharing, we have to pipe the returned (created) gist through the
+    // routing library to update the url properly.
+    if (_overrideNextRouteGist != null && _overrideNextRouteGist.id == gistId) {
+      editableGist.setBackingGist(_overrideNextRouteGist);
+      _overrideNextRouteGist = null;
+      return;
+    }
+
+    _overrideNextRouteGist = null;
+
+    gistLoader.loadGist(gistId).then((Gist gist) {
+      editableGist.setBackingGist(gist);
+
+      if (_gistStorage.hasStoredGist && _gistStorage.storedId == gistId) {
+        loadedFromSaved = true;
+
+        Gist storedGist = _gistStorage.getStoredGist();
+        editableGist.description = storedGist.description;
+        for (GistFile file in storedGist.files) {
+          editableGist.getGistFile(file.name).content = file.content;
+        }
+      }
+
+      _clearOutput();
+
+      // We delay this because of the latency in populating the editors from the
+      // gist data.
+      Timer.run(_autoSwitchSourceTab);
+
+      if (isWebContentShowing != gist.hasWebContent()) {
+        if (gist.hasWebContent()) {
+          showWebContent();
+        } else {
+          hideWebContent();
+        }
+      }
+
+      // Analyze and run it.
+      Timer.run(() {
+        _performAnalysis().then((bool result) {
+          // Only auto-run if the static analysis comes back clean.
+          if (result && !loadedFromSaved) _handleRun();
+        }).catchError((e) => null);
+      });
+    }).catchError((e) {
+      String message = 'Error loading gist $gistId.';
+      DToast.showMessage(message);
+      _logger.severe('$message: $e');
+    });
+  }
+
+  Future _initModules() {
+    ModuleManager modules = ModuleManager();
+
+    modules.register(DartPadModule());
+    modules.register(DartServicesModule());
+    modules.register(DartSupportServicesModule());
+    modules.register(CodeMirrorModule());
+
+    return modules.start();
+  }
+
+  void _initPlayground() {
+    var disablePointerEvents = () {
+      _frame.style.pointerEvents = 'none';
+    };
+    var enablePointerEvents = () {
+      _frame.style.pointerEvents = 'inherit';
+    };
+
+    DSplitter editorSplitter = DSplitter(querySelector('#editor_split'),
+        onDragStart: disablePointerEvents, onDragEnd: enablePointerEvents);
+    editorSplitter.onPositionChanged.listen((pos) {
+      state['editor_split'] = pos;
+      editor.resize();
+    });
+    if (state['editor_split'] != null) {
+      editorSplitter.position = state['editor_split'];
+    }
+
+    DSplitter outputSplitter = DSplitter(querySelector('#output_split'),
+        onDragStart: disablePointerEvents, onDragEnd: enablePointerEvents);
+    outputSplitter.onPositionChanged.listen((pos) {
+      state['output_split'] = pos;
+    });
+    if (state['output_split'] != null) {
+      outputSplitter.position = state['output_split'];
+    }
+
+    // Set up the iframe.
+    deps[ExecutionService] = ExecutionServiceIFrame(_frame);
+    executionService.onStdout.listen(_showOuput);
+    executionService.onStderr.listen((m) => _showOuput(m, error: true));
+
+    // Set up Google Analytics.
+    deps[Analytics] = Analytics();
+
+    // Set up the gist loader.
+    deps[GistLoader] = GistLoader.defaultFilters();
+
+    // Set up the editing area.
+    editor = editorFactory.createFromElement(_editpanel);
+    _editpanel.children.first.attributes['flex'] = '';
+    editor.resize();
+
+    keys.bind(['ctrl-s'], _handleSave, 'Save', hidden: true);
+    keys.bind(['ctrl-enter'], _handleRun, 'Run');
+    keys.bind(['f1'], () {
+      ga.sendEvent('main', 'help');
+      docHandler.generateDoc(_docPanel);
+    }, 'Documentation');
+
+    keys.bind(['alt-enter'], () {
+      editor.showCompletions(onlyShowFixes: true);
+    }, 'Quick fix');
+
+    keys.bind(['ctrl-space', 'macctrl-space'], () {
+      editor.showCompletions();
+    }, 'Completion');
+
+    keys.bind(['shift-ctrl-/', 'shift-macctrl-/'], () {
+      if (settings.isShowing) {
+        settings.hide();
+      } else {
+        settings.show();
+      }
+    }, 'Shortcuts');
+
+    settings = KeysDialog(keys.inverseBindings);
+
+    document.onKeyUp.listen((e) {
+      if (editor.completionActive ||
+          DocHandler.cursorKeys.contains(e.keyCode)) {
+        docHandler.generateDoc(_docPanel);
+      }
+      _handleAutoCompletion(e);
+    });
+
+    outputTabController = TabController()
+      ..registerTab(
+          TabElement(querySelector('#resulttab'), name: 'result', onSelect: () {
+            ga.sendEvent('view', 'result');
+            querySelector('#frame').style.visibility = 'visible';
+            querySelector('#output').style.visibility = 'hidden';
+          }))
+      ..registerTab(TabElement(querySelector('#consoletab'), name: 'console',
+          onSelect: () {
+            ga.sendEvent('view', 'console');
+            querySelector('#output').style.visibility = 'visible';
+            querySelector('#frame').style.visibility = 'hidden';
+          }));
+
+    _context = PlaygroundContext(editor);
+    _context.onModeChange.listen((_) {
+      formatButton.disabled = _context.activeMode != 'dart';
+    });
+    deps[Context] = _context;
+
+    editorFactory.registerCompleter(
+        'dart', DartCompleter(dartServices, _context._dartDoc));
+
+    _context.onHtmlDirty.listen((_) => busyLight.on());
+    _context.onHtmlReconcile.listen((_) {
+      executionService.replaceHtml(_context.htmlSource);
+      busyLight.reset();
+    });
+
+    _context.onCssDirty.listen((_) => busyLight.on());
+    _context.onCssReconcile.listen((_) {
+      executionService.replaceCss(_context.cssSource);
+      busyLight.reset();
+    });
+
+    _context.onDartDirty.listen((_) => busyLight.on());
+    _context.onDartReconcile.listen((_) => _performAnalysis());
+
+    // Listen for changes that would effect the documentation panel.
+    editor.onMouseDown.listen((e) {
+      // Delay to give codemirror time to process the mouse event.
+      Timer.run(() {
+        if (!_context.cursorPositionIsWhitespace()) {
+          docHandler.generateDoc(_docPanel);
+        }
+      });
+    });
+    context.onModeChange.listen((_) => docHandler.generateDoc(_docPanel));
+
+    // Listen for clicks on the 'Show web content' checkbox.
+    showWebContentInputElement.onClick.listen((MouseEvent event) {
+      event.preventDefault();
+
+      // Delay a bit as it looks like we can't programmatically change the value
+      // of a checkbox in an event handler.
+      Timer(const Duration(milliseconds: 100), () {
+        final bool isChecked = showWebContentInputElement.checked;
+
+        if (isChecked) {
+          if (_context.hasWebContent()) {
+            final OkCancelDialog dialog = OkCancelDialog(
+              'Hide web content',
+              'Discard the contents of the HTML and CSS tabs?',
+                  () {
+                _context.htmlSource = '';
+                _context.cssSource = '';
+                hideWebContent();
+              },
+              okText: 'Discard',
+            );
+            dialog.show();
+          } else {
+            hideWebContent();
+          }
+        } else {
+          showWebContent();
+        }
+      });
+    });
+
+    // Bind the editable files to the gist.
+    Property htmlFile =
+    GistFileProperty(editableGist.getGistFile('index.html'));
+    Property htmlDoc = EditorDocumentProperty(_context.htmlDocument, 'html');
+    bind(htmlDoc, htmlFile);
+    bind(htmlFile, htmlDoc);
+
+    Property cssFile = GistFileProperty(editableGist.getGistFile('styles.css'));
+    Property cssDoc = EditorDocumentProperty(_context.cssDocument, 'css');
+    bind(cssDoc, cssFile);
+    bind(cssFile, cssDoc);
+
+    Property dartFile = GistFileProperty(editableGist.getGistFile('main.dart'));
+    Property dartDoc = EditorDocumentProperty(_context.dartDocument, 'dart');
+    bind(dartDoc, dartFile);
+    bind(dartFile, dartDoc);
+
+    // Set up the router.
+    deps[Router] = Router();
+    router.root.addRoute(name: 'home', defaultRoute: true, enter: showHome);
+    router.root.addRoute(name: 'gist', path: '/:gist', enter: showGist);
+    router.listen();
+
+    docHandler = DocHandler(editor, _context);
+
+    dartServices.version().then((VersionResponse version) {
+      // "Based on Dart SDK 1.25.0-dev"
+      String versionText = 'Based on Dart SDK ${version.sdkVersionFull}';
+      querySelector('#dartpad_version').text = versionText;
+    }).catchError((e) => null);
+
+    _finishedInit();
+  }
+
+  void _finishedInit() {
+    // Clear the splash.
+    DSplash splash = DSplash(querySelector('div.splash'));
+    splash.hide();
+  }
+
+  final RegExp cssSymbolRegexp = RegExp(r'[A-Z]');
+
+  void _handleAutoCompletion(KeyboardEvent e) {
+    if (context.focusedEditor == 'dart' && editor.hasFocus) {
+      if (e.keyCode == KeyCode.PERIOD) {
+        editor.showCompletions(autoInvoked: true);
+      }
+    }
+
+    if (!_isCompletionActive && editor.hasFocus) {
+      if (context.focusedEditor == 'html') {
+        if (printKeyEvent(e) == 'shift-,') {
+          editor.showCompletions(autoInvoked: true);
+        }
+      } else if (context.focusedEditor == 'css') {
+        if (cssSymbolRegexp.hasMatch(String.fromCharCode(e.keyCode))) {
+          editor.showCompletions(autoInvoked: true);
+        }
+      }
+    }
+  }
+
+  void _handleRun() async {
+    ga.sendEvent('main', 'run');
+    runButton.disabled = true;
+    overlay.visible = true;
+
+    Stopwatch compilationTimer = Stopwatch()..start();
+
+    final CompileRequest compileRequest = CompileRequest()
+      ..source = context.dartSource;
+
+    try {
+      if (_useDDC) {
+        final CompileDDCResponse response = await dartServices
+            .compileDDC(compileRequest)
+            .timeout(longServiceCallTimeout);
+
+        ga.sendTiming(
+          'action-perf',
+          'compilation-e2e',
+          compilationTimer.elapsedMilliseconds,
+        );
+
+        _autoSwitchOutputTab();
+        _clearOutput();
+
+        return executionService.execute(
+          _context.htmlSource,
+          _context.cssSource,
+          response.result,
+          modulesBaseUrl: response.modulesBaseUrl,
+        );
+      } else {
+        final CompileResponse response = await dartServices
+            .compile(compileRequest)
+            .timeout(longServiceCallTimeout);
+
+        ga.sendTiming(
+          'action-perf',
+          'compilation-e2e',
+          compilationTimer.elapsedMilliseconds,
+        );
+
+        _autoSwitchOutputTab();
+        _clearOutput();
+
+        return executionService.execute(
+          _context.htmlSource,
+          _context.cssSource,
+          response.result,
+        );
+      }
+    } catch (e) {
+      ga.sendException('${e.runtimeType}');
+      final message = (e is DetailedApiRequestError) ? e.message : '$e';
+      DToast.showMessage('Error compiling to JavaScript');
+      _showOuput('Error compiling to JavaScript:\n$message', error: true);
+    } finally {
+      runButton.disabled = false;
+      overlay.visible = false;
+    }
+  }
+
+  /// Switch to the Dart / Html / Css tab depending on the sample type.
+  void _autoSwitchSourceTab() {
+    String htmlSrc = _context.htmlSource.trim();
+    String dartSrc = _context.dartSource.trim();
+
+    if (htmlSrc.isEmpty && dartSrc.isNotEmpty) {
+      sourceTabController.selectTab('dart');
+    }
+  }
+
+  /// Switch to the console or html results tab depending on whether the sample
+  /// has html content or not.
+  void _autoSwitchOutputTab() {
+    if (!isWebContentShowing) {
+      return;
+    }
+
+    String htmlSrc = _context.htmlSource.trim();
+    String dartSrc = _context.dartSource.trim();
+
+    final List<String> webImports = [
+      "import 'dart:html'",
+      'import "dart:html"',
+      //"import 'package:flutter_web",
+      //'import "package:flutter_web',
+    ];
+
+    if (htmlSrc.isNotEmpty) {
+      outputTabController.selectTab('result');
+    } else if (webImports.any((String import) => dartSrc.contains(import))) {
+      outputTabController.selectTab('result');
+    } else {
+      outputTabController.selectTab('console');
+    }
+  }
+
+  /* Future<GistSummary> _createSummary() {
+    return dartSupportServices.getUnusedMappingId().then((UuidContainer id) {
+      _mappingId = id.uuid;
+      SourcesRequest input = new SourcesRequest()
+        ..sources = {
+          'dart': _context.dartSource,
+          'css': _context.cssSource,
+          'html': _context.htmlSource
+        };
+      return dartServices.summarize(input);
+    }).then((SummaryText summary) {
+      return new GistSummary(summary.text,
+          'Find this at [dartpad.dartlang.org/?source=${_mappingId}](https://dartpad.dartlang.org/?source=${_mappingId}).');
+    }).catchError((e) {
+      _logger.severe(e);
+    });
+  } */
+
+  /// Perform static analysis of the source code. Return whether the code
+  /// analyzed cleanly (had no errors or warnings).
+  Future<bool> _performAnalysis() {
+    SourceRequest input = SourceRequest()..source = _context.dartSource;
+
+    Lines lines = Lines(input.source);
+
+    Future<AnalysisResults> request =
+    dartServices.analyze(input).timeout(serviceCallTimeout);
+    _analysisRequest = request;
+
+    return request.then((AnalysisResults result) {
+      // Discard if we requested another analysis.
+      if (_analysisRequest != request) return false;
+
+      // Discard if the document has been mutated since we requested analysis.
+      if (input.source != _context.dartSource) return false;
+
+      busyLight.reset();
+
+      _displayIssues(result.issues);
+
+      _context.dartDocument
+          .setAnnotations(result.issues.map((AnalysisIssue issue) {
+        int startLine = lines.getLineForOffset(issue.charStart);
+        int endLine =
+        lines.getLineForOffset(issue.charStart + issue.charLength);
+
+        Position start = Position(
+            startLine, issue.charStart - lines.offsetForLine(startLine));
+        Position end = Position(
+            endLine,
+            issue.charStart +
+                issue.charLength -
+                lines.offsetForLine(startLine));
+
+        return Annotation(issue.kind, issue.message, issue.line,
+            start: start, end: end);
+      }).toList());
+
+      bool hasErrors = result.issues.any((issue) => issue.kind == 'error');
+      bool hasWarnings = result.issues.any((issue) => issue.kind == 'warning');
+
+      _updateRunButton(hasErrors: hasErrors, hasWarnings: hasWarnings);
+
+      return hasErrors == false && hasWarnings == false;
+    }).catchError((e) {
+      _context.dartDocument.setAnnotations([]);
+      busyLight.reset();
+      _updateRunButton();
+      _logger.severe(e);
+    });
+  }
+
+  Future _format() {
+    String originalSource = _context.dartSource;
+    SourceRequest input = SourceRequest()..source = originalSource;
+    formatButton.disabled = true;
+
+    Future<FormatResponse> request =
+    dartServices.format(input).timeout(serviceCallTimeout);
+    return request.then((FormatResponse result) {
+      busyLight.reset();
+      formatButton.disabled = false;
+
+      if (result.newString == null || result.newString.isEmpty) {
+        _logger.fine('Format returned null/empty result');
+        return;
+      }
+
+      if (originalSource != result.newString) {
+        editor.document.updateValue(result.newString);
+        DToast.showMessage('Format successful.');
+      } else {
+        DToast.showMessage('No formatting changes.');
+      }
+    }).catchError((e) {
+      busyLight.reset();
+      formatButton.disabled = false;
+      _logger.severe(e);
+    });
+  }
+
+  void _handleSave() => ga.sendEvent('main', 'save');
+
+  void _clearOutput() {
+    _outputpanel.text = '';
+  }
+
+  InputElement get showWebContentInputElement =>
+      querySelector('#show-web-content');
+
+  bool get isWebContentShowing =>
+      querySelector('#htmltab').style.visibility != 'hidden';
+
+  void showWebContent() {
+    showWebContentInputElement.checked = true;
+
+    querySelector('#htmltab').style.visibility = 'initial';
+    querySelector('#csstab').style.visibility = 'initial';
+
+    querySelector('#resulttab').style.visibility = 'initial';
+  }
+
+  void hideWebContent() {
+    showWebContentInputElement.checked = false;
+
+    // Switch to dart tab, and the console output tab.
+    sourceTabController.selectTab('dart');
+    outputTabController.selectTab('console');
+
+    querySelector('#htmltab').style.visibility = 'hidden';
+    querySelector('#csstab').style.visibility = 'hidden';
+
+    querySelector('#resulttab').style.visibility = 'hidden';
+  }
+
+  final _bufferedOutput = <SpanElement>[];
+  final _outputDuration = Duration(milliseconds: 32);
+
+  void _showOuput(String message, {bool error = false}) {
+    consoleBusyLight.flash();
+
+    SpanElement span = SpanElement()..text = '$message\n';
+    span.classes.add(error ? 'errorOutput' : 'normal');
+
+    // Buffer the console output so that heavy writing to stdout does not starve
+    // the DOM thread.
+    _bufferedOutput.add(span);
+
+    if (_bufferedOutput.length == 1) {
+      Timer(_outputDuration, () {
+        _outputpanel.children.addAll(_bufferedOutput);
+        _outputpanel.children.last.scrollIntoView(ScrollAlignment.BOTTOM);
+        _bufferedOutput.clear();
+      });
+    }
+  }
+
+  void _handleSelectChanged(SelectElement select) {
+    String value = select.value;
+
+    if (isLegalGistId(value)) {
+      router.go('gist', {'gist': value});
+    }
+
+    select.value = '0';
+  }
+
+  void _displayIssues(List<AnalysisIssue> issues) {
+    Element issuesElement = querySelector('#issues');
+
+    // Detect when hiding; don't remove the content until hidden.
+    bool isHiding = issuesElement.children.isNotEmpty && issues.isEmpty;
+
+    if (isHiding) {
+      issuesElement.classes.toggle('showing', issues.isNotEmpty);
+
+      StreamSubscription sub;
+      sub = issuesElement.onTransitionEnd.listen((_) {
+        issuesElement.children.clear();
+        sub.cancel();
+      });
+    } else {
+      issuesElement.children.clear();
+
+      issues.sort((a, b) => a.charStart - b.charStart);
+
+      // Create an item for each issue.
+      for (AnalysisIssue issue in issues) {
+        DivElement e = DivElement();
+        e.classes.add('issue');
+        e.attributes['layout'] = '';
+        e.attributes['horizontal'] = '';
+        issuesElement.children.add(e);
+        e.onClick.listen((_) {
+          _jumpTo(issue.line, issue.charStart, issue.charLength, focus: true);
+        });
+
+        SpanElement typeSpan = SpanElement();
+        typeSpan.classes.addAll([issue.kind, 'issuelabel']);
+        typeSpan.text = issue.kind;
+        e.children.add(typeSpan);
+
+        SpanElement messageSpan = SpanElement();
+        messageSpan.classes.add('message');
+        messageSpan.attributes['flex'] = '';
+        messageSpan.text = issue.message;
+        e.children.add(messageSpan);
+        if (issue.hasFixes) {
+          e.classes.add('hasFix');
+          e.onClick.listen((e) {
+            // This is a bit of a hack to make sure quick fixes popup is only
+            // shown if the wrench is clicked, and not if the text or label is
+            // clicked.
+            if ((e.target as Element).className == 'issue hasFix') {
+              // codemiror only shows completions if there is no selected text
+              _jumpTo(issue.line, issue.charStart, 0, focus: true);
+              editor.showCompletions(onlyShowFixes: true);
+            }
+          });
+        }
+      }
+
+      issuesElement.classes.toggle('showing', issues.isNotEmpty);
+    }
+  }
+
+  void _updateRunButton({bool hasErrors = false, bool hasWarnings = false}) {
+    const alertSVGIcon =
+        'M5,3H19A2,2 0 0,1 21,5V19A2,2 0 0,1 19,21H5A2,2 0 0,1 3,19V5A2,2 0 0,'
+        '1 5,3M13,13V7H11V13H13M13,17V15H11V17H13Z';
+
+    var path = runButton.element.querySelector('path');
+    path.attributes['d'] =
+    (hasErrors || hasWarnings) ? alertSVGIcon : 'M8 5v14l11-7z';
+
+    path.parent.classes.toggle('error', hasErrors);
+    path.parent.classes.toggle('warning', hasWarnings && !hasErrors);
+  }
+
+  void _jumpTo(int line, int charStart, int charLength, {bool focus = false}) {
+    Document doc = editor.document;
+
+    doc.select(
+        doc.posFromIndex(charStart), doc.posFromIndex(charStart + charLength));
+
+    if (focus) editor.focus();
+  }
+
+  void _jumpToLine(int line) {
+    Document doc = editor.document;
+    doc.select(Position(line, 0), Position(line, 0));
+    editor.focus();
+  }
+}
+
+class PlaygroundContext extends Context {
+  final Editor editor;
+
+  final _modeController = StreamController<String>.broadcast();
+
+  Document _dartDoc;
+  Document _htmlDoc;
+  Document _cssDoc;
+
+  final _cssDirtyController = StreamController.broadcast();
+  final _dartDirtyController = StreamController.broadcast();
+  final _htmlDirtyController = StreamController.broadcast();
+
+  final _cssReconcileController = StreamController.broadcast();
+  final _dartReconcileController = StreamController.broadcast();
+  final _htmlReconcileController = StreamController.broadcast();
+
+  PlaygroundContext(this.editor) {
+    editor.mode = 'dart';
+
+    _dartDoc = editor.document;
+    _htmlDoc = editor.createDocument(content: '', mode: 'html');
+    _cssDoc = editor.createDocument(content: '', mode: 'css');
+
+    _dartDoc.onChange.listen((_) => _dartDirtyController.add(null));
+    _htmlDoc.onChange.listen((_) => _htmlDirtyController.add(null));
+    _cssDoc.onChange.listen((_) => _cssDirtyController.add(null));
+
+    _createReconciler(_cssDoc, _cssReconcileController, 250);
+    _createReconciler(_dartDoc, _dartReconcileController, 1250);
+    _createReconciler(_htmlDoc, _htmlReconcileController, 250);
+  }
+
+  Document get dartDocument => _dartDoc;
+
+  Document get htmlDocument => _htmlDoc;
+
+  Document get cssDocument => _cssDoc;
+
+  @override
+  String get dartSource => _dartDoc.value;
+
+  @override
+  set dartSource(String value) {
+    _dartDoc.value = value;
+  }
+
+  @override
+  String get htmlSource => _htmlDoc.value;
+
+  @override
+  set htmlSource(String value) {
+    _htmlDoc.value = value;
+  }
+
+  @override
+  String get cssSource => _cssDoc.value;
+
+  @override
+  set cssSource(String value) {
+    _cssDoc.value = value;
+  }
+
+  @override
+  String get activeMode => editor.mode;
+
+  @override
+  Stream<String> get onModeChange => _modeController.stream;
+
+  bool hasWebContent() {
+    return htmlSource.trim().isNotEmpty || cssSource.trim().isNotEmpty;
+  }
+
+  @override
+  void switchTo(String name) {
+    String oldMode = activeMode;
+
+    if (name == 'dart') {
+      editor.swapDocument(_dartDoc);
+    } else if (name == 'html') {
+      editor.swapDocument(_htmlDoc);
+    } else if (name == 'css') {
+      editor.swapDocument(_cssDoc);
+    }
+
+    if (oldMode != name) _modeController.add(name);
+
+    editor.focus();
+  }
+
+  @override
+  String get focusedEditor {
+    if (editor.document == _htmlDoc) return 'html';
+    if (editor.document == _cssDoc) return 'css';
+    return 'dart';
+  }
+
+  Stream get onCssDirty => _cssDirtyController.stream;
+
+  Stream get onDartDirty => _dartDirtyController.stream;
+
+  Stream get onHtmlDirty => _htmlDirtyController.stream;
+
+  Stream get onCssReconcile => _cssReconcileController.stream;
+
+  Stream get onDartReconcile => _dartReconcileController.stream;
+
+  Stream get onHtmlReconcile => _htmlReconcileController.stream;
+
+  void markCssClean() => _cssDoc.markClean();
+
+  void markDartClean() => _dartDoc.markClean();
+
+  void markHtmlClean() => _htmlDoc.markClean();
+
+  /// Restore the focus to the last focused editor.
+  void focus() => editor.focus();
+
+  void _createReconciler(Document doc, StreamController controller, int delay) {
+    Timer timer;
+    doc.onChange.listen((_) {
+      if (timer != null) timer.cancel();
+      timer = Timer(Duration(milliseconds: delay), () {
+        controller.add(null);
+      });
+    });
+  }
+
+  /// Return true if the current cursor position is in a whitespace char.
+  bool cursorPositionIsWhitespace() {
+    Document document = editor.document;
+    String str = document.value;
+    int index = document.indexFromPos(document.cursor);
+    if (index < 0 || index >= str.length) return false;
+    String char = str[index];
+    return char != char.trim();
+  }
+}
+
+class GistFileProperty implements Property {
+  final MutableGistFile file;
+
+  GistFileProperty(this.file);
+
+  @override
+  String get() => file.content;
+
+  @override
+  void set(value) {
+    if (file.content != value) {
+      file.content = value;
+    }
+  }
+
+  @override
+  Stream get onChanged => file.onChanged.map((value) => value);
+}
+
+class EditorDocumentProperty implements Property {
+  final Document document;
+  final String debugName;
+
+  EditorDocumentProperty(this.document, [this.debugName]);
+
+  @override
+  String get() => document.value;
+
+  @override
+  void set(str) {
+    document.value = str == null ? '' : str;
+  }
+
+  @override
+  Stream get onChanged => document.onChange.map((_) => get());
+}

--- a/web/experimental/playground_layout.scss
+++ b/web/experimental/playground_layout.scss
@@ -1,0 +1,289 @@
+// Copyright (c) 2014 The Polymer Project Authors. All rights reserved. This
+// code may only be used under the BSD style license found at
+// http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+// at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+// be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+// Google as part of the polymer project is also subject to an additional IP
+// rights grant found at http://polymer.github.io/PATENTS.txt
+
+/*******************************
+          Flex Layout
+*******************************/
+
+html [layout][horizontal],
+html [layout][vertical] {
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}
+
+html [layout][horizontal][inline],
+html [layout][vertical][inline] {
+  display: -ms-inline-flexbox;
+  display: -webkit-inline-flex;
+  display: inline-flex;
+}
+
+html [layout][horizontal] {
+  -ms-flex-direction: row;
+  -webkit-flex-direction: row;
+  flex-direction: row;
+}
+
+html [layout][horizontal][reverse] {
+  -ms-flex-direction: row-reverse;
+  -webkit-flex-direction: row-reverse;
+  flex-direction: row-reverse;
+}
+
+html [layout][vertical] {
+  -ms-flex-direction: column;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+}
+
+html [layout][vertical][reverse] {
+  -ms-flex-direction: column-reverse;
+  -webkit-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
+html [layout][wrap] {
+  -ms-flex-wrap: wrap;
+  -webkit-flex-wrap: wrap;
+  flex-wrap: wrap;
+}
+
+html [layout][wrap-reverse] {
+  -ms-flex-wrap: wrap-reverse;
+  -webkit-flex-wrap: wrap-reverse;
+  flex-wrap: wrap-reverse;
+}
+
+html [flex] {
+  -ms-flex: 1 1 0.000000001px;
+  -webkit-flex: 1;
+  flex: 1;
+  -webkit-flex-basis: 0.000000001px;
+  flex-basis: 0.000000001px;
+}
+
+html [vertical][layout] > [flex][auto-vertical],
+html [vertical][layout]::shadow [flex][auto-vertical] {
+  -ms-flex: 1 1 auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+}
+
+html [flex][auto] {
+  -ms-flex: 1 1 auto;
+  -webkit-flex-basis: auto;
+  flex-basis: auto;
+}
+
+html [flex][none] {
+  -ms-flex: none;
+  -webkit-flex: none;
+  flex: none;
+}
+
+html [flex][one] {
+  -ms-flex: 1;
+  -webkit-flex: 1;
+  flex: 1;
+}
+
+html [flex][two] {
+  -ms-flex: 2;
+  -webkit-flex: 2;
+  flex: 2;
+}
+
+html [flex][three] {
+  -ms-flex: 3;
+  -webkit-flex: 3;
+  flex: 3;
+}
+
+html [flex][four] {
+  -ms-flex: 4;
+  -webkit-flex: 4;
+  flex: 4;
+}
+
+html [flex][five] {
+  -ms-flex: 5;
+  -webkit-flex: 5;
+  flex: 5;
+}
+
+html [flex][six] {
+  -ms-flex: 6;
+  -webkit-flex: 6;
+  flex: 6;
+}
+
+html [flex][seven] {
+  -ms-flex: 7;
+  -webkit-flex: 7;
+  flex: 7;
+}
+
+html [flex][eight] {
+  -ms-flex: 8;
+  -webkit-flex: 8;
+  flex: 8;
+}
+
+html [flex][nine] {
+  -ms-flex: 9;
+  -webkit-flex: 9;
+  flex: 9;
+}
+
+html [flex][ten] {
+  -ms-flex: 10;
+  -webkit-flex: 10;
+  flex: 10;
+}
+
+html [flex][eleven] {
+  -ms-flex: 11;
+  -webkit-flex: 11;
+  flex: 11;
+}
+
+html [flex][twelve] {
+  -ms-flex: 12;
+  -webkit-flex: 12;
+  flex: 12;
+}
+
+/* alignment in cross axis */
+
+html [layout][start] {
+  -ms-flex-align: start;
+  -webkit-align-items: flex-start;
+  align-items: flex-start;
+}
+
+html [layout][center],
+html [layout][center-center] {
+  -ms-flex-align: center;
+  -webkit-align-items: center;
+  align-items: center;
+}
+
+html [layout][end] {
+  -ms-flex-align: end;
+  -webkit-align-items: flex-end;
+  align-items: flex-end;
+}
+
+/* alignment in main axis */
+
+html [layout][start-justified] {
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
+}
+
+html [layout][center-justified],
+html [layout][center-center] {
+  -ms-flex-pack: center;
+  -webkit-justify-content: center;
+  justify-content: center;
+}
+
+html [layout][end-justified] {
+  -ms-flex-pack: end;
+  -webkit-justify-content: flex-end;
+  justify-content: flex-end;
+}
+
+html [layout][around-justified] {
+  -ms-flex-pack: distribute;
+  -webkit-justify-content: space-around;
+  justify-content: space-around;
+}
+
+html [layout][justified] {
+  -ms-flex-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+}
+
+/* self alignment */
+
+html [self-start] {
+  -ms-align-self: flex-start;
+  -webkit-align-self: flex-start;
+  align-self: flex-start;
+}
+
+html [self-center] {
+  -ms-align-self: center;
+  -webkit-align-self: center;
+  align-self: center;
+}
+
+html [self-end] {
+  -ms-align-self: flex-end;
+  -webkit-align-self: flex-end;
+  align-self: flex-end;
+}
+
+html [self-stretch] {
+  -ms-align-self: stretch;
+  -webkit-align-self: stretch;
+  align-self: stretch;
+}
+
+/*******************************
+          Other Layout
+*******************************/
+
+html [block] {
+  display: block;
+}
+
+/* ie support for hidden */
+html [hidden] {
+  display: none !important;
+}
+
+html [relative] {
+  position: relative;
+}
+
+html [fit] {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+body[fullbleed] {
+  margin: 0;
+  height: 100vh;
+}
+
+/*******************************
+            Other
+*******************************/
+
+html [segment],
+html segment {
+  display: block;
+  position: relative;
+  -webkit-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+  margin: 1em 0.5em;
+  padding: 1em;
+  background-color: white;
+  -webkit-box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+  border-radius: 5px 5px 5px 5px;
+}

--- a/web/experimental/playground_styles.scss
+++ b/web/experimental/playground_styles.scss
@@ -1,0 +1,581 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+body {
+  margin: 0;
+  padding: 0;
+
+  background-color: #333;
+  color: #c6c6c6;
+
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  position: absolute;
+
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+
+  overflow: hidden;
+}
+
+.export-text-dialog {
+  padding-right: 12px;
+  min-width: 140px;
+}
+
+#dart-code {
+  display:none;
+}
+
+#html-code {
+  display:none;
+}
+
+#css-code{
+  display:none;
+}
+
+header {
+  line-height: 48px;
+  padding: 0 24px;
+  color: #fff;
+  vertical-align: middle;
+
+  box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+  border-bottom: 1px solid #121212;
+  border-width: 4px;
+
+  margin-bottom: 24px;
+  text-shadow: rgba(0,0,0,0.75) 0 1px;
+}
+
+.header-title {
+  font-size: 16pt;
+  white-space: nowrap;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.header-gist-name {
+  text-overflow: ellipsis;
+  text-align: center;
+  overflow-x: hidden;
+  white-space: nowrap;
+  margin-left: 1em;
+  margin-right: 1em;
+  color: #ccc;
+  font-size: 14pt;
+  min-width: 2em;
+}
+
+input {
+  background-color: #333;
+  color: #c6c6c6;
+  resize: none;
+  border: 1px solid #555;
+  padding: 0.5em;
+}
+
+textarea, input {
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+}
+
+label {
+  user-select: none;
+}
+
+.sharingSummaryText {
+  background-color: #333;
+  color: #c6c6c6;
+  height: 80px;
+  min-height: 80px;
+  resize: none;
+  border: 1px solid #555;
+  padding: 0.5em;
+}
+
+.header-gist-name.dirty::after {
+  content: " •";
+}
+
+#newbutton {
+  margin-left: 10px;
+}
+
+#sharebutton {
+  margin-left: 8px;
+  margin-right: 10px;
+}
+
+#resetbutton {
+  margin-left: 8px;
+}
+
+section {
+  padding: 0 24px 24px 24px;
+  position: relative;
+
+  box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+  border-bottom: 1px solid #121212;
+  border-width: 4px;
+}
+
+footer {
+  margin: 8px 24px;
+  font-size: 13px;
+  text-shadow: rgba(0,0,0,0.75) 0 1px;
+}
+
+.view {
+  position: relative;
+  margin: 0 0;
+  min-width: 260px;
+  min-height: 50px;
+}
+
+pre {
+  margin: 0;
+  padding: 0;
+}
+
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+a,
+a:visited {
+  color: #ccc;
+  fill: #ccc;
+}
+
+a:hover {
+  color: #fff;
+  fill: #fff;
+}
+
+a[selected] {
+  color: #66d9ef;
+  cursor: default;
+  border-bottom: 2px solid #66d9ef;
+}
+
+a[selected]:hover {
+  color: #66d9ef;
+}
+
+.header li {
+  list-style-image: none;
+  list-style-type: none;
+  margin-left: 0;
+  white-space: nowrap;
+}
+
+.header a {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.header a {
+  margin-right: 16px;
+  text-transform: uppercase;
+}
+
+.header {
+  line-height: 24px;
+  font-size: 12pt;
+}
+
+.header.small {
+  font-size: 11pt;
+  line-height: 18px;
+}
+
+.header a[last] {
+  margin-right: 0;
+}
+
+#runbutton svg {
+  width: 18px;
+  height: 18px;
+  padding: 0;
+}
+
+#runbutton svg.error {
+  padding: 0 0 1px 1px;
+  width: 17px;
+  height: 17px;
+  fill: #F7977A;
+}
+
+#runbutton svg.warning {
+  padding: 0 0 1px 1px;
+  width: 17px;
+  height: 17px;
+  fill: #FFF79A;
+}
+
+#runbutton {
+  padding-right: 11px;
+}
+
+#output {
+  display: block;
+  position: absolute;
+  top: 16px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+#frame {
+  min-height: 50px;
+  display: block;
+  visibility: hidden;
+  margin-top: 5px;
+}
+
+iframe {
+  border: none;
+}
+
+div.toggle {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+  padding: 3px 0 3px 6px;
+  height: 24px;
+}
+
+.toggle a {
+  transition: 75ms;
+  min-width: 24px;
+  text-align: center;
+  margin-right: 6px;
+  padding: 2px 6px;
+  display: inline-block;
+  line-height: 1.44em;
+  text-decoration: none;
+  text-shadow: rgba(255, 255, 255, 0.08) 0 1px 0;
+  color: #000;
+}
+
+.toggle a:hover {
+  color: rgba(255, 255, 255, 0.3);
+  box-shadow: rgba(255, 255, 255, 0.1) 0 1px 0, rgba(0, 0, 0, 0.8) 0 1px 7px 0 inset;
+  border-radius: 1em;
+}
+
+.toggle a[selected] {
+  color: rgba(255, 255, 255, 0.7);
+  box-shadow: rgba(255, 255, 255, 0.1) 0 1px 0, rgba(0, 0, 0, 0.8) 0 1px 7px 0 inset;
+  background: #202020;
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 1em;
+}
+
+.horz_divider {
+  margin: 16px 0;
+  box-shadow: rgba(255, 255, 255, 0.07) 0 1px 0;
+  border-top: 1px solid #121212;
+}
+
+.console {
+  font-family: 'Inconsolata', monospace;
+  font-size: 12pt;
+  line-height: 20px;
+  min-height: 50px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  margin-top: 16px;
+}
+
+.console .normal {
+  color: #c6c6c6;
+}
+
+.console .errorOutput {
+  color: #F7977A;
+}
+
+#editpanel {
+  font-family: 'Inconsolata', monospace;
+  font-size: 12pt;
+  line-height: 20px;
+  display: block;
+  position: relative;
+  min-height: 50px;
+  margin-top: 16px;
+  margin-left: -3px;
+}
+
+.right {
+  text-align: right;
+}
+
+.footer-item {
+  margin-right: 10px;
+}
+
+#frame-overlay {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: #333;
+  display: none;
+  opacity: 0.75;
+  cursor: wait;
+}
+
+#frame-overlay.visible {
+  display: block;
+}
+
+#frame-overlay .overlay-progress {
+  position: absolute;
+  left: 45%;
+  top: 60px;
+}
+
+/* documentation and parameter info styling */
+
+#documentation {
+  font-family: 'Roboto', sans-serif;
+  font-size: 11pt;
+  line-height: 20px;
+  position: relative;
+  display: block;
+  overflow: auto;
+  overflow-wrap: break-word;
+  margin-top: 0;
+  margin-left: 0;
+}
+
+#documentation h1 {
+  margin-top: 0;
+  font-size: 12pt;
+  font-weight: bold;
+  color: #eee;
+}
+
+#documentation h2 {
+  margin-bottom: 0;
+}
+
+#documentation h2,
+#documentation strong {
+  font-weight: bold;
+  font-size: inherit;
+  color: #cdcdcd; /* little bit brigher than normal text*/
+}
+
+#documentation p {
+  margin-top: 0;
+}
+
+#documentation a {
+  color: #66d9ef;
+}
+
+#documentation a:hover {
+  color: #66d9ef;
+  text-decoration: underline;
+}
+
+#documentation a {
+  color: #66d9ef;
+}
+
+#documentation a:hover {
+  color: #66d9ef;
+  text-decoration: underline;
+}
+
+#documentation pre {
+  overflow-x: auto;
+  margin: 1em;
+}
+
+#documentation pre code {
+  white-space: inherit;
+  word-wrap: normal;
+}
+
+#documentation code,
+.parameter-hints code {
+  font-family: 'Inconsolata', monospace;
+  font-size: 12pt;
+  color: #999;
+}
+
+#documentation code em {
+  color: #dfaf8f;
+  font-style: normal;
+}
+
+.parameter-hints code {
+  color: #dfaf8f;
+}
+
+#documentation code em {
+  color: #dfaf8f;
+  font-style: normal;
+}
+
+.parameter-hints code em {
+  color: white;
+  font-style: normal;
+  font-weight: bold;
+}
+
+.parameter-hints {
+  position: absolute;
+  z-index: 10;
+  -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  -moz-box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  box-shadow: 2px 3px 5px rgba(0,0,0,.2);
+  border-radius: 3px;
+  font-family: 'Inconsolata', monospace;
+  overflow-y: hidden;
+  border: 1px solid #cc9393;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+.parameter-hints::-webkit-scrollbar {
+  display: none;
+}
+
+.parameter-hint {
+  padding: 4px;
+  background: #3f3f3f;
+}
+
+.sharing-dialog .sharinglabel {
+  min-width: 110px;
+  margin-right: 10px;
+  display: inline-block;
+}
+
+.sharing-dialog .row {
+  margin-bottom: 8px;
+}
+
+.sharing-dialog .inputgroup {
+  display: inline-block;
+}
+
+.sharing-dialog input {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 4px 8px;
+  outline: none;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
+}
+
+.sharing-dialog input[type='radio'] {
+  position: relative;
+  top: 4px;
+}
+
+.keys-dialog {
+  max-width: 300px;
+  top: auto !important;
+  bottom: 20px;
+}
+
+.keys-dialog dl {
+  padding: 0.5em;
+}
+
+.keys-dialog dt {
+  float: left;
+  clear: left;
+}
+
+.keys-dialog dd {
+  text-align: right;
+}
+
+.keys-dialog dd > span {
+  font-family: "Helvetica Neue", "Inconsolata", monospace;
+  padding: 0 4px;
+  background-color: #FFF79A; /**#dfaf8f #f0dfaf #66d9ef #FFF79A #AEA859;*/
+  font-size: 10pt;
+  color: black;
+  border-radius: 2px;
+  margin: 2px 2px;
+  white-space: nowrap;
+  display: inline-block;
+}
+
+.keyboard {
+  display: inline-block;
+  background: url('../pictures/keyboard.svg') center no-repeat;
+  background-size: 100%;
+  width: 22px;
+  height: 18px;
+  margin-top: 1px;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.keyboard:hover {
+  opacity: 1;
+}
+
+.launch-icon {
+  display: inline-block;
+  background: url('../pictures/launch.svg') center no-repeat;
+  background-size: 100%;
+  width: 16px;
+  height: 14px;
+  margin-bottom: -2px;
+}
+
+#samples {
+  width: 100px;
+}
+
+#dartpad_version {
+  cursor: pointer;
+}
+
+@media screen and (max-width: 500px) {
+  #newbutton {
+    display: none;
+  }
+
+  #formatbutton {
+    display: none;
+  }
+
+  #sharebutton {
+    display: none;
+  }
+
+  #keyboard-button {
+    display: none;
+  }
+}
+
+#github-button {
+  background: url(/pictures/github-light-32px.png) no-repeat;
+  filter: brightness(0.5);
+  width: 32px;
+  height: 32px;
+  margin: 8px 0 8px 16px;
+  border: none;
+}
+
+#github-button:hover {
+  filter: brightness(0.75);
+}

--- a/web/new_playground.dart
+++ b/web/new_playground.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_pad/experimental/new_playground.dart' as playground;
+import 'package:logging/logging.dart';
+
+void main() {
+  Logger.root.onRecord.listen(print);
+
+  playground.init();
+}

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+
+<!-- Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+     for details. All rights reserved. Use of this source code is governed by a
+     BSD-style license that can be found in the LICENSE file. -->
+
+<html>
+<head>
+    <meta charset="utf-8">
+    <link rel="shortcut icon" href="/dart-192.png">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <title>DartPad</title>
+
+    <link href="styles/layout.css" rel="stylesheet" media="screen">
+    <link href="styles/index.css" rel="stylesheet" media="screen">
+    <link href="packages/dart_pad/elements/elements.css" rel="stylesheet" media="screen">
+
+    <link href='https://fonts.googleapis.com/css?family=Roboto'
+          rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'
+          rel='stylesheet' type='text/css'>
+
+    <!-- codemirror -->
+    <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
+    <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
+    <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
+    <link href="packages/codemirror/theme/zenburn.css" rel="stylesheet" media="screen">
+    <link href="packages/dart_pad/editing/editor_codemirror.css" rel="stylesheet" media="screen">
+    <script src="packages/codemirror/codemirror.js" defer></script>
+
+    <script defer src="new_playground.dart.js"></script>
+
+    <script src="scripts/ga.js" defer></script>
+    <script src="scripts/polymerpatch.js" defer></script>
+</head>
+
+<body fullbleed layout vertical>
+<header layout horizontal>
+    <div class="header-title">DartPad</div>
+    <div>
+        <button type="button" id="newbutton" class="button">New Pad…</button>
+        <button type="button" id="resetbutton" class="button" disabled>Reset…</button>
+        <button type="button" id="formatbutton" class="button">Format</button>
+    </div>
+    <div class="header-gist-name" flex></div>
+    <div>
+        <button type="button" id="sharebutton" class="button">Share…</button>
+    </div>
+    <div>
+        <select id="samples" required="false">
+            <option value="0">Samples</option>
+            <option disabled></option>
+            <!--- Gists at https://gist.github.com/[value] -->
+            <option value="215ba63265350c02dfbd586dfd30b8c3">Hello World</option>
+            <option value="e93b969fed77325db0b848a85f1cf78e">Int to Double</option>
+            <option value="b60dc2fc7ea49acecb1fd2b57bf9be57">Mixins</option>
+            <option value="7d78af42d7b0aedfd92f00899f93561b">Fibonacci</option>
+            <option value="a559420eed617dab7a196b5ea0b64fba">Sunflower</option>
+            <option value="cb9b199b1085873de191e32a1dd5ca4f">WebSockets</option>
+        </select>
+    </div>
+    <a href="https://github.com/dart-lang/dart-pad" id="github-button"></a>
+</header>
+
+<section flex layout horizontal>
+    <div class="splash"></div>
+
+    <div class="view" flex three layout vertical>
+        <div class="header" layout horizontal wrap>
+            <li><a id="darttab" selected class="arrow_box"><span>Dart</span></a></li>
+            <li><a id="htmltab" style="visibility: hidden;"><span>HTML</span></a></li>
+            <li><a id="csstab" style="visibility: hidden;"><span>CSS</span></a></li>
+            <div flex></div>
+            <div id="dartbusy" class="busylight"></div>
+            <div>
+                <button type="button" id="runbutton" class="button"
+                        title="Run (ctrl-enter / ⌘-enter)">
+                    <svg width="18" height="18" viewBox="0 0 24 24"
+                         style="vertical-align: text-bottom;">
+                        <path d="M8 5v14l11-7z"/>
+                    </svg>
+                    Run
+                </button>
+            </div>
+        </div>
+        <div id="editpanel" flex layout vertical>
+        </div>
+    </div>
+
+    <div class="splitter" vertical id="editor_split">
+        <div class="inner"></div>
+    </div>
+
+    <div class="view" flex two layout vertical>
+        <div class="view" flex two layout vertical>
+            <div id="frame-overlay"></div>
+            <div class="header" layout horizontal wrap>
+                <div flex></div>
+                <li><a id="resulttab" style="visibility: hidden;"><span>HTML Output</span></a></li>
+                <li><a id="consoletab" selected last><span>Console</span></a></li>
+                <div id="consolebusy" class="busylight"></div>
+            </div>
+            <div id="output" class="console" flex></div>
+            <!-- TODO: We might want to embed the iframe into a div, and set -->
+            <!-- div to overflow: scroll. -->
+            <iframe id="frame" sandbox="allow-scripts" flex src="scripts/frame.html">
+            </iframe>
+        </div>
+        <div class="splitter" horizontal id="output_split">
+            <div class="inner"></div>
+        </div>
+        <div class="view" flex layout vertical>
+            <div id="documentation" flex layout vertical></div>
+            <div id="issues"></div>
+        </div>
+    </div>
+</section>
+
+<footer layout horizontal>
+    <div id="keyboard-button" class="keyboard footer-item"></div>
+    <div>
+        <a href="https://www.dartlang.org/tools/dartpad/privacy"
+           target="repo" class="footer-item">Privacy notice</a>
+        <a href="https://github.com/dart-lang/dart-pad/issues"
+           target="repo">Send feedback</a>
+    </div>
+    <div flex></div>
+
+    <input type="checkbox" id="show-web-content" class="footer-items">
+    <label for="show-web-content" class="footer-item">Show web content</label>
+
+    <div id="dartpad_version"> </div>
+</footer>
+</body>
+</html>

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -129,6 +129,9 @@
     </div>
     <div flex></div>
 
+    <input type="checkbox" id="enable-flutter" class="footer-items">
+    <label for="enable-flutter" class="footer-item">Enable Flutter</label>
+
     <input type="checkbox" id="show-web-content" class="footer-items">
     <label for="show-web-content" class="footer-item">Show web content</label>
 

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -14,8 +14,8 @@
 
     <title>DartPad</title>
 
-    <link href="styles/layout.css" rel="stylesheet" media="screen">
-    <link href="styles/index.css" rel="stylesheet" media="screen">
+    <link href="experimental/playground_layout.css" rel="stylesheet" media="screen">
+    <link href="experimental/playground_styles.css" rel="stylesheet" media="screen">
     <link href="packages/dart_pad/elements/elements.css" rel="stylesheet" media="screen">
 
     <link href='https://fonts.googleapis.com/css?family=Roboto'


### PR DESCRIPTION
This currently supports enabling flutter by using a checkbox to set the `_useDDC` flag. As we work through the redesign, this will probably change to a dropdown.

<img width="1197" alt="Screen Shot 2019-08-19 at 12 41 22 PM" src="https://user-images.githubusercontent.com/1145719/63295356-4ecae400-c281-11e9-9f1f-36ff46145a07.png">
