### PR TITLE
Load sample apps from api.flutter.dev

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -399,7 +399,7 @@ class NewEmbed {
   }
 
   String get gistId {
-    Uri url = Uri.parse(window.location.toString());
+    final url = Uri.parse(window.location.toString());
 
     if (url.hasQuery &&
         url.queryParameters['id'] != null &&
@@ -411,7 +411,7 @@ class NewEmbed {
   }
 
   String get sampleId {
-    Uri url = Uri.parse(window.location.toString());
+    final url = Uri.parse(window.location.toString());
 
     if (url.hasQuery && url.queryParameters['sample_id'] != null) {
       return url.queryParameters['sample_id'];
@@ -515,7 +515,7 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
   Future<void> _loadAndShowGist({bool analyze = true}) async {
     if (gistId.isEmpty && sampleId.isEmpty) {
-      print('Can\'t load a gist when neither id nor sample_id is present.');
+      print('Cannot load gist: neither id nor sample_id is present.');
       return;
     }
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -193,7 +193,7 @@ class NewEmbed {
 
     reloadGistButton = DisableableButton(querySelector('#reload-gist'), () {
       if (gistId.isNotEmpty || sampleId.isNotEmpty) {
-        _loadAndShowGist(analyze: false);
+        _loadAndShowGist();
       } else {
         _resetCode();
       }
@@ -514,6 +514,11 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
   }
 
   Future<void> _loadAndShowGist({bool analyze = true}) async {
+    if (gistId.isEmpty && sampleId.isEmpty) {
+      print('Can\'t load a gist when neither id nor sample_id is present.');
+      return;
+    }
+
     editorIsBusy = true;
 
     final GistLoader loader = deps[GistLoader];

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -86,7 +86,17 @@ class GistLoaderException {
 /// A class to load and save gists. Gists can optionally be modified after
 /// loading and before saving.
 class GistLoader {
-  static final String _apiUrl = 'https://api.github.com/gists';
+  static final String _githubApiUrl = 'https://api.github.com/gists';
+  static final String _apiDocsUrl = 'https://cors-anywhere.herokuapp.com/https://api.flutter.dev/snippets';
+  static final String _sampleMain = 'void main() => runApp(MyApp());';
+  static final String _dartPadMain = '''
+import 'package:flutter_web/material.dart';
+import 'package:flutter_web_ui/ui.dart' as ui;
+
+void main() async {
+  await ui.webOnlyInitializePlatform();
+  runApp(MyApp());
+}''';
 
   static final GistFilterHook _defaultLoadHook = (Gist gist) {
     // Update files based on our preferred file names.
@@ -169,7 +179,7 @@ $styleRef$dartRef  </head>
     try {
       // Load the gist using the github gist API:
       // https://developer.github.com/v3/gists/#get-a-single-gist.
-      final gistJson = await HttpRequest.getString('$_apiUrl/$gistId');
+      final gistJson = await HttpRequest.getString('$_githubApiUrl/$gistId');
       final gist = Gist.fromMap(json.decode(gistJson));
 
       if (afterLoadHook != null) {
@@ -189,6 +199,35 @@ $styleRef$dartRef  </head>
     }
   }
 
+  Future<Gist> loadGistFromAPIDocs(String sampleId) async {
+    final contents = await HttpRequest.getString('$_apiDocsUrl/$sampleId');
+
+    // Remove everything up to and including main(), and replace it with a valid
+    // set of flutter_web imports and a new main() that waits for platform
+    // readiness.
+    //
+    // TODO(redbrogdon) This should be removed once the online sample code for
+    // IDEs (which is what api.flutter.dev/snippets makes available) can be
+    // aligned with what DartPad needs.
+    print(contents);
+    print(contents.indexOf(_sampleMain));
+    final spliceIndex = contents.indexOf(_sampleMain) + _sampleMain.length;
+    final modifiedCode = '$_dartPadMain${contents.substring(spliceIndex)}';
+
+    final mainFile = GistFile(
+      name: 'main.dart',
+      content: modifiedCode,
+    );
+
+    final gist = Gist(files: [mainFile]);
+
+    if (afterLoadHook != null) {
+      afterLoadHook(gist);
+    }
+
+    return Gist(files: [mainFile]);
+  }
+
   /// Create a new gist and return the newly created Gist.
   Future<Gist> createAnon(Gist gist) {
     // POST /gists
@@ -197,7 +236,8 @@ $styleRef$dartRef  </head>
       beforeSaveHook(gist);
     }
 
-    return HttpRequest.request(_apiUrl, method: 'POST', sendData: gist.toJson())
+    return HttpRequest.request(_githubApiUrl,
+            method: 'POST', sendData: gist.toJson())
         .then((HttpRequest request) {
       Gist gist = Gist.fromMap(json.decode(request.responseText));
       if (afterLoadHook != null) {

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -87,7 +87,8 @@ class GistLoaderException {
 /// loading and before saving.
 class GistLoader {
   static final String _githubApiUrl = 'https://api.github.com/gists';
-  static final String _apiDocsUrl = 'https://cors-anywhere.herokuapp.com/https://api.flutter.dev/snippets';
+  // TODO(redbrogdon): Remove 'master-' once the new docs go live.
+  static final String _apiDocsUrl = 'https://master-api.flutter.dev/snippets';
   static final String _sampleMain = 'void main() => runApp(MyApp());';
   static final String _dartPadMain = '''
 import 'package:flutter_web/material.dart';
@@ -200,17 +201,15 @@ $styleRef$dartRef  </head>
   }
 
   Future<Gist> loadGistFromAPIDocs(String sampleId) async {
-    final contents = await HttpRequest.getString('$_apiDocsUrl/$sampleId');
+    final contents = await HttpRequest.getString('$_apiDocsUrl/$sampleId.dart');
 
-    // Remove everything up to and including main(), and replace it with a valid
-    // set of flutter_web imports and a new main() that waits for platform
-    // readiness.
-    //
     // TODO(redbrogdon) This should be removed once the online sample code for
     // IDEs (which is what api.flutter.dev/snippets makes available) can be
     // aligned with what DartPad needs.
-    print(contents);
-    print(contents.indexOf(_sampleMain));
+    //
+    // Remove everything up to and including main(), and replace it with a valid
+    // set of flutter_web imports and a new main() that waits for platform
+    // readiness.
     final spliceIndex = contents.indexOf(_sampleMain) + _sampleMain.length;
     final modifiedCode = '$_dartPadMain${contents.substring(spliceIndex)}';
 


### PR DESCRIPTION
Adds code to the DartPad embed UI to load a sample app directly from the Flutter doc server when `sample_id` is present in the URL string. This will be used to embed DartPad in the API docs themselves, and would allow us to have an index of widget-related samples in a dropdown on DartPad if we decide we want it later.

Two notes:

* Right now, the URL targets master-api.flutter.dev, rather than the stable version of the docs. Once the next stable release goes out, the docs at api.flutter.dev will be updated, and the URL can be switched.
* This [flutter/flutter PR](https://github.com/flutter/flutter/pull/39780) needs to land in order for CORS to allow the requests for sample code to work during development and staging.
