### PR TITLE
use mdc_web from source repo

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -348,9 +348,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "upgrade-to-3.1.1"
-      resolved-ref: "421f3575252fd1bb715a730c92954a291b55f895"
-      url: "git://github.com/johnpryan/mdc_web.git"
+      ref: "0ac7d5b4386863d91ec397600a326e622031513f"
+      resolved-ref: "0ac7d5b4386863d91ec397600a326e622031513f"
+      url: "git://github.com/jifalops/mdc_web.git"
     source: git
     version: "0.5.0-pre"
   meta:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,11 @@ dependencies:
   split: ^0.0.2
   html_unescape: ^1.0.0
   sass_builder: ^2.1.0
-  mdc_web: ^0.4.1
+  mdc_web:
+    # https://github.com/jifalops/mdc_web/issues/8
+    git:
+      url: git://github.com/jifalops/mdc_web.git
+      ref: 0ac7d5b4386863d91ec397600a326e622031513f
 dev_dependencies:
   build_runner: any
   build_test: any
@@ -39,9 +43,3 @@ dev_dependencies:
   test: ^1.3.4
   tuneup: any
   yaml: any
-dependency_overrides:
-  mdc_web:
-    # https://github.com/jifalops/mdc_web/pull/6
-    git:
-      url: git://github.com/johnpryan/mdc_web.git
-      ref: upgrade-to-3.1.1


### PR DESCRIPTION
This was using a forked version. When https://github.com/jifalops/mdc_web/issues/8 is resolved we can update to the pre-release