### PR TITLE
Revert "upgrade pubspec.lock and fix asserts"

### DIFF
--- a/lib/experimental/dialog.dart
+++ b/lib/experimental/dialog.dart
@@ -24,8 +24,8 @@ class Dialog {
 
   Dialog()
       : assert(querySelector('.mdc-dialog') != null),
-        assert(querySelector('#dialog-left-button') != null),
-        assert(querySelector('#dialog-right-button') != null),
+        assert(querySelector('.dialog-left-button') != null),
+        assert(querySelector('.dialog-right-button') != null),
         assert(querySelector('#my-dialog-title') != null),
         assert(querySelector('#my-dialog-content') != null),
         _mdcDialog = MDCDialog(querySelector('.mdc-dialog')),

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -476,7 +476,7 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
     var horizontal = true;
     var webOutput = querySelector('#web-output');
-    List<Element> splitterElements;
+    List splitterElements;
     if (options.mode == NewEmbedMode.flutter ||
         options.mode == NewEmbedMode.html) {
       var editorAndConsoleContainer =

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _discoveryapis_commons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.9"
+    version: "0.1.8+1"
   analysis_server_lib:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.2"
+    version: "0.37.0"
   archive:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.1.5"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1+1"
+    version: "0.4.0"
   build_daemon:
     dependency: transitive
     description:
@@ -84,28 +84,28 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.4.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.7"
+    version: "1.6.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.6"
   build_test:
     dependency: "direct dev"
     description:
@@ -119,7 +119,7 @@ packages:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.1.4"
   built_collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.7.1"
+    version: "6.7.0"
   charcode:
     dependency: transitive
     description:
@@ -141,13 +141,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.2"
-  checked_yaml:
-    dependency: transitive
-    description:
-      name: checked_yaml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   cli_repl:
     dependency: transitive
     description:
@@ -182,7 +175,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.11"
   convert:
     dependency: transitive
     description:
@@ -196,7 +189,7 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.0.6"
   csslib:
     dependency: transitive
     description:
@@ -210,7 +203,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.10"
+    version: "1.2.9"
   fixnum:
     dependency: transitive
     description:
@@ -224,7 +217,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.24"
+    version: "0.1.20"
   git:
     dependency: "direct dev"
     description:
@@ -322,14 +315,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.4.0"
   kernel:
     dependency: transitive
     description:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.20"
   logging:
     dependency: "direct main"
     description:
@@ -387,7 +380,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.7"
+    version: "1.4.5"
   octicons_css:
     dependency: "direct main"
     description:
@@ -401,7 +394,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.5"
   package_resolver:
     dependency: transitive
     description:
@@ -457,14 +450,14 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.3"
   route_hierarchical:
     dependency: "direct main"
     description:
@@ -478,7 +471,7 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.22.10"
+    version: "1.22.8"
   sass_builder:
     dependency: "direct main"
     description:
@@ -492,7 +485,7 @@ packages:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
+    version: "0.0.3+2"
   shelf:
     dependency: "direct dev"
     description:
@@ -548,7 +541,7 @@ packages:
       name: split
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.5"
+    version: "0.0.2"
   stack_trace:
     dependency: transitive
     description:
@@ -576,7 +569,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.0.4"
   term_glyph:
     dependency: transitive
     description:
@@ -590,28 +583,28 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "1.6.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9"
+    version: "0.2.7"
   timing:
     dependency: transitive
     description:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+1"
   tuneup:
     dependency: "direct dev"
     description:
@@ -633,13 +626,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
-  vm_service:
+  vm_service_lib:
     dependency: transitive
     description:
-      name: vm_service
+      name: vm_service_lib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "3.22.2+1"
   watcher:
     dependency: transitive
     description:
@@ -653,7 +646,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.15"
+    version: "1.0.14"
   yaml:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
Reverts dart-lang/dart-pad#1242

While we've zeroed in on a specific cause (_discoveryapis_common upgrade), best practice is to revert the entire PR and start fresh with the fix.