### PR TITLE
Make console expand easier to click, fix overflow in console

### DIFF
--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -338,7 +338,7 @@ class NewEmbed {
     if (options.mode == NewEmbedMode.flutter ||
         options.mode == NewEmbedMode.html) {
       consoleExpandController = ConsoleExpandController(
-          expandButton: querySelector('#console-expand-button'),
+          expandButton: querySelector('#console-output-header'),
           footer: querySelector('#console-output-footer'),
           expandIcon: querySelector('#console-expand-icon'),
           unreadCounter: unreadConsoleCounter,

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -135,13 +135,11 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div class="console-output-header">
+            <div id="console-output-header" class="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-button" class="flash-close">
-                    <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
-                </button>
+                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -135,7 +135,7 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div id="console-output-header" class="console-output-header">
+            <div id="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -127,7 +127,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="console-view" hidden>
-        <div class="console-output-header">
+        <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
         <div id="console-output-container" class="custom-scrollbar" hidden></div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -128,7 +128,7 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div id="console-output-header" class="console-output-header">
+            <div id="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -128,13 +128,11 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div class="console-output-header">
+            <div id="console-output-header" class="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-button" class="flash-close">
-                    <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
-                </button>
+                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -153,7 +153,7 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div id="console-output-header" class="console-output-header">
+            <div id="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -153,13 +153,11 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div class="console-output-header">
+            <div id="console-output-header" class="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-button" class="flash-close">
-                    <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
-                </button>
+                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -127,7 +127,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="console-view" hidden>
-        <div class="console-output-header">
+        <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
         <div id="console-output-container" class="custom-scrollbar" hidden></div>

--- a/web/experimental/embed-new-dart.html
+++ b/web/experimental/embed-new-dart.html
@@ -127,7 +127,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="console-view" hidden>
-        <div class="console-output-header">
+        <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
         <div id="console-output-container" class="custom-scrollbar" hidden></div>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -128,7 +128,7 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div id="console-output-header" class="console-output-header">
+            <div id="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -128,13 +128,11 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div class="console-output-header">
+            <div id="console-output-header" class="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-button" class="flash-close">
-                    <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
-                </button>
+                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -153,7 +153,7 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div id="console-output-header" class="console-output-header">
+            <div id="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -153,13 +153,11 @@ BSD-style license that can be found in the LICENSE file. -->
             </div>
         </div>
         <div id="console-output-footer" class="footer-top-border" hidden>
-            <div class="console-output-header">
+            <div id="console-output-header" class="console-output-header">
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-button" class="flash-close">
-                    <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
-                </button>
+                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/experimental/embed-new-inline.html
+++ b/web/experimental/embed-new-inline.html
@@ -127,7 +127,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="console-view" hidden>
-        <div class="console-output-header">
+        <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
         <div id="console-output-container" class="custom-scrollbar" hidden></div>

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -231,6 +231,7 @@ body {
 
 #editor-container {
   flex: 1;
+  overflow: hidden;
 }
 
 #tab-container {

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -189,7 +189,7 @@ body {
 
 // Console Output Footer
 
-.console-output-header {
+#console-output-header {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -194,6 +194,7 @@ body {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  cursor: pointer;
 }
 
 #console-output-footer {
@@ -201,15 +202,15 @@ body {
   flex-direction: column;
   padding-left: 8px;
   padding-bottom: 8px;
+  overflow: auto;
 }
 
-#console-expand-button {
+#console-expand-icon {
   color: $label-color;
   padding: 8px;
-  margin: -4px;
 }
 
-#console-expand-button:focus {
+#console-expand-icon:focus {
   outline: none;
 }
 
@@ -230,7 +231,6 @@ body {
 
 #editor-container {
   flex: 1;
-  overflow: hidden;
 }
 
 #tab-container {
@@ -238,7 +238,6 @@ body {
   width: 100%;
   height: 100%;
   display: flex;
-  flex-direction: row;
 }
 
 // Footer


### PR DESCRIPTION
- Fixes the overflow issue in the embed consoles
- Fixes usability issue where console expand button is hard to click.
  Now the the console can be expanded by clicking anywhere on the panel
  header.

CC: @galeyang 

closes #1232
closes #1187 