### PR TITLE
Adds load-from-repo functionality to gist services and new embed

### DIFF
--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -90,7 +90,6 @@ class SharingDialog extends DDialog {
     _closeButton = DButton.button(text: 'Close');
     _closeButton.onClick.listen((_) => hide());
     _shareButton = DButton.button(text: 'Share it!', classes: 'default');
-    _shareButton.onClick.listen((_) => _performShare());
 
     // Already sharing.
     _div = DElement.tag('div')..layoutVertical();
@@ -237,19 +236,6 @@ class SharingDialog extends DDialog {
       buttonArea.add(_closeButton);
       buttonArea.add(SpanElement()..attributes['flex'] = '');
     }
-  }
-
-  void _performShare() {
-    _shareButton.disabled = true;
-
-    String text = _textArea.value;
-    if (_gistSummary != null) text += '\n\n${_gistSummary.linkText}';
-
-    gistController.shareAnon(summary: text).then((_) {
-      _switchTo(aboutToShare: false);
-    }).whenComplete(() {
-      _shareButton.disabled = false;
-    });
   }
 }
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -425,8 +425,11 @@ class NewEmbed {
   // required to load something, while the fourth, gh_ref, is an optional branch
   // name or commit SHA.
   String get githubOwner => _getQueryParam('gh_owner');
+
   String get githubRepo => _getQueryParam('gh_repo');
+
   String get githubPath => _getQueryParam('gh_path');
+
   String get githubRef => _getQueryParam('gh_ref');
 
   bool get githubParamsPresent =>
@@ -569,7 +572,8 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
       setContextSources(<String, String>{});
 
       if (ex.failureType == GistLoaderFailureType.contentNotFound) {
-        await dialog.showOk('Error loading gist',
+        await dialog.showOk(
+            'Error loading gist',
             'No gist was found for the gist ID, sample ID, or repository '
                 'information provided.');
       } else if (ex.failureType == GistLoaderFailureType.rateLimitExceeded) {
@@ -582,15 +586,18 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
                 'API server) from a single, shared IP address. Quotas are '
                 'typically renewed within an hour, so the best course of action is '
                 'to try back later.');
-      } else if (ex.failureType == GistLoaderFailureType.invalidExerciseMetadata) {
+      } else if (ex.failureType ==
+          GistLoaderFailureType.invalidExerciseMetadata) {
+        if (ex.message != null) {
+          print(ex.message);
+        }
         await dialog.showOk(
             'Error loading files',
             'DartPad could not load the requested exercise. Either one of the '
-            'required files wasn\'t available, or the exercise metadata was '
-            'invalid.');
+                'required files wasn\'t available, or the exercise metadata was '
+                'invalid.');
       } else {
-        await dialog.showOk(
-            'Error loading files',
+        await dialog.showOk('Error loading files',
             'An error occurred while the requested files.');
       }
     }

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -196,7 +196,7 @@ class NewEmbed {
         DisableableButton(querySelector('#execute'), _handleExecute);
 
     reloadGistButton = DisableableButton(querySelector('#reload-gist'), () {
-      if (gistId.isNotEmpty || sampleId.isNotEmpty) {
+      if (gistId.isNotEmpty || sampleId.isNotEmpty || githubParamsPresent) {
         _loadAndShowGist();
       } else {
         _resetCode();
@@ -402,27 +402,33 @@ class NewEmbed {
     window.parent.postMessage({'sender': 'frame', 'type': 'ready'}, '*');
   }
 
+  String _getQueryParam(String key) {
+    final url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery && url.queryParameters[key] != null) {
+      return url.queryParameters[key];
+    }
+
+    return '';
+  }
+
   String get gistId {
-    final url = Uri.parse(window.location.toString());
-
-    if (url.hasQuery &&
-        url.queryParameters['id'] != null &&
-        isLegalGistId(url.queryParameters['id'])) {
-      return url.queryParameters['id'];
-    }
-
-    return '';
+    final id = _getQueryParam('id');
+    return isLegalGistId(id) ? id : '';
   }
 
-  String get sampleId {
-    final url = Uri.parse(window.location.toString());
+  String get sampleId => _getQueryParam('sample_id');
 
-    if (url.hasQuery && url.queryParameters['sample_id'] != null) {
-      return url.queryParameters['sample_id'];
-    }
+  String get githubOwner => _getQueryParam('gh_owner');
 
-    return '';
-  }
+  String get githubRepo => _getQueryParam('gh_repo');
+
+  String get githubPath => _getQueryParam('gh_path');
+
+  String get githubRef => _getQueryParam('gh_ref');
+
+  bool get githubParamsPresent =>
+      githubOwner.isNotEmpty && githubRepo.isNotEmpty && githubPath.isNotEmpty;
 
   Future<void> _initModules() async {
     ModuleManager modules = ModuleManager();
@@ -509,7 +515,7 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
       minSize: [100, 100],
     );
 
-    if (gistId.isNotEmpty || sampleId.isNotEmpty) {
+    if (gistId.isNotEmpty || sampleId.isNotEmpty || githubParamsPresent) {
       _loadAndShowGist(analyze: false);
     }
 
@@ -518,8 +524,9 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
   }
 
   Future<void> _loadAndShowGist({bool analyze = true}) async {
-    if (gistId.isEmpty && sampleId.isEmpty) {
-      print('Cannot load gist: neither id nor sample_id is present.');
+    if (gistId.isEmpty && sampleId.isEmpty && !githubParamsPresent) {
+      print('Cannot load gist: neither id, sample_id, nor GitHub info is '
+          'present.');
       return;
     }
 
@@ -528,9 +535,20 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
     final GistLoader loader = deps[GistLoader];
 
     try {
-      final gist = gistId.isNotEmpty
-          ? await loader.loadGist(gistId)
-          : await loader.loadGistFromAPIDocs(sampleId);
+      Gist gist;
+
+      if (gistId.isNotEmpty) {
+        gist = await loader.loadGist(gistId);
+      } else if (sampleId.isNotEmpty) {
+        gist = await loader.loadGistFromAPIDocs(sampleId);
+      } else {
+        gist = await loader.loadGistFromRepo(
+          owner: githubOwner,
+          repo: githubRepo,
+          path: githubPath,
+          ref: githubRef,
+        );
+      }
 
       setContextSources(<String, String>{
         'main.dart': gist.getFile('main.dart')?.content ?? '',
@@ -548,12 +566,13 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
       // No gist was loaded, so clear the editors.
       setContextSources(<String, String>{});
 
-      if (ex.failureType == GistLoaderFailureType.gistDoesNotExist) {
+      if (ex.failureType == GistLoaderFailureType.contentNotFound) {
         await dialog.showOk('Error loading gist',
-            'No gist was found matching the ID provided ($gistId).');
+            'No gist was found for the gist ID, sample ID, or repository '
+                'information provided.');
       } else if (ex.failureType == GistLoaderFailureType.rateLimitExceeded) {
         await dialog.showOk(
-            'Error loading gist',
+            'Error loading files',
             'GitHub\'s rate limit for '
                 'API requests has been exceeded. This is typically caused by '
                 'repeatedly loading a single page that has many DartPad embeds or '
@@ -561,11 +580,16 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
                 'API server) from a single, shared IP address. Quotas are '
                 'typically renewed within an hour, so the best course of action is '
                 'to try back later.');
+      } else if (ex.failureType == GistLoaderFailureType.invalidExerciseMetadata) {
+        await dialog.showOk(
+            'Error loading files',
+            'DartPad could not load the requested exercise. Either one of the '
+            'required files wasn\'t available, or the exercise metadata was '
+            'invalid.');
       } else {
         await dialog.showOk(
-            'Error loading gist',
-            'An error occurred while '
-                'loading Gist ID $gistId.');
+            'Error loading files',
+            'An error occurred while the requested files.');
       }
     }
   }

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -412,19 +412,21 @@ class NewEmbed {
     return '';
   }
 
+  // ID for a GitHub gist that should be loaded into the editors.
   String get gistId {
     final id = _getQueryParam('id');
     return isLegalGistId(id) ? id : '';
   }
 
+  // ID of an API Doc sample that should be loaded into the editors.
   String get sampleId => _getQueryParam('sample_id');
 
+  // GitHub params for loading an exercise from a repo. The first three are
+  // required to load something, while the fourth, gh_ref, is an optional branch
+  // name or commit SHA.
   String get githubOwner => _getQueryParam('gh_owner');
-
   String get githubRepo => _getQueryParam('gh_repo');
-
   String get githubPath => _getQueryParam('gh_path');
-
   String get githubRef => _getQueryParam('gh_ref');
 
   bool get githubParamsPresent =>
@@ -525,7 +527,7 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
   Future<void> _loadAndShowGist({bool analyze = true}) async {
     if (gistId.isEmpty && sampleId.isEmpty && !githubParamsPresent) {
-      print('Cannot load gist: neither id, sample_id, nor GitHub info is '
+      print('Cannot load gist: neither id, sample_id, nor GitHub repo info is '
           'present.');
       return;
     }

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -90,9 +90,6 @@ class Playground implements GistContainer, GistController {
   Gist _overrideNextRouteGist;
   DocHandler docHandler;
 
-  // The internal ID of the current Gist.
-  String _mappingId;
-
   Console _leftConsole;
   Console _rightConsole;
   Counter unreadConsoleCounter;
@@ -871,26 +868,6 @@ class Playground implements GistContainer, GistController {
     // the Dart source from).
     Timer.run(_performAnalysis);
     _clearOutput();
-  }
-
-  @override
-  Future shareAnon({String summary = ''}) {
-    return gistLoader
-        .createAnon(mutableGist.createGist(summary: summary))
-        .then((Gist newGist) {
-      editableGist.setBackingGist(newGist);
-      overrideNextRoute(newGist);
-      router.go('gist', {'gist': newGist.id});
-      _showSnackbar('Created ${newGist.id}');
-      GistToInternalIdMapping mapping = GistToInternalIdMapping()
-        ..gistId = newGist.id
-        ..internalId = _mappingId;
-      dartSupportServices.storeGist(mapping);
-    }).catchError((e) {
-      String message = 'Error saving gist: $e';
-      _showSnackbar(message);
-      ga.sendException('GistLoader.createAnon: failed to create gist');
-    });
   }
 
   void _displayIssues(List<AnalysisIssue> issues) {

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -40,6 +40,7 @@ import 'services/execution_iframe.dart';
 import 'sharing/editor_doc_property.dart';
 import 'sharing/gist_file_property.dart';
 import 'sharing/gists.dart';
+import 'sharing/gist_storage.dart';
 import 'sharing/mutable_gist.dart';
 import 'src/ga.dart';
 import 'src/util.dart';

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -81,8 +81,6 @@ class Playground implements GistContainer, GistController {
   Gist _overrideNextRouteGist;
   DocHandler docHandler;
 
-  String _mappingId;
-
   Playground() {
     sourceTabController = TabController();
     for (String name in ['dart', 'html', 'css']) {
@@ -307,32 +305,6 @@ class Playground implements GistContainer, GistController {
     router.go('gist', {'gist': ''}, forceReload: true);
 
     return Future.value();
-  }
-
-  @override
-  Future shareAnon({String summary = ''}) {
-    return gistLoader
-        .createAnon(mutableGist.createGist(summary: summary))
-        .then((Gist newGist) {
-      editableGist.setBackingGist(newGist);
-      overrideNextRoute(newGist);
-      router.go('gist', {'gist': newGist.id});
-      var toast = DToast('Created ${newGist.id}')
-        ..show()
-        ..hide();
-      toast.element
-        ..style.cursor = 'pointer'
-        ..onClick.listen((e) => window.open(
-            'https://gist.github.com/anonymous/${newGist.id}', '_blank'));
-      GistToInternalIdMapping mapping = GistToInternalIdMapping()
-        ..gistId = newGist.id
-        ..internalId = _mappingId;
-      dartSupportServices.storeGist(mapping);
-    }).catchError((e) {
-      String message = 'Error saving gist: $e';
-      DToast.showMessage(message);
-      ga.sendException('GistLoader.createAnon: failed to create gist');
-    });
   }
 
   void _showGist(String gistId) {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -32,6 +32,7 @@ import 'services/execution_iframe.dart';
 import 'sharing/editor_doc_property.dart';
 import 'sharing/gist_file_property.dart';
 import 'sharing/gists.dart';
+import 'sharing/gist_storage.dart';
 import 'sharing/mutable_gist.dart';
 import 'src/ga.dart';
 import 'src/util.dart';

--- a/lib/sharing/exercise_metadata.dart
+++ b/lib/sharing/exercise_metadata.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/lib/sharing/exercise_metadata.dart
+++ b/lib/sharing/exercise_metadata.dart
@@ -1,0 +1,93 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An exception thrown when a metadata file has missing or invalid fields.
+class MetadataException implements Exception {
+  final String message;
+
+  const MetadataException(this.message);
+}
+
+/// Modes for individual exercises.
+///
+/// The DartPad editors, output windows, and so on will be configured according
+/// to this value.
+enum ExerciseMode {
+  dart,
+  html,
+  flutter,
+}
+
+final exerciseModeNames = <String, ExerciseMode>{
+  'dart': ExerciseMode.dart,
+  'html': ExerciseMode.html,
+  'flutter': ExerciseMode.flutter,
+};
+
+/// Metadata for a single file within a larger exercise.
+class ExerciseFileMetadata {
+  String name;
+  String alternatePath;
+
+  String get path =>
+      (alternatePath == null || alternatePath.isEmpty) ? name : alternatePath;
+
+  ExerciseFileMetadata.fromJson(Map<String, dynamic> json) {
+    if (json == null) {
+      throw MetadataException('Null json was given to ExerciseFileMetadata().');
+    }
+
+    if (json['name'] == null ||
+        json['name'] is! String ||
+        json['name'].isEmpty) {
+      throw MetadataException('The "name" field is required for each file.');
+    }
+
+    name = json['name'];
+    alternatePath = json['alternatePath'];
+  }
+}
+
+/// Represents the metadata for a single codelab exercise, as defined by the
+/// exercise's `dartpad-metadata.json` file.
+///
+/// This data will be deserialized from that file when an exercise is loaded
+/// from GitHub, and used to set up the DartPad environment for that exercise.
+class ExerciseMetadata {
+  String name;
+  ExerciseMode mode;
+  List<ExerciseFileMetadata> files;
+
+  ExerciseMetadata.fromJson(Map<String, dynamic> json) {
+    if (json == null) {
+      throw MetadataException('Null json was given to ExerciseMetadata().');
+    }
+
+    if (json['name'] == null ||
+        json['name'] is! String ||
+        json['name'].isEmpty) {
+      throw MetadataException('The "name" field is required for an exercise.');
+    }
+
+    if (json['mode'] == null ||
+        json['mode'] is! String ||
+        !exerciseModeNames.containsKey(json['mode'])) {
+      throw MetadataException('A "mode" field of "dart", "html" or "flutter" '
+          'is required for an exercise.');
+    }
+
+    if (json['files'] == null ||
+        json['files'] is! List<dynamic> ||
+        json['files'].isEmpty) {
+      throw MetadataException('Each exercise must have at least one file in '
+          'its "files" array.');
+    }
+
+    name = json['name'];
+    mode = exerciseModeNames[json['mode']];
+    files = (json['files'] as Iterable<dynamic>)
+        .map((f) => ExerciseFileMetadata.fromJson(f))
+        .toList();
+  }
+}

--- a/lib/sharing/exercise_metadata.dart
+++ b/lib/sharing/exercise_metadata.dart
@@ -33,19 +33,19 @@ class ExerciseFileMetadata {
   String get path =>
       (alternatePath == null || alternatePath.isEmpty) ? name : alternatePath;
 
-  ExerciseFileMetadata.fromJson(Map<String, dynamic> json) {
-    if (json == null) {
+  ExerciseFileMetadata.fromMap(Map<String, dynamic> map) {
+    if (map == null) {
       throw MetadataException('Null json was given to ExerciseFileMetadata().');
     }
 
-    if (json['name'] == null ||
-        json['name'] is! String ||
-        json['name'].isEmpty) {
+    if (map['name'] == null ||
+        map['name'] is! String ||
+        map['name'].isEmpty) {
       throw MetadataException('The "name" field is required for each file.');
     }
 
-    name = json['name'];
-    alternatePath = json['alternatePath'];
+    name = map['name'];
+    alternatePath = map['alternatePath'];
   }
 }
 
@@ -59,35 +59,35 @@ class ExerciseMetadata {
   ExerciseMode mode;
   List<ExerciseFileMetadata> files;
 
-  ExerciseMetadata.fromJson(Map<String, dynamic> json) {
-    if (json == null) {
+  ExerciseMetadata.fromMap(Map<String, dynamic> map) {
+    if (map == null) {
       throw MetadataException('Null json was given to ExerciseMetadata().');
     }
 
-    if (json['name'] == null ||
-        json['name'] is! String ||
-        json['name'].isEmpty) {
+    if (map['name'] == null ||
+        map['name'] is! String ||
+        map['name'].isEmpty) {
       throw MetadataException('The "name" field is required for an exercise.');
     }
 
-    if (json['mode'] == null ||
-        json['mode'] is! String ||
-        !exerciseModeNames.containsKey(json['mode'])) {
+    if (map['mode'] == null ||
+        map['mode'] is! String ||
+        !exerciseModeNames.containsKey(map['mode'])) {
       throw MetadataException('A "mode" field of "dart", "html" or "flutter" '
           'is required for an exercise.');
     }
 
-    if (json['files'] == null ||
-        json['files'] is! List<dynamic> ||
-        json['files'].isEmpty) {
+    if (map['files'] == null ||
+        map['files'] is! List<dynamic> ||
+        map['files'].isEmpty) {
       throw MetadataException('Each exercise must have at least one file in '
           'its "files" array.');
     }
 
-    name = json['name'];
-    mode = exerciseModeNames[json['mode']];
-    files = (json['files'] as Iterable<dynamic>)
-        .map((f) => ExerciseFileMetadata.fromJson(f))
+    name = map['name'];
+    mode = exerciseModeNames[map['mode']];
+    files = (map['files'] as Iterable<dynamic>)
+        .map((f) => ExerciseFileMetadata.fromMap(Map.from(f)))
         .toList();
   }
 }

--- a/lib/sharing/gist_storage.dart
+++ b/lib/sharing/gist_storage.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert' show json;
+import 'dart:convert';
+import 'dart:html';
+import 'package:dart_pad/sharing/gists.dart';
+
+/// A class to store gists in html's localStorage.
+class GistStorage {
+  static final String _key = 'gist';
+
+  String _storedId;
+
+  GistStorage() {
+    Gist gist = getStoredGist();
+    if (gist != null) {
+      _storedId = gist.id;
+    }
+  }
+
+  bool get hasStoredGist => window.localStorage.containsKey(_key);
+
+  /// Return the id of the stored gist. This will return `null` if there is no
+  /// gist stored.
+  String get storedId =>
+      _storedId == null || _storedId.isEmpty ? null : _storedId;
+
+  Gist getStoredGist() {
+    String data = window.localStorage[_key];
+    return data == null ? null : Gist.fromMap(json.decode(data));
+  }
+
+  void setStoredGist(Gist gist) {
+    _storedId = gist.id;
+    window.localStorage[_key] = gist.toJson();
+  }
+
+  void clearStoredGist() {
+    _storedId = null;
+    window.localStorage.remove(_key);
+  }
+}
+

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -297,8 +297,8 @@ $styleRef$dartRef  </head>
       throw GistLoaderException(GistLoaderFailureType.invalidExerciseMetadata,
           'Issue parsing metadata: $ex');
     } on FormatException catch (ex) {
-      throw const GistLoaderException(
-          GistLoaderFailureType.invalidExerciseMetadata);
+      throw GistLoaderException(GistLoaderFailureType.invalidExerciseMetadata,
+          'Issue parsing metadata: $ex');
     }
 
     // Make additional requests for the files listed in the metadata.

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -7,11 +7,12 @@ library gists;
 import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:convert';
-import 'package:http/http.dart' as http;
 
 import 'package:dart_pad/sharing/exercise_metadata.dart';
 import 'package:dart_pad/src/sample.dart' as sample;
 import 'package:haikunator/haikunator.dart';
+import 'package:http/http.dart' as http;
+import 'package:yaml/yaml.dart' as yaml;
 
 final String _dartpadLink =
     '[dartpad.dartlang.org](https://dartpad.dartlang.org)';
@@ -92,7 +93,7 @@ class GistLoaderException implements Exception {
 class GistLoader {
   static const String _gistApiUrl = 'https://api.github.com/gists';
   static const String _repoContentsAuthority = 'api.github.com';
-  static const String _metadataFilename = 'dartpad_metadata.json';
+  static const String _metadataFilename = 'dartpad_metadata.yaml';
 
   // TODO(redbrogdon): Remove 'master-' once the new docs go live.
   static const String _apiDocsUrl = 'https://master-api.flutter.dev/snippets';
@@ -285,11 +286,17 @@ $styleRef$dartRef  </head>
     ExerciseMetadata metadata;
 
     try {
-      metadata = ExerciseMetadata.fromJson(json.decode(metadataContent));
+      final yamlMap = yaml.loadYaml(metadataContent);
+
+      if (yamlMap is! Map) {
+        throw FormatException();
+      }
+
+      metadata = ExerciseMetadata.fromMap(Map<String, dynamic>.from(yamlMap));
     } on MetadataException catch (ex) {
       throw GistLoaderException(GistLoaderFailureType.invalidExerciseMetadata,
           'Issue parsing metadata: $ex');
-    } on FormatException {
+    } on FormatException catch (ex) {
       throw const GistLoaderException(
           GistLoaderFailureType.invalidExerciseMetadata);
     }

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -248,7 +248,7 @@ $styleRef$dartRef  </head>
   String _extractContents(String githubResponse) {
     // GitHub's API returns file contents as the "contents" field in a JSON
     // object. The field's value is in base64 encoding, but with line ending
-    // characters   ('\n') included.
+    // characters ('\n') included.
     final contentJson = json.decode(githubResponse);
     final encodedContentStr =
         contentJson['content'].toString().replaceAll('\n', '');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.21"
+    version: "0.1.22"
   boolean_selector:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   build_modules:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.9"
+    version: "1.7.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   build_test:
     dependency: "direct dev"
     description:
@@ -119,7 +119,7 @@ packages:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   built_collection:
     dependency: transitive
     description:
@@ -443,7 +443,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.15"
+    version: "0.14.3"
   pub_semver:
     dependency: transitive
     description:
@@ -590,7 +590,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.9"
+    version: "1.6.10"
   test_api:
     dependency: transitive
     description:
@@ -604,7 +604,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9"
+    version: "0.2.9+1"
   timing:
     dependency: transitive
     description:
@@ -639,7 +639,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   watcher:
     dependency: transitive
     description:
@@ -660,6 +660,6 @@ packages:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.16"
+    version: "2.2.0"
 sdks:
   dart: ">=2.4.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.38.2"
+    version: "0.38.4"
   archive:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   build_config:
     dependency: transitive
     description:
@@ -84,42 +84,42 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.7"
+    version: "1.1.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.7.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.8"
+    version: "0.10.9"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.6.0"
   built_collection:
     dependency: transitive
     description:
@@ -210,7 +210,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.10"
+    version: "1.3.1"
   fixnum:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: front_end
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.24"
+    version: "0.1.26"
   git:
     dependency: "direct dev"
     description:
@@ -266,7 +266,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+2"
+    version: "0.14.0+3"
   html_unescape:
     dependency: "direct main"
     description:
@@ -329,7 +329,7 @@ packages:
       name: kernel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.24"
+    version: "0.3.26"
   logging:
     dependency: "direct main"
     description:
@@ -343,7 +343,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
@@ -443,7 +443,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.3"
+    version: "0.14.4"
   pub_semver:
     dependency: transitive
     description:
@@ -478,7 +478,7 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.22.12"
+    version: "1.23.0"
   sass_builder:
     dependency: "direct main"
     description:
@@ -590,21 +590,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.10"
+    version: "1.8.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.7"
+    version: "0.2.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.9+1"
+    version: "0.2.10"
   timing:
     dependency: transitive
     description:
@@ -625,7 +625,7 @@ packages:
       name: tuple
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   typed_data:
     dependency: transitive
     description:
@@ -639,7 +639,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   watcher:
     dependency: transitive
     description:
@@ -655,11 +655,11 @@ packages:
     source: hosted
     version: "1.0.15"
   yaml:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.5.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
     git:
       url: git://github.com/jifalops/mdc_web.git
       ref: 0ac7d5b4386863d91ec397600a326e622031513f
+  yaml: ^2.2.0
+
 dev_dependencies:
   build_runner: any
   build_test: any
@@ -42,4 +44,3 @@ dev_dependencies:
   shelf_static: ^0.2.8
   test: ^1.3.4
   tuneup: any
-  yaml: any

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -61,7 +61,7 @@ void defineTests() {
     });
   });
 
-  group('GistLoader unit tests', () {
+  group('GistLoader end-to-end tests', () {
     group('Loading by gist ID', () {
       test('Returns valid gist for valid gist id', () async {
         final loader = GistLoader(client: mockClient);

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -18,24 +18,24 @@ void defineTests() {
           return Future.value(http.Response(validGist, 200));
         case 'https://master-api.flutter.dev/snippets/material.AppBar.1.dart':
           return Future.value(http.Response(validSample, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.yaml':
           return Future.value(http.Response(basicDartMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad_metadata.json?ref=some_branch':
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad_metadata.yaml?ref=some_branch':
           return Future.value(http.Response(altBranchMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad_metadata.yaml':
           return Future.value(http.Response(invalidMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad_metadata.yaml':
           return Future.value(http.Response(missingFilesMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_mode/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_mode/dartpad_metadata.yaml':
           return Future.value(http.Response(missingModeMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_name/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_name/dartpad_metadata.yaml':
           return Future.value(http.Response(missingNameMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_file/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_file/dartpad_metadata.yaml':
           return Future.value(
               http.Response(missingIndividualFileMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/dartpad_metadata.yaml':
           return Future.value(http.Response(unnecessaryFileMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad_metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad_metadata.yaml':
           return Future.value(http.Response(alternatePathMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/main.dart':
         case 'https://api.github.com/repos/owner/repo/contents/alt_branch/main.dart?ref=some_branch':
@@ -449,149 +449,80 @@ String _createContentsJson(String content) {
 }
 
 final basicDartMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    },
-    {
-      "name": "hint.txt"
-    }
-  ]
-}
+name: A Dart Exercise
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+  - name: hint.txt
 ''');
 
 final altBranchMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    }
-  ]
-}
+name: A Dart Exercise
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
 ''');
 
 final invalidMetadata = _createContentsJson('''
-There should be valid JSON in this file but there's not.
+There should be valid YAML in this file but there's not.
 Golly, I hope that doesn't cause an error!
 ''');
 
 final missingFilesMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart"
-}
+name: A Dart Exercise
+mode: dart
 ''');
 
 final missingModeMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    }
-  ]
-}
+name: A Dart Exercise
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+  - name: hint.txt
 ''');
 
 final missingNameMetadata = _createContentsJson('''
-{
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    }
-  ]
-}
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+  - name: hint.txt
 ''');
 
 final missingIndividualFileMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    },
-    {
-      "name": "hint.txt"
-    }
-  ]
-}
+name: A Dart Exercise
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+  - name: hint.txt
 ''');
 
 final unnecessaryFileMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart"
-    },
-    {
-      "name": "unnecessary.txt"
-    }
-  ]
-}
+name: A Dart Exercise
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+  - name: unnecessary.txt
 ''');
 
 final alternatePathMetadata = _createContentsJson('''
-{
-  "name": "A Dart Exercise",
-  "mode": "dart",
-  "files": [
-    {
-      "name": "main.dart"
-    },
-    {
-      "name": "solution.dart"
-    },
-    {
-      "name": "test.dart",
-      "alternatePath": "a_subfolder/test.dart"
-    }
-  ]
-}
+name: A Dart Exercise
+mode: dart
+files:
+  - name: main.dart
+  - name: solution.dart
+  - name: test.dart
+    alternatePath: a_subfolder/test.dart
 ''');
 
 final mainFileContent = _createContentsJson('this is main.dart');

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -1,0 +1,572 @@
+import 'dart:convert';
+
+import 'package:dart_pad/sharing/gists.dart';
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  MockClient mockClient;
+  MockClient rateLimitedMockClient;
+
+  setUp(() async {
+    mockClient = MockClient((request) {
+      switch (request.url.toString()) {
+        case 'https://api.github.com/gists/12345678901234567890123456789012':
+          return Future.value(http.Response(validGist, 200));
+        case 'https://master-api.flutter.dev/snippets/material.AppBar.1.dart':
+          return Future.value(http.Response(validSample, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad-metadata.json':
+          return Future.value(http.Response(basicDartMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad-metadata.json':
+          return Future.value(http.Response(invalidMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad-metadata.json':
+          return Future.value(http.Response(missingFilesMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/missing_mode/dartpad-metadata.json':
+          return Future.value(http.Response(missingModeMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/missing_name/dartpad-metadata.json':
+          return Future.value(http.Response(missingNameMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/missing_file/dartpad-metadata.json':
+          return Future.value(
+              http.Response(missingIndividualFileMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/dartpad-metadata.json':
+          return Future.value(http.Response(unnecessaryFileMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad-metadata.json':
+          return Future.value(http.Response(alternatePathMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/basic/main.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/main.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/main.dart':
+          return Future.value(http.Response(mainFileContent, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/basic/test.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/test.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/a_subfolder/test.dart':
+          return Future.value(http.Response(testFileContent, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/basic/solution.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/solution.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/solution.dart':
+          return Future.value(http.Response(solutionFileContent, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/basic/hint.txt':
+          return Future.value(http.Response(hintFileContent, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/unnecessary.txt':
+          return Future.value(http.Response(unnecessaryFileContent, 200));
+      }
+
+      return Future.value(http.Response('File not found!', 404));
+    });
+
+    rateLimitedMockClient = MockClient((request) {
+      return Future.value(http.Response('Over the line!', 403));
+    });
+  });
+
+  group('GistLoader unit tests', () {
+    group('Loading by gist ID', () {
+      test('Returns valid gist for valid gist id', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGist('12345678901234567890123456789012');
+        final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
+        expect(contents.content, 'This is some dart code!');
+      });
+      test('Throws correct exception for nonexistent gist', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGist('12345678901234567890123456789000'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.contentNotFound)));
+      });
+      test('Throws correct exception for rate limit', () async {
+        final loader = GistLoader(client: rateLimitedMockClient);
+        expect(
+            loader.loadGist('12345678901234567890123456789012'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.rateLimitExceeded)));
+      });
+    });
+    group('Loading by sample ID', () {
+      test('Returns valid gist for valid sample id', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGistFromAPIDocs('material.AppBar.1');
+        final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
+        expect(contents.content, processedSample);
+      });
+      test('Throws correct exception for nonexistent sample', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGist('material.WunderWidget.1'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.contentNotFound)));
+      });
+      test('Throws correct exception for rate limit', () async {
+        final loader = GistLoader(client: rateLimitedMockClient);
+        expect(
+            loader.loadGist('material.AppBar.1'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.rateLimitExceeded)));
+      });
+    });
+    group('Loading from Repo', () {
+      test('Returns valid gist for valid repo info', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGistFromRepo(
+            owner: 'owner', repo: 'repo', path: 'basic');
+        final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
+        expect(contents.content, 'this is main.dart');
+      });
+      test('Throws exception for invalid metadata', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'invalid'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType ==
+                GistLoaderFailureType.invalidExerciseMetadata)));
+      });
+      test('Throws correct for metadata missing files propery', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'missing_files'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType ==
+                GistLoaderFailureType.invalidExerciseMetadata)));
+      });
+      test('Throws exception for metadata missing name', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'missing_name'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType ==
+                GistLoaderFailureType.invalidExerciseMetadata)));
+      });
+      test('Throws exception for metadata missing mode', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'missing_mode'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType ==
+                GistLoaderFailureType.invalidExerciseMetadata)));
+      });
+      test('Throws exception for metadata with invalid file path', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'missing_file'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType ==
+                GistLoaderFailureType.invalidExerciseMetadata)));
+      });
+      test('Returns gist with oddly named file included', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGistFromRepo(
+            owner: 'owner', repo: 'repo', path: 'unnecessary_file');
+        final contents =
+            gist.files.firstWhere((f) => f.name == 'unnecessary.txt');
+        expect(contents.content, 'this is unnecessary.txt');
+      });
+      test('Returns gist for metadata with alternate path', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGistFromRepo(
+            owner: 'owner', repo: 'repo', path: 'alternate_path');
+        final contents = gist.files.firstWhere((f) => f.name == 'test.dart');
+        expect(contents.content, 'this is test.dart');
+      });
+      test('Throws correct exception for incorrect metadata path', () async {
+        final loader = GistLoader(client: mockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'does_not_exist'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.contentNotFound)));
+      });
+      test('Throws correct exception when rate limited', () async {
+        final loader = GistLoader(client: rateLimitedMockClient);
+        expect(
+            loader.loadGistFromRepo(
+                owner: 'owner', repo: 'repo', path: 'basic'),
+            throwsA(predicate<GistLoaderException>((e) =>
+                e.failureType == GistLoaderFailureType.rateLimitExceeded)));
+      });
+    });
+  });
+}
+
+final validGist = '''
+{
+  "url": "https://api.github.com/gists/04b97ad82c9779d49683045f3b75bdba",
+  "forks_url": "https://api.github.com/gists/04b97ad82c9779d49683045f3b75bdba/forks",
+  "commits_url": "https://api.github.com/gists/04b97ad82c9779d49683045f3b75bdba/commits",
+  "id": "04b97ad82c9779d49683045f3b75bdba",
+  "node_id": "MDQ6R2lzdDA0Yjk3YWQ4MmM5Nzc5ZDQ5NjgzMDQ1ZjNiNzViZGJh",
+  "git_pull_url": "https://gist.github.com/04b97ad82c9779d49683045f3b75bdba.git",
+  "git_push_url": "https://gist.github.com/04b97ad82c9779d49683045f3b75bdba.git",
+  "html_url": "https://gist.github.com/04b97ad82c9779d49683045f3b75bdba",
+  "files": {
+    "main.dart": {
+      "filename": "main.dart",
+      "type": "application/vnd.dart",
+      "language": "Dart",
+      "raw_url": "https://gist.githubusercontent.com/RedBrogdon/04b97ad82c9779d49683045f3b75bdba/raw/4efa8efa772b952da1123005069758a2e809206c/main.dart",
+      "size": 1768,
+      "truncated": false,
+      "content": "This is some dart code!"
+    }
+  },
+  "public": true,
+  "created_at": "2019-09-19T04:09:27Z",
+  "updated_at": "2019-09-19T04:10:01Z",
+  "description": "Flutter.dev example 1",
+  "comments": 0,
+  "user": null,
+  "comments_url": "https://api.github.com/gists/04b97ad82c9779d49683045f3b75bdba/comments",
+  "owner": {
+    "login": "RedBrogdon",
+    "id": 969662,
+    "node_id": "MDQ6VXNlcjk2OTY2Mg==",
+    "avatar_url": "https://avatars3.githubusercontent.com/u/969662?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/RedBrogdon",
+    "html_url": "https://github.com/RedBrogdon",
+    "followers_url": "https://api.github.com/users/RedBrogdon/followers",
+    "following_url": "https://api.github.com/users/RedBrogdon/following{/other_user}",
+    "gists_url": "https://api.github.com/users/RedBrogdon/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/RedBrogdon/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/RedBrogdon/subscriptions",
+    "organizations_url": "https://api.github.com/users/RedBrogdon/orgs",
+    "repos_url": "https://api.github.com/users/RedBrogdon/repos",
+    "events_url": "https://api.github.com/users/RedBrogdon/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/RedBrogdon/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "truncated": false
+}
+''';
+
+final validSample = '''
+// Flutter code sample for
+
+// This sample shows an [AppBar] with two simple actions. The first action
+// opens a [SnackBar], while the second action navigates to a new page.
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+/// This Widget is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+final SnackBar snackBar = const SnackBar(content: Text('Showing Snackbar'));
+
+void openPage(BuildContext context) {
+  Navigator.push(context, MaterialPageRoute(
+    builder: (BuildContext context) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Next page'),
+        ),
+        body: const Center(
+          child: Text(
+            'This is the next page',
+            style: TextStyle(fontSize: 24),
+          ),
+        ),
+      );
+    },
+  ));
+}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: scaffoldKey,
+      appBar: AppBar(
+        title: const Text('AppBar Demo'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.add_alert),
+            tooltip: 'Show Snackbar',
+            onPressed: () {
+              scaffoldKey.currentState.showSnackBar(snackBar);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.navigate_next),
+            tooltip: 'Next page',
+            onPressed: () {
+              openPage(context);
+            },
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Text(
+          'This is the home page',
+          style: TextStyle(fontSize: 24),
+        ),
+      ),
+    );
+  }
+}
+''';
+
+final processedSample = '''
+import 'package:flutter_web/material.dart';
+import 'package:flutter_web_ui/ui.dart' as ui;
+
+void main() async {
+  await ui.webOnlyInitializePlatform();
+  runApp(MyApp());
+}
+
+/// This Widget is the main application widget.
+class MyApp extends StatelessWidget {
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: MyStatelessWidget(),
+    );
+  }
+}
+
+final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+final SnackBar snackBar = const SnackBar(content: Text('Showing Snackbar'));
+
+void openPage(BuildContext context) {
+  Navigator.push(context, MaterialPageRoute(
+    builder: (BuildContext context) {
+      return Scaffold(
+        appBar: AppBar(
+          title: const Text('Next page'),
+        ),
+        body: const Center(
+          child: Text(
+            'This is the next page',
+            style: TextStyle(fontSize: 24),
+          ),
+        ),
+      );
+    },
+  ));
+}
+
+/// This is the stateless widget that the main application instantiates.
+class MyStatelessWidget extends StatelessWidget {
+  MyStatelessWidget({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: scaffoldKey,
+      appBar: AppBar(
+        title: const Text('AppBar Demo'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.add_alert),
+            tooltip: 'Show Snackbar',
+            onPressed: () {
+              scaffoldKey.currentState.showSnackBar(snackBar);
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.navigate_next),
+            tooltip: 'Next page',
+            onPressed: () {
+              openPage(context);
+            },
+          ),
+        ],
+      ),
+      body: const Center(
+        child: Text(
+          'This is the home page',
+          style: TextStyle(fontSize: 24),
+        ),
+      ),
+    );
+  }
+}
+''';
+
+/// Create a GitHub API-like contents response for the provided content.
+String _createContentsJson(String content) {
+  return '''
+{
+  "name": "this name does not matter",
+  "path": "this does not matter either",
+  "sha": "24e191ed740c5a1835785281ff118f0d3a605596",
+  "size": 9396,
+  "url": "https://api.github.com/repos/RedBrogdon/flutterflip/contents/lib/main.dart?ref=master",
+  "html_url": "https://github.com/RedBrogdon/flutterflip/blob/master/lib/main.dart",
+  "git_url": "https://api.github.com/repos/RedBrogdon/flutterflip/git/blobs/24e191ed740c5a1835785281ff118f0d3a605596",
+  "download_url": "https://raw.githubusercontent.com/RedBrogdon/flutterflip/master/lib/main.dart",
+  "type": "file",
+  "content": "${base64.encode(utf8.encode(content))}",
+  "encoding": "base64",
+  "_links": {
+    "self": "https://api.github.com/repos/RedBrogdon/flutterflip/contents/lib/main.dart?ref=master",
+    "git": "https://api.github.com/repos/RedBrogdon/flutterflip/git/blobs/24e191ed740c5a1835785281ff118f0d3a605596",
+    "html": "https://github.com/RedBrogdon/flutterflip/blob/master/lib/main.dart"
+  }
+}
+''';
+}
+
+final basicDartMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
+    },
+    {
+      "name": "hint.txt"
+    }
+  ]
+}
+''');
+
+final invalidMetadata = _createContentsJson('''
+There should be valid JSON in this file but there's not.
+Golly, I hope that doesn't cause an error!
+''');
+
+final missingFilesMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart"
+}
+''');
+
+final missingModeMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
+    }
+  ]
+}
+''');
+
+final missingNameMetadata = _createContentsJson('''
+{
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
+    }
+  ]
+}
+''');
+
+final missingIndividualFileMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
+    },
+    {
+      "name": "hint.txt"
+    }
+  ]
+}
+''');
+
+final unnecessaryFileMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
+    },
+    {
+      "name": "unnecessary.txt"
+    }
+  ]
+}
+''');
+
+final alternatePathMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart",
+      "alternatePath": "a_subfolder/test.dart"
+    }
+  ]
+}
+''');
+
+final mainFileContent = _createContentsJson('this is main.dart');
+
+final testFileContent = _createContentsJson('this is test.dart');
+
+final solutionFileContent = _createContentsJson('this is solution.dart');
+
+final hintFileContent = _createContentsJson('this is hint.txt');
+
+final unnecessaryFileContent = _createContentsJson('this is unnecessary.txt');

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -18,24 +18,24 @@ void defineTests() {
           return Future.value(http.Response(validGist, 200));
         case 'https://master-api.flutter.dev/snippets/material.AppBar.1.dart':
           return Future.value(http.Response(validSample, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.json':
           return Future.value(http.Response(basicDartMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad-metadata.json?ref=some_branch':
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad_metadata.json?ref=some_branch':
           return Future.value(http.Response(altBranchMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad_metadata.json':
           return Future.value(http.Response(invalidMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad_metadata.json':
           return Future.value(http.Response(missingFilesMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_mode/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_mode/dartpad_metadata.json':
           return Future.value(http.Response(missingModeMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_name/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_name/dartpad_metadata.json':
           return Future.value(http.Response(missingNameMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/missing_file/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/missing_file/dartpad_metadata.json':
           return Future.value(
               http.Response(missingIndividualFileMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/dartpad_metadata.json':
           return Future.value(http.Response(unnecessaryFileMetadata, 200));
-        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad-metadata.json':
+        case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad_metadata.json':
           return Future.value(http.Response(alternatePathMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/main.dart':
         case 'https://api.github.com/repos/owner/repo/contents/alt_branch/main.dart?ref=some_branch':

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -20,6 +20,8 @@ void defineTests() {
           return Future.value(http.Response(validSample, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad-metadata.json':
           return Future.value(http.Response(basicDartMetadata, 200));
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad-metadata.json?ref=some_branch':
+          return Future.value(http.Response(altBranchMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/invalid/dartpad-metadata.json':
           return Future.value(http.Response(invalidMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/missing_files/dartpad-metadata.json':
@@ -36,14 +38,17 @@ void defineTests() {
         case 'https://api.github.com/repos/owner/repo/contents/alternate_path/dartpad-metadata.json':
           return Future.value(http.Response(alternatePathMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/main.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/main.dart?ref=some_branch':
         case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/main.dart':
         case 'https://api.github.com/repos/owner/repo/contents/alternate_path/main.dart':
           return Future.value(http.Response(mainFileContent, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/test.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/test.dart?ref=some_branch':
         case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/test.dart':
         case 'https://api.github.com/repos/owner/repo/contents/alternate_path/a_subfolder/test.dart':
           return Future.value(http.Response(testFileContent, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/solution.dart':
+        case 'https://api.github.com/repos/owner/repo/contents/alt_branch/solution.dart?ref=some_branch':
         case 'https://api.github.com/repos/owner/repo/contents/unnecessary_file/solution.dart':
         case 'https://api.github.com/repos/owner/repo/contents/alternate_path/solution.dart':
           return Future.value(http.Response(solutionFileContent, 200));
@@ -111,6 +116,16 @@ void defineTests() {
         final loader = GistLoader(client: mockClient);
         final gist = await loader.loadGistFromRepo(
             owner: 'owner', repo: 'repo', path: 'basic');
+        final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
+        expect(contents.content, 'this is main.dart');
+      });
+      test('Returns valid gist for alternate branch', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist = await loader.loadGistFromRepo(
+            owner: 'owner',
+            repo: 'repo',
+            path: 'alt_branch',
+            ref: 'some_branch');
         final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
         expect(contents.content, 'this is main.dart');
       });
@@ -449,6 +464,24 @@ final basicDartMetadata = _createContentsJson('''
     },
     {
       "name": "hint.txt"
+    }
+  ]
+}
+''');
+
+final altBranchMetadata = _createContentsJson('''
+{
+  "name": "A Dart Exercise",
+  "mode": "dart",
+  "files": [
+    {
+      "name": "main.dart"
+    },
+    {
+      "name": "solution.dart"
+    },
+    {
+      "name": "test.dart"
     }
   ]
 }

--- a/test/sharing/gists_test.dart
+++ b/test/sharing/gists_test.dart
@@ -6,6 +6,7 @@
 library dart_pad.gists_test;
 
 import 'package:dart_pad/sharing/gists.dart';
+import 'package:dart_pad/sharing/gist_storage.dart';
 import 'package:test/test.dart';
 
 void main() => defineTests();


### PR DESCRIPTION
Changes:

* Updates the new embed to look for four new params in its query string: gh_repo, gh_owner, gh_path, and an optional gh_ref.
* Adds a loadGistFromRepo to GistLoader for loading exercises directly from a GitHub repo.
* Removes the old shareAnon methods, since they no longer function.
* Standardizes gist loading on package:http instead of dart:html requests.
* Moves GistStorage into its own file
* Adds tests for GistLoader's new and existing functions.

GistLoader is getting a little big at this point, but is unlikely to grow again in the short term, so I've left it as a single class with three load methods.

I've added a couple new classes to parse the JSON in the metadata file. These could have been done with built_value or json_serializeable. Since the entire file is <100 lines and neither of those packages is in use elsewhere in the project, though, I've chosen to roll my own rather than take on a new dependency and build step.

A field for "exercise mode" (dart, html, flutter) will need to be added to the Gist class. The new playground will also need to examine that field and set its editors up accordingly. This hasn't been done yet, since John is still finishing the new playground.

