### PR TITLE
Removing scroll from editor/console container.

### DIFF
--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -185,7 +185,6 @@ body {
 #editor-and-console-container {
   display: flex;
   flex-direction: column;
-  overflow-x: scroll;
 }
 
 #editor-container {


### PR DESCRIPTION
Fixes the whitespace-under-console issue that's been popping up of late, which appears to have been the browser reserving space for unnecessary horizontal scrollbars.