### PR TITLE
Updated demo page with more embeds

### DIFF
--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -87,21 +87,41 @@
                 fixed.
             </div>
 
-            <h3>Dart embed</h3>
+            <h3>Dart</h3>
 
-            <iframe src="embed-new-dart.html?id=92dd64a18ebcaaac0e380a50cbd1b0c2&theme=dark"></iframe>
+            <iframe src="../embed-dart.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_all_files"></iframe>
 
-            <h3>Dart inline embed</h3>
+            <h3>Dart (dark)</h3>
 
-            <iframe src="embed-new-inline.html?id=92dd64a18ebcaaac0e380a50cbd1b0c2"></iframe>
+            <iframe src="../embed-dart.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_just_main&theme=dark"></iframe>
 
-            <h3>Flutter embed</h3>
+            <h3>Dart inline</h3>
 
-            <iframe class="tall" src="embed-new-flutter.html?id=453d864648c6d689a27b948a7d72b4a7&split=60&theme=dark"></iframe>
+            <iframe src="../embed-inline.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_all_files"></iframe>
 
-            <h3>HTML embed</h3>
+            <h3>Dart inline (dark)</h3>
 
-            <iframe src="embed-new-html.html?id=a559420eed617dab7a196b5ea0b64fba"></iframe>
+            <iframe src="../embed-inline.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_just_main&theme=dark"></iframe>
+
+            <h3>Dart HTML</h3>
+
+            <iframe src="../embed-html.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_html_all_files"></iframe>
+
+            <h3>Dart HTML (dark)</h3>
+
+            <iframe src="../embed-html.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/dart_html_just_main&theme=dark"></iframe>
+
+            <h3>Flutter</h3>
+
+            <iframe class="tall" src="../embed-flutter.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/flutter_all_files&split=60"></iframe>
+
+            <h3>Flutter (dark)</h3>
+
+            <iframe class="tall" src="../embed-flutter.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/flutter_just_main&split=60&theme=dark"></iframe>
+
+            <h3>Loading an API Doc sample</h3>
+
+            <iframe class="tall" src="../embed-flutter.html?sample_id=material.AppBar.1&split=60"></iframe>
 
         </div>
         <div class="col-md-1"></div>


### PR DESCRIPTION
This page should be used for a final manual check before deploying new version of the front end.

If anyone can think of additional test cases or things to check, fire away. 😄

The links reference a `RedBrogdon` repo, which isn't a good long term solution. Once the new playground is launched and we have a moment to restructure the dart-pad repo to include packages, those examples can be moved in as well.