### PR TITLE
Added option to copy code snippet to clipboard

### DIFF
--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -560,7 +560,7 @@ class TabController {
   }
 
   TabElement get selectedTab =>
-      tabs.firstWhere((tab) => tab.hasAttr('selected'));
+      tabs.firstWhere((tab) => tab.hasAttr('selected'), orElse: () => null);
 
   /// This method will throw if the tabName is not the name of a current tab.
   void selectTab(String tabName) {

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -560,7 +560,7 @@ class TabController {
   }
 
   TabElement get selectedTab =>
-      tabs.firstWhere((tab) => tab.hasAttr('selected'), orElse: () => null);
+      tabs.firstWhere((tab) => tab.hasAttr('selected'));
 
   /// This method will throw if the tabName is not the name of a current tab.
   void selectTab(String tabName) {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -623,15 +623,10 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
   String _getActiveSourceCode() {
     String activeSource;
-    String activeTab = "editor";
+    String activeTabName = tabController.selectedTab == null ? 
+    'editor' : tabController.selectedTab.name;
 
-    try {
-      // TODO: Remove this try-catch block
-      // by fixing the selectedTab to return first tab, if selected attr not available.
-      activeTab = tabController.selectedTab.name;
-    } catch (_) {}
-
-    switch (activeTab) {
+    switch (activeTabName) {
       case 'editor':
         activeSource = context.dartSource;
         break;
@@ -640,6 +635,12 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
         break;
       case 'html':
         activeSource = context.htmlSource;
+        break;
+      case 'solution':
+        activeSource = context.solution;
+        break;
+      case 'test':
+        activeSource = context.testMethod;
         break;
       default:
         activeSource = context.dartSource;

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -623,8 +623,7 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
   String _getActiveSourceCode() {
     String activeSource;
-    String activeTabName = tabController.selectedTab == null ? 
-    'editor' : tabController.selectedTab.name;
+    String activeTabName = tabController.selectedTab.name;
 
     switch (activeTabName) {
       case 'editor':

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -78,6 +78,7 @@ class NewEmbed {
   DisableableButton reloadGistButton;
   DisableableButton formatButton;
   DisableableButton showHintButton;
+  DisableableButton copyCodeButton;
   DisableableButton menuButton;
 
   DElement navBarElement;
@@ -144,6 +145,7 @@ class NewEmbed {
     formatButton.disabled = value;
     reloadGistButton.disabled = value;
     showHintButton?.disabled = value;
+    copyCodeButton?.disabled = value;
   }
 
   NewEmbed(this.options) {
@@ -202,6 +204,9 @@ class NewEmbed {
         _resetCode();
       }
     });
+
+    copyCodeButton =
+        DisableableButton(querySelector('#copy-code'), _handleCopyCode);
 
     showHintButton = DisableableButton(querySelector('#show-hint'), () {
       var hintElement = DivElement()..text = context.hint;
@@ -605,6 +610,43 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
   void _resetCode() {
     setContextSources(lastInjectedSourceCode);
+  }
+
+  void _handleCopyCode() {
+    var textElement = document.createElement('textarea') as TextAreaElement;
+    textElement.value = _getActiveSourceCode();
+    document.body.append(textElement);
+    textElement.select();
+    document.execCommand('copy');
+    textElement.remove();
+  }
+
+  String _getActiveSourceCode() {
+    String activeSource;
+    String activeTab = "editor";
+
+    try {
+      // TODO: Remove this try-catch block
+      // by fixing the selectedTab to return first tab, if selected attr not available.
+      activeTab = tabController.selectedTab.name;
+    } catch (_) {}
+
+    switch (activeTab) {
+      case 'editor':
+        activeSource = context.dartSource;
+        break;
+      case 'css':
+        activeSource = context.cssSource;
+        break;
+      case 'html':
+        activeSource = context.htmlSource;
+        break;
+      default:
+        activeSource = context.dartSource;
+        break;
+    }
+
+    return activeSource;
   }
 
   void setContextSources(Map<String, String> sources) {

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -137,6 +137,7 @@ BSD-style license that can be found in the LICENSE file. -->
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
         </div>
+        <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
         <div id="console-output-footer" class="footer-top-border" hidden>
             <div id="console-output-header">
                 <span class="view-label">

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -61,7 +61,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div class="mdc-tab-scroller">
                 <div class="mdc-tab-scroller__scroll-area">
                     <div class="mdc-tab-scroller__scroll-content">
-                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true"
+                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" selected
                                 tabindex="0">
                              <span class="mdc-tab__content">
                                  <span class="mdc-tab__text-label">Dart</span>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -128,6 +128,7 @@ BSD-style license that can be found in the LICENSE file. -->
         <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
             <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
         </div>
+        <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
     </div>
     <div id="console-view" hidden>
         <div id="console-output-header">

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -130,6 +130,7 @@ BSD-style license that can be found in the LICENSE file. -->
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
         </div>
+        <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
         <div id="console-output-footer" class="footer-top-border" hidden>
             <div id="console-output-header">
                 <span class="view-label">

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -61,7 +61,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div class="mdc-tab-scroller">
                 <div class="mdc-tab-scroller__scroll-area">
                     <div class="mdc-tab-scroller__scroll-content">
-                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true"
+                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" selected
                                 tabindex="0">
                              <span class="mdc-tab__content">
                                  <span class="mdc-tab__text-label">Dart</span>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -155,6 +155,7 @@ BSD-style license that can be found in the LICENSE file. -->
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
         </div>
+        <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
         <div id="console-output-footer" class="footer-top-border" hidden>
             <div id="console-output-header">
                 <span class="view-label">

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -61,7 +61,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div class="mdc-tab-scroller">
                 <div class="mdc-tab-scroller__scroll-area">
                     <div class="mdc-tab-scroller__scroll-content">
-                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true"
+                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" selected
                                 tabindex="0">
                              <span class="mdc-tab__content">
                                  <span class="mdc-tab__text-label">Dart</span>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -129,6 +129,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
         </div>
     </div>
+    <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
     <div id="console-view" hidden>
         <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -61,7 +61,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div class="mdc-tab-scroller">
                 <div class="mdc-tab-scroller__scroll-area">
                     <div class="mdc-tab-scroller__scroll-content">
-                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true"
+                        <button id="editor-tab" class="mdc-tab mdc-tab--active" role="tab" aria-selected="true" selected
                                 tabindex="0">
                              <span class="mdc-tab__content">
                                  <span class="mdc-tab__text-label">Dart</span>

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -195,7 +195,7 @@ body {
   top: 0;
   z-index: 10;
   font-size: 18px;
-  opacity: 0.8;
+  color: $mdc-theme-primary;
 
   &:hover {
     display: block;

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -185,11 +185,35 @@ body {
 #editor-and-console-container {
   display: flex;
   flex-direction: column;
+  position: relative;
+}
+
+#copy-code {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 10;
+  font-size: 18px;
+  opacity: 0.8;
+
+  &:hover {
+    display: block;
+  }
 }
 
 #editor-container {
   flex: 1;
   overflow: hidden;
+  position: relative;
+
+  &:hover + #copy-code {
+    display: block;
+  }
+
+  &:hover > #copy-code {
+    display: block;
+  }
 }
 
 #tab-container {


### PR DESCRIPTION
Added copy option to the code editor, to copy code snippet. Code snippet from the active tab will be copied to clipboard, in case of multiple tabs. Copy code button appear only on hovering the code editor.

![image](https://user-images.githubusercontent.com/14835387/66337002-e4b6ed00-e95b-11e9-9e30-6608bea729bd.png)

Fixed #1259 