### PR TITLE
add auto-run (run=true) query parameter to embeds

### DIFF
--- a/lib/experimental/inject_embed.dart
+++ b/lib/experimental/inject_embed.dart
@@ -12,8 +12,8 @@ import 'package:dart_pad/experimental/inject_parser.dart';
 Logger _logger = Logger('dartpad-embed');
 
 // Use this prefix for local development:
-//var iframePrefix = '';
-var iframePrefix = 'https://dartpad.dev/experimental/';
+//var iframePrefix = '../';
+var iframePrefix = 'https://dartpad.dev/';
 
 /// Replaces all code snippets marked with the 'run-dartpad' class with an
 /// instance of DartPad.
@@ -50,7 +50,21 @@ String iframeSrc(Map<String, String> options) {
     mode = 'dart';
   }
 
-  return '${iframePrefix}embed-new-$mode.html?theme=$theme';
+  String split;
+  if (options.containsKey('split')) {
+    split = options['split'];
+  } else {
+    split = 'false';
+  }
+
+  String run;
+  if (options.containsKey('run')) {
+    run = options['run'];
+  } else {
+    run = 'false';
+  }
+
+  return '${iframePrefix}embed-$mode.html?theme=$theme&run=$run&split=$split';
 }
 
 /// Replaces [host] with an instance of DartPad as an embedded iframe.

--- a/lib/experimental/inject_parser.dart
+++ b/lib/experimental/inject_parser.dart
@@ -78,7 +78,7 @@ class DartPadInjectException implements Exception {
 class LanguageStringParser {
   final String input;
   final RegExp _validExp = RegExp(r'[a-z-]*run-dartpad(:?[a-z-]*)+');
-  final RegExp _optionsExp = RegExp(r':([a-z]*)-([a-z]*)');
+  final RegExp _optionsExp = RegExp(r':([a-z]*)-([a-z0-9]*)');
 
   LanguageStringParser(this.input);
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -393,6 +393,10 @@ class NewEmbed {
       if (type == 'sourceCode') {
         lastInjectedSourceCode = Map<String, String>.from(data['sourceCode']);
         _resetCode();
+
+        if(autoRunEnabled) {
+          _handleExecute();
+        }
       }
     });
   }
@@ -566,6 +570,10 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
 
       if (analyze) {
         _performAnalysis();
+      }
+
+      if(autoRunEnabled) {
+        _handleExecute();
       }
     } on GistLoaderException catch (ex) {
       // No gist was loaded, so clear the editors.
@@ -801,6 +809,11 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
   bool get isDarkMode {
     final url = Uri.parse(window.location.toString());
     return url.queryParameters['theme'] == 'dark';
+  }
+
+  bool get autoRunEnabled {
+    final url = Uri.parse(window.location.toString());
+    return url.queryParameters['run'] == 'true';
   }
 
   int get initialSplitPercent {

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -416,10 +416,22 @@ class NewEmbed {
     return '';
   }
 
-  // ID for a GitHub gist that should be loaded into the editors.
+  // Option for the GitHub gist ID that should be loaded into the editors.
   String get gistId {
     final id = _getQueryParam('id');
     return isLegalGistId(id) ? id : '';
+  }
+
+  // Option for Light / Dark theme (defaults to light)
+  bool get isDarkMode {
+    final url = Uri.parse(window.location.toString());
+    return url.queryParameters['theme'] == 'dark';
+  }
+
+  // Option to run the snippet immediately (defaults to  false)
+  bool get autoRunEnabled {
+    final url = Uri.parse(window.location.toString());
+    return url.queryParameters['run'] == 'true';
   }
 
   // ID of an API Doc sample that should be loaded into the editors.
@@ -804,16 +816,6 @@ major browsers, such as Firefox, Edge (dev channel), or Chrome.
     if (userCodeEditor.hasFocus && e.keyCode == KeyCode.PERIOD) {
       userCodeEditor.showCompletions(autoInvoked: true);
     }
-  }
-
-  bool get isDarkMode {
-    final url = Uri.parse(window.location.toString());
-    return url.queryParameters['theme'] == 'dark';
-  }
-
-  bool get autoRunEnabled {
-    final url = Uri.parse(window.location.toString());
-    return url.queryParameters['run'] == 'true';
   }
 
   int get initialSplitPercent {

--- a/test/experimental/inject_parser_test.dart
+++ b/test/experimental/inject_parser_test.dart
@@ -35,10 +35,12 @@ main() {
     });
 
     test('supports options ', () {
-      var options = LanguageStringParser('run-dartpad:mode-html:theme-dark').options;
+      var options = LanguageStringParser('run-dartpad:mode-html:theme-dark:run-true:split-50').options;
       expect(options, isNotEmpty);
       expect(options['mode'], equals('html'));
       expect(options['theme'], equals('dark'));
+      expect(options['run'], equals('true'));
+      expect(options['split'], equals('50'));
     });
   });
 }

--- a/web/experimental/inject_demo.html
+++ b/web/experimental/inject_demo.html
@@ -37,9 +37,9 @@
 <body>
 <div class="container">
     <div class="col-md-10">
-        <p>mode-flutter, theme-light</p>
+        <p>mode-flutter, theme-light, run-true, split-40</p>
         <pre>
-            <code class="language-run-dartpad:theme-light:mode-flutter">
+            <code class="language-run-dartpad:theme-light:mode-flutter:run-true:split-40">
 import 'package:flutter_web/material.dart';
 import 'package:flutter_web_test/flutter_web_test.dart';
 import 'package:flutter_web_ui/ui.dart' as ui;

--- a/web/experimental/new_embeddings_demo.html
+++ b/web/experimental/new_embeddings_demo.html
@@ -123,6 +123,10 @@
 
             <iframe class="tall" src="../embed-flutter.html?sample_id=material.AppBar.1&split=60"></iframe>
 
+            <h3>Flutter with auto-run</h3>
+
+            <iframe class="tall" src="../embed-flutter.html?gh_owner=RedBrogdon&gh_repo=dartpad_exercises&gh_path=embeddings_demo/flutter_all_files&split=60&run=true"></iframe>
+
         </div>
         <div class="col-md-1"></div>
     </div>


### PR DESCRIPTION
- auto-run must be executed after loading the gist or having code
  injected.
- add run=true and split=<percentage> options to inject API
- change new_embeddings_with_code_tags.html to inject_demo.html

closes #1309
closes #1185