### PR TITLE
Disable editing for test and solution tabs

### DIFF
--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -261,7 +261,7 @@ class _CodeMirrorEditor extends Editor {
   bool get readOnly => cm.getReadOnly();
 
   @override
-  set readOnly(bool ro) => cm.setReadOnly(ro, false);
+  set readOnly(bool ro) => cm.setReadOnly(ro);
 
   @override
   bool get showLineNumbers => cm.getLineNumbers();

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -261,7 +261,7 @@ class _CodeMirrorEditor extends Editor {
   bool get readOnly => cm.getReadOnly();
 
   @override
-  set readOnly(bool ro) => cm.setReadOnly(ro, true);
+  set readOnly(bool ro) => cm.setReadOnly(ro, false);
 
   @override
   bool get showLineNumbers => cm.getLineNumbers();

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -238,22 +238,20 @@ class NewEmbed {
     menu.listen('MDCMenu:selected', (e) {
       final selectedIndex = (e as CustomEvent).detail['index'];
       switch (selectedIndex) {
-        case 0: // Show Test Code
-          {
-            _showTestCode = !_showTestCode;
-            showTestCodeCheckmark.toggleClass('hide', !_showTestCode);
-            tabController.setTabVisibility('test', _showTestCode);
-            break;
-          }
-        case 1: // Editable test/solution
-          {
-            _editableTestSolution = !_editableTestSolution;
-            editableTestSolutionCheckmark.toggleClass(
-                'hide', !_editableTestSolution);
-            testEditor.readOnly =
-                solutionEditor.readOnly = !_editableTestSolution;
-            break;
-          }
+        case 0:
+          // Show test code
+          _showTestCode = !_showTestCode;
+          showTestCodeCheckmark.toggleClass('hide', !_showTestCode);
+          tabController.setTabVisibility('test', _showTestCode);
+          break;
+        case 1:
+          // Editable test/solution
+          _editableTestSolution = !_editableTestSolution;
+          editableTestSolutionCheckmark.toggleClass(
+              'hide', !_editableTestSolution);
+          testEditor.readOnly =
+              solutionEditor.readOnly = !_editableTestSolution;
+          break;
       }
     });
 

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -93,6 +93,8 @@ class NewEmbed {
 
   DElement morePopover;
   DElement showTestCodeCheckmark;
+  DElement editableTestSolutionCheckmark;
+  bool _editableTestSolution = false;
   bool _showTestCode = false;
 
   Counter unreadConsoleCounter;
@@ -223,6 +225,8 @@ class NewEmbed {
 
     tabController.setTabVisibility('test', false);
     showTestCodeCheckmark = DElement(querySelector('#show-test-checkmark'));
+    editableTestSolutionCheckmark =
+        DElement(querySelector('#editable-test-solution-checkmark'));
 
     morePopover = DElement(querySelector('#more-popover'));
     menuButton = DisableableButton(querySelector('#menu-button'), () {
@@ -232,10 +236,24 @@ class NewEmbed {
       ..setAnchorCorner(AnchorCorner.bottomLeft)
       ..setAnchorElement(menuButton._element.element);
     menu.listen('MDCMenu:selected', (e) {
-      if ((e as CustomEvent).detail['index'] == 0) {
-        _showTestCode = !_showTestCode;
-        showTestCodeCheckmark.toggleClass('hide', !_showTestCode);
-        tabController.setTabVisibility('test', _showTestCode);
+      final selectedIndex = (e as CustomEvent).detail['index'];
+      switch (selectedIndex) {
+        case 0: // Show Test Code
+          {
+            _showTestCode = !_showTestCode;
+            showTestCodeCheckmark.toggleClass('hide', !_showTestCode);
+            tabController.setTabVisibility('test', _showTestCode);
+            break;
+          }
+        case 1: // Editable test/solution
+          {
+            _editableTestSolution = !_editableTestSolution;
+            editableTestSolutionCheckmark.toggleClass(
+                'hide', !_editableTestSolution);
+            testEditor.readOnly =
+                solutionEditor.readOnly = !_editableTestSolution;
+            break;
+          }
       }
     });
 
@@ -261,7 +279,7 @@ class NewEmbed {
         options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'dart'
-      ..readOnly = true
+      ..readOnly = !_editableTestSolution
       ..showLineNumbers = true;
 
     solutionEditor = editorFactory.createFromElement(
@@ -269,7 +287,7 @@ class NewEmbed {
         options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'dart'
-      ..readOnly = true
+      ..readOnly = !_editableTestSolution
       ..showLineNumbers = true;
 
     htmlEditor = editorFactory.createFromElement(querySelector('#html-editor'),

--- a/lib/experimental/new_embed.dart
+++ b/lib/experimental/new_embed.dart
@@ -261,9 +261,7 @@ class NewEmbed {
         options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'dart'
-      // TODO(devoncarew): We should make this read-only after initial beta
-      // testing.
-      //..readOnly = true
+      ..readOnly = true
       ..showLineNumbers = true;
 
     solutionEditor = editorFactory.createFromElement(
@@ -271,6 +269,7 @@ class NewEmbed {
         options: codeMirrorOptions)
       ..theme = editorTheme
       ..mode = 'dart'
+      ..readOnly = true
       ..showLineNumbers = true;
 
     htmlEditor = editorFactory.createFromElement(querySelector('#html-editor'),

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -112,6 +112,12 @@ BSD-style license that can be found in the LICENSE file. -->
                         </span>
                         <span class="mdc-list-item__text">Show tests</span>
                     </li>
+                    <li id="editable-test-solution-menu-item" class="mdc-list-item" role="menuitem">
+                        <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
+                            <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                        </span>
+                        <span class="mdc-list-item__text">Editable test/solution</span>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -112,6 +112,12 @@ BSD-style license that can be found in the LICENSE file. -->
                         </span>
                         <span class="mdc-list-item__text">Show tests</span>
                     </li>
+                    <li id="editable-test-solution-menu-item" class="mdc-list-item" role="menuitem">
+                      <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
+                          <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                      </span>
+                      <span class="mdc-list-item__text">Editable test/solution</span>
+                  </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -130,6 +130,12 @@ BSD-style license that can be found in the LICENSE file. -->
                         </span>
                         <span class="mdc-list-item__text">Show tests</span>
                     </li>
+                    <li id="editable-test-solution-menu-item" class="mdc-list-item" role="menuitem">
+                      <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
+                          <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                      </span>
+                      <span class="mdc-list-item__text">Editable test/solution</span>
+                  </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -112,6 +112,12 @@ BSD-style license that can be found in the LICENSE file. -->
                         </span>
                         <span class="mdc-list-item__text">Show tests</span>
                     </li>
+                    <li id="editable-test-solution-menu-item" class="mdc-list-item" role="menuitem">
+                      <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
+                          <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                      </span>
+                      <span class="mdc-list-item__text">Editable test/solution</span>
+                  </li>
                 </ul>
             </div>
         </div>

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -252,7 +252,23 @@ body {
 }
 
 #main-menu {
-  width: 192px;
+  width: 204px;
+
+  .mdc-list-item {
+    height: 40px;
+
+    .mdc-list-item__graphic {
+      margin-right: 8px;
+
+      .mdc-select__icon {
+        font-size: 16px;
+      }
+    }
+
+    .mdc-list-item__text {
+      font-size: 14px;
+    }
+  }
 }
 
 .mdc-tab__content {


### PR DESCRIPTION
I don't see a reason why test and solution tabs have to be editable. So this commit will make both test and solution editors read only.

Note: Also I changed the parameter `nocursor` value to `false` from `true`. Because `nocursor=true` will block the copy functionality also.