### PR TITLE
darken issue label color for light theme

### DIFF
--- a/lib/experimental/scss/colors.scss
+++ b/lib/experimental/scss/colors.scss
@@ -23,7 +23,7 @@ $light-secondary-background-color: #f7f7f7;
 $light-label-color: #586069;
 $light-gutter-background-color: lighten(grey, 45%);
 $light-border-color: $light-gutter-background-color;
-$light-issue-label-color: $light-text-color;
+$light-issue-label-color: darken($light-text-color, 30%);
 $light-flash-info-color: #e7f8ff;
 $light-flash-success-color: #e7fff8;
 $light-flash-warning-color: #fff8e7;

--- a/web/experimental/styles_light.scss
+++ b/web/experimental/styles_light.scss
@@ -68,7 +68,7 @@ a {
 // Flashes
 
 .message-container {
-  color: $light-text-color;
+  color: $light-issue-label-color;
 }
 
 .flash {


### PR DESCRIPTION
before and after:

<img width="600" alt="Screen_Shot_2019-10-14_at_3 52 34_PM" src="https://user-images.githubusercontent.com/1145719/67030885-36324b00-f0c5-11e9-9743-d6c65d52e7be.png">

<img width="413" alt="Screen Shot 2019-10-17 at 9 59 28 AM" src="https://user-images.githubusercontent.com/1145719/67030861-287cc580-f0c5-11e9-8605-3aa2cde875ec.png">
