### PR TITLE
Populate samples when selecting a new Dart / Flutter / HTML project

### DIFF
--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -632,13 +632,14 @@ class Playground implements GistContainer, GistController {
   /// Clears console output, updates the layout if necessary, Called after each
   /// route event.
   Future _finalizeRoute(Layout layout, bool autoRun) async {
-    Uri url = Uri.parse(window.location.toString());
+    var url = Uri.parse(window.location.toString());
     _clearOutput();
     _changeLayout(layout);
-    await _analyzeAndRun(autoRun: autoRun);
     if (url.hasQuery && url.queryParameters['line'] != null) {
       _jumpToLine(int.parse(url.queryParameters['line']));
     }
+
+    await _analyzeAndRun(autoRun: autoRun);
   }
 
   /// Analyzes and runs the gist.  Auto-runs the gist if [autoRun] is true and

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -544,6 +544,10 @@ class Playground implements GistContainer, GistController {
     }
   }
 
+  Future showNewFlutter(RouteEnterEvent event) {
+
+  }
+
   Future showHome(RouteEnterEvent event) async {
     // Don't auto-run if we're re-loading some unsaved edits; the gist might
     // have halting issues (#384).
@@ -554,32 +558,6 @@ class Playground implements GistContainer, GistController {
         url.queryParameters['id'] != null &&
         isLegalGistId(url.queryParameters['id'])) {
       _showGist(url.queryParameters['id']);
-    } else if (url.hasQuery && url.queryParameters['export'] != null) {
-      UuidContainer requestId = UuidContainer()
-        ..uuid = url.queryParameters['export'];
-      Future<PadSaveObject> exportPad =
-          dartSupportServices.pullExportContent(requestId);
-      await exportPad.then((pad) {
-        Gist blankGist = createSampleGist();
-        blankGist.getFile('main.dart').content = pad.dart;
-        blankGist.getFile('index.html').content = pad.html;
-        blankGist.getFile('styles.css').content = pad.css;
-        editableGist.setBackingGist(blankGist);
-      });
-    } else if (url.hasQuery && url.queryParameters['source'] != null) {
-      UuidContainer gistId = await dartSupportServices.retrieveGist(
-          id: url.queryParameters['source']);
-      Gist backing;
-
-      try {
-        backing = await gistLoader.loadGist(gistId.uuid);
-      } catch (ex) {
-        print(ex);
-        backing = Gist();
-      }
-
-      editableGist.setBackingGist(backing);
-      await router.go('gist', {'gist': backing.id});
     } else if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
       loadedFromSaved = true;
 

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -396,7 +396,7 @@ class Playground implements GistContainer, GistController {
     unreadConsoleCounter = Counter(querySelector('#unread-console-counter'));
   }
 
-  Future _initModules() async {
+  Future<void> _initModules() async {
     ModuleManager modules = ModuleManager();
 
     modules.register(DartPadModule());
@@ -562,7 +562,7 @@ class Playground implements GistContainer, GistController {
     }
   }
 
-  Future showNewFlutter() async {
+  Future<void> showNewFlutter() async {
     var loadResult = _loadGist();
     var shouldAutoRun = loadResult == LoadGistResult.storage;
 
@@ -574,7 +574,7 @@ class Playground implements GistContainer, GistController {
     await _finalizeRoute(Layout.dart, shouldAutoRun);
   }
 
-  Future showNewHtml() async {
+  Future<void> showNewHtml() async {
     var loadResult = _loadGist();
     var shouldAutoRun = loadResult == LoadGistResult.storage;
 
@@ -586,7 +586,7 @@ class Playground implements GistContainer, GistController {
     await _finalizeRoute(Layout.dart, shouldAutoRun);
   }
 
-  Future showNewDart() async {
+  Future<void> showNewDart() async {
     var loadResult = _loadGist();
     var shouldAutoRun = loadResult == LoadGistResult.storage;
 
@@ -598,7 +598,7 @@ class Playground implements GistContainer, GistController {
     await _finalizeRoute(Layout.dart, shouldAutoRun);
   }
 
-  Future showHome(RouteEnterEvent event) async {
+  Future<void> showHome(RouteEnterEvent event) async {
     await showNewDart();
   }
 
@@ -631,7 +631,7 @@ class Playground implements GistContainer, GistController {
 
   /// Clears console output, updates the layout if necessary, Called after each
   /// route event.
-  Future _finalizeRoute(Layout layout, bool autoRun) async {
+  Future<void> _finalizeRoute(Layout layout, bool autoRun) async {
     var url = Uri.parse(window.location.toString());
     _clearOutput();
     _changeLayout(layout);
@@ -644,7 +644,7 @@ class Playground implements GistContainer, GistController {
 
   /// Analyzes and runs the gist.  Auto-runs the gist if [autoRun] is true and
   /// the analyzer comes back clean.
-  Future _analyzeAndRun({bool autoRun = false}) {
+  Future<void> _analyzeAndRun({bool autoRun = false}) {
     var completer = Completer();
     Timer.run(() async {
       try {
@@ -835,7 +835,7 @@ class Playground implements GistContainer, GistController {
     });
   }
 
-  Future _format() {
+  Future<void> _format() {
     String originalSource = _context.dartSource;
     SourceRequest input = SourceRequest()..source = originalSource;
     formatButton.disabled = true;
@@ -959,7 +959,7 @@ class Playground implements GistContainer, GistController {
     _overrideNextRouteGist = gist;
   }
 
-  Future _showCreateGistDialog() async {
+  Future<void> _showCreateGistDialog() async {
     var result = await dialog.showOkCancel(
         'Create New Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
@@ -969,7 +969,7 @@ class Playground implements GistContainer, GistController {
     }
   }
 
-  Future _showResetDialog() async {
+  Future<void> _showResetDialog() async {
     var result = await dialog.showOkCancel(
         'Reset Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
@@ -987,7 +987,7 @@ class Playground implements GistContainer, GistController {
   }
 
   @override
-  Future createNewGist() async {
+  Future<void> createNewGist() async {
     _gistStorage.clearStoredGist();
 
     if (ga != null) ga.sendEvent('main', 'new');
@@ -996,7 +996,7 @@ class Playground implements GistContainer, GistController {
     await router.go('gist', {'gist': ''}, forceReload: true);
   }
 
-  Future createGistForLayout(Layout layout) async {
+  Future<void> createGistForLayout(Layout layout) async {
     _gistStorage.clearStoredGist();
 
     if (ga != null) ga.sendEvent('main', 'new');

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -629,7 +629,8 @@ class Playground implements GistContainer, GistController {
     return LoadGistResult.none;
   }
 
-  /// Clears console output, updates the layout if necessary, Called after each route event.
+  /// Clears console output, updates the layout if necessary, Called after each
+  /// route event.
   Future _finalizeRoute(Layout layout, bool autoRun) async {
     Uri url = Uri.parse(window.location.toString());
     _clearOutput();

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -222,7 +222,7 @@ class Playground implements GistContainer, GistController {
       Future<PadSaveObject> exportPad =
           dartSupportServices.pullExportContent(requestId);
       await exportPad.then((pad) {
-        Gist blankGist = createSampleGist();
+        Gist blankGist = createSampleDartGist();
         blankGist.getFile('main.dart').content = pad.dart;
         blankGist.getFile('index.html').content = pad.html;
         blankGist.getFile('styles.css').content = pad.css;
@@ -254,7 +254,7 @@ class Playground implements GistContainer, GistController {
         editableGist.getGistFile(file.name).content = file.content;
       }
     } else {
-      editableGist.setBackingGist(createSampleGist());
+      editableGist.setBackingGist(createSampleDartGist());
     }
 
     _clearOutput();

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -43,13 +43,35 @@ String extractHtmlBody(String html) {
   }
 }
 
-Gist createSampleGist() {
+Gist createSampleDartGist() {
   Gist gist = Gist();
   // "wispy-dust-1337", "patient-king-8872", "purple-breeze-9817"
   gist.description = Haikunator.haikunate();
   gist.files.add(GistFile(name: 'main.dart', content: sample.dartCode));
-  gist.files.add(GistFile(name: 'index.html', content: '\n'));
-  gist.files.add(GistFile(name: 'styles.css', content: '\n'));
+  gist.files.add(GistFile(
+      name: 'readme.md',
+      content: _createReadmeContents(
+          title: gist.description, withLink: _dartpadLink)));
+  return gist;
+}
+
+Gist createSampleWebGist() {
+  Gist gist = Gist();
+  gist.description = Haikunator.haikunate();
+  gist.files.add(GistFile(name: 'main.dart', content: sample.dartCodeHtml));
+  gist.files.add(GistFile(name: 'index.html', content: sample.htmlCode));
+  gist.files.add(GistFile(name: 'styles.css', content: sample.cssCode));
+  gist.files.add(GistFile(
+      name: 'readme.md',
+      content: _createReadmeContents(
+          title: gist.description, withLink: _dartpadLink)));
+  return gist;
+}
+
+Gist createSampleFlutterGist() {
+  Gist gist = Gist();
+  gist.description = Haikunator.haikunate();
+  gist.files.add(GistFile(name: 'main.dart', content: sample.flutterCode));
   gist.files.add(GistFile(
       name: 'readme.md',
       content: _createReadmeContents(

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -55,7 +55,7 @@ Gist createSampleDartGist() {
   return gist;
 }
 
-Gist createSampleWebGist() {
+Gist createSampleHtmlGist() {
   Gist gist = Gist();
   gist.description = Haikunator.haikunate();
   gist.files.add(GistFile(name: 'main.dart', content: sample.dartCodeHtml));

--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -11,3 +11,20 @@ void main() {
   }
 }
 ''';
+
+final String dartCodeHtml = r'''
+// Dart HTML code!
+''';
+
+final String htmlCode = r'''
+/* HTML! */
+''';
+
+final String cssCode = r'''
+
+/* CSS! */
+''';
+
+final String flutterCode = r'''
+// Flutter!
+''';

--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -13,18 +13,114 @@ void main() {
 ''';
 
 final String dartCodeHtml = r'''
-// Dart HTML code!
+import 'dart:html';
+
+void main() {
+  var logo = querySelector('#logo');
+  logo.onClick.listen((_) {
+    if (logo.classes.contains('rotated')) {
+      logo.classes.remove('rotated');
+    } else {
+    logo.classes.add('rotated');
+    }
+  });
+}
 ''';
 
 final String htmlCode = r'''
-/* HTML! */
+<img id="logo" alt="example image" src="https://dartpad.dev/dart-192.png" />
 ''';
 
 final String cssCode = r'''
+body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+p {
+  color: white;
+  font-family: Arial, Helvetica, sans-serif;
+}
+#logo {
+  cursor: pointer;
+  transform: rotate(0deg);
+  transition: transform 400ms ease-in-out;
+}
+#logo.rotated {
+  transform: rotate(360deg);
+}
 
-/* CSS! */
 ''';
 
 final String flutterCode = r'''
-// Flutter!
+import 'package:flutter_web/material.dart';
+import 'package:flutter_web_ui/ui.dart' as ui;
+
+final Color darkBlue = Color.fromARGB(255, 28, 40, 52);
+
+void main() async {
+  await ui.webOnlyInitializePlatform();
+
+  runApp(
+    MaterialApp(
+      theme: ThemeData.dark().copyWith(scaffoldBackgroundColor: darkBlue),
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        body: MyApp(),
+      ),
+    ),
+  );
+}
+
+class MyApp extends StatefulWidget {
+  @override
+  _MyAppState createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
+  AnimationController controller;
+  Animation<double> animation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    controller = AnimationController(
+      duration: Duration(milliseconds: 700),
+      vsync: this,
+    );
+
+    animation = CurvedAnimation(
+      parent: controller,
+      curve: Curves.easeInOutCubic,
+    ).drive(Tween(begin: 0, end: 1));
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        controller
+          ..reset()
+          ..forward();
+      },
+      child: Center(
+        child: RotationTransition(
+          turns: animation,
+          child: FlutterLogo(size: 192),
+        ),
+      ),
+    );
+  }
+}
 ''';

--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -16,19 +16,14 @@ final String dartCodeHtml = r'''
 import 'dart:html';
 
 void main() {
-  var logo = querySelector('#logo');
-  logo.onClick.listen((_) {
-    if (logo.classes.contains('rotated')) {
-      logo.classes.remove('rotated');
-    } else {
-    logo.classes.add('rotated');
-    }
-  });
+  var header = querySelector('#header');
+  header.text = "Hello, World!";
 }
+
 ''';
 
 final String htmlCode = r'''
-<img id="logo" alt="example image" src="https://dartpad.dev/dart-192.png" />
+<h1 id="header"></h1>
 ''';
 
 final String cssCode = r'''
@@ -41,17 +36,10 @@ body {
   width: 100%;
   height: 100%;
 }
-p {
+
+h1 {
   color: white;
   font-family: Arial, Helvetica, sans-serif;
-}
-#logo {
-  cursor: pointer;
-  transform: rotate(0deg);
-  transition: transform 400ms ease-in-out;
-}
-#logo.rotated {
-  transform: rotate(360deg);
 }
 
 ''';
@@ -62,65 +50,31 @@ import 'package:flutter_web_ui/ui.dart' as ui;
 
 final Color darkBlue = Color.fromARGB(255, 28, 40, 52);
 
-void main() async {
+Future main() async {
   await ui.webOnlyInitializePlatform();
+  runApp(MyApp());
+}
 
-  runApp(
-    MaterialApp(
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
       theme: ThemeData.dark().copyWith(scaffoldBackgroundColor: darkBlue),
       debugShowCheckedModeBanner: false,
       home: Scaffold(
-        body: MyApp(),
-      ),
-    ),
-  );
-}
-
-class MyApp extends StatefulWidget {
-  @override
-  _MyAppState createState() => _MyAppState();
-}
-
-class _MyAppState extends State<MyApp> with SingleTickerProviderStateMixin {
-  AnimationController controller;
-  Animation<double> animation;
-
-  @override
-  void initState() {
-    super.initState();
-
-    controller = AnimationController(
-      duration: Duration(milliseconds: 700),
-      vsync: this,
-    );
-
-    animation = CurvedAnimation(
-      parent: controller,
-      curve: Curves.easeInOutCubic,
-    ).drive(Tween(begin: 0, end: 1));
-  }
-
-  @override
-  void dispose() {
-    controller.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: () {
-        controller
-          ..reset()
-          ..forward();
-      },
-      child: Center(
-        child: RotationTransition(
-          turns: animation,
-          child: FlutterLogo(size: 192),
+        body: Center(
+          child: MyWidget(),
         ),
       ),
     );
   }
 }
+
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Text('Hello, World!', style: Theme.of(context).textTheme.display1);
+  }
+}
+
 ''';

--- a/test/sharing/gists_test.dart
+++ b/test/sharing/gists_test.dart
@@ -116,7 +116,7 @@ void defineTests() {
   group('GistStorage', () {
     test('store', () {
       GistStorage storage = GistStorage();
-      storage.setStoredGist(createSampleGist());
+      storage.setStoredGist(createSampleDartGist());
       expect(storage.hasStoredGist, true);
       expect(storage.getStoredGist(), isNotNull);
       expect(storage.storedId, null);
@@ -124,7 +124,7 @@ void defineTests() {
 
     test('clear', () {
       GistStorage storage = GistStorage();
-      storage.setStoredGist(createSampleGist());
+      storage.setStoredGist(createSampleDartGist());
       expect(storage.hasStoredGist, true);
       storage.clearStoredGist();
       expect(storage.hasStoredGist, false);


### PR DESCRIPTION
This adds three new routes, `/flutter`, `/dart`, and `/html`. Each route will populate the editor with sample code if there's no backing gist. When the user selects a type from the new-pad dialog, the app re-routes and the sample is shown.

As far as I can tell, routing only works when the app is deployed and new_playground.html replaces index.html, so this won't be fully tested until #1351 is merged

closes #1326 
