### PR TITLE
UI updates

### DIFF
--- a/lib/experimental/scss/colors.scss
+++ b/lib/experimental/scss/colors.scss
@@ -11,9 +11,10 @@ $squiggle-warning-color: #FFF79A;
 $squiggle-info-color: #7EA7D8;
 
 // Playground
-$playground-background-color: #1c2834;
+$playground-background-color: #12202f;
 $playground-text-color: #fff;
 $playground-link-color: #ccc;
+$playground-header-background-color: #1c2834;
 $playground-footer-background-color: #27323a;
 
 $light-text-color: #808080;

--- a/lib/experimental/scss/shared.scss
+++ b/lib/experimental/scss/shared.scss
@@ -27,6 +27,9 @@
 #flash-container {
   width: 380px;
   z-index: 10;
+  bottom: 40px;
+  right: 8px;
+  position: fixed;
 }
 
 #issues-container {

--- a/lib/experimental/scss/shared.scss
+++ b/lib/experimental/scss/shared.scss
@@ -144,6 +144,20 @@
   }
 }
 
+// Misc
+.view-label {
+  font-family: $editor-font;
+  font-size: $embed-editor-font-size;
+  color: $label-color;
+  &.absolute {
+    position: absolute;
+    left: 0;
+    top: 0;
+    margin-top: 8px;
+    margin-left: 8px;
+  }
+}
+
 // ie support for hidden
 html [hidden] {
   display: none !important;

--- a/lib/experimental/scss/variables.scss
+++ b/lib/experimental/scss/variables.scss
@@ -1,5 +1,8 @@
+@import url(//fonts.googleapis.com/css?family=Google+Sans);
+
 $editor-font: 'Roboto Mono', monospace;
 $normal-font: 'Roboto', sans-serif;
+$google-sans: 'Google Sans', 'Roboto', sans-serif;
 $embed-editor-font-size: 12px;
 $playground-editor-font-size: 14px;
 $border-width: 6px;
@@ -12,4 +15,5 @@ $border-width: 6px;
   padding: 0;
   font: inherit;
   cursor: pointer;
-  outline: inherit;}
+  outline: inherit;
+}

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -89,6 +89,7 @@ class Playground implements GistContainer, GistController {
   MDCButton editorDocsTab;
   MDCButton closePanelButton;
   MDCButton moreMenuButton;
+  DElement editorPanelHeader;
   DElement editorPanelFooter;
   MDCMenu samplesMenu;
   MDCMenu moreMenu;
@@ -97,6 +98,7 @@ class Playground implements GistContainer, GistController {
   DElement titleElement;
   MaterialTabController webLayoutTabController;
   DElement webTabBar;
+  DElement webOutputLabel;
 
   Splitter splitter;
   Splitter rightSplitter;
@@ -129,6 +131,7 @@ class Playground implements GistContainer, GistController {
       _initGistStorage();
       _initLayoutDetection();
       _initButtons();
+      _initLabels();
       _initSamplesMenu();
       _initMoreMenu();
       _initSplitters();
@@ -140,10 +143,13 @@ class Playground implements GistContainer, GistController {
 
   DivElement get _editorHost => querySelector('#editor-host');
   DivElement get _rightConsoleElement => querySelector('#right-output-panel');
+  DivElement get _rightConsoleContentElement => querySelector('#right-output-panel-content');
   DivElement get _leftConsoleElement => querySelector('#left-output-panel');
   IFrameElement get _frame => querySelector('#frame');
   DivElement get _rightDocPanel => querySelector('#right-doc-panel');
+  DivElement get _rightDocContentElement => querySelector('#right-doc-panel-content');
   DivElement get _leftDocPanel => querySelector('#left-doc-panel');
+  DivElement get _editorPanelHeader => querySelector('#editor-panel-header');
   DivElement get _editorPanelFooter => querySelector('#editor-panel-footer');
   bool get _isCompletionActive => editor.completionActive;
 
@@ -214,6 +220,13 @@ class Playground implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => _showKeyboardDialog());
+  }
+
+  void _initLabels() {
+    var webOutputLabelElement = querySelector('#web-output-label');
+    if (webOutputLabelElement != null) {
+      webOutputLabel = DElement(webOutputLabelElement);
+    }
   }
 
   void _initSamplesMenu() {
@@ -368,13 +381,14 @@ class Playground implements GistContainer, GistController {
   }
 
   void _initLayout() {
+    editorPanelHeader = DElement (_editorPanelHeader);
     editorPanelFooter = DElement(_editorPanelFooter);
     _changeLayout(Layout.dart);
   }
 
   void _initConsoles() {
     _leftConsole = Console(DElement(_leftConsoleElement));
-    _rightConsole = Console(DElement(_rightConsoleElement));
+    _rightConsole = Console(DElement(_rightConsoleContentElement));
     unreadConsoleCounter = Counter(querySelector('#unread-console-counter'));
   }
 
@@ -412,7 +426,7 @@ class Playground implements GistContainer, GistController {
     keys.bind(['ctrl-enter'], _handleRun, 'Run');
     keys.bind(['f1'], () {
       ga.sendEvent('main', 'help');
-      docHandler.generateDoc(_rightDocPanel);
+      docHandler.generateDoc(_rightDocContentElement);
       docHandler.generateDoc(_leftDocPanel);
     }, 'Documentation');
 
@@ -434,7 +448,7 @@ class Playground implements GistContainer, GistController {
     document.onKeyUp.listen((e) {
       if (editor.completionActive ||
           DocHandler.cursorKeys.contains(e.keyCode)) {
-        docHandler.generateDoc(_rightDocPanel);
+        docHandler.generateDoc(_rightDocContentElement);
         docHandler.generateDoc(_leftDocPanel);
       }
       _handleAutoCompletion(e);
@@ -470,7 +484,7 @@ class Playground implements GistContainer, GistController {
       // Delay to give codemirror time to process the mouse event.
       Timer.run(() {
         if (!_context.cursorPositionIsWhitespace()) {
-          docHandler.generateDoc(_rightDocPanel);
+          docHandler.generateDoc(_rightDocContentElement);
           docHandler.generateDoc(_leftDocPanel);
         }
       });
@@ -758,6 +772,7 @@ class Playground implements GistContainer, GistController {
       _showOutput('Error compiling to JavaScript:\n$message', error: true);
     } finally {
       runButton.disabled = false;
+      webOutputLabel.setAttr('hidden');
     }
   }
 
@@ -895,6 +910,8 @@ class Playground implements GistContainer, GistController {
       webTabBar.setAttr('hidden');
       webLayoutTabController.selectTab('dart');
       _initRightSplitter();
+      editorPanelHeader.setAttr('hidden');
+      webOutputLabel.setAttr('hidden');
     } else if (layout == Layout.html) {
       _disposeRightSplitter();
       _frame.hidden = false;
@@ -904,6 +921,8 @@ class Playground implements GistContainer, GistController {
       _rightConsoleElement.setAttribute('hidden', '');
       webTabBar.toggleAttr('hidden', false);
       webLayoutTabController.selectTab('dart');
+      editorPanelHeader.clearAttr('hidden');
+      webOutputLabel.setAttr('hidden');
     } else if (layout == Layout.flutter) {
       _disposeRightSplitter();
       _frame.hidden = false;
@@ -913,6 +932,8 @@ class Playground implements GistContainer, GistController {
       _rightConsoleElement.setAttribute('hidden', '');
       webTabBar.setAttr('hidden');
       webLayoutTabController.selectTab('dart');
+      editorPanelHeader.setAttr('hidden');
+      webOutputLabel.clearAttr('hidden');
     }
   }
 

--- a/lib/new_playground.dart
+++ b/lib/new_playground.dart
@@ -1220,7 +1220,7 @@ class NewPadDialog {
       _flutterButton.root.classes.remove('selected');
       _dartButton.root.classes.add('selected');
       _createButton.toggleAttr('disabled', false);
-      _htmlSwitchContainer.toggleAttr('hidden', false);
+      _htmlSwitchContainer.toggleClass('hide', false);
       _htmlSwitch.disabled = false;
     });
 
@@ -1228,7 +1228,7 @@ class NewPadDialog {
       _dartButton.root.classes.remove('selected');
       _flutterButton.root.classes.add('selected');
       _createButton.toggleAttr('disabled', false);
-      _htmlSwitchContainer.toggleAttr('hidden', true);
+      _htmlSwitchContainer.toggleClass('hide', true);
     });
 
     var cancelSub = _cancelButton.onClick.listen((_) {

--- a/test/experimental/new_embed_test.html
+++ b/test/experimental/new_embed_test.html
@@ -152,7 +152,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="web-output">
-        <span id="web-output-label" class="position-absolute view-label">UI Output</span>
+        <span id="web-output-label" class="view-label">UI Output</span>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">
         </iframe>
     </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -151,7 +151,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="web-output">
-        <span id="web-output-label" class="position-absolute view-label">UI Output</span>
+        <span id="web-output-label" class="view-label">UI Output</span>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">
         </iframe>
     </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -175,7 +175,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="web-output">
-        <span id="web-output-label" class="position-absolute view-label">UI Output</span>
+        <span id="web-output-label" class="view-label">UI Output</span>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">
         </iframe>
     </div>

--- a/web/experimental/embed-new-flutter.html
+++ b/web/experimental/embed-new-flutter.html
@@ -141,7 +141,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="web-output">
-        <span id="web-output-label" class="position-absolute view-label">UI Output</span>
+        <span id="web-output-label" class="view-label">UI Output</span>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">
         </iframe>
     </div>

--- a/web/experimental/embed-new-html.html
+++ b/web/experimental/embed-new-html.html
@@ -166,7 +166,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </div>
     <div id="web-output">
-        <span id="web-output-label" class="position-absolute view-label">UI Output</span>
+        <span id="web-output-label" class="view-label absolute">UI Output</span>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">
         </iframe>
     </div>

--- a/web/experimental/new_playground/styles.scss
+++ b/web/experimental/new_playground/styles.scss
@@ -24,7 +24,7 @@ body {
 }
 
 header {
-  background-color: $dark-gutter-background-color;
+  background-color: $playground-header-background-color;
   height: 48px;
   padding-left: 24px;
   @include layout-center;

--- a/web/experimental/new_playground/styles.scss
+++ b/web/experimental/new_playground/styles.scss
@@ -32,7 +32,9 @@ header {
   .header-title {
     @include layout;
     @include layout-center;
-    font-size: 24px;
+    font-family: $google-sans;
+    font-weight: 400;
+    font-size: 16pt;
     margin-right: 8px;
 
     img.logo {

--- a/web/experimental/new_playground/styles.scss
+++ b/web/experimental/new_playground/styles.scss
@@ -275,11 +275,6 @@ a {
   }
 }
 
-.mdc-button {
-  text-transform: none !important;
-  letter-spacing: normal;
-}
-
 .editor-tab {
   @include mdc-button-ink-color(#f8f9fa);
   text-transform: none !important;
@@ -464,10 +459,27 @@ a {
 }
 
 #new-pad-dialog {
+  @include mdc-dialog-content-ink-color(white, 1.0);
+
   .mdc-dialog__content {
     @include layout-horizontal;
+    @include layout-start;
+    @include layout-around-justified;
+  }
+
+  .divider {
+    width: 1px;
+    height: 200px;
+    background-color: #2e3742;
+  }
+
+  .dart-container {
+    @include layout-vertical;
     @include layout-center;
-    @include layout-justified;
+
+    #new-pad-html-switch-container {
+      margin-top: 8px;
+    }
   }
 
   .select-project-button {
@@ -485,7 +497,8 @@ a {
     @include layout-center;
     img {
       width: auto;
-      max-height: 192px;
+      max-height: 120px;
+      margin-bottom: 16px;
     }
   }
 

--- a/web/experimental/new_playground/styles.scss
+++ b/web/experimental/new_playground/styles.scss
@@ -12,6 +12,9 @@ $mdc-theme-background: $playground-background-color;
 $mdc-theme-surface: $playground-background-color;
 $mdc-theme-error: $dark-red;
 
+// Layout constants
+$doc-console-padding: 8px 24px 8px 24px;
+
 @import 'package:mdc_web/material-components-web';
 
 body {
@@ -28,6 +31,7 @@ header {
   height: 48px;
   padding-left: 24px;
   @include layout-center;
+  z-index: 4;
 
   .header-title {
     @include layout;
@@ -139,11 +143,13 @@ a {
 // Editor panel
 #editor-panel {
   @include layout-vertical;
+  @include layout-relative;
 }
 
 #editor-host {
   @include layout-vertical;
   @include layout-flex;
+  margin: 8px 0 0 16px;
   padding: 0 8px;
 
   .CodeMirror {
@@ -160,10 +166,16 @@ a {
   padding: 4px;
   height: 48px;
 
-  .button-group {
-    @include layout-horizontal;
-    @include layout-center;
-  }
+}
+
+.button-group {
+  @include layout-horizontal;
+  @include layout-center;
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 8px 24px 0 0;
+  z-index: 5;
 }
 
 // Console
@@ -171,10 +183,33 @@ a {
 #output-panel {
   @include layout-flex;
   @include layout-vertical;
+  @include layout-relative;
 
   iframe {
     @include layout-flex;
     border: none;
+  }
+}
+
+#right-output-panel {
+  @include layout;
+  @include layout-vertical;
+  #right-output-panel-content {
+    @include layout-flex;
+  }
+  .view-label {
+    margin: 8px;
+  }
+}
+
+#right-doc-panel {
+  @include layout;
+  @include layout-vertical;
+  #right-doc-panel-content {
+    @include layout-flex;
+  }
+  .view-label {
+    margin: 8px;
   }
 }
 
@@ -186,7 +221,7 @@ a {
   min-height: 50px;
   overflow-y: auto;
   white-space: pre-wrap;
-  margin: 16px;
+  padding: $doc-console-padding;
 
   .normal {
     color: $dark-editor-text;
@@ -264,7 +299,7 @@ a {
   @include layout-horizontal;
   @include layout-center;
   @include layout-justified;
-  padding: 4px;
+  padding-left: 8px;
 
   button {
     margin-right: 8px;
@@ -304,7 +339,6 @@ a {
   @include mdc-icon-button-size(16px, 16px, 8px);
 }
 
-// TODO(ryjohn): rename - conflicts with editor-tab-host
 #editor-panel-tab-host {
   @include layout-flex;
   @include layout-vertical;
@@ -314,9 +348,8 @@ a {
 }
 
 // documentation and parameter info styling
-
 .documentation {
-  padding: 8px;
+  padding: $doc-console-padding;
   font-family: 'Roboto', sans-serif;
   font-size: 11pt;
   line-height: 20px;

--- a/web/experimental/new_playground/styles.scss
+++ b/web/experimental/new_playground/styles.scss
@@ -360,10 +360,13 @@ a {
   margin-top: 0;
   margin-left: 0;
 
+  * {
+    color: $dark-editor-text;
+  }
   h1 {
     margin-top: 0;
     font-size: 12pt;
-    color: $dark-comment;
+    color: $dark-blue;
   }
 
   h2 {
@@ -403,7 +406,7 @@ a {
   code, .parameter-hints code {
     font-family: $editor-font;
     font-size: 12pt;
-    color: $dark-comment;
+    color: $dark-blue;
   }
   code em {
     color: $dark-orange;

--- a/web/experimental/styles.scss
+++ b/web/experimental/styles.scss
@@ -293,11 +293,7 @@ body {
 }
 
 // Misc
-
 .view-label {
-  font-family: $editor-font;
-  font-size: $embed-editor-font-size;
-  color: $label-color;
   margin-left: 8px;
 }
 

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -54,7 +54,8 @@
 </head>
 
 <body>
-<header>
+
+<header class="mdc-elevation--z4">
     <div class="header-title">
         <img src="dart-192.png" alt="DartPad Logo" class="logo"/>
         <span>DartPad</span>

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -110,7 +110,7 @@
     <div class="splash"></div>
     <div class="panels">
         <div id="editor-panel">
-            <div class="header">
+            <div id="editor-panel-header" class="header">
                 <nav>
                     <div id="web-tab-bar" class="mdc-tab-bar" role="tablist">
                         <div class="mdc-tab-scroller">
@@ -154,14 +154,14 @@
                         </div>
                     </div>
                 </nav>
-                <div class="button-group">
-                    <div id="dartbusy" class="busylight"></div>
-                    <button type="button" id="run-button"
-                            class="mdc-button mdc-button--raised mdc-button--dense">
-                        <i class="material-icons mdc-button__icon">play_arrow</i>
-                        Run
-                    </button>
-                </div>
+            </div>
+            <div class="button-group">
+                <div id="dartbusy" class="busylight"></div>
+                <button type="button" id="run-button"
+                        class="mdc-button mdc-button--raised mdc-button--dense">
+                    <i class="material-icons mdc-button__icon">play_arrow</i>
+                    Run
+                </button>
             </div>
             <div id="editor-host"></div>
             <div id="editor-panel-footer" class="editor-tab-host border-top">
@@ -182,16 +182,27 @@
                     </button>
                 </div>
                 <div id="editor-panel-tab-host">
-                    <div id="left-output-panel" class="console"></div>
-                    <div id="left-doc-panel" class="documentation"></div>
+                    <div id="left-output-panel" class="console">
+                        <span id="left-output-label" class="view-label">Console</span>
+                    </div>
+                    <div id="left-doc-panel" class="documentation">
+                        <span id="left-doc-label" class="view-label">Documentation</span>
+                    </div>
                 </div>
             </div>
         </div>
         <div id="output-panel">
+            <span id="web-output-label" class="view-label absolute">UI Output</span>
             <iframe id="frame" sandbox="allow-scripts" flex
                     src="scripts/frame.html"></iframe>
-            <div id="right-output-panel" class="console"></div>
-            <div id="right-doc-panel" class="documentation"></div>
+            <div id="right-output-panel">
+                <span class="view-label">Console</span>
+                <div id="right-output-panel-content" class="console"></div>
+            </div>
+            <div id="right-doc-panel">
+                <span id="right-doc-label" class="view-label">Documentation</span>
+                <div id="right-doc-panel-content" class="documentation"></div>
+            </div>
         </div>
     </div>
     <div class="mdc-snackbar">

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -272,10 +272,27 @@
         <div class="mdc-dialog__surface">
             <h2 class="mdc-dialog__title">New Pad</h2>
             <div class="mdc-dialog__content">
-                <div id="new-pad-select-dart" class="select-project-button mdc-ripple-surface mdc-ripple-surface--primary">
-                    <img src="/pictures/logo_dart.png"/>
-                    <span>Dart</span>
+                <div class="dart-container">
+                    <div id="new-pad-select-dart" class="select-project-button mdc-ripple-surface mdc-ripple-surface--primary">
+                        <img src="/pictures/logo_dart.png"/>
+                        <span>Dart</span>
+                    </div>
+                    <div id="new-pad-html-switch-container" class="hide">
+                        <div class="mdc-switch mdc-switch--disabled">
+                            <div class="mdc-switch__track"></div>
+                            <div class="mdc-switch__thumb-underlay">
+                                <div class="mdc-switch__thumb">
+                                    <input type="checkbox"
+                                           id="new-pad-html-switch"
+                                           class="mdc-switch__native-control"
+                                           role="switch">
+                                </div>
+                            </div>
+                        </div>
+                        <label for="new-pad-html-switch">HTML</label>
+                    </div>
                 </div>
+                <div class="divider"></div>
                 <div id="new-pad-select-flutter" class="select-project-button mdc-ripple-surface mdc-ripple-surface--primary">
                     <img src="/pictures/logo_flutter.png"/>
                     <span>Flutter</span>
@@ -283,20 +300,7 @@
             </div>
 
             <footer class="mdc-dialog__actions">
-                <div id="new-pad-html-switch-container" hidden>
-                    <div class="mdc-switch mdc-switch--disabled">
-                        <div class="mdc-switch__track"></div>
-                        <div class="mdc-switch__thumb-underlay">
-                            <div class="mdc-switch__thumb">
-                                <input type="checkbox"
-                                       id="new-pad-html-switch"
-                                       class="mdc-switch__native-control"
-                                       role="switch">
-                            </div>
-                        </div>
-                    </div>
-                    <label for="new-pad-html-switch">HTML</label>
-                </div>
+
                 <button type="button" id="new-pad-cancel-button"
                         class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Cancel</span>

--- a/web/new_playground.html
+++ b/web/new_playground.html
@@ -15,9 +15,6 @@
 
     <title>DartPad</title>
 
-    <!-- primer (used for layout) -->
-    <link rel="stylesheet" type="text/css" href="packages/primer_css/primer_12.1.0.css">
-
     <!-- styles -->
     <link href="experimental/new_playground/styles.css" rel="stylesheet" media="screen">
 
@@ -82,7 +79,7 @@
         </button>
         <div id="samples-menu" class="mdc-menu mdc-menu-surface"></div>
     </div>
-    <div class="position-relative text-right pr-2">
+    <div>
         <button id="more-menu-button" class="mdc-icon-button material-icons">
             more_vert
         </button>
@@ -213,7 +210,7 @@
             </div>
         </div>
     </div>
-    <div id="flash-container" class="position-fixed right-2 bottom-6">
+    <div id="flash-container">
         <div id="analysis-result-box" class="flash flash-error" hidden>
             <button class="flash-close">
                 <div class="octicon octicon-x"></div>


### PR DESCRIPTION
- Update header and background color to match design
- Use Google Sans for the title - this doesn't *exactly* match the design, the font is thicker than it should be, but I couldn't figure out how to use a lighter version of Google Sans.
- Updates to the "new pad" dialog to match the design
  - moves the HTML switch underneath the Dart project type. It might not be necessary to hide and show it anymore, but I left that as-is.
- small tweaks to alignment of the code editor and docs / console panel
- removes primer.css from the playground. It is still used in the embeds for some layout pieces. It was adding unwanted styles to `<ul>` and `<li>` elements.
- updates the colors and formatting for the docs panel. 
