### PR TITLE
Firefox Flex Fix

### DIFF
--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -216,6 +216,7 @@ body {
   width: 100%;
   height: 100%;
   display: flex;
+  overflow: hidden;
 }
 
 // Footer


### PR DESCRIPTION
Added rule to prevent console from overflowing in Firefox when code length requires a vertical scrollbar

closes #1398