### PR TITLE
Adding new query param and tests

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -463,11 +463,19 @@ class Embed {
 
   // An optional channel indicating which version of the API Docs to use when
   // loading a sample.
-  //
-  // If this value is "master", the sample will be loaded from the master API
-  // Doc server. All other values will result in a sample loaded from the stable
-  // server (api.flutter.dev).
-  String get sampleChannel => _getQueryParam('sample_channel');
+  FlutterSdkChannel get sampleChannel {
+    final channelStr = _getQueryParam('sample_channel')?.toLowerCase();
+
+    if (channelStr == 'master') {
+      return FlutterSdkChannel.master;
+    } else if (channelStr == 'dev') {
+      return FlutterSdkChannel.dev;
+    } else if (channelStr == 'beta') {
+      return FlutterSdkChannel.beta;
+    } else {
+      return FlutterSdkChannel.stable;
+    }
+  }
 
   // GitHub params for loading an exercise from a repo. The first three are
   // required to load something, while the fourth, gh_ref, is an optional branch
@@ -581,8 +589,12 @@ class Embed {
       if (gistId.isNotEmpty) {
         gist = await loader.loadGist(gistId);
       } else if (sampleId.isNotEmpty) {
-        final useMaster = sampleChannel?.toLowerCase() == 'master';
-        gist = await loader.loadGistFromAPIDocs(sampleId, useMaster);
+        // Right now, there are only two hosted versions of the docs: master and
+        // stable. Default to stable for dev and beta.
+        final channel = (sampleChannel == FlutterSdkChannel.master)
+            ? FlutterSdkChannel.master
+            : FlutterSdkChannel.stable;
+        gist = await loader.loadGistFromAPIDocs(sampleId, channel);
       } else {
         gist = await loader.loadGistFromRepo(
           owner: githubOwner,

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -462,7 +462,7 @@ class Embed {
   String get sampleId => _getQueryParam('sample_id');
 
   // An optional channel indicating which version of the API Docs to use when
-  // loading a sample.
+  // loading a sample. Defaults to the stable channel.
   FlutterSdkChannel get sampleChannel {
     final channelStr = _getQueryParam('sample_channel')?.toLowerCase();
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -461,6 +461,14 @@ class Embed {
   // ID of an API Doc sample that should be loaded into the editors.
   String get sampleId => _getQueryParam('sample_id');
 
+  // An optional channel indicating which version of the API Docs to use when
+  // loading a sample.
+  //
+  // If this value is "master", the sample will be loaded from the master API
+  // Doc server. All other values will result in a sample loaded from the stable
+  // server (api.flutter.dev).
+  String get sampleChannel => _getQueryParam('sample_channel');
+
   // GitHub params for loading an exercise from a repo. The first three are
   // required to load something, while the fourth, gh_ref, is an optional branch
   // name or commit SHA.
@@ -573,7 +581,8 @@ class Embed {
       if (gistId.isNotEmpty) {
         gist = await loader.loadGist(gistId);
       } else if (sampleId.isNotEmpty) {
-        gist = await loader.loadGistFromAPIDocs(sampleId);
+        final useMaster = sampleChannel?.toLowerCase() == 'master';
+        gist = await loader.loadGistFromAPIDocs(sampleId, useMaster);
       } else {
         gist = await loader.loadGistFromRepo(
           owner: githubOwner,
@@ -855,8 +864,7 @@ class Embed {
 
     try {
       formatButton.disabled = true;
-      var result =
-          await dartServices.format(input).timeout(serviceCallTimeout);
+      var result = await dartServices.format(input).timeout(serviceCallTimeout);
 
       formatButton.disabled = false;
 

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -20,6 +20,13 @@ final String _dartpadLink =
 
 final RegExp _gistRegex = RegExp(r'^[0-9a-f]+$');
 
+enum FlutterSdkChannel {
+  master,
+  dev,
+  beta,
+  stable,
+}
+
 /// Return whether the given string is a valid github gist ID.
 bool isLegalGistId(String id) {
   if (id == null) return false;
@@ -225,8 +232,13 @@ $styleRef$dartRef  </head>
     return gist;
   }
 
-  Future<Gist> loadGistFromAPIDocs(String sampleId, bool useMaster) async {
-    final sampleUrl = useMaster
+  Future<Gist> loadGistFromAPIDocs(
+      String sampleId, FlutterSdkChannel channel) async {
+    if (channel == FlutterSdkChannel.beta || channel == FlutterSdkChannel.dev) {
+      throw ArgumentError('Only stable and master channels are supported!');
+    }
+
+    final sampleUrl = (channel == FlutterSdkChannel.master)
         ? '$_masterApiDocsUrl/$sampleId.dart'
         : '$_stableApiDocsUrl/$sampleId.dart';
 

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -118,7 +118,9 @@ class GistLoader {
   static const String _repoContentsAuthority = 'api.github.com';
   static const String _metadataFilename = 'dartpad_metadata.yaml';
 
-  static const String _apiDocsUrl = 'https://api.flutter.dev/snippets';
+  static const String _stableApiDocsUrl = 'https://api.flutter.dev/snippets';
+  static const String _masterApiDocsUrl =
+      'https://master-api.flutter.dev/snippets';
 
   static final GistFilterHook _defaultLoadHook = (Gist gist) {
     // Update files based on our preferred file names.
@@ -223,8 +225,12 @@ $styleRef$dartRef  </head>
     return gist;
   }
 
-  Future<Gist> loadGistFromAPIDocs(String sampleId) async {
-    final response = await _client.get('$_apiDocsUrl/$sampleId.dart');
+  Future<Gist> loadGistFromAPIDocs(String sampleId, bool useMaster) async {
+    final sampleUrl = useMaster
+        ? '$_masterApiDocsUrl/$sampleId.dart'
+        : '$_stableApiDocsUrl/$sampleId.dart';
+
+    final response = await _client.get(sampleUrl);
 
     if (response.statusCode == 404) {
       throw const GistLoaderException(GistLoaderFailureType.contentNotFound);

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -94,15 +94,15 @@ void defineTests() {
     group('Loading by sample ID', () {
       test('Returns stable version gist for stable sample id', () async {
         final loader = GistLoader(client: mockClient);
-        final gist =
-            await loader.loadGistFromAPIDocs('material.AppBar.1', false);
+        final gist = await loader.loadGistFromAPIDocs(
+            'material.AppBar.1', FlutterSdkChannel.stable);
         final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
         expect(contents.content, stableAPIDocSample);
       });
       test('Returns master version gist for master sample id', () async {
         final loader = GistLoader(client: mockClient);
-        final gist =
-            await loader.loadGistFromAPIDocs('material.AppBar.1', true);
+        final gist = await loader.loadGistFromAPIDocs(
+            'material.AppBar.1', FlutterSdkChannel.master);
         final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
         expect(contents.content, masterAPIDocSample);
       });

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -17,7 +17,9 @@ void defineTests() {
         case 'https://api.github.com/gists/12345678901234567890123456789012':
           return Future.value(http.Response(validGist, 200));
         case 'https://api.flutter.dev/snippets/material.AppBar.1.dart':
-          return Future.value(http.Response(validSample, 200));
+          return Future.value(http.Response(stableAPIDocSample, 200));
+        case 'https://master-api.flutter.dev/snippets/material.AppBar.1.dart':
+          return Future.value(http.Response(masterAPIDocSample, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.yaml':
           return Future.value(http.Response(basicDartMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad_metadata.yaml?ref=some_branch':
@@ -90,11 +92,19 @@ void defineTests() {
       });
     });
     group('Loading by sample ID', () {
-      test('Returns valid gist for valid sample id', () async {
+      test('Returns stable version gist for stable sample id', () async {
         final loader = GistLoader(client: mockClient);
-        final gist = await loader.loadGistFromAPIDocs('material.AppBar.1');
+        final gist =
+            await loader.loadGistFromAPIDocs('material.AppBar.1', false);
         final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
-        expect(contents.content, processedSample);
+        expect(contents.content, stableAPIDocSample);
+      });
+      test('Returns master version gist for master sample id', () async {
+        final loader = GistLoader(client: mockClient);
+        final gist =
+            await loader.loadGistFromAPIDocs('material.AppBar.1', true);
+        final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
+        expect(contents.content, masterAPIDocSample);
       });
       test('Throws correct exception for nonexistent sample', () async {
         final loader = GistLoader(client: mockClient);
@@ -261,169 +271,10 @@ final validGist = '''
 }
 ''';
 
-final validSample = '''
-// Flutter code sample for
-
-// This sample shows an [AppBar] with two simple actions. The first action
-// opens a [SnackBar], while the second action navigates to a new page.
-
-import 'package:flutter/material.dart';
-
-void main() => runApp(MyApp());
-
-/// This Widget is the main application widget.
-class MyApp extends StatelessWidget {
-  static const String _title = 'Flutter Code Sample';
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: _title,
-      home: MyStatelessWidget(),
-    );
-  }
-}
-
-final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-final SnackBar snackBar = const SnackBar(content: Text('Showing Snackbar'));
-
-void openPage(BuildContext context) {
-  Navigator.push(context, MaterialPageRoute(
-    builder: (BuildContext context) {
-      return Scaffold(
-        appBar: AppBar(
-          title: const Text('Next page'),
-        ),
-        body: const Center(
-          child: Text(
-            'This is the next page',
-            style: TextStyle(fontSize: 24),
-          ),
-        ),
-      );
-    },
-  ));
-}
-
-/// This is the stateless widget that the main application instantiates.
-class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('AppBar Demo'),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.add_alert),
-            tooltip: 'Show Snackbar',
-            onPressed: () {
-              scaffoldKey.currentState.showSnackBar(snackBar);
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.navigate_next),
-            tooltip: 'Next page',
-            onPressed: () {
-              openPage(context);
-            },
-          ),
-        ],
-      ),
-      body: const Center(
-        child: Text(
-          'This is the home page',
-          style: TextStyle(fontSize: 24),
-        ),
-      ),
-    );
-  }
-}
-''';
-
-final processedSample = '''
-// Flutter code sample for
-
-// This sample shows an [AppBar] with two simple actions. The first action
-// opens a [SnackBar], while the second action navigates to a new page.
-
-import 'package:flutter/material.dart';
-
-void main() => runApp(MyApp());
-
-/// This Widget is the main application widget.
-class MyApp extends StatelessWidget {
-  static const String _title = 'Flutter Code Sample';
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: _title,
-      home: MyStatelessWidget(),
-    );
-  }
-}
-
-final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-final SnackBar snackBar = const SnackBar(content: Text('Showing Snackbar'));
-
-void openPage(BuildContext context) {
-  Navigator.push(context, MaterialPageRoute(
-    builder: (BuildContext context) {
-      return Scaffold(
-        appBar: AppBar(
-          title: const Text('Next page'),
-        ),
-        body: const Center(
-          child: Text(
-            'This is the next page',
-            style: TextStyle(fontSize: 24),
-          ),
-        ),
-      );
-    },
-  ));
-}
-
-/// This is the stateless widget that the main application instantiates.
-class MyStatelessWidget extends StatelessWidget {
-  MyStatelessWidget({Key key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      key: scaffoldKey,
-      appBar: AppBar(
-        title: const Text('AppBar Demo'),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.add_alert),
-            tooltip: 'Show Snackbar',
-            onPressed: () {
-              scaffoldKey.currentState.showSnackBar(snackBar);
-            },
-          ),
-          IconButton(
-            icon: const Icon(Icons.navigate_next),
-            tooltip: 'Next page',
-            onPressed: () {
-              openPage(context);
-            },
-          ),
-        ],
-      ),
-      body: const Center(
-        child: Text(
-          'This is the home page',
-          style: TextStyle(fontSize: 24),
-        ),
-      ),
-    );
-  }
-}
-''';
+final stableAPIDocSample =
+    'This is some sample code from the stable API Doc server.';
+final masterAPIDocSample =
+    'This is some sample code from the master API Doc server.';
 
 /// Create a GitHub API-like contents response for the provided content.
 String _createContentsJson(String content) {


### PR DESCRIPTION
* Updates `GistLoader` to take a bool indicating whether to use the master server when loading from the API Doc.
* Adds a new query parameter to embed.dart called `sample_channel`
  - If it's set to "master", the embed will tell the `GistLoader` to use the master server.
  - If it's anything else (or missing), the stable server is used.
* Updates tests based on this new, larger reality in which we find ourselves.