### PR TITLE
link to dart.dev and flutter.dev in dropdown

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -330,6 +330,12 @@ class Playground implements GistContainer, GistController {
         case 1:
           _showGitHubPage();
           break;
+        case 2:
+          _showDartDevPage();
+          break;
+        case 3:
+          _showFlutterDevPage();
+          break;
       }
     });
   }
@@ -1004,6 +1010,14 @@ class Playground implements GistContainer, GistController {
 
   void _showGitHubPage() {
     window.open('https://github.com/dart-lang/dart-pad', 'DartPad on GitHub');
+  }
+
+  void _showDartDevPage() {
+    window.open('https://dart.dev', 'dart.dev');
+  }
+
+  void _showFlutterDevPage() {
+    window.open('https://flutter.dev', 'flutter.dev');
   }
 
   @override

--- a/web/index.html
+++ b/web/index.html
@@ -98,6 +98,18 @@
                     </span>
                     <span class="mdc-list-item__text">DartPad on GitHub</span>
                 </li>
+                <li class="mdc-list-item" role="menuitem">
+                    <span class="mdc-list-item__graphic">
+                        <i class="material-icons mdc-select__icon" tabindex="-1" role="button">launch</i>
+                    </span>
+                    <span class="mdc-list-item__text">dart.dev</span>
+                </li>
+                <li class="mdc-list-item" role="menuitem">
+                    <span class="mdc-list-item__graphic">
+                        <i class="material-icons mdc-select__icon" tabindex="-1" role="button">launch</i>
+                    </span>
+                    <span class="mdc-list-item__text">flutter.dev</span>
+                </li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
(draft) adds links to dart.dev and flutter.dev in the dropdown

<img width="707" alt="Screen Shot 2020-02-07 at 10 02 23 AM" src="https://user-images.githubusercontent.com/1145719/74053561-f99aa000-4990-11ea-8cfd-52f81fecb418.png">

cc: @messi01