### PR TITLE
fix "New Pad" sample

### DIFF
--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -69,7 +69,7 @@ class MyApp extends StatelessWidget {
 class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Text('Hello, World!', style: Theme.of(context).textTheme.display1);
+    return Text('Hello, World!', style: Theme.of(context).textTheme.headline4);
   }
 }
 ''';


### PR DESCRIPTION
The "New Pad" sample is still using a deprecated TextTheme API.

related to #1469