### PR TITLE
add octicons_css to the list of allowed handlers in app.yaml

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -191,7 +191,7 @@ void copyPackageResources(String packageName, Directory destDir) {
             joinDir(destDir, ['packages', packageName]));
       } else {
         copyDirectory(
-            Directory(location), joinDir(destDir, ['pacakges', packageName]));
+            Directory(location), joinDir(destDir, ['packages', packageName]));
       }
       return;
     }

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -32,6 +32,9 @@ handlers:
   - url: /packages/split
     static_dir: packages/split
 
+  - url: /packages/octicons_css
+    static_dir: packages/octicons_css
+
   - url: .*
     script: auto
 


### PR DESCRIPTION
This was [accidentally introduced ](https://github.com/dart-lang/dart-pad/pull/1472/files#diff-71c04549f9d4d1196e5d1205b06afd8aL44) and caused requests to `octicons_css` to fail. This also fixes a typo in the grind script.

<img width="629" alt="Screen Shot 2020-02-12 at 4 45 51 PM" src="https://user-images.githubusercontent.com/1145719/74390918-81304680-4db7-11ea-8df2-181330ce8b72.png">

cc/ @legalcodes 


  