### PR TITLE
Display analysis errors 

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -847,13 +847,23 @@ class Playground implements GistContainer, GistController {
       var hasErrors = result.issues.any((issue) => issue.kind == 'error');
       var hasWarnings = result.issues.any((issue) => issue.kind == 'warning');
 
-      // TODO: show errors or warnings
-
       return hasErrors == false && hasWarnings == false;
     }).catchError((e) {
+      if (e is! TimeoutException) {
+        final message = e is ApiRequestError ? e.message : '$e';
+
+        _displayIssues([
+          AnalysisIssue()
+            ..kind = 'error'
+            ..line = 1
+            ..message = message
+        ]);
+      } else {
+        _logger.severe(e);
+      }
+
       _context.dartDocument.setAnnotations([]);
       busyLight.reset();
-      _logger.severe(e);
     });
   }
 


### PR DESCRIPTION
Importing an invalid package results in an ApiRequestError, not a typical analyzer error, so these need to be handled explicitly. (The embeds already handle these in a similar way.)
fixes #1526