### PR TITLE
Add install button

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -899,7 +899,11 @@ class Embed {
   }
 
   void _showInstallPage() {
-    window.location.href = 'https://flutter.dev/get-started/install';
+    if (_modeName == 'dart' || _modeName == 'html') {
+      window.location.href = 'https://dart.dev/get-dart';
+    } else {
+      window.location.href = 'https://flutter.dev/get-started/install';
+    }
   }
 
   void _format() async {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -907,6 +907,8 @@ class Embed {
   }
 
   void _showInstallPage() {
+    ga?.sendEvent('main', 'install');
+    
     if (_modeName == 'dart' || _modeName == 'html') {
       _hostWindow.location.href = 'https://dart.dev/get-dart';
     } else {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -318,6 +318,10 @@ class Embed {
       ..mode = 'css'
       ..showLineNumbers = true;
 
+    if (!showInstallButton) {
+      querySelector('#install-button').setAttribute('hidden', '');
+    }
+
     var editorTabViewElement = querySelector('#user-code-view');
     if (editorTabViewElement != null) {
       editorTabView = TabView(DElement(editorTabViewElement));
@@ -471,6 +475,18 @@ class Embed {
 
   bool get shouldOpenConsole {
     final value = _getQueryParam('open_console');
+    return value == 'true';
+  }
+
+  // Whether or not to show the Install button. (defaults to true)
+  bool get showInstallButton {
+    final value = _getQueryParam('install_button');
+
+    // Default to true
+    if (value.isEmpty) {
+      return true;
+    }
+
     return value == 'true';
   }
 
@@ -908,7 +924,7 @@ class Embed {
 
   void _showInstallPage() {
     ga?.sendEvent('main', 'install');
-    
+
     if (_modeName == 'dart' || _modeName == 'html') {
       _hostWindow.location.href = 'https://dart.dev/get-dart';
     } else {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -923,11 +923,12 @@ class Embed {
   }
 
   void _showInstallPage() {
-    ga?.sendEvent('main', 'install');
 
     if (_modeName == 'dart' || _modeName == 'html') {
+      ga?.sendEvent('main', 'install-dart');
       _hostWindow.location.href = 'https://dart.dev/get-dart';
     } else {
+      ga?.sendEvent('main', 'install-flutter');
       _hostWindow.location.href = 'https://flutter.dev/get-started/install';
     }
   }

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -77,6 +77,7 @@ class Embed {
   var _executionButtonCount = 0;
   MDCButton executeButton;
   MDCButton reloadGistButton;
+  MDCButton installButton;
   MDCButton formatButton;
   MDCButton showHintButton;
   MDCButton copyCodeButton;
@@ -270,6 +271,10 @@ class Embed {
     formatButton = MDCButton(querySelector('#format-code') as ButtonElement)
       ..onClick.listen(
         (_) => _format(),
+      );
+    installButton = MDCButton(querySelector('#install-button') as ButtonElement)
+      ..onClick.listen(
+        (_) => _showInstallPage(),
       );
 
     testResultBox = FlashBox(querySelector('#test-result-box') as DivElement);
@@ -891,6 +896,10 @@ class Embed {
 
   void _showKeyboardDialog() {
     dialog.showOk('Keyboard shortcuts', keyMapToHtml(keys.inverseBindings));
+  }
+
+  void _showInstallPage() {
+    window.location.href = 'https://flutter.dev/get-started/install';
   }
 
   void _format() async {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -898,11 +898,19 @@ class Embed {
     dialog.showOk('Keyboard shortcuts', keyMapToHtml(keys.inverseBindings));
   }
 
+  WindowBase get _hostWindow {
+    if (window.parent != null) {
+      return window.parent;
+    }
+
+    return window;
+  }
+
   void _showInstallPage() {
     if (_modeName == 'dart' || _modeName == 'html') {
-      window.location.href = 'https://dart.dev/get-dart';
+      _hostWindow.location.href = 'https://dart.dev/get-dart';
     } else {
-      window.location.href = 'https://flutter.dev/get-started/install';
+      _hostWindow.location.href = 'https://flutter.dev/get-started/install';
     }
   }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1021,11 +1021,12 @@ class Playground implements GistContainer, GistController {
   }
 
   void _showInstallPage() {
-    ga?.sendEvent('main', 'install');
 
     if (_layout == Layout.dart) {
+      ga?.sendEvent('main', 'install-dart');
       window.location.href = 'https://dart.dev/get-dart';
     } else {
+      ga?.sendEvent('main', 'install-flutter');
       window.location.href = 'https://flutter.dev/get-started/install';
     }
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -217,6 +217,8 @@ class Playground implements GistContainer, GistController {
       ..onClick.listen((_) => _showResetDialog());
     formatButton = MDCButton(querySelector('#format-button') as ButtonElement)
       ..onClick.listen((_) => _format());
+    formatButton = MDCButton(querySelector('#install-button') as ButtonElement)
+      ..onClick.listen((_) => _showInstallPage());
     samplesButton =
         MDCButton(querySelector('#samples-dropdown-button') as ButtonElement)
           ..onClick.listen((e) {
@@ -1002,20 +1004,24 @@ class Playground implements GistContainer, GistController {
   }
 
   void _showSharingPage() {
-    window.open('https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
-        'DartPad Sharing Guide');
+    window.location.href =
+        'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide';
   }
 
   void _showGitHubPage() {
-    window.open('https://github.com/dart-lang/dart-pad', 'DartPad on GitHub');
+    window.location.href = 'https://github.com/dart-lang/dart-pad';
   }
 
   void _showDartDevPage() {
-    window.open('https://dart.dev', 'dart.dev');
+    window.location.href = 'https://dart.dev';
   }
 
   void _showFlutterDevPage() {
-    window.open('https://flutter.dev', 'flutter.dev');
+    window.location.href = 'https://flutter.dev';
+  }
+
+  void _showInstallPage() {
+    window.location.href = 'https://flutter.dev/get-started/install';
   }
 
   @override

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1021,7 +1021,11 @@ class Playground implements GistContainer, GistController {
   }
 
   void _showInstallPage() {
-    window.location.href = 'https://flutter.dev/get-started/install';
+    if (_layout == Layout.dart) {
+      window.location.href = 'https://dart.dev/get-dart';
+    } else {
+      window.location.href = 'https://flutter.dev/get-started/install';
+    }
   }
 
   @override

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1021,6 +1021,8 @@ class Playground implements GistContainer, GistController {
   }
 
   void _showInstallPage() {
+    ga?.sendEvent('main', 'install');
+
     if (_layout == Layout.dart) {
       window.location.href = 'https://dart.dev/get-dart';
     } else {

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -102,6 +102,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
+        <button id="install-button" class="mdc-button">Install SDK</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -95,6 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
+        <button id="install-button" class="mdc-button">Install</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -95,7 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
-        <button id="install-button" class="mdc-button">Install</button>
+        <button id="install-button" class="mdc-button">Install SDK</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -95,6 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
+        <button id="install-button" class="mdc-button">Install</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -95,7 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
-        <button id="install-button" class="mdc-button">Install</button>
+        <button id="install-button" class="mdc-button">Install SDK</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -113,7 +113,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
-        <button id="install-button" class="mdc-button">Install</button>
+        <button id="install-button" class="mdc-button">Install SDK</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -113,6 +113,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
+        <button id="install-button" class="mdc-button">Install</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -95,6 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
+        <button id="install-button" class="mdc-button">Install</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -95,7 +95,7 @@ BSD-style license that can be found in the LICENSE file. -->
         </div>
     </nav>
     <div class="nav-buttons">
-        <button id="install-button" class="mdc-button">Install</button>
+        <button id="install-button" class="mdc-button">Install SDK</button>
         <button id="show-hint" class="mdc-button">Hint</button>
         <button id="format-code" class="mdc-button">Format</button>
         <button id="reload-gist" class="mdc-button">Reset</button>

--- a/web/index.html
+++ b/web/index.html
@@ -72,7 +72,7 @@
         </button>
         <button type="button" id="install-button" class="mdc-button">
             <i class="material-icons mdc-button__icon">computer</i>
-            Install
+            Install SDK
         </button>
     </div>
     <div class="header-gist-name"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -70,6 +70,10 @@
             <i class="material-icons mdc-button__icon">format_align_left</i>
             Format
         </button>
+        <button type="button" id="install-button" class="mdc-button">
+            <i class="material-icons mdc-button__icon">computer</i>
+            Install
+        </button>
     </div>
     <div class="header-gist-name"></div>
     <div>

--- a/web/index.html
+++ b/web/index.html
@@ -71,7 +71,7 @@
             Format
         </button>
         <button type="button" id="install-button" class="mdc-button">
-            <i class="material-icons mdc-button__icon">computer</i>
+            <i class="material-icons mdc-button__icon">get_app</i>
             Install SDK
         </button>
     </div>

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -568,6 +568,10 @@ a {
   #keyboard-button {
     display: none;
   }
+
+  #install-button {
+    display: none;
+  }
 }
 
 @media screen and (max-width: 700px) {


### PR DESCRIPTION
- Adds an "Install SDK" button
- Sends a GA event when clicked
- Redirects the window (or parent window if the embed is in an iframe) to dart.dev or flutter.dev install pages (depending on the embed type or playground editor mode)
- I confirmed that the "Referer" header will be `dartpad.dev` or `dartpad.dev/embed-<name>.html`, including any parameters on the embed.
- added a query param to disable the install button for embeds if we need to.

<img width="986" alt="Screen Shot 2020-04-14 at 10 57 23 AM" src="https://user-images.githubusercontent.com/1145719/79257883-23fc5400-7e3f-11ea-8954-cd660af99a87.png">
<img width="983" alt="Screen Shot 2020-04-14 at 10 57 52 AM" src="https://user-images.githubusercontent.com/1145719/79257887-25c61780-7e3f-11ea-80e1-ab012d862457.png">
