### PR TITLE
Set a canonical header when serving from hosts other than dartpad.dev

### DIFF
--- a/bin/serve.dart
+++ b/bin/serve.dart
@@ -10,6 +10,7 @@ Future<void> main() async {
   final handler = const Pipeline()
       .addMiddleware(createCorsHeadersMiddleware())
       .addMiddleware(logRequests())
+      .addMiddleware(_canonicalHeadersMiddleware)
       .addHandler(createStaticHandler('build', defaultDocument: 'index.html'));
 
   final server = await io.serve(handler, 'localhost', 8000)
@@ -17,6 +18,32 @@ Future<void> main() async {
 
   print('Serving at http://${server.address.host}:${server.port}');
 }
+
+const _canonicalHost = 'dartpad.dev';
+
+// Ensures that alternate hosts for this site (dartpad.dartlang.org) hint to
+// search engines where the "real" domain is.
+//
+// See https://en.wikipedia.org/wiki/Canonical_link_element
+Handler _canonicalHeadersMiddleware(Handler innerHandler) => (request) async {
+      var response = await innerHandler(request);
+
+      if (
+          // Only set the header if there is a mismatch
+          request.requestedUri.host != _canonicalHost &&
+              // Only set the header for HTML content.
+              response.headers['content-type'] == 'text/html') {
+        final newUri = request.requestedUri.replace(host: _canonicalHost);
+
+        response = response.change(
+          headers: {
+            'Link': '<$newUri>; rel="canonical"',
+          },
+        );
+      }
+
+      return response;
+    };
 
 /// Middleware which adds [CORS headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS)
 /// to shelf responses. Also handles preflight (OPTIONS) requests.


### PR DESCRIPTION
Related to https://github.com/dart-lang/dart-pad/issues/1146
Should improve SEO