### PR TITLE
Using hasSelectionOffset instead of selectionOffset != null

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -78,7 +78,7 @@ class DartCompleter extends CodeCompleter {
 
           // If a specific offset is provided, prefer it to the one calculated
           // from the linked edit groups.
-          if (assist.selectionOffset != null) {
+          if (assist.hasSelectionOffset()) {
             absoluteCursorPosition = assist.selectionOffset;
           }
 


### PR DESCRIPTION
This prevents cursor from going to the beginning of the file when using Alt+Enter, "wrap with column". This fixes the first bullet point of https://github.com/dart-lang/dart-pad/issues/1546
