### PR TITLE
Expose Flutter version in Playground footer

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -545,7 +545,7 @@ class Playground implements GistContainer, GistController {
     docHandler = DocHandler(editor, _context);
 
     dartServices.version().then((VersionResponse version) {
-      // "Based on Dart SDK 2.4.0"
+      // "Based on Flutter 1.19.0-4.1.pre Dart SDK 2.8.4"
       var versionText = 'Based on Flutter ${version.flutterVersion} Dart SDK ${version.sdkVersionFull}';
       querySelector('#dartpad-version').text = versionText;
     }).catchError((e) => null);

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -546,7 +546,7 @@ class Playground implements GistContainer, GistController {
 
     dartServices.version().then((VersionResponse version) {
       // "Based on Dart SDK 2.4.0"
-      var versionText = 'Based on Dart SDK ${version.sdkVersionFull}';
+      var versionText = 'Based on Flutter ${version.flutterVersion} Dart SDK ${version.sdkVersionFull}';
       querySelector('#dartpad-version').text = versionText;
     }).catchError((e) => null);
 


### PR DESCRIPTION
Now when Dart Services API v2 is available it's possible to show current Flutter version 

![image](https://user-images.githubusercontent.com/16854239/87786434-36b96700-c83a-11ea-91a0-652644716320.png)

closes #1430 