### PR TITLE
default cache-control header to 10 minutes

### DIFF
--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,4 +1,5 @@
 runtime: python37
+default_expiration: "0d 0h 10m"
 
 handlers:
   - url: /pictures

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,5 +1,4 @@
 runtime: python37
-default_expiration: "0d 3h"
 
 handlers:
   - url: /pictures


### PR DESCRIPTION
this is an attempt to address https://github.com/dart-lang/dart-pad/issues/1605.

In Chrome on my machine these two links show different results (search for check_localstorage):

```
view-source:https://dart-pad.appspot.com/
view-source:https://dartpad.dev/
```

https://cloud.google.com/appengine/docs/standard/python/config/appref

