### PR TITLE
Setting cookie flags

### DIFF
--- a/web/scripts/ga.js
+++ b/web/scripts/ga.js
@@ -3,6 +3,9 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-26406144-18', 'auto');
+ga('create', 'UA-26406144-18', {
+  cookieFlags: 'secure;samesite=none',
+  cookieDomain: 'auto'
+});
 ga('set', 'referrer', document.referrer.split('?')[0]);
 ga('send', 'pageview');


### PR DESCRIPTION
Changes the Google Analytics init so it'll use the correct cookie flags. See these links for rationale:

* https://www.chromestatus.com/feature/5633521622188032
* https://www.chromestatus.com/feature/5088147346030592

Bottom line is that we're losing GA data for Chrome users in embedded cross-domain layouts. This will hopefully fix the issue.