### PR TITLE
Add null safety switch

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -102,6 +102,9 @@ class Embed {
   bool _editableTestSolution = false;
   bool _showTestCode = false;
 
+  DElement nullSafetyCheckmark;
+  bool _nullSafetyEnabled = false;
+
   Counter unreadConsoleCounter;
 
   FlashBox testResultBox;
@@ -251,6 +254,8 @@ class Embed {
     showTestCodeCheckmark = DElement(querySelector('#show-test-checkmark'));
     editableTestSolutionCheckmark =
         DElement(querySelector('#editable-test-solution-checkmark'));
+    nullSafetyCheckmark =
+        DElement(querySelector('#toggle-null-safety-checkmark'));
 
     morePopover = DElement(querySelector('#more-popover'));
     menuButton =
@@ -277,6 +282,11 @@ class Embed {
               'hide', !_editableTestSolution);
           testEditor.readOnly =
               solutionEditor.readOnly = !_editableTestSolution;
+          break;
+        case 2:
+          // Null safety
+          nullSafetyEnabled = !nullSafetyEnabled;
+          nullSafetyCheckmark.toggleClass('hide', !nullSafetyEnabled);
           break;
       }
     });
@@ -425,15 +435,11 @@ class Embed {
 
     featureMessage = DElement(querySelector('#feature-message'));
     featureMessage.toggleAttr('hidden', true);
-    if (QueryParams.hasNullSafety && QueryParams.nullSafety) {
-      featureMessage.text = 'Null safety';
-      featureMessage.toggleAttr('hidden', false);
-    }
 
     linearProgress = MDCLinearProgress(querySelector('#progress-bar'));
     linearProgress.determinate = false;
 
-    _initModules().then((_) => _init()).then((_) => _emitReady());
+    _initModules().then((_) => _init()).then((_) => _emitReady()).then((_) => _initNullSafety());
   }
 
   /// Initializes a listener for messages from the parent window. Allows this
@@ -542,6 +548,40 @@ class Embed {
 
   bool get githubParamsPresent =>
       githubOwner.isNotEmpty && githubRepo.isNotEmpty && githubPath.isNotEmpty;
+
+  void _initNullSafety() {
+    if (QueryParams.hasNullSafety && QueryParams.nullSafety) {
+      nullSafetyEnabled = true;
+    }
+  }
+
+  set nullSafetyEnabled(bool enabled) {
+    _nullSafetyEnabled = enabled;
+    _handleNullSafetySwitched(enabled);
+    if (enabled) {
+      featureMessage.text = 'Null safety';
+      featureMessage.toggleAttr('hidden', false);
+    } else {
+      featureMessage.text = 'Null safety';
+      featureMessage.toggleAttr('hidden', false);
+    }
+  }
+
+  bool get nullSafetyEnabled {
+    return _nullSafetyEnabled;
+  }
+
+  void _handleNullSafetySwitched(bool enabled) {
+    var api = deps[DartservicesApi] as DartservicesApi;
+    if (enabled) {
+      api.rootUrl = nullSafetyServerUrl;
+      window.localStorage['null_safety'] = 'true';
+    } else {
+      api.rootUrl = serverUrl;
+      window.localStorage['null_safety'] = 'false';
+    }
+    _performAnalysis();
+  }
 
   Future<void> _initModules() async {
     var modules = ModuleManager();
@@ -770,7 +810,8 @@ class Embed {
     }
     tabController.setTabVisibility(
         'test', context.testMethod.isNotEmpty && _showTestCode);
-    menuButton.toggleAttr('hidden', context.testMethod.isEmpty);
+    // menuButton.toggleAttr('hidden', context.testMethod.isEmpty);
+    menuButton.toggleAttr('hidden', false);
     showHintButton.element.hidden = context.hint.isEmpty;
     solutionTab?.toggleAttr('hidden', context.solution.isEmpty);
     editorIsBusy = false;

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -32,6 +32,7 @@ import 'services/execution_iframe.dart';
 import 'sharing/gists.dart';
 import 'src/util.dart';
 import 'util/keymap.dart';
+import 'util/query_params.dart';
 
 const int defaultSplitterWidth = 6;
 
@@ -123,6 +124,7 @@ class Embed {
 
   Console consoleExpandController;
   DElement webOutputLabel;
+  DElement featureMessage;
 
   MDCLinearProgress linearProgress;
   Dialog dialog;
@@ -419,6 +421,11 @@ class Embed {
     var webOutputLabelElement = querySelector('#web-output-label');
     if (webOutputLabelElement != null) {
       webOutputLabel = DElement(webOutputLabelElement);
+    }
+
+    featureMessage = DElement(querySelector('#feature-message'));
+    if (QueryParams.hasNullSafety && QueryParams.nullSafety) {
+      featureMessage.text = 'Null Safety Enabled';
     }
 
     linearProgress = MDCLinearProgress(querySelector('#progress-bar'));

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -424,8 +424,10 @@ class Embed {
     }
 
     featureMessage = DElement(querySelector('#feature-message'));
+    featureMessage.toggleAttr('hidden', true);
     if (QueryParams.hasNullSafety && QueryParams.nullSafety) {
-      featureMessage.text = 'Null Safety Enabled';
+      featureMessage.text = 'Null safety';
+      featureMessage.toggleAttr('hidden', false);
     }
 
     linearProgress = MDCLinearProgress(querySelector('#progress-bar'));

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -810,7 +810,6 @@ class Embed {
     }
     tabController.setTabVisibility(
         'test', context.testMethod.isNotEmpty && _showTestCode);
-    // menuButton.toggleAttr('hidden', context.testMethod.isEmpty);
     menuButton.toggleAttr('hidden', false);
     showHintButton.element.hidden = context.hint.isEmpty;
     solutionTab?.toggleAttr('hidden', context.solution.isEmpty);

--- a/lib/inject/inject_embed.dart
+++ b/lib/inject/inject_embed.dart
@@ -41,11 +41,12 @@ String iframeSrc(Map<String, String> options) {
   var theme = 'theme=${_valueOr(options, 'theme', 'light')}';
   var run = 'run=${_valueOr(options, 'run', 'false')}';
   var split = 'split=${_valueOr(options, 'split', 'false')}';
+  var nullSafety = 'null_safety=${_valueOr(options, 'null_safety', 'false')}';
   // A unique ID used to distinguish between DartPad instances in an article or
   // codelab.
   var analytics = 'ga_id=${_valueOr(options, 'ga_id', 'false')}';
 
-  return '$iframePrefix$prefix?$theme&$run&$split&$analytics';
+  return '$iframePrefix$prefix?$theme&$run&$split&$analytics&$nullSafety';
 }
 
 String _valueOr(Map<String, String> map, String value, String defaultValue) {

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -63,7 +63,7 @@ class DartServicesModule extends Module {
   @override
   Future init() {
     var client = SanitizingBrowserClient();
-    deps[DartservicesApi] = DartservicesApi(client, rootUrl: serverURL);
+    deps[DartservicesApi] = DartservicesApi(client, rootUrl: serverUrl);
     return Future.value();
   }
 }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -251,6 +251,12 @@ class Playground implements GistContainer, GistController {
         .listen((_) => _showKeyboardDialog());
     var nullSafetyEnabled = window.localStorage.containsKey('null_safety') &&
         window.localStorage['null_safety'] == 'true';
+
+    // Override if a query parameter is provided
+    if (_hasNullSafetyQueryParam) {
+      nullSafetyEnabled = _nullSafetyQueryParam;
+    }
+
     nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
       ..checked = nullSafetyEnabled
       ..listen('change', (event) {
@@ -993,6 +999,23 @@ class Playground implements GistContainer, GistController {
       window.localStorage['null_safety'] = 'false';
     }
     _performAnalysis();
+  }
+
+  bool get _nullSafetyQueryParam {
+    var url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery &&
+        url.queryParameters['null_safety'] != null &&
+        url.queryParameters['null_safety'] == 'true') {
+      return true;
+    }
+
+    return false;
+  }
+
+  bool get _hasNullSafetyQueryParam {
+    var url = Uri.parse(window.location.toString());
+    return url.hasQuery && url.queryParameters['null_safety'] != null;
   }
 
   // GistContainer interface

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:html' hide Console;
 
 import 'package:dart_pad/editing/editor_codemirror.dart';
+import 'package:dart_pad/util/query_params.dart';
 import 'package:logging/logging.dart';
 import 'package:mdc_web/mdc_web.dart';
 import 'package:meta/meta.dart';
@@ -253,8 +254,8 @@ class Playground implements GistContainer, GistController {
         window.localStorage['null_safety'] == 'true';
 
     // Override if a query parameter is provided
-    if (_hasNullSafetyQueryParam) {
-      nullSafetyEnabled = _nullSafetyQueryParam;
+    if (QueryParams.hasNullSafety) {
+      nullSafetyEnabled = QueryParams.nullSafety;
     }
 
     nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
@@ -999,23 +1000,6 @@ class Playground implements GistContainer, GistController {
       window.localStorage['null_safety'] = 'false';
     }
     _performAnalysis();
-  }
-
-  bool get _nullSafetyQueryParam {
-    var url = Uri.parse(window.location.toString());
-
-    if (url.hasQuery &&
-        url.queryParameters['null_safety'] != null &&
-        url.queryParameters['null_safety'] == 'true') {
-      return true;
-    }
-
-    return false;
-  }
-
-  bool get _hasNullSafetyQueryParam {
-    var url = Uri.parse(window.location.toString());
-    return url.hasQuery && url.queryParameters['null_safety'] != null;
   }
 
   // GistContainer interface

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -124,6 +124,8 @@ class Playground implements GistContainer, GistController {
   Console _rightConsole;
   Counter unreadConsoleCounter;
 
+  bool nullSafetyEnabled;
+
   Playground() {
     _initDialogs();
     _checkLocalStorage();
@@ -135,7 +137,7 @@ class Playground implements GistContainer, GistController {
       _initLayoutDetection();
       _initButtons();
       _initLabels();
-      _initSamplesMenu();
+      _initSamplesMenu(nullSafe: nullSafetyEnabled);
       _initMoreMenu();
       _initSplitters();
       _initTabs();
@@ -250,7 +252,7 @@ class Playground implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => _showKeyboardDialog());
-    var nullSafetyEnabled = window.localStorage.containsKey('null_safety') &&
+    nullSafetyEnabled = window.localStorage.containsKey('null_safety') &&
         window.localStorage['null_safety'] == 'true';
 
     // Override if a query parameter is provided
@@ -273,21 +275,38 @@ class Playground implements GistContainer, GistController {
     }
   }
 
-  void _initSamplesMenu() {
+  void _initSamplesMenu({bool nullSafe = false}) {
     var element = querySelector('#samples-menu');
+    element.children.clear();
 
-    var samples = [
-      Sample('215ba63265350c02dfbd586dfd30b8c3', 'Hello World', Layout.dart),
-      Sample('e93b969fed77325db0b848a85f1cf78e', 'Int to Double', Layout.dart),
-      Sample('b60dc2fc7ea49acecb1fd2b57bf9be57', 'Mixins', Layout.dart),
-      Sample('7d78af42d7b0aedfd92f00899f93561b', 'Fibonacci', Layout.dart),
-      Sample('b6409e10de32b280b8938aa75364fa7b', 'Counter', Layout.flutter),
-      Sample('b3ccb26497ac84895540185935ed5825', 'Sunflower', Layout.flutter),
-      Sample('ecb28c29c646b7f38139b1e7f44129b7', 'Draggables & physics',
-          Layout.flutter),
-      Sample('40308e0a5f47acba46ba62f4d8be2bf4', 'Implicit animations',
-          Layout.flutter),
-    ];
+    List<Sample> samples;
+    if (nullSafe) {
+      samples = [
+        Sample('215ba63265350c02dfbd586dfd30b8c3', 'Hello World', Layout.dart),
+        Sample('e93b969fed77325db0b848a85f1cf78e', 'Int to Double', Layout.dart),
+        Sample('b60dc2fc7ea49acecb1fd2b57bf9be57', 'Mixins', Layout.dart),
+        Sample('7d78af42d7b0aedfd92f00899f93561b', 'Fibonacci', Layout.dart),
+        Sample('1a28bdd9203250d3226cc25d512579ec', 'Counter', Layout.flutter),
+        Sample('e0a2e942e85fde2cd39b2741ff0c49e5', 'Sunflower', Layout.flutter),
+        Sample('516c310a7c7d0c6fea90fcb8d26feec2', 'Draggables & physics',
+            Layout.flutter),
+        Sample('4d7650278c256e6bc5c9ba0bfb4b5f35', 'Implicit animations',
+            Layout.flutter),
+      ];
+    } else {
+      samples = [
+        Sample('215ba63265350c02dfbd586dfd30b8c3', 'Hello World', Layout.dart),
+        Sample('e93b969fed77325db0b848a85f1cf78e', 'Int to Double', Layout.dart),
+        Sample('b60dc2fc7ea49acecb1fd2b57bf9be57', 'Mixins', Layout.dart),
+        Sample('7d78af42d7b0aedfd92f00899f93561b', 'Fibonacci', Layout.dart),
+        Sample('b6409e10de32b280b8938aa75364fa7b', 'Counter', Layout.flutter),
+        Sample('b3ccb26497ac84895540185935ed5825', 'Sunflower', Layout.flutter),
+        Sample('ecb28c29c646b7f38139b1e7f44129b7', 'Draggables & physics',
+            Layout.flutter),
+        Sample('40308e0a5f47acba46ba62f4d8be2bf4', 'Implicit animations',
+            Layout.flutter),
+      ];
+    }
 
     var listElement = UListElement()
       ..classes.add('mdc-list')
@@ -1000,6 +1019,7 @@ class Playground implements GistContainer, GistController {
       window.localStorage['null_safety'] = 'false';
     }
     _performAnalysis();
+    _initSamplesMenu(nullSafe: enabled);
   }
 
   // GistContainer interface

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -575,8 +575,8 @@ class Playground implements GistContainer, GistController {
 
     dartServices.version().then((VersionResponse version) {
       // "Based on Flutter 1.19.0-4.1.pre Dart SDK 2.8.4"
-      var versionText =
-          'Based on Flutter ${version.flutterVersion} Dart SDK ${version.sdkVersionFull}';
+      var versionText = 'Based on Flutter ${version.flutterVersion}'
+          ' Dart SDK ${version.sdkVersionFull}';
       querySelector('#dartpad-version').text = versionText;
     }).catchError((e) => null);
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -99,6 +99,7 @@ class Playground implements GistContainer, GistController {
   MaterialTabController webLayoutTabController;
   DElement webTabBar;
   DElement webOutputLabel;
+  MDCSwitch nullSafetySwitch;
 
   Splitter splitter;
   Splitter rightSplitter;
@@ -248,6 +249,10 @@ class Playground implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => _showKeyboardDialog());
+    nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
+      ..listen('change', (event) {
+        _handleNullSafetySwitched(nullSafetySwitch.checked);
+      });
   }
 
   void _initLabels() {
@@ -972,6 +977,16 @@ class Playground implements GistContainer, GistController {
       editorPanelHeader.setAttr('hidden');
       webOutputLabel.clearAttr('hidden');
     }
+  }
+
+  void _handleNullSafetySwitched(bool enabled) {
+    var api = deps[DartservicesApi] as DartservicesApi;
+    if (enabled) {
+      api.rootUrl = nullSafetyServerUrl;
+    } else {
+      api.rootUrl = serverUrl;
+    }
+    _performAnalysis();
   }
 
   // GistContainer interface

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -288,9 +288,9 @@ class Playground implements GistContainer, GistController {
         Sample('7d78af42d7b0aedfd92f00899f93561b', 'Fibonacci', Layout.dart),
         Sample('1a28bdd9203250d3226cc25d512579ec', 'Counter', Layout.flutter),
         Sample('e0a2e942e85fde2cd39b2741ff0c49e5', 'Sunflower', Layout.flutter),
-        Sample('516c310a7c7d0c6fea90fcb8d26feec2', 'Draggables & physics',
+        Sample('5e28c5273c2c1a41d30bad9f9d11da56', 'Draggables & physics',
             Layout.flutter),
-        Sample('4d7650278c256e6bc5c9ba0bfb4b5f35', 'Implicit animations',
+        Sample('289ecf8480ad005f01faeace70bd529a', 'Implicit animations',
             Layout.flutter),
       ];
     } else {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -249,10 +249,14 @@ class Playground implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => _showKeyboardDialog());
+    var nullSafetyEnabled = window.localStorage.containsKey('null_safety') &&
+        window.localStorage['null_safety'] == 'true';
     nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
+      ..checked = nullSafetyEnabled
       ..listen('change', (event) {
         _handleNullSafetySwitched(nullSafetySwitch.checked);
       });
+    _handleNullSafetySwitched(nullSafetyEnabled);
   }
 
   void _initLabels() {
@@ -983,8 +987,10 @@ class Playground implements GistContainer, GistController {
     var api = deps[DartservicesApi] as DartservicesApi;
     if (enabled) {
       api.rootUrl = nullSafetyServerUrl;
+      window.localStorage['null_safety'] = 'true';
     } else {
       api.rootUrl = serverUrl;
+      window.localStorage['null_safety'] = 'false';
     }
     _performAnalysis();
   }

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -48,11 +48,20 @@
   }
 }
 
-#issues-message {
+.info-message {
   font-family: $editor-font;
   font-size: $embed-editor-font-size;
   cursor: default;
   margin-right: 12px;
+}
+
+// Feature messages have a blue border
+#feature-message {
+  user-select: none;
+  color: var(--mdc-theme-primary, #168AFD);
+  padding: 2px 4px 2px 4px;
+  border-radius: 3px;
+  border: 1px solid var(--mdc-theme-primary, #168AFD);
 }
 
 #issues-toggle {

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -55,13 +55,10 @@
   margin-right: 12px;
 }
 
-// Feature messages have a blue border
+// Enabled features (e.g. null safety)
 #feature-message {
-  user-select: none;
-  color: var(--mdc-theme-primary, #168AFD);
-  padding: 2px 4px 2px 4px;
-  border-radius: 3px;
-  border: 1px solid var(--mdc-theme-primary, #168AFD);
+  font-family: Roboto;
+  font-weight: bolder;
 }
 
 #issues-toggle {

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -9,10 +9,13 @@ import 'dart:math';
 // A list of several endpoints running dart-services, across which DartPad can
 // spread its traffic. For simplicity's sake, at the current time DartPad picks
 // one at launch and sticks with it until the window is closed.
-final serverURLs = [
+final serverUrls = [
   'https://dart-services.appspot.com/',
   'https://dart-services-0.appspot.com/',
 ];
+
+// Used when null safety is enabled in the UI.
+final nullSafetyServerUrl = 'https://dart-services-beta-0.appspot.com/';
 
 // A set of URLs to use while debugging.
 //final serverURLs = [
@@ -20,7 +23,7 @@ final serverURLs = [
 //];
 
 // The actual server URL, chosen at random from one of the above lists.
-final serverURL = serverURLs[Random().nextInt(serverURLs.length)];
+final serverUrl = serverUrls[Random().nextInt(serverUrls.length)];
 
 final Duration serviceCallTimeout = Duration(seconds: 10);
 final Duration longServiceCallTimeout = Duration(seconds: 60);

--- a/lib/services/dartservices.dart
+++ b/lib/services/dartservices.dart
@@ -12,7 +12,7 @@ class DartservicesApi {
   DartservicesApi(this._client, {@required this.rootUrl});
 
   final BrowserClient _client;
-  final String rootUrl;
+  String rootUrl;
 
   Future<AnalysisResults> analyze(SourceRequest request) => _request(
         'analyze',

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -1,0 +1,20 @@
+import 'dart:html';
+
+class QueryParams {
+  static bool get nullSafety {
+    var url = Uri.parse(window.location.toString());
+
+    if (url.hasQuery &&
+        url.queryParameters['null_safety'] != null &&
+        url.queryParameters['null_safety'] == 'true') {
+      return true;
+    }
+
+    return false;
+  }
+
+  static bool get hasNullSafety {
+    var url = Uri.parse(window.location.toString());
+    return url.hasQuery && url.queryParameters['null_safety'] != null;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "11.0.0"
   analysis_server_lib:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.17"
+    version: "0.40.4"
   archive:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   build_config:
     dependency: transitive
     description:
@@ -84,42 +84,42 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.10.1"
+    version: "3.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.11"
+    version: "1.4.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "6.0.3"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.2"
   built_collection:
     dependency: transitive
     description:
@@ -175,7 +175,7 @@ packages:
       name: codemirror
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.20+5.57.0"
+    version: "0.5.21+5.58.0"
   collection:
     dependency: "direct dev"
     description:
@@ -217,7 +217,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.7"
   fixnum:
     dependency: transitive
     description:
@@ -231,7 +231,7 @@ packages:
       name: git
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   glob:
     dependency: transitive
     description:
@@ -266,7 +266,7 @@ packages:
       name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0+3"
+    version: "0.14.0+4"
   html_unescape:
     dependency: "direct main"
     description:
@@ -322,7 +322,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   logging:
     dependency: "direct main"
     description:
@@ -476,7 +476,7 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.26.10"
+    version: "1.26.11"
   sass_builder:
     dependency: "direct main"
     description:
@@ -588,7 +588,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.3"
+    version: "1.15.4"
   test_api:
     dependency: transitive
     description:
@@ -602,7 +602,7 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.11"
+    version: "0.3.11+1"
   timing:
     dependency: transitive
     description:
@@ -667,4 +667,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.8.1 <3.0.0"
+  dart: ">=2.10.0 <3.0.0"

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -175,6 +175,7 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 
 <footer flex layout horizontal class="footer">
+    <div id="feature-message" class="info-message"></div>
     <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -114,7 +114,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="menu-button" class="mdc-icon-button material-icons" hidden>more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="main-menu" class="mdc-menu mdc-menu-surface">
                 <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
                     <li id="show-test-menu-item" class="mdc-list-item" role="menuitem">
@@ -122,6 +122,18 @@ BSD-style license that can be found in the LICENSE file. -->
                             <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
                         </span>
                         <span class="mdc-list-item__text">Show tests</span>
+                    </li>
+                    <li id="editable-test-solution-menu-item" class="mdc-list-item" role="menuitem">
+                      <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
+                          <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                      </span>
+                        <span class="mdc-list-item__text">Editable test/solution</span>
+                    </li>
+                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
+                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
+                      <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                    </span>
+                        <span class="mdc-list-item__text">Null Safety</span>
                     </li>
                 </ul>
             </div>

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -163,7 +163,7 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 
 <footer flex layout horizontal class="footer">
-    <div id="issues-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 

--- a/test/inject/inject_embed_test.dart
+++ b/test/inject/inject_embed_test.dart
@@ -24,7 +24,7 @@ void main() {
       var iframe = iframes.first;
       expect(iframe, TypeMatcher<IFrameElement>());
       expect(iframe.attributes['src'],
-          'embed-flutter.html?theme=dark&run=false&split=false&ga_id=example1');
+          'embed-flutter.html?theme=dark&run=false&split=false&ga_id=example1&null_safety=false');
     });
   });
 }

--- a/test/inject/inject_embed_test.html
+++ b/test/inject/inject_embed_test.html
@@ -39,7 +39,7 @@
     <h4>Hello, World!</h4>
     <p>Below is a 'Hello, World!' app.</p>
     <pre>
-        <code class="language-run-dartpad:theme-dark:mode-flutter:ga_id-example1">foo</code>
+        <code class="language-run-dartpad:theme-dark:mode-flutter:ga_id-example1:null_safety-false">foo</code>
     </pre>
     <pre>
         <code class="language-run-dartpad:theme-dark:mode-flutter">foo</code>

--- a/test/inject/inject_parser_test.dart
+++ b/test/inject/inject_parser_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     test('supports options ', () {
       var options = LanguageStringParser('run-dartpad:mode-html:theme-dark'
-              ':run-true:split-50:width-100%:height-400px:ga_id-example1')
+              ':run-true:split-50:width-100%:height-400px:ga_id-example1:null_safety-true')
           .options;
       expect(options, isNotEmpty);
       expect(options['mode'], equals('html'));
@@ -46,6 +46,7 @@ void main() {
       expect(options['width'], equals('100%'));
       expect(options['height'], equals('400px'));
       expect(options['ga_id'], equals('example1'));
+      expect(options['null_safety'], equals('true'));
     });
   });
 }

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -155,7 +155,8 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
 </section>
 <footer flex layout horizontal class="footer">
-    <div id="issues-message"></div>
+    <div id="feature-message" class="info-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -107,7 +107,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="menu-button" class="mdc-icon-button material-icons" hidden>more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="main-menu" class="mdc-menu mdc-menu-surface">
                 <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
                     <li id="show-test-menu-item" class="mdc-list-item" role="menuitem">
@@ -121,6 +121,12 @@ BSD-style license that can be found in the LICENSE file. -->
                             <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
                         </span>
                         <span class="mdc-list-item__text">Editable test/solution</span>
+                    </li>
+                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
+                        <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
+                            <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                        </span>
+                        <span class="mdc-list-item__text">Null Safety</span>
                     </li>
                 </ul>
             </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -139,7 +139,6 @@ BSD-style license that can be found in the LICENSE file. -->
             <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
-            <div id="feature-message" class="feature-message"></div>
         </div>
         <div class="editor-button-group">
             <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>
@@ -163,7 +162,8 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 
 <footer flex layout horizontal class="footer">
-    <div id="issues-message"></div>
+    <div id="feature-message" class="info-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -107,7 +107,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="menu-button" class="mdc-icon-button material-icons" hidden>more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="main-menu" class="mdc-menu mdc-menu-surface">
                 <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
                     <li id="show-test-menu-item" class="mdc-list-item" role="menuitem">
@@ -121,6 +121,12 @@ BSD-style license that can be found in the LICENSE file. -->
                           <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
                       </span>
                       <span class="mdc-list-item__text">Editable test/solution</span>
+                  </li>
+                  <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
+                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
+                      <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                    </span>
+                    <span class="mdc-list-item__text">Null Safety</span>
                   </li>
                 </ul>
             </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -139,6 +139,7 @@ BSD-style license that can be found in the LICENSE file. -->
             <div id="test-view" class="flex-auto d-flex flex-row no-overflow" spellcheck="false" hidden>
                 <div id="test-editor" class="flex-auto d-flex flex-column" spellcheck="false"></div>
             </div>
+            <div id="feature-message" class="feature-message"></div>
         </div>
         <div class="editor-button-group">
             <button id="copy-code" title="Copy code" class="mdc-icon-button material-icons">file_copy</button>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -125,7 +125,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="menu-button" class="mdc-icon-button material-icons" hidden>more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="main-menu" class="mdc-menu mdc-menu-surface">
                 <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
                     <li id="show-test-menu-item" class="mdc-list-item" role="menuitem">
@@ -139,6 +139,12 @@ BSD-style license that can be found in the LICENSE file. -->
                           <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
                       </span>
                       <span class="mdc-list-item__text">Editable test/solution</span>
+                  </li>
+                  <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
+                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
+                        <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                    </span>
+                    <span class="mdc-list-item__text">Null Safety</span>
                   </li>
                 </ul>
             </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -186,7 +186,8 @@ BSD-style license that can be found in the LICENSE file. -->
 </section>
 
 <footer flex layout horizontal class="footer">
-    <div id="issues-message"></div>
+    <div id="feature-message" class="info-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -155,7 +155,8 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
 </section>
 <footer flex layout horizontal class="footer">
-    <div id="issues-message"></div>
+    <div id="feature-message" class="info-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <button id="issues-toggle" class="mdc-button mdc-button--dense mdc-button--outlined" hidden></button>
 </footer>
 

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -107,7 +107,7 @@ BSD-style license that can be found in the LICENSE file. -->
             Run
         </button>
         <div class="position-relative text-right pr-2">
-            <button id="menu-button" class="mdc-icon-button material-icons" hidden>more_vert</button>
+            <button id="menu-button" class="mdc-icon-button material-icons">more_vert</button>
             <div id="main-menu" class="mdc-menu mdc-menu-surface">
                 <ul class="mdc-list" role="menu" aria-hidden="true" aria-orientation="vertical" tabindex="-1">
                     <li id="show-test-menu-item" class="mdc-list-item" role="menuitem">
@@ -120,8 +120,14 @@ BSD-style license that can be found in the LICENSE file. -->
                       <span id="editable-test-solution-checkmark" class="mdc-list-item__graphic hide">
                           <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
                       </span>
-                      <span class="mdc-list-item__text">Editable test/solution</span>
-                  </li>
+                        <span class="mdc-list-item__text">Editable test/solution</span>
+                    </li>
+                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
+                        <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
+                            <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
+                        </span>
+                        <span class="mdc-list-item__text">Null Safety</span>
+                    </li>
                 </ul>
             </div>
         </div>

--- a/web/example/inject.html
+++ b/web/example/inject.html
@@ -149,6 +149,15 @@ void main() {
 }
             </code>
         </pre>
+
+        <p>null_safety-true</p>
+        <pre>
+            <code class="language-run-dartpad:mode-flutter:null_safety-true:theme-dark">
+void main() {
+  int x = null; // Invalid with null safety enabled!
+}
+            </code>
+        </pre>
     </div>
 </div>
 </body>

--- a/web/index.html
+++ b/web/index.html
@@ -260,6 +260,16 @@
         <a href="https://github.com/dart-lang/dart-pad/issues"
            target="repo">Send feedback</a>
     </div>
+    <div>
+        <div id="null-safety-switch" class="mdc-switch">
+            <div class="mdc-switch__track"></div>
+            <div class="mdc-switch__thumb-underlay">
+                <div class="mdc-switch__thumb"></div>
+                <input type="checkbox" id="basic-switch" class="mdc-switch__native-control" role="switch" aria-checked="false">
+            </div>
+        </div>
+        <label for="basic-switch">Null Safety</label>
+    </div>
     <div class="flex"></div>
     <div id="issues-message"></div>
     <a id="issues-toggle" hidden></a>

--- a/web/index.html
+++ b/web/index.html
@@ -254,13 +254,13 @@
 
 <footer>
     <div id="keyboard-button" class="keyboard footer-item"></div>
-    <div>
+    <div class="footer-item">
         <a href="https://www.dartlang.org/tools/dartpad/privacy"
            target="repo" class="footer-item">Privacy notice</a>
         <a href="https://github.com/dart-lang/dart-pad/issues"
            target="repo">Send feedback</a>
     </div>
-    <div>
+    <div class="footer-item">
         <div id="null-safety-switch" class="mdc-switch">
             <div class="mdc-switch__track"></div>
             <div class="mdc-switch__thumb-underlay">

--- a/web/index.html
+++ b/web/index.html
@@ -271,7 +271,7 @@
         <label for="basic-switch">Null Safety</label>
     </div>
     <div class="flex"></div>
-    <div id="issues-message"></div>
+    <div id="issues-message" class="info-message"></div>
     <a id="issues-toggle" hidden></a>
     <div id="dartpad-version"></div>
 </footer>

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -50,7 +50,7 @@ a {
   border-top: $border-width solid $dark-border-color;
 }
 
-#issues-message {
+.info-message {
   color: $dark-issue-label-color;
 }
 

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -37,7 +37,7 @@ a {
   border-top: $border-width solid $light-border-color;
 }
 
-#issues-message {
+.info-message {
   color: $light-label-color;
 }
 

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -89,7 +89,7 @@ body>footer {
   }
 
   .footer-item {
-    margin-right: 10px;
+    margin-right: 14px;
   }
 
   * {


### PR DESCRIPTION
This changes the backend to the one used for https://nullsafety.dartpad.dev/

- [x] Add this feature to inject script
- [x] Update samples dropdown links when null safety mode is selected (create new gists)