### PR TITLE
Toggle null safety query param

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -350,7 +350,8 @@ class Playground implements GistContainer, GistController {
     samplesMenu.listen('MDCMenu:selected', (e) {
       var index = (e as CustomEvent).detail['index'] as int;
       var gistId = samples.elementAt(index).gistId;
-      router.go('gist', {'gist': gistId});
+      router.go('gist', {'gist': gistId},
+          queryParameters: QueryParams.parameters);
     });
   }
 
@@ -1088,7 +1089,8 @@ class Playground implements GistContainer, GistController {
     if (ga != null) ga.sendEvent('main', 'new');
 
     _showSnackbar('New pad created');
-    await router.go('gist', {'gist': ''}, forceReload: true);
+    await router.go('gist', {'gist': ''},
+        queryParameters: QueryParams.parameters, forceReload: true);
   }
 
   Future<void> createGistForLayout(Layout layout) async {
@@ -1100,7 +1102,8 @@ class Playground implements GistContainer, GistController {
 
     var layoutStr = _layoutToString(layout);
 
-    await router.go(layoutStr, {}, forceReload: true);
+    await router.go(layoutStr, {},
+        forceReload: true, queryParameters: QueryParams.parameters);
   }
 
   void _resetGists() {

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1020,6 +1020,9 @@ class Playground implements GistContainer, GistController {
       api.rootUrl = serverUrl;
       window.localStorage['null_safety'] = 'false';
     }
+
+    QueryParams.nullSafety = enabled;
+
     _performAnalysis();
     _initSamplesMenu(nullSafe: enabled);
   }

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -1,7 +1,6 @@
 import 'dart:html';
 
 class QueryParams {
-
   static Map<String, String> get parameters {
     return Uri.parse(window.location.toString()).queryParameters;
   }

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -13,6 +13,18 @@ class QueryParams {
     return false;
   }
 
+  static set nullSafety(bool enabled) {
+    var url = Uri.parse(window.location.toString());
+    var params = Map<String, String>.from(url.queryParameters);
+    if (enabled) {
+      params['null_safety'] = 'true';
+    } else if (params.containsKey('null_safety')) {
+      params.remove('null_safety');
+    }
+    url = url.replace(queryParameters: params);
+    window.history.replaceState({}, 'DartPad', url.toString());
+  }
+
   static bool get hasNullSafety {
     var url = Uri.parse(window.location.toString());
     return url.hasQuery && url.queryParameters['null_safety'] != null;

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -1,6 +1,11 @@
 import 'dart:html';
 
 class QueryParams {
+
+  static Map<String, String> get parameters {
+    return Uri.parse(window.location.toString()).queryParameters;
+  }
+
   static bool get nullSafety {
     var url = Uri.parse(window.location.toString());
 


### PR DESCRIPTION
This sets the query parameter in when null safety is toggled so links can include the flag when they're shared.
cc: @mit-mit 