### PR TITLE
Updates test decoration for null safety

### DIFF
--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -43,5 +43,5 @@ abstract class ExecutionService {
   /// report a test result while executing via this service. It calls `print` with a specially
   /// constructed string, which is caught by the `dartPrint` method and routed
   /// to [testResults] rather than the [onStdout] stream.
-  String testResultDecoration;
+  String get testResultDecoration;
 }

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -39,9 +39,9 @@ abstract class ExecutionService {
 
   Stream<TestResult> get testResults;
 
-  /// This method should be added to any Dart code that needs to report a test
-  /// result while executing via this service. It calls `print` with a specially
+  /// The method returned here should be added to any Dart code that needs to
+  /// report a test result while executing via this service. It calls `print` with a specially
   /// constructed string, which is caught by the `dartPrint` method and routed
   /// to [testResults] rather than the [onStdout] stream.
-  String get testResultDecoration;
+  String testResultDecoration;
 }

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -68,7 +68,7 @@ class ExecutionServiceIFrame implements ExecutionService {
 
   /// TODO(redbrogdon): Format message so internal double quotes are escaped.
   @override
-  String testResultDecoration => '''
+  String get testResultDecoration => '''
 void _result(bool success, [List<String> messages = const []]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
   final joinedMessages = messages.map((m) => '"\$m"').join(',');

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -68,11 +68,10 @@ class ExecutionServiceIFrame implements ExecutionService {
 
   /// TODO(redbrogdon): Format message so internal double quotes are escaped.
   @override
-  String get testResultDecoration => '''
-void _result(bool success, [List<String> messages]) {
+  String testResultDecoration => '''
+void _result(bool success, [List<String> messages = const []]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
-  final joinedMessages = messages?.map((m) => '"\$m"')?.join(',') ?? '';
-
+  final joinedMessages = messages.map((m) => '"\$m"').join(',');
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 


### PR DESCRIPTION
There's a little method that gets added to the user's code in embeds for reporting test results. Previously, it wasn't correct when built with null safety. I've worked out a new version that will run whether null safety is on or off, which solves the issue.