### PR TITLE
Update some links to .dev domains

### DIFF
--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -48,7 +48,7 @@ class AboutDialog extends DDialog {
 }
 
 class SharingDialog extends DDialog {
-  final String home = 'dartpad.dartlang.org';
+  final String home = 'dartpad.dev';
   final String _dartThumbnail = 'pictures/embed-dart.png';
   final String _htmlThumbnail = 'pictures/embed-html.png';
   final GistContainer gistContainer;
@@ -225,7 +225,7 @@ class SharingDialog extends DDialog {
       _textArea.style.display = 'none';
       var gist = gistContainer.mutableGist;
       content.add(_div);
-      _padUrl.value = 'https://dartpad.dartlang.org/${gist.id}';
+      _padUrl.value = 'https://dartpad.dev/${gist.id}';
       _gistUrl.value = gist.htmlUrl;
       _embedHtmlRadio.checked = false;
       _embedDartRadio.checked = true;

--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -176,7 +176,7 @@ ${libraryName == null ? '' : apiLink}\n\n''';
       if (libraryName.contains('dart:')) {
         libraryName = libraryName.replaceAll(':', '-');
         apiLink.write(
-            'https://api.dartlang.org/stable/$libraryName/$libraryName-library.html');
+            'https://api.dart.dev/stable/$libraryName/$libraryName-library.html');
 
         return '[Open library docs]($apiLink)';
       }

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -15,8 +15,7 @@ import 'package:http/http.dart' as http;
 import 'package:yaml/yaml.dart' as yaml;
 import '../util/detect_flutter.dart' as detect_flutter;
 
-final String _dartpadLink =
-    '[dartpad.dev](https://dartpad.dev)';
+final String _dartpadLink = '[dartpad.dev](https://dartpad.dev)';
 
 final RegExp _gistRegex = RegExp(r'^[0-9a-f]+$');
 

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -16,7 +16,7 @@ import 'package:yaml/yaml.dart' as yaml;
 import '../util/detect_flutter.dart' as detect_flutter;
 
 final String _dartpadLink =
-    '[dartpad.dartlang.org](https://dartpad.dartlang.org)';
+    '[dartpad.dev](https://dartpad.dev)';
 
 final RegExp _gistRegex = RegExp(r'^[0-9a-f]+$');
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -38,7 +38,7 @@ running in Google Cloud Platform to be analyzed for errors/warnings, compiled
 to JavaScript, and returned to the browser.
 <br><br>
 Learn more about how DartPad stores your data in our
-<a href="https://www.dartlang.org/tools/dartpad/privacy">privacy notice</a>.
+<a href="https://dart.dev/tools/dartpad/privacy>privacy notice</a>.
 We look forward to your
 <a href="https://github.com/dart-lang/dart-pad/issues" target="feedback">feedback</a>.
 <br><br>

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -38,7 +38,7 @@ running in Google Cloud Platform to be analyzed for errors/warnings, compiled
 to JavaScript, and returned to the browser.
 <br><br>
 Learn more about how DartPad stores your data in our
-<a href="https://dart.dev/tools/dartpad/privacy>privacy notice</a>.
+<a href="https://dart.dev/tools/dartpad/privacy">privacy notice</a>.
 We look forward to your
 <a href="https://github.com/dart-lang/dart-pad/issues" target="feedback">feedback</a>.
 <br><br>

--- a/web/index.html
+++ b/web/index.html
@@ -255,7 +255,7 @@
 <footer>
     <div id="keyboard-button" class="keyboard footer-item"></div>
     <div class="footer-item">
-        <a href="https://www.dartlang.org/tools/dartpad/privacy"
+        <a href="https://dart.dev/tools/dartpad/privacy"
            target="repo" class="footer-item">Privacy notice</a>
         <a href="https://github.com/dart-lang/dart-pad/issues"
            target="repo">Send feedback</a>

--- a/web/mobile.html
+++ b/web/mobile.html
@@ -10,7 +10,7 @@
     <meta http-equiv="refresh" content="0;URL='https://dartpad.dartlang.org/index.html'" />    
   </head>    
   <body> 
-    <p>This page has moved to a <a href="https://dartpad.dev/index.html">
+    <p>This page has moved to a <a href="https://dartpad.dev/">
       https://dartpad.dev/</a>.</p>
   </body>
 </html>

--- a/web/mobile.html
+++ b/web/mobile.html
@@ -10,7 +10,7 @@
     <meta http-equiv="refresh" content="0;URL='https://dartpad.dartlang.org/index.html'" />    
   </head>    
   <body> 
-    <p>This page has moved to a <a href="https://dartpad.dartlang.org/index.html">
-      https://dartpad.dartlang.org/</a>.</p> 
+    <p>This page has moved to a <a href="https://dartpad.dev/index.html">
+      https://dartpad.dev/</a>.</p>
   </body>
 </html>


### PR DESCRIPTION
Updates some old `dartlang.org` urls to their new `.dev` counterparts.