### PR TITLE
Fix null safety toggle info message

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -286,7 +286,6 @@ class Embed {
         case 2:
           // Null safety
           nullSafetyEnabled = !nullSafetyEnabled;
-          nullSafetyCheckmark.toggleClass('hide', !nullSafetyEnabled);
           break;
       }
     });
@@ -563,6 +562,7 @@ class Embed {
     _handleNullSafetySwitched(enabled);
     featureMessage.text = 'Null safety';
     featureMessage.toggleAttr('hidden', !enabled);
+    nullSafetyCheckmark.toggleClass('hide', !enabled);
   }
 
   bool get nullSafetyEnabled {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -561,13 +561,8 @@ class Embed {
   set nullSafetyEnabled(bool enabled) {
     _nullSafetyEnabled = enabled;
     _handleNullSafetySwitched(enabled);
-    if (enabled) {
-      featureMessage.text = 'Null safety';
-      featureMessage.toggleAttr('hidden', false);
-    } else {
-      featureMessage.text = 'Null safety';
-      featureMessage.toggleAttr('hidden', false);
-    }
+    featureMessage.text = 'Null safety';
+    featureMessage.toggleAttr('hidden', !enabled);
   }
 
   bool get nullSafetyEnabled {


### PR DESCRIPTION
Previously in an embed, if you enabled null safety, it would unhide the null safety info message in the bottom right corner, but disabling it did not result in the message being rehidden.

This message:
![image](https://user-images.githubusercontent.com/18372958/101978648-18ef0300-3c1c-11eb-8cfe-4069d3b2f7df.png)

Fixes #1687 