### PR TITLE
Fix displaying a snackbar of new pad created when it hasn't been

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1041,7 +1041,10 @@ class Playground implements GistContainer, GistController {
     var result = await dialog.showOkCancel(
         'Create New Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
-      var layout = await newPadDialog.show();
+      final layout = await newPadDialog.show();
+      if (layout == null) {
+        return;
+      }
       await createGistForLayout(layout);
       _changeLayout(layout);
     }


### PR DESCRIPTION
Currently if you navigate to the new pad page and click 'Cancel' the 'New pad created' snackbar was still displayed. 

This fix doesn't attempt to change the layout if the `newPadDialog()` call was cancelled and returned `null`. 

New pad dialog:
![image](https://user-images.githubusercontent.com/18372958/101980397-9a4d9200-3c2a-11eb-882e-2c432747b8ee.png)

Snackbar:
![image](https://user-images.githubusercontent.com/18372958/101980420-c79a4000-3c2a-11eb-99ef-d3c783e88604.png)

