### PR TITLE
Fix Dart HTML sample for null safe dart pad

### DIFF
--- a/lib/src/sample.dart
+++ b/lib/src/sample.dart
@@ -16,8 +16,8 @@ final String dartCodeHtml = r'''
 import 'dart:html';
 
 void main() {
-  var header = querySelector('#header');
-  header.text = "Hello, World!";
+  final header = querySelector('#header');
+  header?.text = "Hello, World!";
 }
 ''';
 


### PR DESCRIPTION
You would get an error if you were in null safe mode due to `querySelector` returning `Element?`. This change allows the sample to work in both versions in a way that makes sense as elements are often not present.

![image](https://user-images.githubusercontent.com/18372958/102308321-02062480-3f2c-11eb-9763-ba9dcca6d5a2.png)
