### PR TITLE
Replace remaining octicons with mdc icons

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -1141,27 +1141,6 @@ class DisableableButton {
   }
 }
 
-class Octicon {
-  static const prefix = 'octicon-';
-
-  Octicon(this.element);
-
-  final DivElement element;
-
-  String get iconName {
-    return element.classes
-        .firstWhere((s) => s.startsWith(prefix), orElse: () => '');
-  }
-
-  set iconName(String name) {
-    element.classes.removeWhere((s) => s.startsWith(prefix));
-    element.classes.add('$prefix$name');
-  }
-
-  static bool elementIsOcticon(Element el) =>
-      el.classes.any((s) => s.startsWith(prefix));
-}
-
 enum FlashBoxStyle {
   warn,
   error,
@@ -1279,15 +1258,13 @@ class ConsoleExpandController extends Console {
       _initSplitter();
       _splitter.setSizes([60, 40]);
       element.toggleAttr('hidden', false);
-      expandIcon.element.classes.remove('octicon-triangle-up');
-      expandIcon.element.classes.add('octicon-triangle-down');
+      expandIcon.element.innerText = 'expand_more';
       footer.toggleClass('footer-top-border', false);
       unreadCounter.clear();
     } else {
       _splitter.setSizes([100, 0]);
       element.toggleAttr('hidden', true);
-      expandIcon.element.classes.remove('octicon-triangle-down');
-      expandIcon.element.classes.add('octicon-triangle-up');
+      expandIcon.element.innerText = 'expand_less';
       footer.toggleClass('footer-top-border', true);
       try {
         _splitter.destroy();

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -124,6 +124,7 @@
 .issue .message {
   padding-left: 5px;
   line-height: 20px;
+  font-family: 'Roboto', sans-serif;
 }
 
 // Keys dialog

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -22,6 +22,10 @@
 .flash-close {
   padding: 6px;
   margin: -12px;
+
+  i {
+    font-size: 20px;
+  }
 }
 
 #flash-container {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -393,13 +393,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.12"
-  octicons_css:
-    dependency: "direct main"
-    description:
-      name: octicons_css
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1"
   package_config:
     dependency: transitive
     description:
@@ -435,13 +428,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
-  primer_css:
-    dependency: "direct main"
-    description:
-      name: primer_css
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2"
   protobuf:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,8 +16,6 @@ dependencies:
   logging: '>=0.11.4 <0.12.0'
   markdown: ^3.0.0
   meta: ^1.2.4
-  octicons_css: ^0.0.1
-  primer_css: ^0.0.1
   protobuf: ^1.1.0
   route_hierarchical:
     path: third_party/pkg/route.dart/

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -19,8 +19,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href='https://fonts.googleapis.com/css?family=Inconsolata:400,700'
           rel='stylesheet' type='text/css'>
 
-    <link rel="stylesheet" type="text/css" href="../packages/octicons_css/octicons_4.4.0.css">
-
     <!-- codemirror -->
     <link href="../packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="../packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
@@ -28,9 +26,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="cm-dartpad-light.css" rel="stylesheet" media="screen">
-
-    <!-- primer -->
-    <link rel="stylesheet" type="text/css" href="../packages/primer_css/primer_12.1.0.css">
 
     <script src="../packages/codemirror/codemirror.js" defer></script>
     <script src="../packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
@@ -162,7 +157,9 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
+                <button id="console-expand-icon"
+                        class="mdc-icon-button material-icons" hidden>expand_less
+                </button>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>
@@ -181,21 +178,15 @@ BSD-style license that can be found in the LICENSE file. -->
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
-    <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">
-            <div class="octicon octicon-x"></div>
-        </button>
-        <div class="message-container custom-scrollbar"></div>
-    </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -157,9 +157,11 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-icon"
-                        class="mdc-icon-button material-icons" hidden>expand_less
-                </button>
+                <div id="console-expand-icon-container">
+                    <button id="console-expand-icon" title="Expand console" class="mdc-icon-button material-icons">
+                        expand_less
+                    </button>
+                </div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/app.yaml
+++ b/web/app.yaml
@@ -44,9 +44,6 @@ handlers:
   - url: /packages/split
     static_dir: packages/split
 
-  - url: /packages/octicons_css
-    static_dir: packages/octicons_css
-
   - url: .*
     script: auto
 

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -16,8 +16,6 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="packages/octicons_css/octicons_4.4.0.css">
-
     <!-- codemirror -->
     <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
@@ -25,9 +23,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
-
-    <!-- primer -->
-    <link rel="stylesheet" type="text/css" href="packages/primer_css/primer_12.1.0.css">
 
     <script src="packages/codemirror/codemirror.js" defer></script>
     <script src="packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
@@ -167,21 +162,15 @@ BSD-style license that can be found in the LICENSE file. -->
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
-    <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">
-            <div class="octicon octicon-x"></div>
-        </button>
-        <div class="message-container custom-scrollbar"></div>
-    </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -16,8 +16,6 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="packages/octicons_css/octicons_4.4.0.css">
-
     <!-- codemirror -->
     <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
@@ -25,9 +23,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
-
-    <!-- primer -->
-    <link rel="stylesheet" type="text/css" href="packages/primer_css/primer_12.1.0.css">
 
     <script src="packages/codemirror/codemirror.js" defer></script>
     <script src="packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
@@ -155,7 +150,9 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
+                <button id="console-expand-icon"
+                        class="mdc-icon-button material-icons" hidden>expand_less
+                </button>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>
@@ -174,21 +171,15 @@ BSD-style license that can be found in the LICENSE file. -->
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
-    <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">
-            <div class="octicon octicon-x"></div>
-        </button>
-        <div class="message-container custom-scrollbar"></div>
-    </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -150,9 +150,11 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-icon"
-                        class="mdc-icon-button material-icons" hidden>expand_less
-                </button>
+                <div id="console-expand-icon-container">
+                    <button id="console-expand-icon" title="Expand console" class="mdc-icon-button material-icons">
+                        expand_less
+                    </button>
+                </div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -16,8 +16,6 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="packages/octicons_css/octicons_4.4.0.css">
-
     <!-- codemirror -->
     <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
@@ -25,9 +23,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
-
-    <!-- primer -->
-    <link rel="stylesheet" type="text/css" href="packages/primer_css/primer_12.1.0.css">
 
     <script src="packages/codemirror/codemirror.js" defer></script>
     <script src="packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
@@ -179,7 +174,9 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <div id="console-expand-icon" class="octicon octicon-triangle-up"></div>
+                <button id="console-expand-icon"
+                        class="mdc-icon-button material-icons" hidden>expand_less
+                </button>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>
@@ -198,21 +195,15 @@ BSD-style license that can be found in the LICENSE file. -->
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
-    <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">
-            <div class="octicon octicon-x"></div>
-        </button>
-        <div class="message-container custom-scrollbar"></div>
-    </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -174,9 +174,11 @@ BSD-style license that can be found in the LICENSE file. -->
                 <span class="view-label">
                     Console <span id="unread-console-counter" class="Counter" hidden></span>
                 </span>
-                <button id="console-expand-icon"
-                        class="mdc-icon-button material-icons" hidden>expand_less
-                </button>
+                <div id="console-expand-icon-container">
+                    <button id="console-expand-icon" title="Expand console" class="mdc-icon-button material-icons">
+                        expand_less
+                    </button>
+                </div>
             </div>
             <div id="console-output-container" class="custom-scrollbar" hidden></div>
         </div>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -16,8 +16,6 @@ BSD-style license that can be found in the LICENSE file. -->
 
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" type="text/css" href="packages/octicons_css/octicons_4.4.0.css">
-
     <!-- codemirror -->
     <link href="packages/codemirror/css/codemirror.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
@@ -25,9 +23,6 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
-
-    <!-- primer -->
-    <link rel="stylesheet" type="text/css" href="packages/primer_css/primer_12.1.0.css">
 
     <script src="packages/codemirror/codemirror.js" defer></script>
     <script src="packages/codemirror/addon/scroll/simplescrollbars.js" defer></script>
@@ -167,21 +162,15 @@ BSD-style license that can be found in the LICENSE file. -->
 </footer>
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
-    <div id="analysis-result-box" class="flash flash-error" hidden>
-        <button class="flash-close">
-            <div class="octicon octicon-x"></div>
-        </button>
-        <div class="message-container custom-scrollbar"></div>
-    </div>
     <div id="test-result-box" class="flash flash-warn" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
         <button class="flash-close">
-            <div class="octicon octicon-x"></div>
+            <i class="material-icons mdc-button__icon">close</i>
         </button>
         <div class="message-container custom-scrollbar"></div>
     </div>

--- a/web/index.html
+++ b/web/index.html
@@ -230,21 +230,15 @@
         </div>
     </div>
     <div id="flash-container">
-        <div id="analysis-result-box" class="flash flash-error" hidden>
-            <button class="flash-close">
-                <div class="octicon octicon-x"></div>
-            </button>
-            <div class="message-container custom-scrollbar"></div>
-        </div>
         <div id="test-result-box" class="flash flash-warn" hidden>
             <button class="flash-close">
-                <div class="octicon octicon-x"></div>
+                <i class="material-icons mdc-button__icon">close</i>
             </button>
             <div class="message-container custom-scrollbar"></div>
         </div>
         <div id="hint-box" class="flash" hidden>
             <button class="flash-close">
-                <div class="octicon octicon-x"></div>
+                <i class="material-icons mdc-button__icon">close</i>
             </button>
             <div class="message-container custom-scrollbar"></div>
         </div>

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -17,11 +17,6 @@ body {
   font-size: 14px;
 }
 
-
-.medium-octicon {
-  font-size: 19px;
-}
-
 // Tab Navigation
 
 #navbar {
@@ -159,11 +154,7 @@ body {
 
 #console-expand-icon {
   color: $label-color;
-  padding: 8px;
-}
-
-#console-expand-icon:focus {
-  outline: none;
+  @include mdc-icon-button-size(16px, 16px, 8px);
 }
 
 #console-output-container {
@@ -231,11 +222,6 @@ body {
   align-items: center;
   padding: 4px 12px 4px 12px;
   height: 40px;
-}
-
-// Primer
-.Popover-message {
-  padding: 8px !important;
 }
 
 // Material Design

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -7,7 +7,12 @@
 @import 'package:dart_pad/scss/variables';
 @import 'package:dart_pad/scss/shared';
 
+* {
+  box-sizing: border-box;
+}
+
 body {
+  margin: 0;
   top: 0;
   bottom: 0;
   left: 0;
@@ -15,6 +20,8 @@ body {
   position: absolute;
   overflow: hidden;
   font-size: 14px;
+  display: flex !important;
+  flex-direction: column !important;
 }
 
 // Tab Navigation
@@ -150,6 +157,11 @@ body {
   padding-left: 8px;
   padding-bottom: 8px;
   overflow: auto;
+}
+
+#console-expand-icon-container {
+  height: 32px;
+  width: 32px;
 }
 
 #console-expand-icon {

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -97,7 +97,7 @@ a {
 }
 
 .flash-close {
-  .octicon {
+  i {
     color: $dark-flash-text-color;
   }
 }

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -76,7 +76,7 @@ a {
 }
 
 .flash-close {
-  .octicon {
+  i {
     color: $light-text-color;
   }
 }


### PR DESCRIPTION
Removes Primer and Octicon package shims, replacing the remaining uses with mdc icons. 

I recommend testing this out locally to see if it looks and works as expected.

Fixes #1218
