### PR TITLE
Fix issue message when only 1 issue

### DIFF
--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -50,7 +50,8 @@ class AnalysisResultsController {
   }
 
   void display(List<AnalysisIssue> issues) {
-    if (issues.isEmpty) {
+    final amount = issues.length;
+    if (amount == 0) {
       message.text = _noIssuesMsg;
 
       // hide the flash without toggling the hidden state
@@ -66,7 +67,7 @@ class AnalysisResultsController {
     }
 
     showToggle();
-    message.text = '${issues.length} issues';
+    message.text = '${amount} ${amount == 1 ? 'issue' : 'issues'}';
 
     flash.clearChildren();
     for (var elem in issues.map(_issueElement)) {


### PR DESCRIPTION
Previously when there was only 1 issue, the UI said `1 issues` instead of `1 issue`. This fixes that.

Previously:

![image](https://user-images.githubusercontent.com/18372958/102677433-06b71c80-4168-11eb-8669-06fac8755684.png)

After:

![image](https://user-images.githubusercontent.com/18372958/102677444-10408480-4168-11eb-981f-8e364c43d70a.png)
