### PR TITLE
Fix reassigning format button

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -84,6 +84,7 @@ class Playground implements GistContainer, GistController {
   MDCButton newButton;
   MDCButton resetButton;
   MDCButton formatButton;
+  MDCButton installButton;
   MDCButton samplesButton;
   MDCButton runButton;
   MDCButton editorConsoleTab;
@@ -224,7 +225,7 @@ class Playground implements GistContainer, GistController {
       ..onClick.listen((_) => _showResetDialog());
     formatButton = MDCButton(querySelector('#format-button') as ButtonElement)
       ..onClick.listen((_) => _format());
-    formatButton = MDCButton(querySelector('#install-button') as ButtonElement)
+    installButton = MDCButton(querySelector('#install-button') as ButtonElement)
       ..onClick.listen((_) => _showInstallPage());
     samplesButton =
         MDCButton(querySelector('#samples-dropdown-button') as ButtonElement)


### PR DESCRIPTION
Previously, we accidentally reassigned the `install-button` element to the `formatButton`. This caused the 'Install SDK' button to be disabled while formatting instead of the other way around.

This change, fixes that, properly disabling the 'Format' button instead.