### PR TITLE
Add TODO function to testResultDecoration

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -77,6 +77,9 @@ void _result(bool success, [List<String> messages = const []]) {
 
 // Ensure we have at least one use of `_result`.
 var resultFunction = _result;
+
+// Placeholder for unimplemented methods in dart-pad exercises.
+Never TODO([String? message]) => throw UnimplementedError(message);
 ''';
 
   String _decorateJavaScript(String javaScript, {String modulesBaseUrl}) {


### PR DESCRIPTION
As discussed with @RedBrogdon, in this PR we introduce a `TODO(message)` function built into DartPad, so we can use it in codelab exercises.

I apologise because I haven't been able to run this locally (I wasn't able to complete my setup so I couldn't verify the functionality) but I was told that this should work ;) I am also not sure if this would need tests, let me know if that's the case.

Please @RedBrogdon feel free to modify the code if you find it convenient.

