### PR TITLE
Go direct to Cloud Run

### DIFF
--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -4,25 +4,14 @@
 
 library dart_pad.common;
 
-import 'dart:math';
-
-// A list of several endpoints running dart-services, across which DartPad can
-// spread its traffic. For simplicity's sake, at the current time DartPad picks
-// one at launch and sticks with it until the window is closed.
-final serverUrls = [
-  'https://v1.api.dartpad.dev/',
-];
+// The endpoint running dart-services.
+final serverUrl = 'https://v1.api.dartpad.dev/';
 
 // Used when null safety is enabled in the UI.
 final nullSafetyServerUrl = 'https://dart-services-beta-0.appspot.com/';
 
-// A set of URLs to use while debugging.
-//final serverURLs = [
-//  'http://127.0.0.1:8082/',
-//];
-
-// The actual server URL, chosen at random from one of the above lists.
-final serverUrl = serverUrls[Random().nextInt(serverUrls.length)];
+// A URL to use while debugging.
+//final serverURL = 'http://127.0.0.1:8082/';
 
 final Duration serviceCallTimeout = Duration(seconds: 10);
 final Duration longServiceCallTimeout = Duration(seconds: 60);

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -10,8 +10,7 @@ import 'dart:math';
 // spread its traffic. For simplicity's sake, at the current time DartPad picks
 // one at launch and sticks with it until the window is closed.
 final serverUrls = [
-  'https://dart-services.appspot.com/',
-  'https://dart-services-0.appspot.com/',
+  'https://v1.api.dartpad.dev/',
 ];
 
 // Used when null safety is enabled in the UI.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -91,14 +91,14 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.5.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.10"
+    version: "1.10.11"
   build_runner_core:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: build_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   build_web_compilers:
     dependency: "direct dev"
     description:
@@ -175,7 +175,7 @@ packages:
       name: codemirror
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.21+5.58.0"
+    version: "0.5.23+5.59.1"
   collection:
     dependency: "direct dev"
     description:
@@ -483,7 +483,7 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.30.0"
+    version: "1.32.2"
   sass_builder:
     dependency: "direct main"
     description:
@@ -518,7 +518,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+1"
   shelf_web_socket:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "1.6.1"
   build_config:
     dependency: transitive
     description:
@@ -77,35 +77,35 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.5"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.11"
+    version: "1.10.12"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.1.6"
   build_test:
     dependency: "direct dev"
     description:
@@ -497,7 +497,7 @@ packages:
       name: scratch_space
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4+2"
+    version: "0.0.4+3"
   shelf:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
We can improve RTT by skipping the AppEngine Flex layer. Thoughts?