### PR TITLE
Cleanup to prepare for future canonical score and recommended lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -8,7 +8,49 @@ analyzer:
     - 'doc/api/**'
     - 'last_prod/**'
     - 'lib/bower/**'
-    - 'lib/services/_dartpadsupportservices.dart'
-    - 'lib/services/dartservices.dart'
     - 'lib/src/protos/**'
     - 'third_party/pkg/**'
+
+linter:
+  rules:
+    - await_only_futures
+    - camel_case_types
+    - file_names
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - non_constant_identifier_names
+    - package_prefixed_library_names
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+    - unawaited_futures
+    - unnecessary_overrides
+    - unrelated_type_equality_checks
+    - valid_regexps
+    - void_checks
+    - avoid_function_literals_in_foreach_calls
+    - avoid_private_typedef_functions
+    - avoid_renaming_method_parameters
+    - avoid_returning_null_for_void
+    - avoid_single_cascade_in_expression_statements
+    - constant_identifier_names
+    - control_flow_in_finally
+    - empty_constructor_bodies
+    - empty_statements
+    - exhaustive_cases
+    - implementation_imports
+    - overridden_fields
+    - package_names
+    - prefer_function_declarations_over_variables
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_is_not_operator
+    - prefer_mixin
+    - prefer_null_aware_operators
+    - prefer_void_to_null
+    - slash_for_doc_comments
+    - type_init_formals
+    - unnecessary_brace_in_string_interps
+    - unnecessary_getters_setters
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -67,7 +67,7 @@ class AnalysisResultsController {
     }
 
     showToggle();
-    message.text = '${amount} ${amount == 1 ? 'issue' : 'issues'}';
+    message.text = '$amount ${amount == 1 ? 'issue' : 'issues'}';
 
     flash.clearChildren();
     for (var elem in issues.map(_issueElement)) {

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -174,11 +174,11 @@ class DSplitter extends DElement {
       element.children.add(e);
     }
 
-    var cancel = () {
+    void cancel() {
       if (_moveSub != null) _moveSub.cancel();
       if (_upSub != null) _upSub.cancel();
       if (onDragEnd != null) onDragEnd();
-    };
+    }
 
     element.onMouseDown.listen((MouseEvent e) {
       if (e.button != 0) return;

--- a/lib/inject/inject_parser.dart
+++ b/lib/inject/inject_parser.dart
@@ -72,7 +72,8 @@ class DartPadInjectException implements Exception {
   final String message;
   DartPadInjectException(this.message);
   @override
-  String toString() => message;
+  // ignore: unnecessary_string_interpolations
+  String toString() => '$message';
 }
 
 /// Parses the dartpad CSS class names to extract

--- a/lib/inject/inject_parser.dart
+++ b/lib/inject/inject_parser.dart
@@ -72,7 +72,7 @@ class DartPadInjectException implements Exception {
   final String message;
   DartPadInjectException(this.message);
   @override
-  String toString() => '$message';
+  String toString() => message;
 }
 
 /// Parses the dartpad CSS class names to extract

--- a/lib/parameter_popup.dart
+++ b/lib/parameter_popup.dart
@@ -192,7 +192,7 @@ class ParameterPopup {
   /// `{openingParenIndex: 9, parameterIndex: 1}`.
   Map<String, int> _parameterInfo(String source, int offset) {
     var parameterIndex = 0;
-    var openingParenIndex;
+    int /*?*/ openingParenIndex;
     var nesting = 0;
 
     while (openingParenIndex == null && offset > 0) {
@@ -226,7 +226,7 @@ class ParameterPopup {
     return openingParenIndex == null
         ? null
         : {
-            'openingParenIndex': openingParenIndex as int,
+            'openingParenIndex': openingParenIndex,
             'parameterIndex': parameterIndex
           };
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -811,7 +811,7 @@ class Playground implements GistContainer, GistController {
 
         _clearOutput();
 
-        return executionService.execute(
+        await executionService.execute(
           _context.htmlSource,
           _context.cssSource,
           response.result,
@@ -830,7 +830,7 @@ class Playground implements GistContainer, GistController {
 
         _clearOutput();
 
-        return await executionService.execute(
+        await executionService.execute(
           _context.htmlSource,
           _context.cssSource,
           response.result,
@@ -1309,7 +1309,9 @@ class TabExpandController {
     consoleButton.toggleClass('active', false);
 
     // Clear listeners
-    _subscriptions.forEach((s) => s.cancel());
+    for (var s in _subscriptions) {
+      s.cancel();
+    }
     _subscriptions.clear();
   }
 }

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -128,7 +128,7 @@ class GistLoader {
   static const String _masterApiDocsUrl =
       'https://master-api.flutter.dev/snippets';
 
-  static final GistFilterHook _defaultLoadHook = (Gist gist) {
+  static void _defaultLoadHook(Gist gist) {
     // Update files based on our preferred file names.
     if (gist.getFile('body.html') != null &&
         gist.getFile('index.html') == null) {
@@ -153,9 +153,9 @@ class GistLoader {
     if (htmlFile != null) {
       htmlFile.content = extractHtmlBody(htmlFile.content);
     }
-  };
+  }
 
-  static final GistFilterHook _defaultSaveHook = (Gist gist) {
+  static void _defaultSaveHook(Gist gist) {
     // Create a full html file on save.
     var hasStyles = gist.getFile('styles.css') != null;
     var styleRef =
@@ -193,7 +193,7 @@ $styleRef$dartRef  </head>
             summary: gist.summary,
             withLink: _dartpadLink));
     gist.files.add(readmeFile);
-  };
+  }
 
   final GistFilterHook afterLoadHook;
   final GistFilterHook beforeSaveHook;
@@ -280,7 +280,7 @@ $styleRef$dartRef  </head>
     return Uri.https(
       _repoContentsAuthority,
       'repos/$owner/$repo/contents/$path',
-      (ref != null && ref.isNotEmpty) ? {'ref': '$ref'} : null,
+      (ref != null && ref.isNotEmpty) ? {'ref': ref} : null,
     );
   }
 

--- a/test/elements/bind_test.dart
+++ b/test/elements/bind_test.dart
@@ -35,8 +35,7 @@ void defineTests() {
     test('target functions', () {
       var from = TestProperty('foo');
       Object val;
-      var to = (_val) => val = _val;
-      bind(from, to).flush();
+      bind(from, (_val) => val = _val).flush();
       expect(val, from.value);
     });
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -49,7 +49,7 @@ updateThirdParty() {
 
 @Task()
 analyze() {
-  PubApp.local('tuneup')..run(['check']);
+  PubApp.local('tuneup').run(['check']);
 }
 
 @Task()
@@ -269,7 +269,7 @@ coverage() {
 
 @DefaultTask()
 @Depends(analyze, testCli, testWeb, coverage, build)
-void buildbot() => null;
+void buildbot() {}
 
 @Task('Prepare the app for deployment')
 @Depends(buildbot)

--- a/web/example/picker.dart
+++ b/web/example/picker.dart
@@ -96,6 +96,6 @@ class DartPadPicker {
   }
 
   String iFrameSrc({String theme, String mode}) {
-    return '${dartPadUrl}/embed-$mode.html?theme=$theme';
+    return '$dartPadUrl/embed-$mode.html?theme=$theme';
   }
 }


### PR DESCRIPTION
I added the lints found here(https://github.com/dart-lang/linter/tree/master/tool/canonical) not previously present in pedantic to the `analysis_options.yaml` resulting in some minor cleanup to ease the inclusion of those rulesets at some point.