### PR TITLE
Fixing TODO so it works with or without NNBD

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -79,7 +79,7 @@ void _result(bool success, [List<String> messages = const []]) {
 var resultFunction = _result;
 
 // Placeholder for unimplemented methods in dart-pad exercises.
-Never TODO([String? message]) => throw UnimplementedError(message);
+Never TODO([String message = '']) => throw UnimplementedError(message);
 ''';
 
   String _decorateJavaScript(String javaScript, {String modulesBaseUrl}) {


### PR DESCRIPTION
Previous TODO implementation only worked when null safety was active, and we need one that works either way.