### PR TITLE
Only retrieve documentation once and process it only if needed

### DIFF
--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -30,7 +30,7 @@ class DocHandler {
 
   final NodeValidator _htmlValidator = PermissiveNodeValidator();
 
-  int /*?*/ _previousDoc;
+  int /*?*/ _previousDocHash;
 
   DocHandler(this._editor, this._context);
 
@@ -40,7 +40,7 @@ class DocHandler {
     }
 
     if (_context.focusedEditor != 'dart') {
-      _previousDoc = null;
+      _previousDocHash = null;
       for (final docPanel in docElements) {
         docPanel.innerHtml = '';
       }
@@ -71,10 +71,10 @@ class DocHandler {
       final hash = result.hashCode;
       // If nothing has changed, don't need to parse Markdown and
       // manipulate HTML again.
-      if (hash == _previousDoc) {
+      if (hash == _previousDocHash) {
         return;
       }
-      _previousDoc = hash;
+      _previousDocHash = hash;
 
       final docResult = _getHtmlTextFor(result);
 

--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -18,32 +18,41 @@ import 'services/dartservices.dart';
 import 'src/util.dart';
 
 class DocHandler {
-  static const List cursorKeys = [
+  static const Set<int> cursorKeys = {
     KeyCode.LEFT,
     KeyCode.RIGHT,
     KeyCode.UP,
     KeyCode.DOWN
-  ];
+  };
 
   final Editor _editor;
   final Context _context;
 
   final NodeValidator _htmlValidator = PermissiveNodeValidator();
 
+  int /*?*/ _previousDoc;
+
   DocHandler(this._editor, this._context);
 
-  void generateDocWithText(DivElement docPanel) {
+  void generateDoc(List<DivElement> docElements) {
+    if (docElements.isEmpty) {
+      return;
+    }
+
     if (_context.focusedEditor != 'dart') {
-      docPanel.innerHtml = 'Documentation';
+      _previousDoc = null;
+      for (final docPanel in docElements) {
+        docPanel.innerHtml = '';
+      }
       return;
     }
     if (!_editor.hasFocus || _editor.document.selection.isNotEmpty) {
       return;
     }
 
-    var offset = _editor.document.indexFromPos(_editor.document.cursor);
+    final offset = _editor.document.indexFromPos(_editor.document.cursor);
 
-    var request = SourceRequest()..offset = offset;
+    final request = SourceRequest()..offset = offset;
 
     if (_editor.completionActive) {
       // If the completion popup is open we create a new source as if the
@@ -59,57 +68,25 @@ class DocHandler {
         .document(request)
         .timeout(serviceCallTimeout)
         .then((DocumentResponse result) {
-      final docResult = _getHtmlTextFor(result);
-      if (docResult.html == '') {
-        docPanel.innerHtml =
-            "<div class='default-text-div layout horizontal center-center'>"
-            "<span class='default-text'>Documentation</span></div>";
+      final hash = result.hashCode;
+      // If nothing has changed, don't need to parse Markdown and
+      // manipulate HTML again.
+      if (hash == _previousDoc) {
         return;
       }
-      docPanel.setInnerHtml(docResult.html, validator: _htmlValidator);
-      for (final a in docPanel.querySelectorAll('a')) {
-        if (a is AnchorElement) a.target = 'docs';
-      }
-      for (final h in docPanel.querySelectorAll('h1')) {
-        h.classes.add('type-${docResult.entityKind}');
-      }
-    });
-  }
+      _previousDoc = hash;
 
-  void generateDoc(DivElement docPanel) {
-    if (_context.focusedEditor != 'dart') {
-      docPanel.innerHtml = '';
-      return;
-    }
-    if (!_editor.hasFocus || _editor.document.selection.isNotEmpty) {
-      return;
-    }
-
-    var offset = _editor.document.indexFromPos(_editor.document.cursor);
-
-    var request = SourceRequest()..offset = offset;
-
-    if (_editor.completionActive) {
-      // If the completion popup is open we create a new source as if the
-      // completion popup was chosen, and ask for the documentation of that
-      // source.
-      request.source =
-          _sourceWithCompletionInserted(_context.dartSource, offset);
-    } else {
-      request.source = _context.dartSource;
-    }
-
-    dartServices
-        .document(request)
-        .timeout(serviceCallTimeout)
-        .then((DocumentResponse result) {
       final docResult = _getHtmlTextFor(result);
-      docPanel.setInnerHtml(docResult.html, validator: _htmlValidator);
-      for (final a in docPanel.querySelectorAll('a')) {
-        if (a is AnchorElement) a.target = 'docs';
-      }
-      for (final h in docPanel.querySelectorAll('h1')) {
-        h.classes.add('type-${docResult.entityKind}');
+
+      final docType = 'type-${docResult.entityKind}';
+      for (final docPanel in docElements) {
+        docPanel.setInnerHtml(docResult.html, validator: _htmlValidator);
+        for (final a in docPanel.querySelectorAll('a')) {
+          if (a is AnchorElement) a.target = 'docs';
+        }
+        for (final h in docPanel.querySelectorAll('h1')) {
+          h.classes.add(docType);
+        }
       }
     });
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -510,8 +510,7 @@ class Playground implements GistContainer, GistController {
     keys.bind(['ctrl-enter'], _handleRun, 'Run');
     keys.bind(['f1'], () {
       ga.sendEvent('main', 'help');
-      docHandler.generateDoc(_rightDocContentElement);
-      docHandler.generateDoc(_leftDocPanel);
+      docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
     }, 'Documentation');
 
     keys.bind(['alt-enter'], () {
@@ -532,8 +531,7 @@ class Playground implements GistContainer, GistController {
     document.onKeyUp.listen((e) {
       if (editor.completionActive ||
           DocHandler.cursorKeys.contains(e.keyCode)) {
-        docHandler.generateDoc(_rightDocContentElement);
-        docHandler.generateDoc(_leftDocPanel);
+        docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
       }
       _handleAutoCompletion(e);
     });
@@ -568,8 +566,7 @@ class Playground implements GistContainer, GistController {
       // Delay to give codemirror time to process the mouse event.
       Timer.run(() {
         if (!_context.cursorPositionIsWhitespace()) {
-          docHandler.generateDoc(_rightDocContentElement);
-          docHandler.generateDoc(_leftDocPanel);
+          docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
         }
       });
     });


### PR DESCRIPTION
The primary purpose of this change is to avoid sending two requests for documentation, reducing potential strain on the servers. This is accomplished by changing our doc retrieval method to accept an array of elements to apply the changes to instead of doing so separately.

I've also gone ahead and added an addition of only generating the HTML and manipulating the HTML if something actually changed. We still need to make the request unfortunately, as it's not trivial without further, more complex, changes to know if they're requesting the same documentation from the client. But if the result is the same at least we avoid the markdown parsing, html generation, and requiring the browser to do DOM manipulation and parsing. 

Beyond that I've modified `cursorKeys` to a `Set` with a static type as we just use it for `contains` as well as removed a method we are no longer using, and is quite similar to this existing method if we ever need to add it back.

Fixes https://github.com/dart-lang/dart-pad/issues/1375