### PR TITLE
Fix and clean up flash close buttons - Fixes #1754

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -1133,7 +1133,7 @@ class FlashBox {
     _element = DElement(div);
     _messageContainer = DElement(div.querySelector('.message-container'));
 
-    final closeLink = DElement(div.querySelector('.flash-close'));
+    final closeLink = DElement(div.querySelector('.close-flash-container'));
     closeLink.onClick.listen((event) {
       hide();
     });

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -16,16 +16,7 @@
 .flash {
   border-radius: 0;
   border: none;
-  padding: 12px;
-}
-
-.flash-close {
   padding: 6px;
-  margin: -12px;
-
-  i {
-    font-size: 20px;
-  }
 }
 
 #flash-container {
@@ -42,7 +33,8 @@
 
 .message-container {
   letter-spacing: 0.05em;
-  padding-right: 22px;
+  padding: 6px 18px 6px 6px;
+  min-height: 32px;
   max-height: 120px;
   overflow-y: auto;
   font-family: Roboto Light, sans-serif;

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -181,15 +181,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="issues" hidden></div>

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -163,15 +163,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="issues" hidden></div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -174,15 +174,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="issues" hidden></div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -198,15 +198,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="issues" hidden></div>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -163,15 +163,15 @@ BSD-style license that can be found in the LICENSE file. -->
 
 <div id="flash-container" class="position-fixed right-2 bottom-6">
     <div id="test-result-box" class="flash flash-warn" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="hint-box" class="flash" hidden>
-        <button class="flash-close">
-            <i class="material-icons mdc-button__icon">close</i>
-        </button>
+        <div title="Close" class="close-flash-container">
+            <button class="close-flash-button mdc-icon-button material-icons">close</button>
+        </div>
         <div class="message-container custom-scrollbar"></div>
     </div>
     <div id="issues" hidden></div>

--- a/web/index.html
+++ b/web/index.html
@@ -231,15 +231,15 @@
     </div>
     <div id="flash-container">
         <div id="test-result-box" class="flash flash-warn" hidden>
-            <button class="flash-close">
-                <i class="material-icons mdc-button__icon">close</i>
-            </button>
+            <div title="Close" class="close-flash-container">
+                <button class="close-flash-button mdc-icon-button material-icons">close</button>
+            </div>
             <div class="message-container custom-scrollbar"></div>
         </div>
         <div id="hint-box" class="flash" hidden>
-            <button class="flash-close">
-                <i class="material-icons mdc-button__icon">close</i>
-            </button>
+            <<div title="Close" class="close-flash-container">
+                <button class="close-flash-button mdc-icon-button material-icons">close</button>
+            </div>
             <div class="message-container custom-scrollbar"></div>
         </div>
         <div id="issues" hidden></div>

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -159,12 +159,12 @@ body {
   overflow: auto;
 }
 
-#console-expand-icon-container {
+#console-expand-icon-container, .close-flash-container {
   height: 32px;
   width: 32px;
 }
 
-#console-expand-icon {
+#console-expand-icon, .close-flash-container .close-flash-button {
   color: $label-color;
   @include mdc-icon-button-size(16px, 16px, 8px);
 }
@@ -176,6 +176,10 @@ body {
   font-family: $editor-font;
   font-size: $embed-editor-font-size;
   white-space: pre-wrap;
+}
+
+.close-flash-container {
+  float: right;
 }
 
 // HTML Mode

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -96,12 +96,6 @@ a {
   background-color: $dark-flash-info-color;
 }
 
-.flash-close {
-  i {
-    color: $dark-flash-text-color;
-  }
-}
-
 .flash-success {
   background-color: $dark-flash-success-color;
 }

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -75,12 +75,6 @@ a {
   background-color: $light-flash-info-color;
 }
 
-.flash-close {
-  i {
-    color: $light-text-color;
-  }
-}
-
 .flash-success {
   background-color: $light-flash-success-color;
 }


### PR DESCRIPTION
This fixes the styling and positioning of the close/exit buttons on the flash windows.

Now they properly use the material styles and are positioned in the upper right:

**Light:**
![image](https://user-images.githubusercontent.com/18372958/107708409-0e3b0380-6c89-11eb-98ae-b4dc92d541f3.png)

**Dark:**
![image](https://user-images.githubusercontent.com/18372958/107708526-3f1b3880-6c89-11eb-957a-612a519c2f63.png)

**Hover style example:**
![image](https://user-images.githubusercontent.com/18372958/107708601-5ce89d80-6c89-11eb-94c4-329fd0ae2442.png)

Fixes #1754

CC @theacodes @johnpryan 