### PR TITLE
Add a border below web output so issues don't overlap it - Fixes #1744

### DIFF
--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -109,6 +109,10 @@ body {
 
 // Web output
 
+#web-output {
+  min-width: 180px;
+}
+
 #frame {
   border: none;
   width: 100%;

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -29,6 +29,7 @@ a {
 
 #web-output {
   background-color: $dark-code-background-color;
+  border-bottom: 46px solid $dark-border-color;
 }
 
 #console-output-footer {

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -26,6 +26,7 @@ a {
 
 #web-output {
   background-color: $light-code-background-color;
+  border-bottom: 46px solid $light-border-color;
 }
 
 #console-output-footer {


### PR DESCRIPTION
Leaves us with a little less vertical space, but is an okay solution without a larger UI overhaul. Matches the height of the collapsed console.

Previously:
https://user-images.githubusercontent.com/1227763/106179882-78fc2300-6150-11eb-9bd9-26faec2f654f.png

After:
![image](https://user-images.githubusercontent.com/18372958/107723608-35083280-6ca7-11eb-8d13-cbdde68d0936.png)

CC @johnpryan 