### PR TITLE
Fix scrollbar margin revealing background

### DIFF
--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -58,11 +58,14 @@ body {
 #user-code-editor, #solution-editor, #test-editor, #html-editor, #solution-editor {
   flex: 1;
   width: 100%;
-  margin-right: 8px;
 }
 
 .CodeMirror-hints {
   max-height: 11em;
+}
+
+.CodeMirror-simplescroll-vertical {
+  margin-right: 4px;
 }
 
 // Console


### PR DESCRIPTION
I'm pretty sure this was introduced after readding the flex styles from Primer.

Seen on https://master-api.flutter.dev/flutter/material/BottomNavigationBar-class.html

Previously:

![image](https://user-images.githubusercontent.com/18372958/107724927-98e02a80-6caa-11eb-9b1d-84a9c9589884.png)

After:

![image](https://user-images.githubusercontent.com/18372958/107724951-a4cbec80-6caa-11eb-9784-563f7ff87726.png)

CC @johnpryan 
