### PR TITLE
Significantly increase contrast for the dark theme.

### DIFF
--- a/lib/scss/colors.scss
+++ b/lib/scss/colors.scss
@@ -1,5 +1,6 @@
 // light + dark colors
 $label-color: #808080;
+$dark-label-color: #DEDEDE;
 $scrollbar-color: $label-color;
 
 // errors and warnings
@@ -59,11 +60,7 @@ $dark-orange: darken(desaturate(#ff916e, 20%), 5%);
 $dark-red: darken(desaturate(#ff2d64, 20%), 5%);
 $dark-pink-2: darken(desaturate(#ff00fA, 20%), 5%);
 $dark-orange-2: darken(desaturate(#ff9b00, 20%), 5%);
-$dark-editor-text: darken(desaturate(#c4cedb, 20%), 5%);
-$dark-comment: darken(desaturate(#909cce, 20%), 5%);
-$dark-line-count: darken(desaturate(#414c58, 20%), 5%);
 $dark-gutter-line-number-color: $dark-text-color;
-$dark-selection-color: lighten($dark-code-background-color, 10%);
 
 $light-green: #007a27;
 $light-blue: #00677a;
@@ -78,3 +75,20 @@ $light-comment: #929292;
 $light-line-count: #d5d5d5;
 $light-gutter-line-number-color: #d0d0d2;
 $light-selection-color: darken($light-code-background-color, 7%);
+
+// Colors used by *exclusively* by the Dark code editor theme. Separated
+// from the $dark-* colors above so that they can be independently adjusted
+// to maximize contrast.
+
+$dark-editor-background: #0e161f;
+$dark-editor-selection-color: lighten($dark-editor-background, 20%);
+$dark-editor-text: #fff;
+$dark-editor-comment: #9198b4;
+$dark-editor-green: #50ffa0;
+$dark-editor-pink: #f99fb5;
+$dark-editor-red: #ff8888;
+$dark-editor-blue: #75dbf0;
+$dark-editor-yellow: #fbff36;
+$dark-editor-orange: #f9a085;
+$dark-editor-purple: #d962ff;
+$dark-editor-cyan: #a5f6ff;

--- a/web/styles/cm-dartpad-dark.scss
+++ b/web/styles/cm-dartpad-dark.scss
@@ -9,28 +9,31 @@
   font-weight: 400;
 }
 
-.cm-s-darkpad .CodeMirror-matchingbracket {color: $dark-red !important;}
-.cm-s-darkpad .CodeMirror-selected {background: $dark-selection-color !important;}
+.cm-s-darkpad .CodeMirror-matchingbracket {color: $dark-editor-purple !important;}
+.cm-s-darkpad .CodeMirror-selected {background: $dark-editor-selection-color !important;}
 
-.cm-s-darkpad .CodeMirror-gutters { background: $dark-code-background-color !important; border-right: none}
+.cm-s-darkpad .CodeMirror-gutters { background: $dark-editor-background !important; border-right: none}
 .cm-s-darkpad .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: $dark-gutter-line-number-color; }
 .cm-s-darkpad .CodeMirror-linenumber { color: $dark-gutter-line-number-color; }
 .cm-s-darkpad .CodeMirror-cursor { border-left: 1px solid white; }
-.cm-s-darkpad { background-color: $dark-code-background-color; color: $dark-editor-text; }
+.cm-s-darkpad {
+    background-color: $dark-editor-background;
+    color: $dark-editor-text;
+}
 .cm-s-darkpad span.cm-builtin { color: $dark-editor-text; }
-.cm-s-darkpad span.cm-comment { color: $dark-comment; }
-.cm-s-darkpad span.cm-keyword { color: $dark-green;}
-.cm-s-darkpad span.cm-atom { color: $dark-orange; }
-.cm-s-darkpad span.cm-variable { color: $dark-blue; }
-.cm-s-darkpad span.cm-variable-2 { color: $dark-orange;}
-.cm-s-darkpad span.cm-string { color: $dark-pink; }
-.cm-s-darkpad span.cm-string-2 { color: $dark-pink-2; }
-.cm-s-darkpad span.cm-number { color: $dark-teal; }
-.cm-s-darkpad span.cm-attribute { color: $dark-blue; }
-.cm-s-darkpad span.cm-qualifier { color: $dark-orange-2; }
-.cm-s-darkpad span.cm-meta { color: $dark-teal; }
-.cm-s-darkpad span.cm-header { color: $dark-blue; }
+.cm-s-darkpad span.cm-comment { color: $dark-editor-comment; }
+.cm-s-darkpad span.cm-keyword { color: $dark-editor-green;}
+.cm-s-darkpad span.cm-atom { color: $dark-editor-orange; }
+.cm-s-darkpad span.cm-variable { color: $dark-editor-blue; }
+.cm-s-darkpad span.cm-variable-2 { color: $dark-editor-cyan; }
+.cm-s-darkpad span.cm-string { color: $dark-editor-pink; }
+.cm-s-darkpad span.cm-string-2 { color: $dark-editor-red; }
+.cm-s-darkpad span.cm-number { color: $dark-editor-yellow; }
+.cm-s-darkpad span.cm-attribute { color: $dark-editor-blue; }
+.cm-s-darkpad span.cm-qualifier { color: $dark-editor-cyan; }
+.cm-s-darkpad span.cm-meta { color: $dark-editor-yellow; }
+.cm-s-darkpad span.cm-header { color: $dark-editor-blue; }
 .cm-s-darkpad span.cm-operator { color: $dark-editor-text; }
 .cm-s-darkpad span.cm-def { color: $dark-editor-text; }
-.cm-s-darkpad span.cm-tag { color: $dark-green; }
-.cm-s-darkpad span.cm-property { color: $dark-red; }
+.cm-s-darkpad span.cm-tag { color: $dark-editor-green; }
+.cm-s-darkpad span.cm-property { color: $dark-editor-red; }

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -7,7 +7,7 @@
 // These variables must be set before importing material-components-web.scss.
 // Since `styles.scss` loads mdc_web these must be before `styles.scss` is
 // imported
-$mdc-theme-primary: #168AFD;
+$mdc-theme-primary: #a5f6ff;
 $mdc-theme-secondary: #676767;
 $mdc-theme-background: $dark-code-background-color;
 $mdc-theme-surface: $dark-code-background-color;
@@ -78,7 +78,7 @@ a {
   color: $dark-text-color !important;
 }
 .mdc-tab--active .mdc-tab__text-label {
-  color: #168AFD !important;
+  color: $mdc-theme-primary !important;
 }
 
 .message-container {
@@ -107,4 +107,10 @@ a {
 
 .flash-warn {
   background-color: $dark-flash-warning-color;
+}
+
+// Misc
+
+.view-label {
+  color: $dark-label-color;
 }

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -144,6 +144,7 @@ a {
 
 // Editor panel
 #editor-panel {
+  background-color: $dark-editor-background;
   @include layout-vertical;
   @include layout-relative;
 }


### PR DESCRIPTION
* Establish separate, exclusive styles for the code editor in dark mode.
* Adjust dark mode editor colors to maintain >= 8.0 contrast ratio (most colors are >= 10).
* Change the material primary color for embedded dark mode to a much lighter blue.
* Ligten the output label color.

Main UI before:

![dartpad dev_e93b969fed77325db0b848a85f1cf78e_null_safety=true](https://user-images.githubusercontent.com/250995/108130854-4faf2280-707e-11eb-8581-981d660878be.png)

Main UI after:

![localhost_8000_e93b969fed77325db0b848a85f1cf78e](https://user-images.githubusercontent.com/250995/108130924-71100e80-707e-11eb-8ea0-7cbb99121423.png)

Embedded UI before:

![dartpad dev__example_embed html](https://user-images.githubusercontent.com/250995/108130967-84bb7500-707e-11eb-955a-83375e6c738c.png)

Embedded UI after:

![localhost_8000_example_embed html](https://user-images.githubusercontent.com/250995/108130982-8ab15600-707e-11eb-8ce4-d1a81beed67f.png)

Fixes #1628 