### PR TITLE
Context messages

### DIFF
--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -83,7 +83,6 @@ class AnalysisResultsController {
 
   Element _issueElement(AnalysisIssue issue) {
     var message = issue.message;
-    message = _stripPeriod(message);
 
     var elem = DivElement()..classes.addAll(['issue', 'clickable']);
 
@@ -100,9 +99,8 @@ class AnalysisResultsController {
 
     // Add the correction, if any.
     if (issue.correction != null && issue.correction.isNotEmpty) {
-      var correctionMessage = _stripPeriod(issue.correction);
       columnElem.children.add(DivElement()
-        ..text = correctionMessage
+        ..text = issue.correction
         ..classes.add('message'));
     }
 
@@ -125,13 +123,6 @@ class AnalysisResultsController {
     });
 
     return elem;
-  }
-
-  String _stripPeriod(String s) {
-    if (s.endsWith('.')) {
-      s = s.substring(0, s.length - 1);
-    }
-    return s;
   }
 
   Element _diagnosticElement(DiagnosticMessage diagnosticMessage) {

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -92,9 +92,18 @@ class AnalysisResultsController {
       ..text = issue.kind
       ..classes.addAll(_classesForType[issue.kind]));
 
-    elem.children.add(SpanElement()
+    var messageSpan = SpanElement()
       ..text = '$message - line ${issue.line}'
-      ..classes.add('message'));
+      ..classes.add('message');
+    elem.children.add(messageSpan);
+
+    if (issue.url != null && issue.url.isNotEmpty) {
+      messageSpan.children.add(AnchorElement()
+        ..href = issue.url
+        ..text = ' Open Documentation'
+        ..target = '_blank'
+        ..classes.add('issue-anchor'));
+    }
 
     elem.onClick.listen((_) {
       _onClickController.add(LineInfo(

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -73,6 +73,11 @@ class AnalysisResultsController {
     for (var issue in issues) {
       var elem = _issueElement(issue);
       flash.add(elem);
+
+      if (issue.correction != null && issue.correction.isNotEmpty) {
+        flash.add(_correctionElement(issue));
+      }
+
       for (var diagnostic in issue.diagnosticMessages) {
         var diagnosticElement = _diagnosticElement(diagnostic);
         flash.add(diagnosticElement);
@@ -135,6 +140,23 @@ class AnalysisResultsController {
           charStart: diagnosticMessage.charStart,
           charLength: diagnosticMessage.charLength));
     });
+
+    return elem;
+  }
+
+  Element _correctionElement(AnalysisIssue issue) {
+    var message = issue.correction;
+    if (message.endsWith('.')) {
+      message = message.substring(0, message.length - 1);
+    }
+
+    var elem = DivElement()..classes.add('issue');
+
+    elem.children.add(SpanElement()..classes.add('issue-indent'));
+
+    elem.children.add(SpanElement()
+      ..text = message
+      ..classes.add('message'));
 
     return elem;
   }

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -25,10 +25,10 @@ class AnalysisResultsController {
   final DElement toggle;
   bool _flashHidden;
 
-  final StreamController<LineInfo> _onClickController =
+  final StreamController<Location> _onClickController =
       StreamController.broadcast();
 
-  Stream<LineInfo> get onItemClicked => _onClickController.stream;
+  Stream<Location> get onItemClicked => _onClickController.stream;
 
   AnalysisResultsController(this.flash, this.message, this.toggle) {
     // Show issues by default, but hide the flash element (otherwise an empty
@@ -118,7 +118,7 @@ class AnalysisResultsController {
     elem.children.add(columnElem);
 
     elem.onClick.listen((_) {
-      _onClickController.add(LineInfo(
+      _onClickController.add(Location(
           line: issue.line,
           charStart: issue.charStart,
           charLength: issue.charLength));
@@ -149,7 +149,7 @@ class AnalysisResultsController {
       ..classes.add('message'));
 
     elem.onClick.listen((_) {
-      _onClickController.add(LineInfo(
+      _onClickController.add(Location(
           line: diagnosticMessage.line,
           charStart: diagnosticMessage.charStart,
           charLength: diagnosticMessage.charLength));
@@ -179,12 +179,13 @@ class AnalysisResultsController {
   }
 }
 
-class LineInfo {
+/// A range of text in the file.
+class Location {
   final int line;
   final int charStart;
   final int charLength;
 
-  LineInfo({
+  Location({
     this.line,
     this.charStart,
     this.charLength,

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -93,7 +93,7 @@ class AnalysisResultsController {
     var columnElem = DivElement()..classes.add('issue-column');
 
     var messageSpan = DivElement()
-      ..text = '$message - line ${issue.line}'
+      ..text = '$message (line ${issue.line})'
       ..classes.add('message');
     columnElem.children.add(messageSpan);
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -401,8 +401,7 @@ class Embed {
         DElement(querySelector('#issues-message')),
         DElement(querySelector('#issues-toggle')))
       ..onItemClicked.listen((item) {
-        _jumpTo(item.line, item.charStart, item.charLength,
-            focus: true);
+        _jumpTo(item.line, item.charStart, item.charLength, focus: true);
       });
 
     if (options.mode == EmbedMode.flutter || options.mode == EmbedMode.html) {
@@ -1017,12 +1016,11 @@ class Embed {
     return s;
   }
 
-  void _jumpTo(int line, int charStart, int charLength,
-      {bool focus = false, bool relativeToLine = false}) {
+  void _jumpTo(int line, int charStart, int charLength, {bool focus = false}) {
     var doc = userCodeEditor.document;
 
-      doc.select(doc.posFromIndex(charStart),
-          doc.posFromIndex(charStart + charLength));
+    doc.select(
+        doc.posFromIndex(charStart), doc.posFromIndex(charStart + charLength));
 
     if (focus) userCodeEditor.focus();
   }

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -400,8 +400,9 @@ class Embed {
         DElement(querySelector('#issues')),
         DElement(querySelector('#issues-message')),
         DElement(querySelector('#issues-toggle')))
-      ..onIssueClick.listen((issue) {
-        _jumpTo(issue.line, issue.charStart, issue.charLength, focus: true);
+      ..onItemClicked.listen((item) {
+        _jumpTo(item.line, item.charStart, item.charLength,
+            focus: true);
       });
 
     if (options.mode == EmbedMode.flutter || options.mode == EmbedMode.html) {
@@ -1016,11 +1017,12 @@ class Embed {
     return s;
   }
 
-  void _jumpTo(int line, int charStart, int charLength, {bool focus = false}) {
+  void _jumpTo(int line, int charStart, int charLength,
+      {bool focus = false, bool relativeToLine = false}) {
     var doc = userCodeEditor.document;
 
-    doc.select(
-        doc.posFromIndex(charStart), doc.posFromIndex(charStart + charLength));
+      doc.select(doc.posFromIndex(charStart),
+          doc.posFromIndex(charStart + charLength));
 
     if (focus) userCodeEditor.focus();
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -600,8 +600,8 @@ class Playground implements GistContainer, GistController {
         DElement(querySelector('#issues')),
         DElement(querySelector('#issues-message')),
         DElement(querySelector('#issues-toggle')))
-      ..onIssueClick.listen((issue) {
-        _jumpTo(issue.line, issue.charStart, issue.charLength, focus: true);
+      ..onItemClicked.listen((item) {
+        _jumpTo(item.line, item.charStart, item.charLength, focus: true);
       });
 
     _finishedInit();

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -3,6 +3,12 @@
 @import 'package:dart_pad/scss/colors';
 @import 'package:dart_pad/scss/variables';
 
+a {
+  text-decoration: none;
+  cursor: pointer;
+  font-family: Roboto, sans-serif;
+}
+
 // Flashes
 #flash-container > div + div {
   // Adds space between the flashes in the flash container, if more than one is displayed.
@@ -82,6 +88,8 @@
   padding: 4px;
   margin: 0;
 }
+
+
 
 .clickable {
   cursor: pointer;

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -76,6 +76,7 @@
 #issues .issue {
   display: flex;
   flex-direction: row;
+  align-items: start;
   line-height: 20px;
   border-radius: 3px;
   cursor: pointer;
@@ -92,7 +93,7 @@
   font-size: $embed-editor-font-size;
   display: inline-block;
   border-radius: 3px;
-  padding: 2px 5px;
+  padding: 0 5px 2px 5px;
   min-width: 62px;
 }
 

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -79,9 +79,12 @@
   align-items: start;
   line-height: 20px;
   border-radius: 3px;
-  cursor: pointer;
   padding: 4px;
   margin: 0;
+}
+
+.clickable {
+  cursor: pointer;
 }
 
 .issue + .issue {

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -95,6 +95,11 @@
   min-width: 62px;
 }
 
+.issue-indent {
+  padding: 2px 5px; // to match size of issuelabel
+  min-width: 62px;
+}
+
 .issue .issuelabel.error {
   color: $issue-error-color;
   border: 1px solid $issue-error-color;

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -69,7 +69,6 @@
 
 // Issues
 #issues {
-  padding: 8px;
   overflow-y: auto;
   max-height: 50vh;
 }
@@ -80,6 +79,8 @@
   line-height: 20px;
   border-radius: 3px;
   cursor: pointer;
+  padding: 4px;
+  margin: 0;
 }
 
 .issue + .issue {
@@ -96,8 +97,13 @@
 }
 
 .issue-indent {
+  border: 1px;
   padding: 2px 5px; // to match size of issuelabel
   min-width: 62px;
+}
+
+.issue-anchor {
+  margin: 0 4px;
 }
 
 .issue .issuelabel.error {

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -5,14 +5,14 @@
 library dart_pad.common;
 
 // The endpoint running dart-services.
-// const serverUrl = 'https://v1.api.dartpad.dev/';
+const serverUrl = 'https://v1.api.dartpad.dev/';
 
 // Used when null safety is enabled in the UI.
-// const nullSafetyServerUrl = 'https://nullsafety.api.dartpad.dev/';
+const nullSafetyServerUrl = 'https://nullsafety.api.dartpad.dev/';
 
 // A URL to use while debugging.
-final serverUrl = 'http://127.0.0.1:8082/';
-const nullSafetyServerUrl = 'http://127.0.0.1:8082/';
+// final serverUrl = 'http://127.0.0.1:8082/';
+// const nullSafetyServerUrl = 'http://127.0.0.1:8082/';
 
 const Duration serviceCallTimeout = Duration(seconds: 10);
 const Duration longServiceCallTimeout = Duration(seconds: 60);

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -5,13 +5,14 @@
 library dart_pad.common;
 
 // The endpoint running dart-services.
-const serverUrl = 'https://v1.api.dartpad.dev/';
+// const serverUrl = 'https://v1.api.dartpad.dev/';
 
 // Used when null safety is enabled in the UI.
-const nullSafetyServerUrl = 'https://nullsafety.api.dartpad.dev/';
+// const nullSafetyServerUrl = 'https://nullsafety.api.dartpad.dev/';
 
 // A URL to use while debugging.
-// final serverUrl = 'http://127.0.0.1:8082/';
+final serverUrl = 'http://127.0.0.1:8082/';
+const nullSafetyServerUrl = 'http://127.0.0.1:8082/';
 
 const Duration serviceCallTimeout = Duration(seconds: 10);
 const Duration longServiceCallTimeout = Duration(seconds: 60);

--- a/lib/src/protos/dart_services.pb.dart
+++ b/lib/src/protos/dart_services.pb.dart
@@ -10,11 +10,27 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class CompileRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'returnSourceMap', protoName: 'returnSourceMap')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CompileRequest',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'source')
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'returnSourceMap',
+        protoName: 'returnSourceMap')
+    ..hasRequiredFields = false;
 
   CompileRequest._() : super();
   factory CompileRequest({
@@ -30,31 +46,40 @@ class CompileRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CompileRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CompileRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CompileRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CompileRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CompileRequest clone() => CompileRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CompileRequest copyWith(void Function(CompileRequest) updates) => super.copyWith((message) => updates(message as CompileRequest)) as CompileRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CompileRequest copyWith(void Function(CompileRequest) updates) =>
+      super.copyWith((message) => updates(message as CompileRequest))
+          as CompileRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileRequest create() => CompileRequest._();
   CompileRequest createEmptyInstance() => create();
-  static $pb.PbList<CompileRequest> createRepeated() => $pb.PbList<CompileRequest>();
+  static $pb.PbList<CompileRequest> createRepeated() =>
+      $pb.PbList<CompileRequest>();
   @$core.pragma('dart2js:noInline')
-  static CompileRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileRequest>(create);
+  static CompileRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CompileRequest>(create);
   static CompileRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get source => $_getSZ(0);
   @$pb.TagNumber(1)
-  set source($core.String v) { $_setString(0, v); }
+  set source($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSource() => $_has(0);
   @$pb.TagNumber(1)
@@ -63,7 +88,10 @@ class CompileRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get returnSourceMap => $_getBF(1);
   @$pb.TagNumber(2)
-  set returnSourceMap($core.bool v) { $_setBool(1, v); }
+  set returnSourceMap($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasReturnSourceMap() => $_has(1);
   @$pb.TagNumber(2)
@@ -71,10 +99,21 @@ class CompileRequest extends $pb.GeneratedMessage {
 }
 
 class CompileDDCRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileDDCRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CompileDDCRequest',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'source')
+    ..hasRequiredFields = false;
 
   CompileDDCRequest._() : super();
   factory CompileDDCRequest({
@@ -86,31 +125,40 @@ class CompileDDCRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CompileDDCRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CompileDDCRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CompileDDCRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CompileDDCRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CompileDDCRequest clone() => CompileDDCRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CompileDDCRequest copyWith(void Function(CompileDDCRequest) updates) => super.copyWith((message) => updates(message as CompileDDCRequest)) as CompileDDCRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CompileDDCRequest copyWith(void Function(CompileDDCRequest) updates) =>
+      super.copyWith((message) => updates(message as CompileDDCRequest))
+          as CompileDDCRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileDDCRequest create() => CompileDDCRequest._();
   CompileDDCRequest createEmptyInstance() => create();
-  static $pb.PbList<CompileDDCRequest> createRepeated() => $pb.PbList<CompileDDCRequest>();
+  static $pb.PbList<CompileDDCRequest> createRepeated() =>
+      $pb.PbList<CompileDDCRequest>();
   @$core.pragma('dart2js:noInline')
-  static CompileDDCRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileDDCRequest>(create);
+  static CompileDDCRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CompileDDCRequest>(create);
   static CompileDDCRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get source => $_getSZ(0);
   @$pb.TagNumber(1)
-  set source($core.String v) { $_setString(0, v); }
+  set source($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSource() => $_has(0);
   @$pb.TagNumber(1)
@@ -118,11 +166,27 @@ class CompileDDCRequest extends $pb.GeneratedMessage {
 }
 
 class SourceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SourceRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'SourceRequest',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'source')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'offset',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
 
   SourceRequest._() : super();
   factory SourceRequest({
@@ -138,31 +202,40 @@ class SourceRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SourceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SourceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SourceRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SourceRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SourceRequest clone() => SourceRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SourceRequest copyWith(void Function(SourceRequest) updates) => super.copyWith((message) => updates(message as SourceRequest)) as SourceRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SourceRequest copyWith(void Function(SourceRequest) updates) =>
+      super.copyWith((message) => updates(message as SourceRequest))
+          as SourceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceRequest create() => SourceRequest._();
   SourceRequest createEmptyInstance() => create();
-  static $pb.PbList<SourceRequest> createRepeated() => $pb.PbList<SourceRequest>();
+  static $pb.PbList<SourceRequest> createRepeated() =>
+      $pb.PbList<SourceRequest>();
   @$core.pragma('dart2js:noInline')
-  static SourceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceRequest>(create);
+  static SourceRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SourceRequest>(create);
   static SourceRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get source => $_getSZ(0);
   @$pb.TagNumber(1)
-  set source($core.String v) { $_setString(0, v); }
+  set source($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSource() => $_has(0);
   @$pb.TagNumber(1)
@@ -171,7 +244,10 @@ class SourceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get offset => $_getIZ(1);
   @$pb.TagNumber(2)
-  set offset($core.int v) { $_setSignedInt32(1, v); }
+  set offset($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasOffset() => $_has(1);
   @$pb.TagNumber(2)
@@ -179,12 +255,24 @@ class SourceRequest extends $pb.GeneratedMessage {
 }
 
 class AnalysisResults extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AnalysisResults', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..pc<AnalysisIssue>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'issues', $pb.PbFieldType.PM, subBuilder: AnalysisIssue.create)
-    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'packageImports', protoName: 'packageImports')
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'AnalysisResults',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..pc<AnalysisIssue>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'issues', $pb.PbFieldType.PM,
+        subBuilder: AnalysisIssue.create)
+    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'packageImports',
+        protoName: 'packageImports')
+    ..aOM<ErrorMessage>(
+        99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   AnalysisResults._() : super();
   factory AnalysisResults({
@@ -204,25 +292,31 @@ class AnalysisResults extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AnalysisResults.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AnalysisResults.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AnalysisResults.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AnalysisResults.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AnalysisResults clone() => AnalysisResults()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AnalysisResults copyWith(void Function(AnalysisResults) updates) => super.copyWith((message) => updates(message as AnalysisResults)) as AnalysisResults; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AnalysisResults copyWith(void Function(AnalysisResults) updates) =>
+      super.copyWith((message) => updates(message as AnalysisResults))
+          as AnalysisResults; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AnalysisResults create() => AnalysisResults._();
   AnalysisResults createEmptyInstance() => create();
-  static $pb.PbList<AnalysisResults> createRepeated() => $pb.PbList<AnalysisResults>();
+  static $pb.PbList<AnalysisResults> createRepeated() =>
+      $pb.PbList<AnalysisResults>();
   @$core.pragma('dart2js:noInline')
-  static AnalysisResults getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AnalysisResults>(create);
+  static AnalysisResults getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<AnalysisResults>(create);
   static AnalysisResults _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -234,7 +328,10 @@ class AnalysisResults extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -244,19 +341,39 @@ class AnalysisResults extends $pb.GeneratedMessage {
 }
 
 class AnalysisIssue extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AnalysisIssue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kind')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'line', $pb.PbFieldType.O3)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceName', protoName: 'sourceName')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'AnalysisIssue',
+      package: const $pb.PackageName($core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'kind')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'line',
+        $pb.PbFieldType.O3)
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'message')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceName',
+        protoName: 'sourceName')
     ..aOB(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hasFixes', protoName: 'hasFixes')
     ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charStart', $pb.PbFieldType.O3, protoName: 'charStart')
     ..a<$core.int>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
     ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
     ..pc<DiagnosticMessage>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'diagnosticMessages', $pb.PbFieldType.PM, protoName: 'diagnosticMessages', subBuilder: DiagnosticMessage.create)
     ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'correction')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   AnalysisIssue._() : super();
   factory AnalysisIssue({
@@ -304,31 +421,40 @@ class AnalysisIssue extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AnalysisIssue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AnalysisIssue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AnalysisIssue.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AnalysisIssue.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AnalysisIssue clone() => AnalysisIssue()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AnalysisIssue copyWith(void Function(AnalysisIssue) updates) => super.copyWith((message) => updates(message as AnalysisIssue)) as AnalysisIssue; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AnalysisIssue copyWith(void Function(AnalysisIssue) updates) =>
+      super.copyWith((message) => updates(message as AnalysisIssue))
+          as AnalysisIssue; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AnalysisIssue create() => AnalysisIssue._();
   AnalysisIssue createEmptyInstance() => create();
-  static $pb.PbList<AnalysisIssue> createRepeated() => $pb.PbList<AnalysisIssue>();
+  static $pb.PbList<AnalysisIssue> createRepeated() =>
+      $pb.PbList<AnalysisIssue>();
   @$core.pragma('dart2js:noInline')
-  static AnalysisIssue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AnalysisIssue>(create);
+  static AnalysisIssue getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<AnalysisIssue>(create);
   static AnalysisIssue _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get kind => $_getSZ(0);
   @$pb.TagNumber(1)
-  set kind($core.String v) { $_setString(0, v); }
+  set kind($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasKind() => $_has(0);
   @$pb.TagNumber(1)
@@ -337,7 +463,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get line => $_getIZ(1);
   @$pb.TagNumber(2)
-  set line($core.int v) { $_setSignedInt32(1, v); }
+  set line($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLine() => $_has(1);
   @$pb.TagNumber(2)
@@ -346,7 +475,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get message => $_getSZ(2);
   @$pb.TagNumber(3)
-  set message($core.String v) { $_setString(2, v); }
+  set message($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasMessage() => $_has(2);
   @$pb.TagNumber(3)
@@ -355,7 +487,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get sourceName => $_getSZ(3);
   @$pb.TagNumber(4)
-  set sourceName($core.String v) { $_setString(3, v); }
+  set sourceName($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasSourceName() => $_has(3);
   @$pb.TagNumber(4)
@@ -364,7 +499,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get hasFixes => $_getBF(4);
   @$pb.TagNumber(5)
-  set hasFixes($core.bool v) { $_setBool(4, v); }
+  set hasFixes($core.bool v) {
+    $_setBool(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasHasFixes() => $_has(4);
   @$pb.TagNumber(5)
@@ -373,7 +511,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get charStart => $_getIZ(5);
   @$pb.TagNumber(6)
-  set charStart($core.int v) { $_setSignedInt32(5, v); }
+  set charStart($core.int v) {
+    $_setSignedInt32(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasCharStart() => $_has(5);
   @$pb.TagNumber(6)
@@ -382,7 +523,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get charLength => $_getIZ(6);
   @$pb.TagNumber(7)
-  set charLength($core.int v) { $_setSignedInt32(6, v); }
+  set charLength($core.int v) {
+    $_setSignedInt32(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasCharLength() => $_has(6);
   @$pb.TagNumber(7)
@@ -391,7 +535,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get url => $_getSZ(7);
   @$pb.TagNumber(8)
-  set url($core.String v) { $_setString(7, v); }
+  set url($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasUrl() => $_has(7);
   @$pb.TagNumber(8)
@@ -403,7 +550,10 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get correction => $_getSZ(9);
   @$pb.TagNumber(10)
-  set correction($core.String v) { $_setString(9, v); }
+  set correction($core.String v) {
+    $_setString(9, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasCorrection() => $_has(9);
   @$pb.TagNumber(10)
@@ -411,13 +561,32 @@ class AnalysisIssue extends $pb.GeneratedMessage {
 }
 
 class DiagnosticMessage extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DiagnosticMessage', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'line', $pb.PbFieldType.O3)
-    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charStart', $pb.PbFieldType.O3, protoName: 'charStart')
-    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'DiagnosticMessage',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'message')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'line',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charStart', $pb.PbFieldType.O3,
+        protoName: 'charStart')
+    ..a<$core.int>(
+        4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3,
+        protoName: 'charLength')
+    ..hasRequiredFields = false;
 
   DiagnosticMessage._() : super();
   factory DiagnosticMessage({
@@ -441,31 +610,40 @@ class DiagnosticMessage extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DiagnosticMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DiagnosticMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory DiagnosticMessage.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DiagnosticMessage.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   DiagnosticMessage clone() => DiagnosticMessage()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DiagnosticMessage copyWith(void Function(DiagnosticMessage) updates) => super.copyWith((message) => updates(message as DiagnosticMessage)) as DiagnosticMessage; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DiagnosticMessage copyWith(void Function(DiagnosticMessage) updates) =>
+      super.copyWith((message) => updates(message as DiagnosticMessage))
+          as DiagnosticMessage; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DiagnosticMessage create() => DiagnosticMessage._();
   DiagnosticMessage createEmptyInstance() => create();
-  static $pb.PbList<DiagnosticMessage> createRepeated() => $pb.PbList<DiagnosticMessage>();
+  static $pb.PbList<DiagnosticMessage> createRepeated() =>
+      $pb.PbList<DiagnosticMessage>();
   @$core.pragma('dart2js:noInline')
-  static DiagnosticMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DiagnosticMessage>(create);
+  static DiagnosticMessage getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DiagnosticMessage>(create);
   static DiagnosticMessage _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) { $_setString(0, v); }
+  set message($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -474,7 +652,10 @@ class DiagnosticMessage extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get line => $_getIZ(1);
   @$pb.TagNumber(2)
-  set line($core.int v) { $_setSignedInt32(1, v); }
+  set line($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLine() => $_has(1);
   @$pb.TagNumber(2)
@@ -483,7 +664,10 @@ class DiagnosticMessage extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get charStart => $_getIZ(2);
   @$pb.TagNumber(3)
-  set charStart($core.int v) { $_setSignedInt32(2, v); }
+  set charStart($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCharStart() => $_has(2);
   @$pb.TagNumber(3)
@@ -492,7 +676,10 @@ class DiagnosticMessage extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get charLength => $_getIZ(3);
   @$pb.TagNumber(4)
-  set charLength($core.int v) { $_setSignedInt32(3, v); }
+  set charLength($core.int v) {
+    $_setSignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasCharLength() => $_has(3);
   @$pb.TagNumber(4)
@@ -500,41 +687,71 @@ class DiagnosticMessage extends $pb.GeneratedMessage {
 }
 
 class VersionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'VersionRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'VersionRequest',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..hasRequiredFields = false;
 
   VersionRequest._() : super();
   factory VersionRequest() => create();
-  factory VersionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory VersionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory VersionRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory VersionRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   VersionRequest clone() => VersionRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  VersionRequest copyWith(void Function(VersionRequest) updates) => super.copyWith((message) => updates(message as VersionRequest)) as VersionRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  VersionRequest copyWith(void Function(VersionRequest) updates) =>
+      super.copyWith((message) => updates(message as VersionRequest))
+          as VersionRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static VersionRequest create() => VersionRequest._();
   VersionRequest createEmptyInstance() => create();
-  static $pb.PbList<VersionRequest> createRepeated() => $pb.PbList<VersionRequest>();
+  static $pb.PbList<VersionRequest> createRepeated() =>
+      $pb.PbList<VersionRequest>();
   @$core.pragma('dart2js:noInline')
-  static VersionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VersionRequest>(create);
+  static VersionRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<VersionRequest>(create);
   static VersionRequest _defaultInstance;
 }
 
 class CompileResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'result')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceMap', protoName: 'sourceMap')
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CompileResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'result')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceMap',
+        protoName: 'sourceMap')
+    ..aOM<ErrorMessage>(
+        99,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   CompileResponse._() : super();
   factory CompileResponse({
@@ -554,31 +771,40 @@ class CompileResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CompileResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CompileResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CompileResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CompileResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CompileResponse clone() => CompileResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CompileResponse copyWith(void Function(CompileResponse) updates) => super.copyWith((message) => updates(message as CompileResponse)) as CompileResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CompileResponse copyWith(void Function(CompileResponse) updates) =>
+      super.copyWith((message) => updates(message as CompileResponse))
+          as CompileResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileResponse create() => CompileResponse._();
   CompileResponse createEmptyInstance() => create();
-  static $pb.PbList<CompileResponse> createRepeated() => $pb.PbList<CompileResponse>();
+  static $pb.PbList<CompileResponse> createRepeated() =>
+      $pb.PbList<CompileResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompileResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileResponse>(create);
+  static CompileResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CompileResponse>(create);
   static CompileResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get result => $_getSZ(0);
   @$pb.TagNumber(1)
-  set result($core.String v) { $_setString(0, v); }
+  set result($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasResult() => $_has(0);
   @$pb.TagNumber(1)
@@ -587,7 +813,10 @@ class CompileResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get sourceMap => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sourceMap($core.String v) { $_setString(1, v); }
+  set sourceMap($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSourceMap() => $_has(1);
   @$pb.TagNumber(2)
@@ -596,7 +825,10 @@ class CompileResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -606,12 +838,29 @@ class CompileResponse extends $pb.GeneratedMessage {
 }
 
 class CompileDDCResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileDDCResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'result')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'modulesBaseUrl', protoName: 'modulesBaseUrl')
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CompileDDCResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'result')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'modulesBaseUrl',
+        protoName: 'modulesBaseUrl')
+    ..aOM<ErrorMessage>(
+        99,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   CompileDDCResponse._() : super();
   factory CompileDDCResponse({
@@ -631,31 +880,40 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CompileDDCResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CompileDDCResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CompileDDCResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CompileDDCResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CompileDDCResponse clone() => CompileDDCResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CompileDDCResponse copyWith(void Function(CompileDDCResponse) updates) => super.copyWith((message) => updates(message as CompileDDCResponse)) as CompileDDCResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CompileDDCResponse copyWith(void Function(CompileDDCResponse) updates) =>
+      super.copyWith((message) => updates(message as CompileDDCResponse))
+          as CompileDDCResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileDDCResponse create() => CompileDDCResponse._();
   CompileDDCResponse createEmptyInstance() => create();
-  static $pb.PbList<CompileDDCResponse> createRepeated() => $pb.PbList<CompileDDCResponse>();
+  static $pb.PbList<CompileDDCResponse> createRepeated() =>
+      $pb.PbList<CompileDDCResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompileDDCResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileDDCResponse>(create);
+  static CompileDDCResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CompileDDCResponse>(create);
   static CompileDDCResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get result => $_getSZ(0);
   @$pb.TagNumber(1)
-  set result($core.String v) { $_setString(0, v); }
+  set result($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasResult() => $_has(0);
   @$pb.TagNumber(1)
@@ -664,7 +922,10 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get modulesBaseUrl => $_getSZ(1);
   @$pb.TagNumber(2)
-  set modulesBaseUrl($core.String v) { $_setString(1, v); }
+  set modulesBaseUrl($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasModulesBaseUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -673,7 +934,10 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -683,11 +947,28 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
 }
 
 class DocumentResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DocumentResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..m<$core.String, $core.String>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'info', entryClassName: 'DocumentResponse.InfoEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('dart_services.api'))
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'DocumentResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..m<$core.String, $core.String>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'info',
+        entryClassName: 'DocumentResponse.InfoEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('dart_services.api'))
+    ..aOM<ErrorMessage>(
+        99,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   DocumentResponse._() : super();
   factory DocumentResponse({
@@ -703,25 +984,31 @@ class DocumentResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory DocumentResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory DocumentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory DocumentResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory DocumentResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   DocumentResponse clone() => DocumentResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  DocumentResponse copyWith(void Function(DocumentResponse) updates) => super.copyWith((message) => updates(message as DocumentResponse)) as DocumentResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  DocumentResponse copyWith(void Function(DocumentResponse) updates) =>
+      super.copyWith((message) => updates(message as DocumentResponse))
+          as DocumentResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DocumentResponse create() => DocumentResponse._();
   DocumentResponse createEmptyInstance() => create();
-  static $pb.PbList<DocumentResponse> createRepeated() => $pb.PbList<DocumentResponse>();
+  static $pb.PbList<DocumentResponse> createRepeated() =>
+      $pb.PbList<DocumentResponse>();
   @$core.pragma('dart2js:noInline')
-  static DocumentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DocumentResponse>(create);
+  static DocumentResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<DocumentResponse>(create);
   static DocumentResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -730,7 +1017,10 @@ class DocumentResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -740,13 +1030,26 @@ class DocumentResponse extends $pb.GeneratedMessage {
 }
 
 class CompleteResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompleteResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementOffset', $pb.PbFieldType.O3, protoName: 'replacementOffset')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementLength', $pb.PbFieldType.O3, protoName: 'replacementLength')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'CompleteResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..a<$core.int>(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementOffset', $pb.PbFieldType.O3,
+        protoName: 'replacementOffset')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementLength',
+        $pb.PbFieldType.O3,
+        protoName: 'replacementLength')
     ..pc<Completion>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'completions', $pb.PbFieldType.PM, subBuilder: Completion.create)
     ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   CompleteResponse._() : super();
   factory CompleteResponse({
@@ -770,31 +1073,40 @@ class CompleteResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CompleteResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CompleteResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CompleteResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CompleteResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CompleteResponse clone() => CompleteResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CompleteResponse copyWith(void Function(CompleteResponse) updates) => super.copyWith((message) => updates(message as CompleteResponse)) as CompleteResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CompleteResponse copyWith(void Function(CompleteResponse) updates) =>
+      super.copyWith((message) => updates(message as CompleteResponse))
+          as CompleteResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompleteResponse create() => CompleteResponse._();
   CompleteResponse createEmptyInstance() => create();
-  static $pb.PbList<CompleteResponse> createRepeated() => $pb.PbList<CompleteResponse>();
+  static $pb.PbList<CompleteResponse> createRepeated() =>
+      $pb.PbList<CompleteResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompleteResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompleteResponse>(create);
+  static CompleteResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CompleteResponse>(create);
   static CompleteResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get replacementOffset => $_getIZ(0);
   @$pb.TagNumber(1)
-  set replacementOffset($core.int v) { $_setSignedInt32(0, v); }
+  set replacementOffset($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasReplacementOffset() => $_has(0);
   @$pb.TagNumber(1)
@@ -803,7 +1115,10 @@ class CompleteResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get replacementLength => $_getIZ(1);
   @$pb.TagNumber(2)
-  set replacementLength($core.int v) { $_setSignedInt32(1, v); }
+  set replacementLength($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasReplacementLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -815,7 +1130,10 @@ class CompleteResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(3);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(99)
@@ -825,10 +1143,25 @@ class CompleteResponse extends $pb.GeneratedMessage {
 }
 
 class Completion extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Completion', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..m<$core.String, $core.String>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'completion', entryClassName: 'Completion.CompletionEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('dart_services.api'))
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'Completion',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..m<$core.String, $core.String>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'completion',
+        entryClassName: 'Completion.CompletionEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OS,
+        packageName: const $pb.PackageName('dart_services.api'))
+    ..hasRequiredFields = false;
 
   Completion._() : super();
   factory Completion({
@@ -840,25 +1173,30 @@ class Completion extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Completion.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Completion.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Completion.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Completion.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Completion clone() => Completion()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Completion copyWith(void Function(Completion) updates) => super.copyWith((message) => updates(message as Completion)) as Completion; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Completion copyWith(void Function(Completion) updates) =>
+      super.copyWith((message) => updates(message as Completion))
+          as Completion; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Completion create() => Completion._();
   Completion createEmptyInstance() => create();
   static $pb.PbList<Completion> createRepeated() => $pb.PbList<Completion>();
   @$core.pragma('dart2js:noInline')
-  static Completion getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Completion>(create);
+  static Completion getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<Completion>(create);
   static Completion _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -866,11 +1204,26 @@ class Completion extends $pb.GeneratedMessage {
 }
 
 class FixesResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FixesResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..pc<ProblemAndFixes>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fixes', $pb.PbFieldType.PM, subBuilder: ProblemAndFixes.create)
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'FixesResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..pc<ProblemAndFixes>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'fixes',
+        $pb.PbFieldType.PM,
+        subBuilder: ProblemAndFixes.create)
+    ..aOM<ErrorMessage>(
+        99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   FixesResponse._() : super();
   factory FixesResponse({
@@ -886,25 +1239,31 @@ class FixesResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory FixesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory FixesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory FixesResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FixesResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   FixesResponse clone() => FixesResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  FixesResponse copyWith(void Function(FixesResponse) updates) => super.copyWith((message) => updates(message as FixesResponse)) as FixesResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  FixesResponse copyWith(void Function(FixesResponse) updates) =>
+      super.copyWith((message) => updates(message as FixesResponse))
+          as FixesResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FixesResponse create() => FixesResponse._();
   FixesResponse createEmptyInstance() => create();
-  static $pb.PbList<FixesResponse> createRepeated() => $pb.PbList<FixesResponse>();
+  static $pb.PbList<FixesResponse> createRepeated() =>
+      $pb.PbList<FixesResponse>();
   @$core.pragma('dart2js:noInline')
-  static FixesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FixesResponse>(create);
+  static FixesResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FixesResponse>(create);
   static FixesResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -913,7 +1272,10 @@ class FixesResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -923,13 +1285,27 @@ class FixesResponse extends $pb.GeneratedMessage {
 }
 
 class ProblemAndFixes extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ProblemAndFixes', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..pc<CandidateFix>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fixes', $pb.PbFieldType.PM, subBuilder: CandidateFix.create)
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'problemMessage', protoName: 'problemMessage')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ProblemAndFixes',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..pc<CandidateFix>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'fixes',
+        $pb.PbFieldType.PM,
+        subBuilder: CandidateFix.create)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'problemMessage',
+        protoName: 'problemMessage')
     ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
     ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   ProblemAndFixes._() : super();
   factory ProblemAndFixes({
@@ -953,25 +1329,31 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ProblemAndFixes.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ProblemAndFixes.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ProblemAndFixes.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ProblemAndFixes.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ProblemAndFixes clone() => ProblemAndFixes()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ProblemAndFixes copyWith(void Function(ProblemAndFixes) updates) => super.copyWith((message) => updates(message as ProblemAndFixes)) as ProblemAndFixes; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ProblemAndFixes copyWith(void Function(ProblemAndFixes) updates) =>
+      super.copyWith((message) => updates(message as ProblemAndFixes))
+          as ProblemAndFixes; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ProblemAndFixes create() => ProblemAndFixes._();
   ProblemAndFixes createEmptyInstance() => create();
-  static $pb.PbList<ProblemAndFixes> createRepeated() => $pb.PbList<ProblemAndFixes>();
+  static $pb.PbList<ProblemAndFixes> createRepeated() =>
+      $pb.PbList<ProblemAndFixes>();
   @$core.pragma('dart2js:noInline')
-  static ProblemAndFixes getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ProblemAndFixes>(create);
+  static ProblemAndFixes getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ProblemAndFixes>(create);
   static ProblemAndFixes _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -980,7 +1362,10 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get problemMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set problemMessage($core.String v) { $_setString(1, v); }
+  set problemMessage($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasProblemMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -989,7 +1374,10 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get offset => $_getIZ(2);
   @$pb.TagNumber(3)
-  set offset($core.int v) { $_setSignedInt32(2, v); }
+  set offset($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasOffset() => $_has(2);
   @$pb.TagNumber(3)
@@ -998,7 +1386,10 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get length => $_getIZ(3);
   @$pb.TagNumber(4)
-  set length($core.int v) { $_setSignedInt32(3, v); }
+  set length($core.int v) {
+    $_setSignedInt32(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasLength() => $_has(3);
   @$pb.TagNumber(4)
@@ -1006,13 +1397,30 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
 }
 
 class CandidateFix extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CandidateFix', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..pc<SourceEdit>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'edits', $pb.PbFieldType.PM, subBuilder: SourceEdit.create)
-    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'selectionOffset', $pb.PbFieldType.O3, protoName: 'selectionOffset')
-    ..pc<LinkedEditGroup>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'linkedEditGroups', $pb.PbFieldType.PM, protoName: 'linkedEditGroups', subBuilder: LinkedEditGroup.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CandidateFix',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'message')
+    ..pc<SourceEdit>(
+        2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'edits', $pb.PbFieldType.PM,
+        subBuilder: SourceEdit.create)
+    ..a<$core.int>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'selectionOffset', $pb.PbFieldType.O3,
+        protoName: 'selectionOffset')
+    ..pc<LinkedEditGroup>(
+        4,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'linkedEditGroups',
+        $pb.PbFieldType.PM,
+        protoName: 'linkedEditGroups',
+        subBuilder: LinkedEditGroup.create)
+    ..hasRequiredFields = false;
 
   CandidateFix._() : super();
   factory CandidateFix({
@@ -1036,31 +1444,40 @@ class CandidateFix extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory CandidateFix.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory CandidateFix.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory CandidateFix.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory CandidateFix.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   CandidateFix clone() => CandidateFix()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  CandidateFix copyWith(void Function(CandidateFix) updates) => super.copyWith((message) => updates(message as CandidateFix)) as CandidateFix; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  CandidateFix copyWith(void Function(CandidateFix) updates) =>
+      super.copyWith((message) => updates(message as CandidateFix))
+          as CandidateFix; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CandidateFix create() => CandidateFix._();
   CandidateFix createEmptyInstance() => create();
-  static $pb.PbList<CandidateFix> createRepeated() => $pb.PbList<CandidateFix>();
+  static $pb.PbList<CandidateFix> createRepeated() =>
+      $pb.PbList<CandidateFix>();
   @$core.pragma('dart2js:noInline')
-  static CandidateFix getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CandidateFix>(create);
+  static CandidateFix getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<CandidateFix>(create);
   static CandidateFix _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) { $_setString(0, v); }
+  set message($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -1072,7 +1489,10 @@ class CandidateFix extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get selectionOffset => $_getIZ(2);
   @$pb.TagNumber(3)
-  set selectionOffset($core.int v) { $_setSignedInt32(2, v); }
+  set selectionOffset($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasSelectionOffset() => $_has(2);
   @$pb.TagNumber(3)
@@ -1083,12 +1503,30 @@ class CandidateFix extends $pb.GeneratedMessage {
 }
 
 class SourceEdit extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SourceEdit', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacement')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'SourceEdit',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'offset',
+        $pb.PbFieldType.O3)
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'length',
+        $pb.PbFieldType.O3)
+    ..aOS(3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacement')
+    ..hasRequiredFields = false;
 
   SourceEdit._() : super();
   factory SourceEdit({
@@ -1108,31 +1546,39 @@ class SourceEdit extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory SourceEdit.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory SourceEdit.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory SourceEdit.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory SourceEdit.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   SourceEdit clone() => SourceEdit()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  SourceEdit copyWith(void Function(SourceEdit) updates) => super.copyWith((message) => updates(message as SourceEdit)) as SourceEdit; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  SourceEdit copyWith(void Function(SourceEdit) updates) =>
+      super.copyWith((message) => updates(message as SourceEdit))
+          as SourceEdit; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceEdit create() => SourceEdit._();
   SourceEdit createEmptyInstance() => create();
   static $pb.PbList<SourceEdit> createRepeated() => $pb.PbList<SourceEdit>();
   @$core.pragma('dart2js:noInline')
-  static SourceEdit getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceEdit>(create);
+  static SourceEdit getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<SourceEdit>(create);
   static SourceEdit _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get offset => $_getIZ(0);
   @$pb.TagNumber(1)
-  set offset($core.int v) { $_setSignedInt32(0, v); }
+  set offset($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasOffset() => $_has(0);
   @$pb.TagNumber(1)
@@ -1141,7 +1587,10 @@ class SourceEdit extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get length => $_getIZ(1);
   @$pb.TagNumber(2)
-  set length($core.int v) { $_setSignedInt32(1, v); }
+  set length($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -1150,7 +1599,10 @@ class SourceEdit extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get replacement => $_getSZ(2);
   @$pb.TagNumber(3)
-  set replacement($core.String v) { $_setString(2, v); }
+  set replacement($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasReplacement() => $_has(2);
   @$pb.TagNumber(3)
@@ -1158,12 +1610,33 @@ class SourceEdit extends $pb.GeneratedMessage {
 }
 
 class LinkedEditGroup extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LinkedEditGroup', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..p<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'positions', $pb.PbFieldType.P3)
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
-    ..pc<LinkedEditSuggestion>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'suggestions', $pb.PbFieldType.PM, subBuilder: LinkedEditSuggestion.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'LinkedEditGroup',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..p<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'positions',
+        $pb.PbFieldType.P3)
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'length',
+        $pb.PbFieldType.O3)
+    ..pc<LinkedEditSuggestion>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'suggestions',
+        $pb.PbFieldType.PM,
+        subBuilder: LinkedEditSuggestion.create)
+    ..hasRequiredFields = false;
 
   LinkedEditGroup._() : super();
   factory LinkedEditGroup({
@@ -1183,25 +1656,31 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LinkedEditGroup.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LinkedEditGroup.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory LinkedEditGroup.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LinkedEditGroup.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   LinkedEditGroup clone() => LinkedEditGroup()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LinkedEditGroup copyWith(void Function(LinkedEditGroup) updates) => super.copyWith((message) => updates(message as LinkedEditGroup)) as LinkedEditGroup; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LinkedEditGroup copyWith(void Function(LinkedEditGroup) updates) =>
+      super.copyWith((message) => updates(message as LinkedEditGroup))
+          as LinkedEditGroup; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LinkedEditGroup create() => LinkedEditGroup._();
   LinkedEditGroup createEmptyInstance() => create();
-  static $pb.PbList<LinkedEditGroup> createRepeated() => $pb.PbList<LinkedEditGroup>();
+  static $pb.PbList<LinkedEditGroup> createRepeated() =>
+      $pb.PbList<LinkedEditGroup>();
   @$core.pragma('dart2js:noInline')
-  static LinkedEditGroup getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LinkedEditGroup>(create);
+  static LinkedEditGroup getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<LinkedEditGroup>(create);
   static LinkedEditGroup _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1210,7 +1689,10 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get length => $_getIZ(1);
   @$pb.TagNumber(2)
-  set length($core.int v) { $_setSignedInt32(1, v); }
+  set length($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -1221,11 +1703,26 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
 }
 
 class LinkedEditSuggestion extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LinkedEditSuggestion', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kind')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'LinkedEditSuggestion',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'value')
+    ..aOS(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'kind')
+    ..hasRequiredFields = false;
 
   LinkedEditSuggestion._() : super();
   factory LinkedEditSuggestion({
@@ -1241,31 +1738,41 @@ class LinkedEditSuggestion extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory LinkedEditSuggestion.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory LinkedEditSuggestion.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
-  LinkedEditSuggestion clone() => LinkedEditSuggestion()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  LinkedEditSuggestion copyWith(void Function(LinkedEditSuggestion) updates) => super.copyWith((message) => updates(message as LinkedEditSuggestion)) as LinkedEditSuggestion; // ignore: deprecated_member_use
+  factory LinkedEditSuggestion.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory LinkedEditSuggestion.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  LinkedEditSuggestion clone() =>
+      LinkedEditSuggestion()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  LinkedEditSuggestion copyWith(void Function(LinkedEditSuggestion) updates) =>
+      super.copyWith((message) => updates(message as LinkedEditSuggestion))
+          as LinkedEditSuggestion; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LinkedEditSuggestion create() => LinkedEditSuggestion._();
   LinkedEditSuggestion createEmptyInstance() => create();
-  static $pb.PbList<LinkedEditSuggestion> createRepeated() => $pb.PbList<LinkedEditSuggestion>();
+  static $pb.PbList<LinkedEditSuggestion> createRepeated() =>
+      $pb.PbList<LinkedEditSuggestion>();
   @$core.pragma('dart2js:noInline')
-  static LinkedEditSuggestion getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LinkedEditSuggestion>(create);
+  static LinkedEditSuggestion getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<LinkedEditSuggestion>(create);
   static LinkedEditSuggestion _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get value => $_getSZ(0);
   @$pb.TagNumber(1)
-  set value($core.String v) { $_setString(0, v); }
+  set value($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -1274,7 +1781,10 @@ class LinkedEditSuggestion extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get kind => $_getSZ(1);
   @$pb.TagNumber(2)
-  set kind($core.String v) { $_setString(1, v); }
+  set kind($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasKind() => $_has(1);
   @$pb.TagNumber(2)
@@ -1282,12 +1792,28 @@ class LinkedEditSuggestion extends $pb.GeneratedMessage {
 }
 
 class FormatResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FormatResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'newString', protoName: 'newString')
-    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'FormatResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'newString',
+        protoName: 'newString')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'offset',
+        $pb.PbFieldType.O3)
+    ..aOM<ErrorMessage>(
+        99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   FormatResponse._() : super();
   factory FormatResponse({
@@ -1307,31 +1833,40 @@ class FormatResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory FormatResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory FormatResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory FormatResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory FormatResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   FormatResponse clone() => FormatResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  FormatResponse copyWith(void Function(FormatResponse) updates) => super.copyWith((message) => updates(message as FormatResponse)) as FormatResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  FormatResponse copyWith(void Function(FormatResponse) updates) =>
+      super.copyWith((message) => updates(message as FormatResponse))
+          as FormatResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FormatResponse create() => FormatResponse._();
   FormatResponse createEmptyInstance() => create();
-  static $pb.PbList<FormatResponse> createRepeated() => $pb.PbList<FormatResponse>();
+  static $pb.PbList<FormatResponse> createRepeated() =>
+      $pb.PbList<FormatResponse>();
   @$core.pragma('dart2js:noInline')
-  static FormatResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FormatResponse>(create);
+  static FormatResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<FormatResponse>(create);
   static FormatResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get newString => $_getSZ(0);
   @$pb.TagNumber(1)
-  set newString($core.String v) { $_setString(0, v); }
+  set newString($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasNewString() => $_has(0);
   @$pb.TagNumber(1)
@@ -1340,7 +1875,10 @@ class FormatResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get offset => $_getIZ(1);
   @$pb.TagNumber(2)
-  set offset($core.int v) { $_setSignedInt32(1, v); }
+  set offset($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasOffset() => $_has(1);
   @$pb.TagNumber(2)
@@ -1349,7 +1887,10 @@ class FormatResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -1359,11 +1900,26 @@ class FormatResponse extends $pb.GeneratedMessage {
 }
 
 class AssistsResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AssistsResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..pc<CandidateFix>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'assists', $pb.PbFieldType.PM, subBuilder: CandidateFix.create)
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'AssistsResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..pc<CandidateFix>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'assists',
+        $pb.PbFieldType.PM,
+        subBuilder: CandidateFix.create)
+    ..aOM<ErrorMessage>(
+        99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   AssistsResponse._() : super();
   factory AssistsResponse({
@@ -1379,25 +1935,31 @@ class AssistsResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory AssistsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory AssistsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory AssistsResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory AssistsResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   AssistsResponse clone() => AssistsResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  AssistsResponse copyWith(void Function(AssistsResponse) updates) => super.copyWith((message) => updates(message as AssistsResponse)) as AssistsResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  AssistsResponse copyWith(void Function(AssistsResponse) updates) =>
+      super.copyWith((message) => updates(message as AssistsResponse))
+          as AssistsResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AssistsResponse create() => AssistsResponse._();
   AssistsResponse createEmptyInstance() => create();
-  static $pb.PbList<AssistsResponse> createRepeated() => $pb.PbList<AssistsResponse>();
+  static $pb.PbList<AssistsResponse> createRepeated() =>
+      $pb.PbList<AssistsResponse>();
   @$core.pragma('dart2js:noInline')
-  static AssistsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AssistsResponse>(create);
+  static AssistsResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<AssistsResponse>(create);
   static AssistsResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1406,7 +1968,10 @@ class AssistsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -1416,18 +1981,29 @@ class AssistsResponse extends $pb.GeneratedMessage {
 }
 
 class VersionResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'VersionResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersion', protoName: 'sdkVersion')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersionFull', protoName: 'sdkVersionFull')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'runtimeVersion', protoName: 'runtimeVersion')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appEngineVersion', protoName: 'appEngineVersion')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'VersionResponse',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersion',
+        protoName: 'sdkVersion')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersionFull',
+        protoName: 'sdkVersionFull')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'runtimeVersion',
+        protoName: 'runtimeVersion')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appEngineVersion',
+        protoName: 'appEngineVersion')
     ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'servicesVersion', protoName: 'servicesVersion')
     ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterVersion', protoName: 'flutterVersion')
     ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterDartVersion', protoName: 'flutterDartVersion')
     ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterDartVersionFull', protoName: 'flutterDartVersionFull')
     ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   VersionResponse._() : super();
   factory VersionResponse({
@@ -1471,31 +2047,40 @@ class VersionResponse extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory VersionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory VersionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory VersionResponse.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory VersionResponse.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   VersionResponse clone() => VersionResponse()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  VersionResponse copyWith(void Function(VersionResponse) updates) => super.copyWith((message) => updates(message as VersionResponse)) as VersionResponse; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  VersionResponse copyWith(void Function(VersionResponse) updates) =>
+      super.copyWith((message) => updates(message as VersionResponse))
+          as VersionResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static VersionResponse create() => VersionResponse._();
   VersionResponse createEmptyInstance() => create();
-  static $pb.PbList<VersionResponse> createRepeated() => $pb.PbList<VersionResponse>();
+  static $pb.PbList<VersionResponse> createRepeated() =>
+      $pb.PbList<VersionResponse>();
   @$core.pragma('dart2js:noInline')
-  static VersionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VersionResponse>(create);
+  static VersionResponse getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<VersionResponse>(create);
   static VersionResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sdkVersion => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sdkVersion($core.String v) { $_setString(0, v); }
+  set sdkVersion($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasSdkVersion() => $_has(0);
   @$pb.TagNumber(1)
@@ -1504,7 +2089,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get sdkVersionFull => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sdkVersionFull($core.String v) { $_setString(1, v); }
+  set sdkVersionFull($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasSdkVersionFull() => $_has(1);
   @$pb.TagNumber(2)
@@ -1513,7 +2101,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get runtimeVersion => $_getSZ(2);
   @$pb.TagNumber(3)
-  set runtimeVersion($core.String v) { $_setString(2, v); }
+  set runtimeVersion($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasRuntimeVersion() => $_has(2);
   @$pb.TagNumber(3)
@@ -1522,7 +2113,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get appEngineVersion => $_getSZ(3);
   @$pb.TagNumber(4)
-  set appEngineVersion($core.String v) { $_setString(3, v); }
+  set appEngineVersion($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasAppEngineVersion() => $_has(3);
   @$pb.TagNumber(4)
@@ -1531,7 +2125,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get servicesVersion => $_getSZ(4);
   @$pb.TagNumber(5)
-  set servicesVersion($core.String v) { $_setString(4, v); }
+  set servicesVersion($core.String v) {
+    $_setString(4, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasServicesVersion() => $_has(4);
   @$pb.TagNumber(5)
@@ -1540,7 +2137,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get flutterVersion => $_getSZ(5);
   @$pb.TagNumber(6)
-  set flutterVersion($core.String v) { $_setString(5, v); }
+  set flutterVersion($core.String v) {
+    $_setString(5, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasFlutterVersion() => $_has(5);
   @$pb.TagNumber(6)
@@ -1549,7 +2149,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get flutterDartVersion => $_getSZ(6);
   @$pb.TagNumber(7)
-  set flutterDartVersion($core.String v) { $_setString(6, v); }
+  set flutterDartVersion($core.String v) {
+    $_setString(6, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasFlutterDartVersion() => $_has(6);
   @$pb.TagNumber(7)
@@ -1558,7 +2161,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get flutterDartVersionFull => $_getSZ(7);
   @$pb.TagNumber(8)
-  set flutterDartVersionFull($core.String v) { $_setString(7, v); }
+  set flutterDartVersionFull($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasFlutterDartVersionFull() => $_has(7);
   @$pb.TagNumber(8)
@@ -1567,7 +2173,10 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(8);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(8);
   @$pb.TagNumber(99)
@@ -1577,10 +2186,22 @@ class VersionResponse extends $pb.GeneratedMessage {
 }
 
 class BadRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BadRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'BadRequest',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOM<ErrorMessage>(
+        99,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'error',
+        subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false;
 
   BadRequest._() : super();
   factory BadRequest({
@@ -1592,31 +2213,39 @@ class BadRequest extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory BadRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory BadRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory BadRequest.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory BadRequest.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   BadRequest clone() => BadRequest()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  BadRequest copyWith(void Function(BadRequest) updates) => super.copyWith((message) => updates(message as BadRequest)) as BadRequest; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  BadRequest copyWith(void Function(BadRequest) updates) =>
+      super.copyWith((message) => updates(message as BadRequest))
+          as BadRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BadRequest create() => BadRequest._();
   BadRequest createEmptyInstance() => create();
   static $pb.PbList<BadRequest> createRepeated() => $pb.PbList<BadRequest>();
   @$core.pragma('dart2js:noInline')
-  static BadRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BadRequest>(create);
+  static BadRequest getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<BadRequest>(create);
   static BadRequest _defaultInstance;
 
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(0);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) { setField(99, v); }
+  set error(ErrorMessage v) {
+    setField(99, v);
+  }
+
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(0);
   @$pb.TagNumber(99)
@@ -1626,10 +2255,21 @@ class BadRequest extends $pb.GeneratedMessage {
 }
 
 class ErrorMessage extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ErrorMessage', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'ErrorMessage',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'dart_services.api'),
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'message')
+    ..hasRequiredFields = false;
 
   ErrorMessage._() : super();
   factory ErrorMessage({
@@ -1641,34 +2281,42 @@ class ErrorMessage extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ErrorMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ErrorMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ErrorMessage.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ErrorMessage.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ErrorMessage clone() => ErrorMessage()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ErrorMessage copyWith(void Function(ErrorMessage) updates) => super.copyWith((message) => updates(message as ErrorMessage)) as ErrorMessage; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ErrorMessage copyWith(void Function(ErrorMessage) updates) =>
+      super.copyWith((message) => updates(message as ErrorMessage))
+          as ErrorMessage; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ErrorMessage create() => ErrorMessage._();
   ErrorMessage createEmptyInstance() => create();
-  static $pb.PbList<ErrorMessage> createRepeated() => $pb.PbList<ErrorMessage>();
+  static $pb.PbList<ErrorMessage> createRepeated() =>
+      $pb.PbList<ErrorMessage>();
   @$core.pragma('dart2js:noInline')
-  static ErrorMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ErrorMessage>(create);
+  static ErrorMessage getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<ErrorMessage>(create);
   static ErrorMessage _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) { $_setString(0, v); }
+  set message($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
   void clearMessage() => clearField(1);
 }
-

--- a/lib/src/protos/dart_services.pb.dart
+++ b/lib/src/protos/dart_services.pb.dart
@@ -1614,10 +1614,9 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
       const $core.bool.fromEnvironment('protobuf.omit_message_names')
           ? ''
           : 'LinkedEditGroup',
-      package: const $pb.PackageName(
-          $core.bool.fromEnvironment('protobuf.omit_message_names')
-              ? ''
-              : 'dart_services.api'),
+      package: const $pb.PackageName($core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'dart_services.api'),
       createEmptyInstance: create)
     ..p<$core.int>(
         1,

--- a/lib/src/protos/dart_services.pb.dart
+++ b/lib/src/protos/dart_services.pb.dart
@@ -2,50 +2,59 @@
 //  Generated code. Do not modify.
 //  source: protos/dart_services.proto
 //
-// @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
 
 import 'dart:core' as $core;
 
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class CompileRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CompileRequest',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'source')
-    ..aOB(2, 'returnSourceMap', protoName: 'returnSourceMap')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
+    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'returnSourceMap', protoName: 'returnSourceMap')
+    ..hasRequiredFields = false
+  ;
 
   CompileRequest._() : super();
-  factory CompileRequest() => create();
-  factory CompileRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CompileRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CompileRequest({
+    $core.String source,
+    $core.bool returnSourceMap,
+  }) {
+    final _result = create();
+    if (source != null) {
+      _result.source = source;
+    }
+    if (returnSourceMap != null) {
+      _result.returnSourceMap = returnSourceMap;
+    }
+    return _result;
+  }
+  factory CompileRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CompileRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CompileRequest clone() => CompileRequest()..mergeFromMessage(this);
-  CompileRequest copyWith(void Function(CompileRequest) updates) =>
-      super.copyWith((message) => updates(message as CompileRequest));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CompileRequest copyWith(void Function(CompileRequest) updates) => super.copyWith((message) => updates(message as CompileRequest)) as CompileRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileRequest create() => CompileRequest._();
   CompileRequest createEmptyInstance() => create();
-  static $pb.PbList<CompileRequest> createRepeated() =>
-      $pb.PbList<CompileRequest>();
+  static $pb.PbList<CompileRequest> createRepeated() => $pb.PbList<CompileRequest>();
   @$core.pragma('dart2js:noInline')
-  static CompileRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CompileRequest>(create);
+  static CompileRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileRequest>(create);
   static CompileRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get source => $_getSZ(0);
   @$pb.TagNumber(1)
-  set source($core.String v) {
-    $_setString(0, v);
-  }
-
+  set source($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSource() => $_has(0);
   @$pb.TagNumber(1)
@@ -54,53 +63,106 @@ class CompileRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get returnSourceMap => $_getBF(1);
   @$pb.TagNumber(2)
-  set returnSourceMap($core.bool v) {
-    $_setBool(1, v);
-  }
-
+  set returnSourceMap($core.bool v) { $_setBool(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasReturnSourceMap() => $_has(1);
   @$pb.TagNumber(2)
   void clearReturnSourceMap() => clearField(2);
 }
 
+class CompileDDCRequest extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileDDCRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
+    ..hasRequiredFields = false
+  ;
+
+  CompileDDCRequest._() : super();
+  factory CompileDDCRequest({
+    $core.String source,
+  }) {
+    final _result = create();
+    if (source != null) {
+      _result.source = source;
+    }
+    return _result;
+  }
+  factory CompileDDCRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CompileDDCRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  CompileDDCRequest clone() => CompileDDCRequest()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CompileDDCRequest copyWith(void Function(CompileDDCRequest) updates) => super.copyWith((message) => updates(message as CompileDDCRequest)) as CompileDDCRequest; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static CompileDDCRequest create() => CompileDDCRequest._();
+  CompileDDCRequest createEmptyInstance() => create();
+  static $pb.PbList<CompileDDCRequest> createRepeated() => $pb.PbList<CompileDDCRequest>();
+  @$core.pragma('dart2js:noInline')
+  static CompileDDCRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileDDCRequest>(create);
+  static CompileDDCRequest _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get source => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set source($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasSource() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearSource() => clearField(1);
+}
+
 class SourceRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceRequest',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'source')
-    ..a<$core.int>(2, 'offset', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SourceRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'source')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
 
   SourceRequest._() : super();
-  factory SourceRequest() => create();
-  factory SourceRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SourceRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SourceRequest({
+    $core.String source,
+    $core.int offset,
+  }) {
+    final _result = create();
+    if (source != null) {
+      _result.source = source;
+    }
+    if (offset != null) {
+      _result.offset = offset;
+    }
+    return _result;
+  }
+  factory SourceRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SourceRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SourceRequest clone() => SourceRequest()..mergeFromMessage(this);
-  SourceRequest copyWith(void Function(SourceRequest) updates) =>
-      super.copyWith((message) => updates(message as SourceRequest));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SourceRequest copyWith(void Function(SourceRequest) updates) => super.copyWith((message) => updates(message as SourceRequest)) as SourceRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceRequest create() => SourceRequest._();
   SourceRequest createEmptyInstance() => create();
-  static $pb.PbList<SourceRequest> createRepeated() =>
-      $pb.PbList<SourceRequest>();
+  static $pb.PbList<SourceRequest> createRepeated() => $pb.PbList<SourceRequest>();
   @$core.pragma('dart2js:noInline')
-  static SourceRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SourceRequest>(create);
+  static SourceRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceRequest>(create);
   static SourceRequest _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get source => $_getSZ(0);
   @$pb.TagNumber(1)
-  set source($core.String v) {
-    $_setString(0, v);
-  }
-
+  set source($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSource() => $_has(0);
   @$pb.TagNumber(1)
@@ -109,10 +171,7 @@ class SourceRequest extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get offset => $_getIZ(1);
   @$pb.TagNumber(2)
-  set offset($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set offset($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOffset() => $_has(1);
   @$pb.TagNumber(2)
@@ -120,35 +179,50 @@ class SourceRequest extends $pb.GeneratedMessage {
 }
 
 class AnalysisResults extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AnalysisResults',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..pc<AnalysisIssue>(1, 'issues', $pb.PbFieldType.PM,
-        subBuilder: AnalysisIssue.create)
-    ..pPS(2, 'packageImports', protoName: 'packageImports')
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AnalysisResults', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..pc<AnalysisIssue>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'issues', $pb.PbFieldType.PM, subBuilder: AnalysisIssue.create)
+    ..pPS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'packageImports', protoName: 'packageImports')
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   AnalysisResults._() : super();
-  factory AnalysisResults() => create();
-  factory AnalysisResults.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AnalysisResults.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AnalysisResults({
+    $core.Iterable<AnalysisIssue> issues,
+    $core.Iterable<$core.String> packageImports,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (issues != null) {
+      _result.issues.addAll(issues);
+    }
+    if (packageImports != null) {
+      _result.packageImports.addAll(packageImports);
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory AnalysisResults.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AnalysisResults.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AnalysisResults clone() => AnalysisResults()..mergeFromMessage(this);
-  AnalysisResults copyWith(void Function(AnalysisResults) updates) =>
-      super.copyWith((message) => updates(message as AnalysisResults));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AnalysisResults copyWith(void Function(AnalysisResults) updates) => super.copyWith((message) => updates(message as AnalysisResults)) as AnalysisResults; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AnalysisResults create() => AnalysisResults._();
   AnalysisResults createEmptyInstance() => create();
-  static $pb.PbList<AnalysisResults> createRepeated() =>
-      $pb.PbList<AnalysisResults>();
+  static $pb.PbList<AnalysisResults> createRepeated() => $pb.PbList<AnalysisResults>();
   @$core.pragma('dart2js:noInline')
-  static AnalysisResults getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AnalysisResults>(create);
+  static AnalysisResults getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AnalysisResults>(create);
   static AnalysisResults _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -160,10 +234,7 @@ class AnalysisResults extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -173,47 +244,86 @@ class AnalysisResults extends $pb.GeneratedMessage {
 }
 
 class AnalysisIssue extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AnalysisIssue',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'kind')
-    ..a<$core.int>(2, 'line', $pb.PbFieldType.O3)
-    ..aOS(3, 'message')
-    ..aOS(4, 'sourceName', protoName: 'sourceName')
-    ..aOB(5, 'hasFixes', protoName: 'hasFixes')
-    ..a<$core.int>(6, 'charStart', $pb.PbFieldType.O3, protoName: 'charStart')
-    ..a<$core.int>(7, 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AnalysisIssue', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kind')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'line', $pb.PbFieldType.O3)
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceName', protoName: 'sourceName')
+    ..aOB(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hasFixes', protoName: 'hasFixes')
+    ..a<$core.int>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charStart', $pb.PbFieldType.O3, protoName: 'charStart')
+    ..a<$core.int>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
+    ..pc<DiagnosticMessage>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'diagnosticMessages', $pb.PbFieldType.PM, protoName: 'diagnosticMessages', subBuilder: DiagnosticMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   AnalysisIssue._() : super();
-  factory AnalysisIssue() => create();
-  factory AnalysisIssue.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AnalysisIssue.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AnalysisIssue({
+    $core.String kind,
+    $core.int line,
+    $core.String message,
+    $core.String sourceName,
+    $core.bool hasFixes,
+    $core.int charStart,
+    $core.int charLength,
+    $core.String url,
+    $core.Iterable<DiagnosticMessage> diagnosticMessages,
+  }) {
+    final _result = create();
+    if (kind != null) {
+      _result.kind = kind;
+    }
+    if (line != null) {
+      _result.line = line;
+    }
+    if (message != null) {
+      _result.message = message;
+    }
+    if (sourceName != null) {
+      _result.sourceName = sourceName;
+    }
+    if (hasFixes != null) {
+      _result.hasFixes = hasFixes;
+    }
+    if (charStart != null) {
+      _result.charStart = charStart;
+    }
+    if (charLength != null) {
+      _result.charLength = charLength;
+    }
+    if (url != null) {
+      _result.url = url;
+    }
+    if (diagnosticMessages != null) {
+      _result.diagnosticMessages.addAll(diagnosticMessages);
+    }
+    return _result;
+  }
+  factory AnalysisIssue.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AnalysisIssue.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AnalysisIssue clone() => AnalysisIssue()..mergeFromMessage(this);
-  AnalysisIssue copyWith(void Function(AnalysisIssue) updates) =>
-      super.copyWith((message) => updates(message as AnalysisIssue));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AnalysisIssue copyWith(void Function(AnalysisIssue) updates) => super.copyWith((message) => updates(message as AnalysisIssue)) as AnalysisIssue; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AnalysisIssue create() => AnalysisIssue._();
   AnalysisIssue createEmptyInstance() => create();
-  static $pb.PbList<AnalysisIssue> createRepeated() =>
-      $pb.PbList<AnalysisIssue>();
+  static $pb.PbList<AnalysisIssue> createRepeated() => $pb.PbList<AnalysisIssue>();
   @$core.pragma('dart2js:noInline')
-  static AnalysisIssue getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AnalysisIssue>(create);
+  static AnalysisIssue getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AnalysisIssue>(create);
   static AnalysisIssue _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get kind => $_getSZ(0);
   @$pb.TagNumber(1)
-  set kind($core.String v) {
-    $_setString(0, v);
-  }
-
+  set kind($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasKind() => $_has(0);
   @$pb.TagNumber(1)
@@ -222,10 +332,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get line => $_getIZ(1);
   @$pb.TagNumber(2)
-  set line($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set line($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLine() => $_has(1);
   @$pb.TagNumber(2)
@@ -234,10 +341,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get message => $_getSZ(2);
   @$pb.TagNumber(3)
-  set message($core.String v) {
-    $_setString(2, v);
-  }
-
+  set message($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasMessage() => $_has(2);
   @$pb.TagNumber(3)
@@ -246,10 +350,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get sourceName => $_getSZ(3);
   @$pb.TagNumber(4)
-  set sourceName($core.String v) {
-    $_setString(3, v);
-  }
-
+  set sourceName($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasSourceName() => $_has(3);
   @$pb.TagNumber(4)
@@ -258,10 +359,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.bool get hasFixes => $_getBF(4);
   @$pb.TagNumber(5)
-  set hasFixes($core.bool v) {
-    $_setBool(4, v);
-  }
-
+  set hasFixes($core.bool v) { $_setBool(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasHasFixes() => $_has(4);
   @$pb.TagNumber(5)
@@ -270,10 +368,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.int get charStart => $_getIZ(5);
   @$pb.TagNumber(6)
-  set charStart($core.int v) {
-    $_setSignedInt32(5, v);
-  }
-
+  set charStart($core.int v) { $_setSignedInt32(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasCharStart() => $_has(5);
   @$pb.TagNumber(6)
@@ -282,83 +377,194 @@ class AnalysisIssue extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.int get charLength => $_getIZ(6);
   @$pb.TagNumber(7)
-  set charLength($core.int v) {
-    $_setSignedInt32(6, v);
-  }
-
+  set charLength($core.int v) { $_setSignedInt32(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasCharLength() => $_has(6);
   @$pb.TagNumber(7)
   void clearCharLength() => clearField(7);
+
+  @$pb.TagNumber(8)
+  $core.String get url => $_getSZ(7);
+  @$pb.TagNumber(8)
+  set url($core.String v) { $_setString(7, v); }
+  @$pb.TagNumber(8)
+  $core.bool hasUrl() => $_has(7);
+  @$pb.TagNumber(8)
+  void clearUrl() => clearField(8);
+
+  @$pb.TagNumber(9)
+  $core.List<DiagnosticMessage> get diagnosticMessages => $_getList(8);
+}
+
+class DiagnosticMessage extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DiagnosticMessage', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'line', $pb.PbFieldType.O3)
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charStart', $pb.PbFieldType.O3, protoName: 'charStart')
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
+    ..hasRequiredFields = false
+  ;
+
+  DiagnosticMessage._() : super();
+  factory DiagnosticMessage({
+    $core.String message,
+    $core.int line,
+    $core.int charStart,
+    $core.int charLength,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    if (line != null) {
+      _result.line = line;
+    }
+    if (charStart != null) {
+      _result.charStart = charStart;
+    }
+    if (charLength != null) {
+      _result.charLength = charLength;
+    }
+    return _result;
+  }
+  factory DiagnosticMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DiagnosticMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  DiagnosticMessage clone() => DiagnosticMessage()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DiagnosticMessage copyWith(void Function(DiagnosticMessage) updates) => super.copyWith((message) => updates(message as DiagnosticMessage)) as DiagnosticMessage; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static DiagnosticMessage create() => DiagnosticMessage._();
+  DiagnosticMessage createEmptyInstance() => create();
+  static $pb.PbList<DiagnosticMessage> createRepeated() => $pb.PbList<DiagnosticMessage>();
+  @$core.pragma('dart2js:noInline')
+  static DiagnosticMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DiagnosticMessage>(create);
+  static DiagnosticMessage _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get message => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set message($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasMessage() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearMessage() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get line => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set line($core.int v) { $_setSignedInt32(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasLine() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearLine() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get charStart => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set charStart($core.int v) { $_setSignedInt32(2, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasCharStart() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearCharStart() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.int get charLength => $_getIZ(3);
+  @$pb.TagNumber(4)
+  set charLength($core.int v) { $_setSignedInt32(3, v); }
+  @$pb.TagNumber(4)
+  $core.bool hasCharLength() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearCharLength() => clearField(4);
 }
 
 class VersionRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('VersionRequest',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'VersionRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..hasRequiredFields = false
+  ;
 
   VersionRequest._() : super();
   factory VersionRequest() => create();
-  factory VersionRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VersionRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VersionRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VersionRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VersionRequest clone() => VersionRequest()..mergeFromMessage(this);
-  VersionRequest copyWith(void Function(VersionRequest) updates) =>
-      super.copyWith((message) => updates(message as VersionRequest));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VersionRequest copyWith(void Function(VersionRequest) updates) => super.copyWith((message) => updates(message as VersionRequest)) as VersionRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static VersionRequest create() => VersionRequest._();
   VersionRequest createEmptyInstance() => create();
-  static $pb.PbList<VersionRequest> createRepeated() =>
-      $pb.PbList<VersionRequest>();
+  static $pb.PbList<VersionRequest> createRepeated() => $pb.PbList<VersionRequest>();
   @$core.pragma('dart2js:noInline')
-  static VersionRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<VersionRequest>(create);
+  static VersionRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VersionRequest>(create);
   static VersionRequest _defaultInstance;
 }
 
 class CompileResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CompileResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'result')
-    ..aOS(2, 'sourceMap', protoName: 'sourceMap')
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'result')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sourceMap', protoName: 'sourceMap')
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   CompileResponse._() : super();
-  factory CompileResponse() => create();
-  factory CompileResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CompileResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CompileResponse({
+    $core.String result,
+    $core.String sourceMap,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (result != null) {
+      _result.result = result;
+    }
+    if (sourceMap != null) {
+      _result.sourceMap = sourceMap;
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory CompileResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CompileResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CompileResponse clone() => CompileResponse()..mergeFromMessage(this);
-  CompileResponse copyWith(void Function(CompileResponse) updates) =>
-      super.copyWith((message) => updates(message as CompileResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CompileResponse copyWith(void Function(CompileResponse) updates) => super.copyWith((message) => updates(message as CompileResponse)) as CompileResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileResponse create() => CompileResponse._();
   CompileResponse createEmptyInstance() => create();
-  static $pb.PbList<CompileResponse> createRepeated() =>
-      $pb.PbList<CompileResponse>();
+  static $pb.PbList<CompileResponse> createRepeated() => $pb.PbList<CompileResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompileResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CompileResponse>(create);
+  static CompileResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileResponse>(create);
   static CompileResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get result => $_getSZ(0);
   @$pb.TagNumber(1)
-  set result($core.String v) {
-    $_setString(0, v);
-  }
-
+  set result($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResult() => $_has(0);
   @$pb.TagNumber(1)
@@ -367,10 +573,7 @@ class CompileResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get sourceMap => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sourceMap($core.String v) {
-    $_setString(1, v);
-  }
-
+  set sourceMap($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSourceMap() => $_has(1);
   @$pb.TagNumber(2)
@@ -379,10 +582,7 @@ class CompileResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -392,43 +592,56 @@ class CompileResponse extends $pb.GeneratedMessage {
 }
 
 class CompileDDCResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CompileDDCResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'result')
-    ..aOS(2, 'modulesBaseUrl', protoName: 'modulesBaseUrl')
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompileDDCResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'result')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'modulesBaseUrl', protoName: 'modulesBaseUrl')
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   CompileDDCResponse._() : super();
-  factory CompileDDCResponse() => create();
-  factory CompileDDCResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CompileDDCResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CompileDDCResponse({
+    $core.String result,
+    $core.String modulesBaseUrl,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (result != null) {
+      _result.result = result;
+    }
+    if (modulesBaseUrl != null) {
+      _result.modulesBaseUrl = modulesBaseUrl;
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory CompileDDCResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CompileDDCResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CompileDDCResponse clone() => CompileDDCResponse()..mergeFromMessage(this);
-  CompileDDCResponse copyWith(void Function(CompileDDCResponse) updates) =>
-      super.copyWith((message) => updates(message as CompileDDCResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CompileDDCResponse copyWith(void Function(CompileDDCResponse) updates) => super.copyWith((message) => updates(message as CompileDDCResponse)) as CompileDDCResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompileDDCResponse create() => CompileDDCResponse._();
   CompileDDCResponse createEmptyInstance() => create();
-  static $pb.PbList<CompileDDCResponse> createRepeated() =>
-      $pb.PbList<CompileDDCResponse>();
+  static $pb.PbList<CompileDDCResponse> createRepeated() => $pb.PbList<CompileDDCResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompileDDCResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CompileDDCResponse>(create);
+  static CompileDDCResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompileDDCResponse>(create);
   static CompileDDCResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get result => $_getSZ(0);
   @$pb.TagNumber(1)
-  set result($core.String v) {
-    $_setString(0, v);
-  }
-
+  set result($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasResult() => $_has(0);
   @$pb.TagNumber(1)
@@ -437,10 +650,7 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get modulesBaseUrl => $_getSZ(1);
   @$pb.TagNumber(2)
-  set modulesBaseUrl($core.String v) {
-    $_setString(1, v);
-  }
-
+  set modulesBaseUrl($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasModulesBaseUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -449,10 +659,7 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -462,37 +669,45 @@ class CompileDDCResponse extends $pb.GeneratedMessage {
 }
 
 class DocumentResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('DocumentResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..m<$core.String, $core.String>(1, 'info',
-        entryClassName: 'DocumentResponse.InfoEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('dart_services.api'))
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'DocumentResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..m<$core.String, $core.String>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'info', entryClassName: 'DocumentResponse.InfoEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('dart_services.api'))
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   DocumentResponse._() : super();
-  factory DocumentResponse() => create();
-  factory DocumentResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory DocumentResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory DocumentResponse({
+    $core.Map<$core.String, $core.String> info,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (info != null) {
+      _result.info.addAll(info);
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory DocumentResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory DocumentResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   DocumentResponse clone() => DocumentResponse()..mergeFromMessage(this);
-  DocumentResponse copyWith(void Function(DocumentResponse) updates) =>
-      super.copyWith((message) => updates(message as DocumentResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  DocumentResponse copyWith(void Function(DocumentResponse) updates) => super.copyWith((message) => updates(message as DocumentResponse)) as DocumentResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static DocumentResponse create() => DocumentResponse._();
   DocumentResponse createEmptyInstance() => create();
-  static $pb.PbList<DocumentResponse> createRepeated() =>
-      $pb.PbList<DocumentResponse>();
+  static $pb.PbList<DocumentResponse> createRepeated() => $pb.PbList<DocumentResponse>();
   @$core.pragma('dart2js:noInline')
-  static DocumentResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<DocumentResponse>(create);
+  static DocumentResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<DocumentResponse>(create);
   static DocumentResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -501,10 +716,7 @@ class DocumentResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -514,47 +726,61 @@ class DocumentResponse extends $pb.GeneratedMessage {
 }
 
 class CompleteResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CompleteResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..a<$core.int>(1, 'replacementOffset', $pb.PbFieldType.O3,
-        protoName: 'replacementOffset')
-    ..a<$core.int>(2, 'replacementLength', $pb.PbFieldType.O3,
-        protoName: 'replacementLength')
-    ..pc<Completion>(3, 'completions', $pb.PbFieldType.PM,
-        subBuilder: Completion.create)
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CompleteResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementOffset', $pb.PbFieldType.O3, protoName: 'replacementOffset')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacementLength', $pb.PbFieldType.O3, protoName: 'replacementLength')
+    ..pc<Completion>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'completions', $pb.PbFieldType.PM, subBuilder: Completion.create)
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   CompleteResponse._() : super();
-  factory CompleteResponse() => create();
-  factory CompleteResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CompleteResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CompleteResponse({
+    $core.int replacementOffset,
+    $core.int replacementLength,
+    $core.Iterable<Completion> completions,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (replacementOffset != null) {
+      _result.replacementOffset = replacementOffset;
+    }
+    if (replacementLength != null) {
+      _result.replacementLength = replacementLength;
+    }
+    if (completions != null) {
+      _result.completions.addAll(completions);
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory CompleteResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CompleteResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CompleteResponse clone() => CompleteResponse()..mergeFromMessage(this);
-  CompleteResponse copyWith(void Function(CompleteResponse) updates) =>
-      super.copyWith((message) => updates(message as CompleteResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CompleteResponse copyWith(void Function(CompleteResponse) updates) => super.copyWith((message) => updates(message as CompleteResponse)) as CompleteResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CompleteResponse create() => CompleteResponse._();
   CompleteResponse createEmptyInstance() => create();
-  static $pb.PbList<CompleteResponse> createRepeated() =>
-      $pb.PbList<CompleteResponse>();
+  static $pb.PbList<CompleteResponse> createRepeated() => $pb.PbList<CompleteResponse>();
   @$core.pragma('dart2js:noInline')
-  static CompleteResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CompleteResponse>(create);
+  static CompleteResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CompleteResponse>(create);
   static CompleteResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get replacementOffset => $_getIZ(0);
   @$pb.TagNumber(1)
-  set replacementOffset($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set replacementOffset($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasReplacementOffset() => $_has(0);
   @$pb.TagNumber(1)
@@ -563,10 +789,7 @@ class CompleteResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get replacementLength => $_getIZ(1);
   @$pb.TagNumber(2)
-  set replacementLength($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set replacementLength($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasReplacementLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -578,10 +801,7 @@ class CompleteResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(3);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(3);
   @$pb.TagNumber(99)
@@ -591,35 +811,40 @@ class CompleteResponse extends $pb.GeneratedMessage {
 }
 
 class Completion extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('Completion',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..m<$core.String, $core.String>(1, 'completion',
-        entryClassName: 'Completion.CompletionEntry',
-        keyFieldType: $pb.PbFieldType.OS,
-        valueFieldType: $pb.PbFieldType.OS,
-        packageName: const $pb.PackageName('dart_services.api'))
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Completion', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..m<$core.String, $core.String>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'completion', entryClassName: 'Completion.CompletionEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OS, packageName: const $pb.PackageName('dart_services.api'))
+    ..hasRequiredFields = false
+  ;
 
   Completion._() : super();
-  factory Completion() => create();
-  factory Completion.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Completion.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory Completion({
+    $core.Map<$core.String, $core.String> completion,
+  }) {
+    final _result = create();
+    if (completion != null) {
+      _result.completion.addAll(completion);
+    }
+    return _result;
+  }
+  factory Completion.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Completion.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Completion clone() => Completion()..mergeFromMessage(this);
-  Completion copyWith(void Function(Completion) updates) =>
-      super.copyWith((message) => updates(message as Completion));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Completion copyWith(void Function(Completion) updates) => super.copyWith((message) => updates(message as Completion)) as Completion; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Completion create() => Completion._();
   Completion createEmptyInstance() => create();
   static $pb.PbList<Completion> createRepeated() => $pb.PbList<Completion>();
   @$core.pragma('dart2js:noInline')
-  static Completion getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<Completion>(create);
+  static Completion getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Completion>(create);
   static Completion _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -627,34 +852,45 @@ class Completion extends $pb.GeneratedMessage {
 }
 
 class FixesResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FixesResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..pc<ProblemAndFixes>(1, 'fixes', $pb.PbFieldType.PM,
-        subBuilder: ProblemAndFixes.create)
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FixesResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..pc<ProblemAndFixes>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fixes', $pb.PbFieldType.PM, subBuilder: ProblemAndFixes.create)
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   FixesResponse._() : super();
-  factory FixesResponse() => create();
-  factory FixesResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory FixesResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory FixesResponse({
+    $core.Iterable<ProblemAndFixes> fixes,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (fixes != null) {
+      _result.fixes.addAll(fixes);
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory FixesResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FixesResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   FixesResponse clone() => FixesResponse()..mergeFromMessage(this);
-  FixesResponse copyWith(void Function(FixesResponse) updates) =>
-      super.copyWith((message) => updates(message as FixesResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FixesResponse copyWith(void Function(FixesResponse) updates) => super.copyWith((message) => updates(message as FixesResponse)) as FixesResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FixesResponse create() => FixesResponse._();
   FixesResponse createEmptyInstance() => create();
-  static $pb.PbList<FixesResponse> createRepeated() =>
-      $pb.PbList<FixesResponse>();
+  static $pb.PbList<FixesResponse> createRepeated() => $pb.PbList<FixesResponse>();
   @$core.pragma('dart2js:noInline')
-  static FixesResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<FixesResponse>(create);
+  static FixesResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FixesResponse>(create);
   static FixesResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -663,10 +899,7 @@ class FixesResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -676,36 +909,55 @@ class FixesResponse extends $pb.GeneratedMessage {
 }
 
 class ProblemAndFixes extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ProblemAndFixes',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..pc<CandidateFix>(1, 'fixes', $pb.PbFieldType.PM,
-        subBuilder: CandidateFix.create)
-    ..aOS(2, 'problemMessage', protoName: 'problemMessage')
-    ..a<$core.int>(3, 'offset', $pb.PbFieldType.O3)
-    ..a<$core.int>(4, 'length', $pb.PbFieldType.O3)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ProblemAndFixes', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..pc<CandidateFix>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'fixes', $pb.PbFieldType.PM, subBuilder: CandidateFix.create)
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'problemMessage', protoName: 'problemMessage')
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
+    ..a<$core.int>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
+    ..hasRequiredFields = false
+  ;
 
   ProblemAndFixes._() : super();
-  factory ProblemAndFixes() => create();
-  factory ProblemAndFixes.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ProblemAndFixes.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ProblemAndFixes({
+    $core.Iterable<CandidateFix> fixes,
+    $core.String problemMessage,
+    $core.int offset,
+    $core.int length,
+  }) {
+    final _result = create();
+    if (fixes != null) {
+      _result.fixes.addAll(fixes);
+    }
+    if (problemMessage != null) {
+      _result.problemMessage = problemMessage;
+    }
+    if (offset != null) {
+      _result.offset = offset;
+    }
+    if (length != null) {
+      _result.length = length;
+    }
+    return _result;
+  }
+  factory ProblemAndFixes.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ProblemAndFixes.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ProblemAndFixes clone() => ProblemAndFixes()..mergeFromMessage(this);
-  ProblemAndFixes copyWith(void Function(ProblemAndFixes) updates) =>
-      super.copyWith((message) => updates(message as ProblemAndFixes));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ProblemAndFixes copyWith(void Function(ProblemAndFixes) updates) => super.copyWith((message) => updates(message as ProblemAndFixes)) as ProblemAndFixes; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ProblemAndFixes create() => ProblemAndFixes._();
   ProblemAndFixes createEmptyInstance() => create();
-  static $pb.PbList<ProblemAndFixes> createRepeated() =>
-      $pb.PbList<ProblemAndFixes>();
+  static $pb.PbList<ProblemAndFixes> createRepeated() => $pb.PbList<ProblemAndFixes>();
   @$core.pragma('dart2js:noInline')
-  static ProblemAndFixes getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ProblemAndFixes>(create);
+  static ProblemAndFixes getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ProblemAndFixes>(create);
   static ProblemAndFixes _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -714,10 +966,7 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get problemMessage => $_getSZ(1);
   @$pb.TagNumber(2)
-  set problemMessage($core.String v) {
-    $_setString(1, v);
-  }
-
+  set problemMessage($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasProblemMessage() => $_has(1);
   @$pb.TagNumber(2)
@@ -726,10 +975,7 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get offset => $_getIZ(2);
   @$pb.TagNumber(3)
-  set offset($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set offset($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasOffset() => $_has(2);
   @$pb.TagNumber(3)
@@ -738,10 +984,7 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.int get length => $_getIZ(3);
   @$pb.TagNumber(4)
-  set length($core.int v) {
-    $_setSignedInt32(3, v);
-  }
-
+  set length($core.int v) { $_setSignedInt32(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasLength() => $_has(3);
   @$pb.TagNumber(4)
@@ -749,47 +992,61 @@ class ProblemAndFixes extends $pb.GeneratedMessage {
 }
 
 class CandidateFix extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('CandidateFix',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'message')
-    ..pc<SourceEdit>(2, 'edits', $pb.PbFieldType.PM,
-        subBuilder: SourceEdit.create)
-    ..a<$core.int>(3, 'selectionOffset', $pb.PbFieldType.O3,
-        protoName: 'selectionOffset')
-    ..pc<LinkedEditGroup>(4, 'linkedEditGroups', $pb.PbFieldType.PM,
-        protoName: 'linkedEditGroups', subBuilder: LinkedEditGroup.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'CandidateFix', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..pc<SourceEdit>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'edits', $pb.PbFieldType.PM, subBuilder: SourceEdit.create)
+    ..a<$core.int>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'selectionOffset', $pb.PbFieldType.O3, protoName: 'selectionOffset')
+    ..pc<LinkedEditGroup>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'linkedEditGroups', $pb.PbFieldType.PM, protoName: 'linkedEditGroups', subBuilder: LinkedEditGroup.create)
+    ..hasRequiredFields = false
+  ;
 
   CandidateFix._() : super();
-  factory CandidateFix() => create();
-  factory CandidateFix.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory CandidateFix.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory CandidateFix({
+    $core.String message,
+    $core.Iterable<SourceEdit> edits,
+    $core.int selectionOffset,
+    $core.Iterable<LinkedEditGroup> linkedEditGroups,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    if (edits != null) {
+      _result.edits.addAll(edits);
+    }
+    if (selectionOffset != null) {
+      _result.selectionOffset = selectionOffset;
+    }
+    if (linkedEditGroups != null) {
+      _result.linkedEditGroups.addAll(linkedEditGroups);
+    }
+    return _result;
+  }
+  factory CandidateFix.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory CandidateFix.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   CandidateFix clone() => CandidateFix()..mergeFromMessage(this);
-  CandidateFix copyWith(void Function(CandidateFix) updates) =>
-      super.copyWith((message) => updates(message as CandidateFix));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  CandidateFix copyWith(void Function(CandidateFix) updates) => super.copyWith((message) => updates(message as CandidateFix)) as CandidateFix; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static CandidateFix create() => CandidateFix._();
   CandidateFix createEmptyInstance() => create();
-  static $pb.PbList<CandidateFix> createRepeated() =>
-      $pb.PbList<CandidateFix>();
+  static $pb.PbList<CandidateFix> createRepeated() => $pb.PbList<CandidateFix>();
   @$core.pragma('dart2js:noInline')
-  static CandidateFix getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<CandidateFix>(create);
+  static CandidateFix getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<CandidateFix>(create);
   static CandidateFix _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) {
-    $_setString(0, v);
-  }
-
+  set message($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
@@ -801,10 +1058,7 @@ class CandidateFix extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.int get selectionOffset => $_getIZ(2);
   @$pb.TagNumber(3)
-  set selectionOffset($core.int v) {
-    $_setSignedInt32(2, v);
-  }
-
+  set selectionOffset($core.int v) { $_setSignedInt32(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasSelectionOffset() => $_has(2);
   @$pb.TagNumber(3)
@@ -815,42 +1069,56 @@ class CandidateFix extends $pb.GeneratedMessage {
 }
 
 class SourceEdit extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('SourceEdit',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..a<$core.int>(1, 'offset', $pb.PbFieldType.O3)
-    ..a<$core.int>(2, 'length', $pb.PbFieldType.O3)
-    ..aOS(3, 'replacement')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'SourceEdit', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..a<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'replacement')
+    ..hasRequiredFields = false
+  ;
 
   SourceEdit._() : super();
-  factory SourceEdit() => create();
-  factory SourceEdit.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory SourceEdit.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory SourceEdit({
+    $core.int offset,
+    $core.int length,
+    $core.String replacement,
+  }) {
+    final _result = create();
+    if (offset != null) {
+      _result.offset = offset;
+    }
+    if (length != null) {
+      _result.length = length;
+    }
+    if (replacement != null) {
+      _result.replacement = replacement;
+    }
+    return _result;
+  }
+  factory SourceEdit.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory SourceEdit.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   SourceEdit clone() => SourceEdit()..mergeFromMessage(this);
-  SourceEdit copyWith(void Function(SourceEdit) updates) =>
-      super.copyWith((message) => updates(message as SourceEdit));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  SourceEdit copyWith(void Function(SourceEdit) updates) => super.copyWith((message) => updates(message as SourceEdit)) as SourceEdit; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static SourceEdit create() => SourceEdit._();
   SourceEdit createEmptyInstance() => create();
   static $pb.PbList<SourceEdit> createRepeated() => $pb.PbList<SourceEdit>();
   @$core.pragma('dart2js:noInline')
-  static SourceEdit getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<SourceEdit>(create);
+  static SourceEdit getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<SourceEdit>(create);
   static SourceEdit _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.int get offset => $_getIZ(0);
   @$pb.TagNumber(1)
-  set offset($core.int v) {
-    $_setSignedInt32(0, v);
-  }
-
+  set offset($core.int v) { $_setSignedInt32(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasOffset() => $_has(0);
   @$pb.TagNumber(1)
@@ -859,10 +1127,7 @@ class SourceEdit extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get length => $_getIZ(1);
   @$pb.TagNumber(2)
-  set length($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set length($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -871,10 +1136,7 @@ class SourceEdit extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get replacement => $_getSZ(2);
   @$pb.TagNumber(3)
-  set replacement($core.String v) {
-    $_setString(2, v);
-  }
-
+  set replacement($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasReplacement() => $_has(2);
   @$pb.TagNumber(3)
@@ -882,35 +1144,50 @@ class SourceEdit extends $pb.GeneratedMessage {
 }
 
 class LinkedEditGroup extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LinkedEditGroup',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..p<$core.int>(1, 'positions', $pb.PbFieldType.P3)
-    ..a<$core.int>(2, 'length', $pb.PbFieldType.O3)
-    ..pc<LinkedEditSuggestion>(3, 'suggestions', $pb.PbFieldType.PM,
-        subBuilder: LinkedEditSuggestion.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LinkedEditGroup', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..p<$core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'positions', $pb.PbFieldType.P3)
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'length', $pb.PbFieldType.O3)
+    ..pc<LinkedEditSuggestion>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'suggestions', $pb.PbFieldType.PM, subBuilder: LinkedEditSuggestion.create)
+    ..hasRequiredFields = false
+  ;
 
   LinkedEditGroup._() : super();
-  factory LinkedEditGroup() => create();
-  factory LinkedEditGroup.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LinkedEditGroup.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory LinkedEditGroup({
+    $core.Iterable<$core.int> positions,
+    $core.int length,
+    $core.Iterable<LinkedEditSuggestion> suggestions,
+  }) {
+    final _result = create();
+    if (positions != null) {
+      _result.positions.addAll(positions);
+    }
+    if (length != null) {
+      _result.length = length;
+    }
+    if (suggestions != null) {
+      _result.suggestions.addAll(suggestions);
+    }
+    return _result;
+  }
+  factory LinkedEditGroup.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LinkedEditGroup.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   LinkedEditGroup clone() => LinkedEditGroup()..mergeFromMessage(this);
-  LinkedEditGroup copyWith(void Function(LinkedEditGroup) updates) =>
-      super.copyWith((message) => updates(message as LinkedEditGroup));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LinkedEditGroup copyWith(void Function(LinkedEditGroup) updates) => super.copyWith((message) => updates(message as LinkedEditGroup)) as LinkedEditGroup; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LinkedEditGroup create() => LinkedEditGroup._();
   LinkedEditGroup createEmptyInstance() => create();
-  static $pb.PbList<LinkedEditGroup> createRepeated() =>
-      $pb.PbList<LinkedEditGroup>();
+  static $pb.PbList<LinkedEditGroup> createRepeated() => $pb.PbList<LinkedEditGroup>();
   @$core.pragma('dart2js:noInline')
-  static LinkedEditGroup getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LinkedEditGroup>(create);
+  static LinkedEditGroup getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LinkedEditGroup>(create);
   static LinkedEditGroup _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -919,10 +1196,7 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get length => $_getIZ(1);
   @$pb.TagNumber(2)
-  set length($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set length($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasLength() => $_has(1);
   @$pb.TagNumber(2)
@@ -933,43 +1207,51 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
 }
 
 class LinkedEditSuggestion extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('LinkedEditSuggestion',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'value')
-    ..aOS(2, 'kind')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'LinkedEditSuggestion', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'kind')
+    ..hasRequiredFields = false
+  ;
 
   LinkedEditSuggestion._() : super();
-  factory LinkedEditSuggestion() => create();
-  factory LinkedEditSuggestion.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory LinkedEditSuggestion.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  LinkedEditSuggestion clone() =>
-      LinkedEditSuggestion()..mergeFromMessage(this);
-  LinkedEditSuggestion copyWith(void Function(LinkedEditSuggestion) updates) =>
-      super.copyWith((message) => updates(message as LinkedEditSuggestion));
+  factory LinkedEditSuggestion({
+    $core.String value,
+    $core.String kind,
+  }) {
+    final _result = create();
+    if (value != null) {
+      _result.value = value;
+    }
+    if (kind != null) {
+      _result.kind = kind;
+    }
+    return _result;
+  }
+  factory LinkedEditSuggestion.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory LinkedEditSuggestion.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  LinkedEditSuggestion clone() => LinkedEditSuggestion()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  LinkedEditSuggestion copyWith(void Function(LinkedEditSuggestion) updates) => super.copyWith((message) => updates(message as LinkedEditSuggestion)) as LinkedEditSuggestion; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static LinkedEditSuggestion create() => LinkedEditSuggestion._();
   LinkedEditSuggestion createEmptyInstance() => create();
-  static $pb.PbList<LinkedEditSuggestion> createRepeated() =>
-      $pb.PbList<LinkedEditSuggestion>();
+  static $pb.PbList<LinkedEditSuggestion> createRepeated() => $pb.PbList<LinkedEditSuggestion>();
   @$core.pragma('dart2js:noInline')
-  static LinkedEditSuggestion getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<LinkedEditSuggestion>(create);
+  static LinkedEditSuggestion getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<LinkedEditSuggestion>(create);
   static LinkedEditSuggestion _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get value => $_getSZ(0);
   @$pb.TagNumber(1)
-  set value($core.String v) {
-    $_setString(0, v);
-  }
-
+  set value($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -978,10 +1260,7 @@ class LinkedEditSuggestion extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get kind => $_getSZ(1);
   @$pb.TagNumber(2)
-  set kind($core.String v) {
-    $_setString(1, v);
-  }
-
+  set kind($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasKind() => $_has(1);
   @$pb.TagNumber(2)
@@ -989,43 +1268,56 @@ class LinkedEditSuggestion extends $pb.GeneratedMessage {
 }
 
 class FormatResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('FormatResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'newString', protoName: 'newString')
-    ..a<$core.int>(2, 'offset', $pb.PbFieldType.O3)
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'FormatResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'newString', protoName: 'newString')
+    ..a<$core.int>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'offset', $pb.PbFieldType.O3)
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   FormatResponse._() : super();
-  factory FormatResponse() => create();
-  factory FormatResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory FormatResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory FormatResponse({
+    $core.String newString,
+    $core.int offset,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (newString != null) {
+      _result.newString = newString;
+    }
+    if (offset != null) {
+      _result.offset = offset;
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory FormatResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory FormatResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   FormatResponse clone() => FormatResponse()..mergeFromMessage(this);
-  FormatResponse copyWith(void Function(FormatResponse) updates) =>
-      super.copyWith((message) => updates(message as FormatResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  FormatResponse copyWith(void Function(FormatResponse) updates) => super.copyWith((message) => updates(message as FormatResponse)) as FormatResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static FormatResponse create() => FormatResponse._();
   FormatResponse createEmptyInstance() => create();
-  static $pb.PbList<FormatResponse> createRepeated() =>
-      $pb.PbList<FormatResponse>();
+  static $pb.PbList<FormatResponse> createRepeated() => $pb.PbList<FormatResponse>();
   @$core.pragma('dart2js:noInline')
-  static FormatResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<FormatResponse>(create);
+  static FormatResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<FormatResponse>(create);
   static FormatResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get newString => $_getSZ(0);
   @$pb.TagNumber(1)
-  set newString($core.String v) {
-    $_setString(0, v);
-  }
-
+  set newString($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasNewString() => $_has(0);
   @$pb.TagNumber(1)
@@ -1034,10 +1326,7 @@ class FormatResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.int get offset => $_getIZ(1);
   @$pb.TagNumber(2)
-  set offset($core.int v) {
-    $_setSignedInt32(1, v);
-  }
-
+  set offset($core.int v) { $_setSignedInt32(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasOffset() => $_has(1);
   @$pb.TagNumber(2)
@@ -1046,10 +1335,7 @@ class FormatResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(2);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(2);
   @$pb.TagNumber(99)
@@ -1059,34 +1345,45 @@ class FormatResponse extends $pb.GeneratedMessage {
 }
 
 class AssistsResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('AssistsResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..pc<CandidateFix>(1, 'assists', $pb.PbFieldType.PM,
-        subBuilder: CandidateFix.create)
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'AssistsResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..pc<CandidateFix>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'assists', $pb.PbFieldType.PM, subBuilder: CandidateFix.create)
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   AssistsResponse._() : super();
-  factory AssistsResponse() => create();
-  factory AssistsResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory AssistsResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory AssistsResponse({
+    $core.Iterable<CandidateFix> assists,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (assists != null) {
+      _result.assists.addAll(assists);
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory AssistsResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory AssistsResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   AssistsResponse clone() => AssistsResponse()..mergeFromMessage(this);
-  AssistsResponse copyWith(void Function(AssistsResponse) updates) =>
-      super.copyWith((message) => updates(message as AssistsResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  AssistsResponse copyWith(void Function(AssistsResponse) updates) => super.copyWith((message) => updates(message as AssistsResponse)) as AssistsResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static AssistsResponse create() => AssistsResponse._();
   AssistsResponse createEmptyInstance() => create();
-  static $pb.PbList<AssistsResponse> createRepeated() =>
-      $pb.PbList<AssistsResponse>();
+  static $pb.PbList<AssistsResponse> createRepeated() => $pb.PbList<AssistsResponse>();
   @$core.pragma('dart2js:noInline')
-  static AssistsResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<AssistsResponse>(create);
+  static AssistsResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<AssistsResponse>(create);
   static AssistsResponse _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -1095,10 +1392,7 @@ class AssistsResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(1);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(1);
   @$pb.TagNumber(99)
@@ -1108,49 +1402,86 @@ class AssistsResponse extends $pb.GeneratedMessage {
 }
 
 class VersionResponse extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('VersionResponse',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'sdkVersion', protoName: 'sdkVersion')
-    ..aOS(2, 'sdkVersionFull', protoName: 'sdkVersionFull')
-    ..aOS(3, 'runtimeVersion', protoName: 'runtimeVersion')
-    ..aOS(4, 'appEngineVersion', protoName: 'appEngineVersion')
-    ..aOS(5, 'servicesVersion', protoName: 'servicesVersion')
-    ..aOS(6, 'flutterVersion', protoName: 'flutterVersion')
-    ..aOS(7, 'flutterDartVersion', protoName: 'flutterDartVersion')
-    ..aOS(8, 'flutterDartVersionFull', protoName: 'flutterDartVersionFull')
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'VersionResponse', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersion', protoName: 'sdkVersion')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'sdkVersionFull', protoName: 'sdkVersionFull')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'runtimeVersion', protoName: 'runtimeVersion')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appEngineVersion', protoName: 'appEngineVersion')
+    ..aOS(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'servicesVersion', protoName: 'servicesVersion')
+    ..aOS(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterVersion', protoName: 'flutterVersion')
+    ..aOS(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterDartVersion', protoName: 'flutterDartVersion')
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'flutterDartVersionFull', protoName: 'flutterDartVersionFull')
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   VersionResponse._() : super();
-  factory VersionResponse() => create();
-  factory VersionResponse.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory VersionResponse.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory VersionResponse({
+    $core.String sdkVersion,
+    $core.String sdkVersionFull,
+    $core.String runtimeVersion,
+    $core.String appEngineVersion,
+    $core.String servicesVersion,
+    $core.String flutterVersion,
+    $core.String flutterDartVersion,
+    $core.String flutterDartVersionFull,
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (sdkVersion != null) {
+      _result.sdkVersion = sdkVersion;
+    }
+    if (sdkVersionFull != null) {
+      _result.sdkVersionFull = sdkVersionFull;
+    }
+    if (runtimeVersion != null) {
+      _result.runtimeVersion = runtimeVersion;
+    }
+    if (appEngineVersion != null) {
+      _result.appEngineVersion = appEngineVersion;
+    }
+    if (servicesVersion != null) {
+      _result.servicesVersion = servicesVersion;
+    }
+    if (flutterVersion != null) {
+      _result.flutterVersion = flutterVersion;
+    }
+    if (flutterDartVersion != null) {
+      _result.flutterDartVersion = flutterDartVersion;
+    }
+    if (flutterDartVersionFull != null) {
+      _result.flutterDartVersionFull = flutterDartVersionFull;
+    }
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory VersionResponse.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory VersionResponse.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   VersionResponse clone() => VersionResponse()..mergeFromMessage(this);
-  VersionResponse copyWith(void Function(VersionResponse) updates) =>
-      super.copyWith((message) => updates(message as VersionResponse));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  VersionResponse copyWith(void Function(VersionResponse) updates) => super.copyWith((message) => updates(message as VersionResponse)) as VersionResponse; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static VersionResponse create() => VersionResponse._();
   VersionResponse createEmptyInstance() => create();
-  static $pb.PbList<VersionResponse> createRepeated() =>
-      $pb.PbList<VersionResponse>();
+  static $pb.PbList<VersionResponse> createRepeated() => $pb.PbList<VersionResponse>();
   @$core.pragma('dart2js:noInline')
-  static VersionResponse getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<VersionResponse>(create);
+  static VersionResponse getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<VersionResponse>(create);
   static VersionResponse _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get sdkVersion => $_getSZ(0);
   @$pb.TagNumber(1)
-  set sdkVersion($core.String v) {
-    $_setString(0, v);
-  }
-
+  set sdkVersion($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasSdkVersion() => $_has(0);
   @$pb.TagNumber(1)
@@ -1159,10 +1490,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get sdkVersionFull => $_getSZ(1);
   @$pb.TagNumber(2)
-  set sdkVersionFull($core.String v) {
-    $_setString(1, v);
-  }
-
+  set sdkVersionFull($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasSdkVersionFull() => $_has(1);
   @$pb.TagNumber(2)
@@ -1171,10 +1499,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get runtimeVersion => $_getSZ(2);
   @$pb.TagNumber(3)
-  set runtimeVersion($core.String v) {
-    $_setString(2, v);
-  }
-
+  set runtimeVersion($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasRuntimeVersion() => $_has(2);
   @$pb.TagNumber(3)
@@ -1183,10 +1508,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get appEngineVersion => $_getSZ(3);
   @$pb.TagNumber(4)
-  set appEngineVersion($core.String v) {
-    $_setString(3, v);
-  }
-
+  set appEngineVersion($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasAppEngineVersion() => $_has(3);
   @$pb.TagNumber(4)
@@ -1195,10 +1517,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   $core.String get servicesVersion => $_getSZ(4);
   @$pb.TagNumber(5)
-  set servicesVersion($core.String v) {
-    $_setString(4, v);
-  }
-
+  set servicesVersion($core.String v) { $_setString(4, v); }
   @$pb.TagNumber(5)
   $core.bool hasServicesVersion() => $_has(4);
   @$pb.TagNumber(5)
@@ -1207,10 +1526,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $core.String get flutterVersion => $_getSZ(5);
   @$pb.TagNumber(6)
-  set flutterVersion($core.String v) {
-    $_setString(5, v);
-  }
-
+  set flutterVersion($core.String v) { $_setString(5, v); }
   @$pb.TagNumber(6)
   $core.bool hasFlutterVersion() => $_has(5);
   @$pb.TagNumber(6)
@@ -1219,10 +1535,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $core.String get flutterDartVersion => $_getSZ(6);
   @$pb.TagNumber(7)
-  set flutterDartVersion($core.String v) {
-    $_setString(6, v);
-  }
-
+  set flutterDartVersion($core.String v) { $_setString(6, v); }
   @$pb.TagNumber(7)
   $core.bool hasFlutterDartVersion() => $_has(6);
   @$pb.TagNumber(7)
@@ -1231,10 +1544,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get flutterDartVersionFull => $_getSZ(7);
   @$pb.TagNumber(8)
-  set flutterDartVersionFull($core.String v) {
-    $_setString(7, v);
-  }
-
+  set flutterDartVersionFull($core.String v) { $_setString(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasFlutterDartVersionFull() => $_has(7);
   @$pb.TagNumber(8)
@@ -1243,10 +1553,7 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(8);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(8);
   @$pb.TagNumber(99)
@@ -1256,40 +1563,46 @@ class VersionResponse extends $pb.GeneratedMessage {
 }
 
 class BadRequest extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('BadRequest',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOM<ErrorMessage>(99, 'error', subBuilder: ErrorMessage.create)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'BadRequest', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOM<ErrorMessage>(99, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'error', subBuilder: ErrorMessage.create)
+    ..hasRequiredFields = false
+  ;
 
   BadRequest._() : super();
-  factory BadRequest() => create();
-  factory BadRequest.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory BadRequest.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory BadRequest({
+    ErrorMessage error,
+  }) {
+    final _result = create();
+    if (error != null) {
+      _result.error = error;
+    }
+    return _result;
+  }
+  factory BadRequest.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory BadRequest.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   BadRequest clone() => BadRequest()..mergeFromMessage(this);
-  BadRequest copyWith(void Function(BadRequest) updates) =>
-      super.copyWith((message) => updates(message as BadRequest));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  BadRequest copyWith(void Function(BadRequest) updates) => super.copyWith((message) => updates(message as BadRequest)) as BadRequest; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static BadRequest create() => BadRequest._();
   BadRequest createEmptyInstance() => create();
   static $pb.PbList<BadRequest> createRepeated() => $pb.PbList<BadRequest>();
   @$core.pragma('dart2js:noInline')
-  static BadRequest getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<BadRequest>(create);
+  static BadRequest getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<BadRequest>(create);
   static BadRequest _defaultInstance;
 
   @$pb.TagNumber(99)
   ErrorMessage get error => $_getN(0);
   @$pb.TagNumber(99)
-  set error(ErrorMessage v) {
-    setField(99, v);
-  }
-
+  set error(ErrorMessage v) { setField(99, v); }
   @$pb.TagNumber(99)
   $core.bool hasError() => $_has(0);
   @$pb.TagNumber(99)
@@ -1299,43 +1612,49 @@ class BadRequest extends $pb.GeneratedMessage {
 }
 
 class ErrorMessage extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo('ErrorMessage',
-      package: const $pb.PackageName('dart_services.api'),
-      createEmptyInstance: create)
-    ..aOS(1, 'message')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ErrorMessage', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'dart_services.api'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'message')
+    ..hasRequiredFields = false
+  ;
 
   ErrorMessage._() : super();
-  factory ErrorMessage() => create();
-  factory ErrorMessage.fromBuffer($core.List<$core.int> i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ErrorMessage.fromJson($core.String i,
-          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
+  factory ErrorMessage({
+    $core.String message,
+  }) {
+    final _result = create();
+    if (message != null) {
+      _result.message = message;
+    }
+    return _result;
+  }
+  factory ErrorMessage.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ErrorMessage.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ErrorMessage clone() => ErrorMessage()..mergeFromMessage(this);
-  ErrorMessage copyWith(void Function(ErrorMessage) updates) =>
-      super.copyWith((message) => updates(message as ErrorMessage));
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ErrorMessage copyWith(void Function(ErrorMessage) updates) => super.copyWith((message) => updates(message as ErrorMessage)) as ErrorMessage; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ErrorMessage create() => ErrorMessage._();
   ErrorMessage createEmptyInstance() => create();
-  static $pb.PbList<ErrorMessage> createRepeated() =>
-      $pb.PbList<ErrorMessage>();
+  static $pb.PbList<ErrorMessage> createRepeated() => $pb.PbList<ErrorMessage>();
   @$core.pragma('dart2js:noInline')
-  static ErrorMessage getDefault() => _defaultInstance ??=
-      $pb.GeneratedMessage.$_defaultFor<ErrorMessage>(create);
+  static ErrorMessage getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<ErrorMessage>(create);
   static ErrorMessage _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get message => $_getSZ(0);
   @$pb.TagNumber(1)
-  set message($core.String v) {
-    $_setString(0, v);
-  }
-
+  set message($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasMessage() => $_has(0);
   @$pb.TagNumber(1)
   void clearMessage() => clearField(1);
 }
+

--- a/lib/src/protos/dart_services.pb.dart
+++ b/lib/src/protos/dart_services.pb.dart
@@ -254,6 +254,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
     ..a<$core.int>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'charLength', $pb.PbFieldType.O3, protoName: 'charLength')
     ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
     ..pc<DiagnosticMessage>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'diagnosticMessages', $pb.PbFieldType.PM, protoName: 'diagnosticMessages', subBuilder: DiagnosticMessage.create)
+    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'correction')
     ..hasRequiredFields = false
   ;
 
@@ -268,6 +269,7 @@ class AnalysisIssue extends $pb.GeneratedMessage {
     $core.int charLength,
     $core.String url,
     $core.Iterable<DiagnosticMessage> diagnosticMessages,
+    $core.String correction,
   }) {
     final _result = create();
     if (kind != null) {
@@ -296,6 +298,9 @@ class AnalysisIssue extends $pb.GeneratedMessage {
     }
     if (diagnosticMessages != null) {
       _result.diagnosticMessages.addAll(diagnosticMessages);
+    }
+    if (correction != null) {
+      _result.correction = correction;
     }
     return _result;
   }
@@ -394,6 +399,15 @@ class AnalysisIssue extends $pb.GeneratedMessage {
 
   @$pb.TagNumber(9)
   $core.List<DiagnosticMessage> get diagnosticMessages => $_getList(8);
+
+  @$pb.TagNumber(10)
+  $core.String get correction => $_getSZ(9);
+  @$pb.TagNumber(10)
+  set correction($core.String v) { $_setString(9, v); }
+  @$pb.TagNumber(10)
+  $core.bool hasCorrection() => $_has(9);
+  @$pb.TagNumber(10)
+  void clearCorrection() => clearField(10);
 }
 
 class DiagnosticMessage extends $pb.GeneratedMessage {

--- a/lib/src/protos/dart_services.pbenum.dart
+++ b/lib/src/protos/dart_services.pbenum.dart
@@ -4,4 +4,3 @@
 //
 // @dart = 2.7
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
-

--- a/lib/src/protos/dart_services.pbenum.dart
+++ b/lib/src/protos/dart_services.pbenum.dart
@@ -2,5 +2,6 @@
 //  Generated code. Do not modify.
 //  source: protos/dart_services.proto
 //
-// @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+

--- a/lib/src/protos/dart_services.pbjson.dart
+++ b/lib/src/protos/dart_services.pbjson.dart
@@ -8,299 +8,494 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use compileRequestDescriptor instead')
-const CompileRequest$json = const {
+const CompileRequest$json = {
   '1': 'CompileRequest',
-  '2': const [
-    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
-    const {'1': 'returnSourceMap', '3': 2, '4': 1, '5': 8, '10': 'returnSourceMap'},
+  '2': [
+    {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+    {'1': 'returnSourceMap', '3': 2, '4': 1, '5': 8, '10': 'returnSourceMap'},
   ],
 };
 
 /// Descriptor for `CompileRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List compileRequestDescriptor = $convert.base64Decode('Cg5Db21waWxlUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZRIoCg9yZXR1cm5Tb3VyY2VNYXAYAiABKAhSD3JldHVyblNvdXJjZU1hcA==');
+final $typed_data.Uint8List compileRequestDescriptor = $convert.base64Decode(
+    'Cg5Db21waWxlUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZRIoCg9yZXR1cm5Tb3VyY2VNYXAYAiABKAhSD3JldHVyblNvdXJjZU1hcA==');
 @$core.Deprecated('Use compileDDCRequestDescriptor instead')
-const CompileDDCRequest$json = const {
+const CompileDDCRequest$json = {
   '1': 'CompileDDCRequest',
-  '2': const [
-    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+  '2': [
+    {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
   ],
 };
 
 /// Descriptor for `CompileDDCRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List compileDDCRequestDescriptor = $convert.base64Decode('ChFDb21waWxlRERDUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZQ==');
+final $typed_data.Uint8List compileDDCRequestDescriptor = $convert.base64Decode(
+    'ChFDb21waWxlRERDUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZQ==');
 @$core.Deprecated('Use sourceRequestDescriptor instead')
-const SourceRequest$json = const {
+const SourceRequest$json = {
   '1': 'SourceRequest',
-  '2': const [
-    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
-    const {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
+  '2': [
+    {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+    {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
   ],
 };
 
 /// Descriptor for `SourceRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sourceRequestDescriptor = $convert.base64Decode('Cg1Tb3VyY2VSZXF1ZXN0EhYKBnNvdXJjZRgBIAEoCVIGc291cmNlEhYKBm9mZnNldBgCIAEoBVIGb2Zmc2V0');
+final $typed_data.Uint8List sourceRequestDescriptor = $convert.base64Decode(
+    'Cg1Tb3VyY2VSZXF1ZXN0EhYKBnNvdXJjZRgBIAEoCVIGc291cmNlEhYKBm9mZnNldBgCIAEoBVIGb2Zmc2V0');
 @$core.Deprecated('Use analysisResultsDescriptor instead')
-const AnalysisResults$json = const {
+const AnalysisResults$json = {
   '1': 'AnalysisResults',
-  '2': const [
-    const {'1': 'issues', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.AnalysisIssue', '10': 'issues'},
-    const {'1': 'packageImports', '3': 2, '4': 3, '5': 9, '10': 'packageImports'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'issues',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.AnalysisIssue',
+      '10': 'issues'
+    },
+    {'1': 'packageImports', '3': 2, '4': 3, '5': 9, '10': 'packageImports'},
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `AnalysisResults`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List analysisResultsDescriptor = $convert.base64Decode('Cg9BbmFseXNpc1Jlc3VsdHMSOAoGaXNzdWVzGAEgAygLMiAuZGFydF9zZXJ2aWNlcy5hcGkuQW5hbHlzaXNJc3N1ZVIGaXNzdWVzEiYKDnBhY2thZ2VJbXBvcnRzGAIgAygJUg5wYWNrYWdlSW1wb3J0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+final $typed_data.Uint8List analysisResultsDescriptor = $convert.base64Decode(
+    'Cg9BbmFseXNpc1Jlc3VsdHMSOAoGaXNzdWVzGAEgAygLMiAuZGFydF9zZXJ2aWNlcy5hcGkuQW5hbHlzaXNJc3N1ZVIGaXNzdWVzEiYKDnBhY2thZ2VJbXBvcnRzGAIgAygJUg5wYWNrYWdlSW1wb3J0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
 @$core.Deprecated('Use analysisIssueDescriptor instead')
-const AnalysisIssue$json = const {
+const AnalysisIssue$json = {
   '1': 'AnalysisIssue',
-  '2': const [
-    const {'1': 'kind', '3': 1, '4': 1, '5': 9, '10': 'kind'},
-    const {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
-    const {'1': 'message', '3': 3, '4': 1, '5': 9, '10': 'message'},
-    const {'1': 'sourceName', '3': 4, '4': 1, '5': 9, '10': 'sourceName'},
-    const {'1': 'hasFixes', '3': 5, '4': 1, '5': 8, '10': 'hasFixes'},
-    const {'1': 'charStart', '3': 6, '4': 1, '5': 5, '10': 'charStart'},
-    const {'1': 'charLength', '3': 7, '4': 1, '5': 5, '10': 'charLength'},
-    const {'1': 'url', '3': 8, '4': 1, '5': 9, '10': 'url'},
-    const {'1': 'diagnosticMessages', '3': 9, '4': 3, '5': 11, '6': '.dart_services.api.DiagnosticMessage', '10': 'diagnosticMessages'},
-    const {'1': 'correction', '3': 10, '4': 1, '5': 9, '10': 'correction'},
+  '2': [
+    {'1': 'kind', '3': 1, '4': 1, '5': 9, '10': 'kind'},
+    {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
+    {'1': 'message', '3': 3, '4': 1, '5': 9, '10': 'message'},
+    {'1': 'sourceName', '3': 4, '4': 1, '5': 9, '10': 'sourceName'},
+    {'1': 'hasFixes', '3': 5, '4': 1, '5': 8, '10': 'hasFixes'},
+    {'1': 'charStart', '3': 6, '4': 1, '5': 5, '10': 'charStart'},
+    {'1': 'charLength', '3': 7, '4': 1, '5': 5, '10': 'charLength'},
+    {'1': 'url', '3': 8, '4': 1, '5': 9, '10': 'url'},
+    {
+      '1': 'diagnosticMessages',
+      '3': 9,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.DiagnosticMessage',
+      '10': 'diagnosticMessages'
+    },
+    {'1': 'correction', '3': 10, '4': 1, '5': 9, '10': 'correction'},
   ],
 };
 
 /// Descriptor for `AnalysisIssue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List analysisIssueDescriptor = $convert.base64Decode('Cg1BbmFseXNpc0lzc3VlEhIKBGtpbmQYASABKAlSBGtpbmQSEgoEbGluZRgCIAEoBVIEbGluZRIYCgdtZXNzYWdlGAMgASgJUgdtZXNzYWdlEh4KCnNvdXJjZU5hbWUYBCABKAlSCnNvdXJjZU5hbWUSGgoIaGFzRml4ZXMYBSABKAhSCGhhc0ZpeGVzEhwKCWNoYXJTdGFydBgGIAEoBVIJY2hhclN0YXJ0Eh4KCmNoYXJMZW5ndGgYByABKAVSCmNoYXJMZW5ndGgSEAoDdXJsGAggASgJUgN1cmwSVAoSZGlhZ25vc3RpY01lc3NhZ2VzGAkgAygLMiQuZGFydF9zZXJ2aWNlcy5hcGkuRGlhZ25vc3RpY01lc3NhZ2VSEmRpYWdub3N0aWNNZXNzYWdlcxIeCgpjb3JyZWN0aW9uGAogASgJUgpjb3JyZWN0aW9u');
+final $typed_data.Uint8List analysisIssueDescriptor = $convert.base64Decode(
+    'Cg1BbmFseXNpc0lzc3VlEhIKBGtpbmQYASABKAlSBGtpbmQSEgoEbGluZRgCIAEoBVIEbGluZRIYCgdtZXNzYWdlGAMgASgJUgdtZXNzYWdlEh4KCnNvdXJjZU5hbWUYBCABKAlSCnNvdXJjZU5hbWUSGgoIaGFzRml4ZXMYBSABKAhSCGhhc0ZpeGVzEhwKCWNoYXJTdGFydBgGIAEoBVIJY2hhclN0YXJ0Eh4KCmNoYXJMZW5ndGgYByABKAVSCmNoYXJMZW5ndGgSEAoDdXJsGAggASgJUgN1cmwSVAoSZGlhZ25vc3RpY01lc3NhZ2VzGAkgAygLMiQuZGFydF9zZXJ2aWNlcy5hcGkuRGlhZ25vc3RpY01lc3NhZ2VSEmRpYWdub3N0aWNNZXNzYWdlcxIeCgpjb3JyZWN0aW9uGAogASgJUgpjb3JyZWN0aW9u');
 @$core.Deprecated('Use diagnosticMessageDescriptor instead')
-const DiagnosticMessage$json = const {
+const DiagnosticMessage$json = {
   '1': 'DiagnosticMessage',
-  '2': const [
-    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    const {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
-    const {'1': 'charStart', '3': 3, '4': 1, '5': 5, '10': 'charStart'},
-    const {'1': 'charLength', '3': 4, '4': 1, '5': 5, '10': 'charLength'},
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+    {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
+    {'1': 'charStart', '3': 3, '4': 1, '5': 5, '10': 'charStart'},
+    {'1': 'charLength', '3': 4, '4': 1, '5': 5, '10': 'charLength'},
   ],
 };
 
 /// Descriptor for `DiagnosticMessage`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List diagnosticMessageDescriptor = $convert.base64Decode('ChFEaWFnbm9zdGljTWVzc2FnZRIYCgdtZXNzYWdlGAEgASgJUgdtZXNzYWdlEhIKBGxpbmUYAiABKAVSBGxpbmUSHAoJY2hhclN0YXJ0GAMgASgFUgljaGFyU3RhcnQSHgoKY2hhckxlbmd0aBgEIAEoBVIKY2hhckxlbmd0aA==');
+final $typed_data.Uint8List diagnosticMessageDescriptor = $convert.base64Decode(
+    'ChFEaWFnbm9zdGljTWVzc2FnZRIYCgdtZXNzYWdlGAEgASgJUgdtZXNzYWdlEhIKBGxpbmUYAiABKAVSBGxpbmUSHAoJY2hhclN0YXJ0GAMgASgFUgljaGFyU3RhcnQSHgoKY2hhckxlbmd0aBgEIAEoBVIKY2hhckxlbmd0aA==');
 @$core.Deprecated('Use versionRequestDescriptor instead')
-const VersionRequest$json = const {
+const VersionRequest$json = {
   '1': 'VersionRequest',
 };
 
 /// Descriptor for `VersionRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List versionRequestDescriptor = $convert.base64Decode('Cg5WZXJzaW9uUmVxdWVzdA==');
+final $typed_data.Uint8List versionRequestDescriptor =
+    $convert.base64Decode('Cg5WZXJzaW9uUmVxdWVzdA==');
 @$core.Deprecated('Use compileResponseDescriptor instead')
-const CompileResponse$json = const {
+const CompileResponse$json = {
   '1': 'CompileResponse',
-  '2': const [
-    const {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
-    const {'1': 'sourceMap', '3': 2, '4': 1, '5': 9, '10': 'sourceMap'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
+    {'1': 'sourceMap', '3': 2, '4': 1, '5': 9, '10': 'sourceMap'},
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `CompileResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List compileResponseDescriptor = $convert.base64Decode('Cg9Db21waWxlUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSHAoJc291cmNlTWFwGAIgASgJUglzb3VyY2VNYXASNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
+final $typed_data.Uint8List compileResponseDescriptor = $convert.base64Decode(
+    'Cg9Db21waWxlUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSHAoJc291cmNlTWFwGAIgASgJUglzb3VyY2VNYXASNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
 @$core.Deprecated('Use compileDDCResponseDescriptor instead')
-const CompileDDCResponse$json = const {
+const CompileDDCResponse$json = {
   '1': 'CompileDDCResponse',
-  '2': const [
-    const {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
-    const {'1': 'modulesBaseUrl', '3': 2, '4': 1, '5': 9, '10': 'modulesBaseUrl'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
+    {'1': 'modulesBaseUrl', '3': 2, '4': 1, '5': 9, '10': 'modulesBaseUrl'},
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `CompileDDCResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List compileDDCResponseDescriptor = $convert.base64Decode('ChJDb21waWxlRERDUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSJgoObW9kdWxlc0Jhc2VVcmwYAiABKAlSDm1vZHVsZXNCYXNlVXJsEjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
+final $typed_data.Uint8List compileDDCResponseDescriptor = $convert.base64Decode(
+    'ChJDb21waWxlRERDUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSJgoObW9kdWxlc0Jhc2VVcmwYAiABKAlSDm1vZHVsZXNCYXNlVXJsEjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
 @$core.Deprecated('Use documentResponseDescriptor instead')
-const DocumentResponse$json = const {
+const DocumentResponse$json = {
   '1': 'DocumentResponse',
-  '2': const [
-    const {'1': 'info', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.DocumentResponse.InfoEntry', '10': 'info'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'info',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.DocumentResponse.InfoEntry',
+      '10': 'info'
+    },
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
-  '3': const [DocumentResponse_InfoEntry$json],
+  '3': [DocumentResponse_InfoEntry$json],
 };
 
 @$core.Deprecated('Use documentResponseDescriptor instead')
-const DocumentResponse_InfoEntry$json = const {
+const DocumentResponse_InfoEntry$json = {
   '1': 'InfoEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `DocumentResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List documentResponseDescriptor = $convert.base64Decode('ChBEb2N1bWVudFJlc3BvbnNlEkEKBGluZm8YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Eb2N1bWVudFJlc3BvbnNlLkluZm9FbnRyeVIEaW5mbxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3IaNwoJSW5mb0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+final $typed_data.Uint8List documentResponseDescriptor = $convert.base64Decode(
+    'ChBEb2N1bWVudFJlc3BvbnNlEkEKBGluZm8YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Eb2N1bWVudFJlc3BvbnNlLkluZm9FbnRyeVIEaW5mbxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3IaNwoJSW5mb0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
 @$core.Deprecated('Use completeResponseDescriptor instead')
-const CompleteResponse$json = const {
+const CompleteResponse$json = {
   '1': 'CompleteResponse',
-  '2': const [
-    const {'1': 'replacementOffset', '3': 1, '4': 1, '5': 5, '10': 'replacementOffset'},
-    const {'1': 'replacementLength', '3': 2, '4': 1, '5': 5, '10': 'replacementLength'},
-    const {'1': 'completions', '3': 3, '4': 3, '5': 11, '6': '.dart_services.api.Completion', '10': 'completions'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'replacementOffset',
+      '3': 1,
+      '4': 1,
+      '5': 5,
+      '10': 'replacementOffset'
+    },
+    {
+      '1': 'replacementLength',
+      '3': 2,
+      '4': 1,
+      '5': 5,
+      '10': 'replacementLength'
+    },
+    {
+      '1': 'completions',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.Completion',
+      '10': 'completions'
+    },
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `CompleteResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List completeResponseDescriptor = $convert.base64Decode('ChBDb21wbGV0ZVJlc3BvbnNlEiwKEXJlcGxhY2VtZW50T2Zmc2V0GAEgASgFUhFyZXBsYWNlbWVudE9mZnNldBIsChFyZXBsYWNlbWVudExlbmd0aBgCIAEoBVIRcmVwbGFjZW1lbnRMZW5ndGgSPwoLY29tcGxldGlvbnMYAyADKAsyHS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uUgtjb21wbGV0aW9ucxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+final $typed_data.Uint8List completeResponseDescriptor = $convert.base64Decode(
+    'ChBDb21wbGV0ZVJlc3BvbnNlEiwKEXJlcGxhY2VtZW50T2Zmc2V0GAEgASgFUhFyZXBsYWNlbWVudE9mZnNldBIsChFyZXBsYWNlbWVudExlbmd0aBgCIAEoBVIRcmVwbGFjZW1lbnRMZW5ndGgSPwoLY29tcGxldGlvbnMYAyADKAsyHS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uUgtjb21wbGV0aW9ucxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
 @$core.Deprecated('Use completionDescriptor instead')
-const Completion$json = const {
+const Completion$json = {
   '1': 'Completion',
-  '2': const [
-    const {'1': 'completion', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.Completion.CompletionEntry', '10': 'completion'},
+  '2': [
+    {
+      '1': 'completion',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.Completion.CompletionEntry',
+      '10': 'completion'
+    },
   ],
-  '3': const [Completion_CompletionEntry$json],
+  '3': [Completion_CompletionEntry$json],
 };
 
 @$core.Deprecated('Use completionDescriptor instead')
-const Completion_CompletionEntry$json = const {
+const Completion_CompletionEntry$json = {
   '1': 'CompletionEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `Completion`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List completionDescriptor = $convert.base64Decode('CgpDb21wbGV0aW9uEk0KCmNvbXBsZXRpb24YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uLkNvbXBsZXRpb25FbnRyeVIKY29tcGxldGlvbho9Cg9Db21wbGV0aW9uRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List completionDescriptor = $convert.base64Decode(
+    'CgpDb21wbGV0aW9uEk0KCmNvbXBsZXRpb24YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uLkNvbXBsZXRpb25FbnRyeVIKY29tcGxldGlvbho9Cg9Db21wbGV0aW9uRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use fixesResponseDescriptor instead')
-const FixesResponse$json = const {
+const FixesResponse$json = {
   '1': 'FixesResponse',
-  '2': const [
-    const {'1': 'fixes', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.ProblemAndFixes', '10': 'fixes'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'fixes',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.ProblemAndFixes',
+      '10': 'fixes'
+    },
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `FixesResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List fixesResponseDescriptor = $convert.base64Decode('Cg1GaXhlc1Jlc3BvbnNlEjgKBWZpeGVzGAEgAygLMiIuZGFydF9zZXJ2aWNlcy5hcGkuUHJvYmxlbUFuZEZpeGVzUgVmaXhlcxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+final $typed_data.Uint8List fixesResponseDescriptor = $convert.base64Decode(
+    'Cg1GaXhlc1Jlc3BvbnNlEjgKBWZpeGVzGAEgAygLMiIuZGFydF9zZXJ2aWNlcy5hcGkuUHJvYmxlbUFuZEZpeGVzUgVmaXhlcxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
 @$core.Deprecated('Use problemAndFixesDescriptor instead')
-const ProblemAndFixes$json = const {
+const ProblemAndFixes$json = {
   '1': 'ProblemAndFixes',
-  '2': const [
-    const {'1': 'fixes', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.CandidateFix', '10': 'fixes'},
-    const {'1': 'problemMessage', '3': 2, '4': 1, '5': 9, '10': 'problemMessage'},
-    const {'1': 'offset', '3': 3, '4': 1, '5': 5, '10': 'offset'},
-    const {'1': 'length', '3': 4, '4': 1, '5': 5, '10': 'length'},
+  '2': [
+    {
+      '1': 'fixes',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.CandidateFix',
+      '10': 'fixes'
+    },
+    {'1': 'problemMessage', '3': 2, '4': 1, '5': 9, '10': 'problemMessage'},
+    {'1': 'offset', '3': 3, '4': 1, '5': 5, '10': 'offset'},
+    {'1': 'length', '3': 4, '4': 1, '5': 5, '10': 'length'},
   ],
 };
 
 /// Descriptor for `ProblemAndFixes`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List problemAndFixesDescriptor = $convert.base64Decode('Cg9Qcm9ibGVtQW5kRml4ZXMSNQoFZml4ZXMYASADKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5DYW5kaWRhdGVGaXhSBWZpeGVzEiYKDnByb2JsZW1NZXNzYWdlGAIgASgJUg5wcm9ibGVtTWVzc2FnZRIWCgZvZmZzZXQYAyABKAVSBm9mZnNldBIWCgZsZW5ndGgYBCABKAVSBmxlbmd0aA==');
+final $typed_data.Uint8List problemAndFixesDescriptor = $convert.base64Decode(
+    'Cg9Qcm9ibGVtQW5kRml4ZXMSNQoFZml4ZXMYASADKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5DYW5kaWRhdGVGaXhSBWZpeGVzEiYKDnByb2JsZW1NZXNzYWdlGAIgASgJUg5wcm9ibGVtTWVzc2FnZRIWCgZvZmZzZXQYAyABKAVSBm9mZnNldBIWCgZsZW5ndGgYBCABKAVSBmxlbmd0aA==');
 @$core.Deprecated('Use candidateFixDescriptor instead')
-const CandidateFix$json = const {
+const CandidateFix$json = {
   '1': 'CandidateFix',
-  '2': const [
-    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    const {'1': 'edits', '3': 2, '4': 3, '5': 11, '6': '.dart_services.api.SourceEdit', '10': 'edits'},
-    const {'1': 'selectionOffset', '3': 3, '4': 1, '5': 5, '10': 'selectionOffset'},
-    const {'1': 'linkedEditGroups', '3': 4, '4': 3, '5': 11, '6': '.dart_services.api.LinkedEditGroup', '10': 'linkedEditGroups'},
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+    {
+      '1': 'edits',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.SourceEdit',
+      '10': 'edits'
+    },
+    {'1': 'selectionOffset', '3': 3, '4': 1, '5': 5, '10': 'selectionOffset'},
+    {
+      '1': 'linkedEditGroups',
+      '3': 4,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.LinkedEditGroup',
+      '10': 'linkedEditGroups'
+    },
   ],
 };
 
 /// Descriptor for `CandidateFix`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List candidateFixDescriptor = $convert.base64Decode('CgxDYW5kaWRhdGVGaXgSGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZRIzCgVlZGl0cxgCIAMoCzIdLmRhcnRfc2VydmljZXMuYXBpLlNvdXJjZUVkaXRSBWVkaXRzEigKD3NlbGVjdGlvbk9mZnNldBgDIAEoBVIPc2VsZWN0aW9uT2Zmc2V0Ek4KEGxpbmtlZEVkaXRHcm91cHMYBCADKAsyIi5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0R3JvdXBSEGxpbmtlZEVkaXRHcm91cHM=');
+final $typed_data.Uint8List candidateFixDescriptor = $convert.base64Decode(
+    'CgxDYW5kaWRhdGVGaXgSGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZRIzCgVlZGl0cxgCIAMoCzIdLmRhcnRfc2VydmljZXMuYXBpLlNvdXJjZUVkaXRSBWVkaXRzEigKD3NlbGVjdGlvbk9mZnNldBgDIAEoBVIPc2VsZWN0aW9uT2Zmc2V0Ek4KEGxpbmtlZEVkaXRHcm91cHMYBCADKAsyIi5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0R3JvdXBSEGxpbmtlZEVkaXRHcm91cHM=');
 @$core.Deprecated('Use sourceEditDescriptor instead')
-const SourceEdit$json = const {
+const SourceEdit$json = {
   '1': 'SourceEdit',
-  '2': const [
-    const {'1': 'offset', '3': 1, '4': 1, '5': 5, '10': 'offset'},
-    const {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
-    const {'1': 'replacement', '3': 3, '4': 1, '5': 9, '10': 'replacement'},
+  '2': [
+    {'1': 'offset', '3': 1, '4': 1, '5': 5, '10': 'offset'},
+    {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
+    {'1': 'replacement', '3': 3, '4': 1, '5': 9, '10': 'replacement'},
   ],
 };
 
 /// Descriptor for `SourceEdit`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List sourceEditDescriptor = $convert.base64Decode('CgpTb3VyY2VFZGl0EhYKBm9mZnNldBgBIAEoBVIGb2Zmc2V0EhYKBmxlbmd0aBgCIAEoBVIGbGVuZ3RoEiAKC3JlcGxhY2VtZW50GAMgASgJUgtyZXBsYWNlbWVudA==');
+final $typed_data.Uint8List sourceEditDescriptor = $convert.base64Decode(
+    'CgpTb3VyY2VFZGl0EhYKBm9mZnNldBgBIAEoBVIGb2Zmc2V0EhYKBmxlbmd0aBgCIAEoBVIGbGVuZ3RoEiAKC3JlcGxhY2VtZW50GAMgASgJUgtyZXBsYWNlbWVudA==');
 @$core.Deprecated('Use linkedEditGroupDescriptor instead')
-const LinkedEditGroup$json = const {
+const LinkedEditGroup$json = {
   '1': 'LinkedEditGroup',
-  '2': const [
-    const {'1': 'positions', '3': 1, '4': 3, '5': 5, '10': 'positions'},
-    const {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
-    const {'1': 'suggestions', '3': 3, '4': 3, '5': 11, '6': '.dart_services.api.LinkedEditSuggestion', '10': 'suggestions'},
+  '2': [
+    {'1': 'positions', '3': 1, '4': 3, '5': 5, '10': 'positions'},
+    {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
+    {
+      '1': 'suggestions',
+      '3': 3,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.LinkedEditSuggestion',
+      '10': 'suggestions'
+    },
   ],
 };
 
 /// Descriptor for `LinkedEditGroup`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List linkedEditGroupDescriptor = $convert.base64Decode('Cg9MaW5rZWRFZGl0R3JvdXASHAoJcG9zaXRpb25zGAEgAygFUglwb3NpdGlvbnMSFgoGbGVuZ3RoGAIgASgFUgZsZW5ndGgSSQoLc3VnZ2VzdGlvbnMYAyADKAsyJy5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0U3VnZ2VzdGlvblILc3VnZ2VzdGlvbnM=');
+final $typed_data.Uint8List linkedEditGroupDescriptor = $convert.base64Decode(
+    'Cg9MaW5rZWRFZGl0R3JvdXASHAoJcG9zaXRpb25zGAEgAygFUglwb3NpdGlvbnMSFgoGbGVuZ3RoGAIgASgFUgZsZW5ndGgSSQoLc3VnZ2VzdGlvbnMYAyADKAsyJy5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0U3VnZ2VzdGlvblILc3VnZ2VzdGlvbnM=');
 @$core.Deprecated('Use linkedEditSuggestionDescriptor instead')
-const LinkedEditSuggestion$json = const {
+const LinkedEditSuggestion$json = {
   '1': 'LinkedEditSuggestion',
-  '2': const [
-    const {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
-    const {'1': 'kind', '3': 2, '4': 1, '5': 9, '10': 'kind'},
+  '2': [
+    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
+    {'1': 'kind', '3': 2, '4': 1, '5': 9, '10': 'kind'},
   ],
 };
 
 /// Descriptor for `LinkedEditSuggestion`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List linkedEditSuggestionDescriptor = $convert.base64Decode('ChRMaW5rZWRFZGl0U3VnZ2VzdGlvbhIUCgV2YWx1ZRgBIAEoCVIFdmFsdWUSEgoEa2luZBgCIAEoCVIEa2luZA==');
+final $typed_data.Uint8List linkedEditSuggestionDescriptor = $convert.base64Decode(
+    'ChRMaW5rZWRFZGl0U3VnZ2VzdGlvbhIUCgV2YWx1ZRgBIAEoCVIFdmFsdWUSEgoEa2luZBgCIAEoCVIEa2luZA==');
 @$core.Deprecated('Use formatResponseDescriptor instead')
-const FormatResponse$json = const {
+const FormatResponse$json = {
   '1': 'FormatResponse',
-  '2': const [
-    const {'1': 'newString', '3': 1, '4': 1, '5': 9, '10': 'newString'},
-    const {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {'1': 'newString', '3': 1, '4': 1, '5': 9, '10': 'newString'},
+    {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `FormatResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List formatResponseDescriptor = $convert.base64Decode('Cg5Gb3JtYXRSZXNwb25zZRIcCgluZXdTdHJpbmcYASABKAlSCW5ld1N0cmluZxIWCgZvZmZzZXQYAiABKAVSBm9mZnNldBI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+final $typed_data.Uint8List formatResponseDescriptor = $convert.base64Decode(
+    'Cg5Gb3JtYXRSZXNwb25zZRIcCgluZXdTdHJpbmcYASABKAlSCW5ld1N0cmluZxIWCgZvZmZzZXQYAiABKAVSBm9mZnNldBI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
 @$core.Deprecated('Use assistsResponseDescriptor instead')
-const AssistsResponse$json = const {
+const AssistsResponse$json = {
   '1': 'AssistsResponse',
-  '2': const [
-    const {'1': 'assists', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.CandidateFix', '10': 'assists'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'assists',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.dart_services.api.CandidateFix',
+      '10': 'assists'
+    },
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `AssistsResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List assistsResponseDescriptor = $convert.base64Decode('Cg9Bc3Npc3RzUmVzcG9uc2USOQoHYXNzaXN0cxgBIAMoCzIfLmRhcnRfc2VydmljZXMuYXBpLkNhbmRpZGF0ZUZpeFIHYXNzaXN0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+final $typed_data.Uint8List assistsResponseDescriptor = $convert.base64Decode(
+    'Cg9Bc3Npc3RzUmVzcG9uc2USOQoHYXNzaXN0cxgBIAMoCzIfLmRhcnRfc2VydmljZXMuYXBpLkNhbmRpZGF0ZUZpeFIHYXNzaXN0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
 @$core.Deprecated('Use versionResponseDescriptor instead')
-const VersionResponse$json = const {
+const VersionResponse$json = {
   '1': 'VersionResponse',
-  '2': const [
-    const {'1': 'sdkVersion', '3': 1, '4': 1, '5': 9, '10': 'sdkVersion'},
-    const {'1': 'sdkVersionFull', '3': 2, '4': 1, '5': 9, '10': 'sdkVersionFull'},
-    const {'1': 'runtimeVersion', '3': 3, '4': 1, '5': 9, '10': 'runtimeVersion'},
-    const {'1': 'appEngineVersion', '3': 4, '4': 1, '5': 9, '10': 'appEngineVersion'},
-    const {'1': 'servicesVersion', '3': 5, '4': 1, '5': 9, '10': 'servicesVersion'},
-    const {'1': 'flutterVersion', '3': 6, '4': 1, '5': 9, '10': 'flutterVersion'},
-    const {'1': 'flutterDartVersion', '3': 7, '4': 1, '5': 9, '10': 'flutterDartVersion'},
-    const {'1': 'flutterDartVersionFull', '3': 8, '4': 1, '5': 9, '10': 'flutterDartVersionFull'},
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {'1': 'sdkVersion', '3': 1, '4': 1, '5': 9, '10': 'sdkVersion'},
+    {'1': 'sdkVersionFull', '3': 2, '4': 1, '5': 9, '10': 'sdkVersionFull'},
+    {'1': 'runtimeVersion', '3': 3, '4': 1, '5': 9, '10': 'runtimeVersion'},
+    {'1': 'appEngineVersion', '3': 4, '4': 1, '5': 9, '10': 'appEngineVersion'},
+    {'1': 'servicesVersion', '3': 5, '4': 1, '5': 9, '10': 'servicesVersion'},
+    {'1': 'flutterVersion', '3': 6, '4': 1, '5': 9, '10': 'flutterVersion'},
+    {
+      '1': 'flutterDartVersion',
+      '3': 7,
+      '4': 1,
+      '5': 9,
+      '10': 'flutterDartVersion'
+    },
+    {
+      '1': 'flutterDartVersionFull',
+      '3': 8,
+      '4': 1,
+      '5': 9,
+      '10': 'flutterDartVersionFull'
+    },
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `VersionResponse`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List versionResponseDescriptor = $convert.base64Decode('Cg9WZXJzaW9uUmVzcG9uc2USHgoKc2RrVmVyc2lvbhgBIAEoCVIKc2RrVmVyc2lvbhImCg5zZGtWZXJzaW9uRnVsbBgCIAEoCVIOc2RrVmVyc2lvbkZ1bGwSJgoOcnVudGltZVZlcnNpb24YAyABKAlSDnJ1bnRpbWVWZXJzaW9uEioKEGFwcEVuZ2luZVZlcnNpb24YBCABKAlSEGFwcEVuZ2luZVZlcnNpb24SKAoPc2VydmljZXNWZXJzaW9uGAUgASgJUg9zZXJ2aWNlc1ZlcnNpb24SJgoOZmx1dHRlclZlcnNpb24YBiABKAlSDmZsdXR0ZXJWZXJzaW9uEi4KEmZsdXR0ZXJEYXJ0VmVyc2lvbhgHIAEoCVISZmx1dHRlckRhcnRWZXJzaW9uEjYKFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwYCCABKAlSFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwSNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
+final $typed_data.Uint8List versionResponseDescriptor = $convert.base64Decode(
+    'Cg9WZXJzaW9uUmVzcG9uc2USHgoKc2RrVmVyc2lvbhgBIAEoCVIKc2RrVmVyc2lvbhImCg5zZGtWZXJzaW9uRnVsbBgCIAEoCVIOc2RrVmVyc2lvbkZ1bGwSJgoOcnVudGltZVZlcnNpb24YAyABKAlSDnJ1bnRpbWVWZXJzaW9uEioKEGFwcEVuZ2luZVZlcnNpb24YBCABKAlSEGFwcEVuZ2luZVZlcnNpb24SKAoPc2VydmljZXNWZXJzaW9uGAUgASgJUg9zZXJ2aWNlc1ZlcnNpb24SJgoOZmx1dHRlclZlcnNpb24YBiABKAlSDmZsdXR0ZXJWZXJzaW9uEi4KEmZsdXR0ZXJEYXJ0VmVyc2lvbhgHIAEoCVISZmx1dHRlckRhcnRWZXJzaW9uEjYKFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwYCCABKAlSFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwSNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
 @$core.Deprecated('Use badRequestDescriptor instead')
-const BadRequest$json = const {
+const BadRequest$json = {
   '1': 'BadRequest',
-  '2': const [
-    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
+  '2': [
+    {
+      '1': 'error',
+      '3': 99,
+      '4': 1,
+      '5': 11,
+      '6': '.dart_services.api.ErrorMessage',
+      '10': 'error'
+    },
   ],
 };
 
 /// Descriptor for `BadRequest`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List badRequestDescriptor = $convert.base64Decode('CgpCYWRSZXF1ZXN0EjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
+final $typed_data.Uint8List badRequestDescriptor = $convert.base64Decode(
+    'CgpCYWRSZXF1ZXN0EjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
 @$core.Deprecated('Use errorMessageDescriptor instead')
-const ErrorMessage$json = const {
+const ErrorMessage$json = {
   '1': 'ErrorMessage',
-  '2': const [
-    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+  '2': [
+    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
   ],
 };
 
 /// Descriptor for `ErrorMessage`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List errorMessageDescriptor = $convert.base64Decode('CgxFcnJvck1lc3NhZ2USGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZQ==');
+final $typed_data.Uint8List errorMessageDescriptor = $convert
+    .base64Decode('CgxFcnJvck1lc3NhZ2USGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZQ==');

--- a/lib/src/protos/dart_services.pbjson.dart
+++ b/lib/src/protos/dart_services.pbjson.dart
@@ -65,11 +65,12 @@ const AnalysisIssue$json = const {
     const {'1': 'charLength', '3': 7, '4': 1, '5': 5, '10': 'charLength'},
     const {'1': 'url', '3': 8, '4': 1, '5': 9, '10': 'url'},
     const {'1': 'diagnosticMessages', '3': 9, '4': 3, '5': 11, '6': '.dart_services.api.DiagnosticMessage', '10': 'diagnosticMessages'},
+    const {'1': 'correction', '3': 10, '4': 1, '5': 9, '10': 'correction'},
   ],
 };
 
 /// Descriptor for `AnalysisIssue`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List analysisIssueDescriptor = $convert.base64Decode('Cg1BbmFseXNpc0lzc3VlEhIKBGtpbmQYASABKAlSBGtpbmQSEgoEbGluZRgCIAEoBVIEbGluZRIYCgdtZXNzYWdlGAMgASgJUgdtZXNzYWdlEh4KCnNvdXJjZU5hbWUYBCABKAlSCnNvdXJjZU5hbWUSGgoIaGFzRml4ZXMYBSABKAhSCGhhc0ZpeGVzEhwKCWNoYXJTdGFydBgGIAEoBVIJY2hhclN0YXJ0Eh4KCmNoYXJMZW5ndGgYByABKAVSCmNoYXJMZW5ndGgSEAoDdXJsGAggASgJUgN1cmwSVAoSZGlhZ25vc3RpY01lc3NhZ2VzGAkgAygLMiQuZGFydF9zZXJ2aWNlcy5hcGkuRGlhZ25vc3RpY01lc3NhZ2VSEmRpYWdub3N0aWNNZXNzYWdlcw==');
+final $typed_data.Uint8List analysisIssueDescriptor = $convert.base64Decode('Cg1BbmFseXNpc0lzc3VlEhIKBGtpbmQYASABKAlSBGtpbmQSEgoEbGluZRgCIAEoBVIEbGluZRIYCgdtZXNzYWdlGAMgASgJUgdtZXNzYWdlEh4KCnNvdXJjZU5hbWUYBCABKAlSCnNvdXJjZU5hbWUSGgoIaGFzRml4ZXMYBSABKAhSCGhhc0ZpeGVzEhwKCWNoYXJTdGFydBgGIAEoBVIJY2hhclN0YXJ0Eh4KCmNoYXJMZW5ndGgYByABKAVSCmNoYXJMZW5ndGgSEAoDdXJsGAggASgJUgN1cmwSVAoSZGlhZ25vc3RpY01lc3NhZ2VzGAkgAygLMiQuZGFydF9zZXJ2aWNlcy5hcGkuRGlhZ25vc3RpY01lc3NhZ2VSEmRpYWdub3N0aWNNZXNzYWdlcxIeCgpjb3JyZWN0aW9uGAogASgJUgpjb3JyZWN0aW9u');
 @$core.Deprecated('Use diagnosticMessageDescriptor instead')
 const DiagnosticMessage$json = const {
   '1': 'DiagnosticMessage',

--- a/lib/src/protos/dart_services.pbjson.dart
+++ b/lib/src/protos/dart_services.pbjson.dart
@@ -2,374 +2,304 @@
 //  Generated code. Do not modify.
 //  source: protos/dart_services.proto
 //
-// @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
-const CompileRequest$json = {
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+@$core.Deprecated('Use compileRequestDescriptor instead')
+const CompileRequest$json = const {
   '1': 'CompileRequest',
-  '2': [
-    {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
-    {'1': 'returnSourceMap', '3': 2, '4': 1, '5': 8, '10': 'returnSourceMap'},
+  '2': const [
+    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+    const {'1': 'returnSourceMap', '3': 2, '4': 1, '5': 8, '10': 'returnSourceMap'},
   ],
 };
 
-const SourceRequest$json = {
+/// Descriptor for `CompileRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List compileRequestDescriptor = $convert.base64Decode('Cg5Db21waWxlUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZRIoCg9yZXR1cm5Tb3VyY2VNYXAYAiABKAhSD3JldHVyblNvdXJjZU1hcA==');
+@$core.Deprecated('Use compileDDCRequestDescriptor instead')
+const CompileDDCRequest$json = const {
+  '1': 'CompileDDCRequest',
+  '2': const [
+    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+  ],
+};
+
+/// Descriptor for `CompileDDCRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List compileDDCRequestDescriptor = $convert.base64Decode('ChFDb21waWxlRERDUmVxdWVzdBIWCgZzb3VyY2UYASABKAlSBnNvdXJjZQ==');
+@$core.Deprecated('Use sourceRequestDescriptor instead')
+const SourceRequest$json = const {
   '1': 'SourceRequest',
-  '2': [
-    {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
-    {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
+  '2': const [
+    const {'1': 'source', '3': 1, '4': 1, '5': 9, '10': 'source'},
+    const {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
   ],
 };
 
-const AnalysisResults$json = {
+/// Descriptor for `SourceRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sourceRequestDescriptor = $convert.base64Decode('Cg1Tb3VyY2VSZXF1ZXN0EhYKBnNvdXJjZRgBIAEoCVIGc291cmNlEhYKBm9mZnNldBgCIAEoBVIGb2Zmc2V0');
+@$core.Deprecated('Use analysisResultsDescriptor instead')
+const AnalysisResults$json = const {
   '1': 'AnalysisResults',
-  '2': [
-    {
-      '1': 'issues',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.AnalysisIssue',
-      '10': 'issues'
-    },
-    {'1': 'packageImports', '3': 2, '4': 3, '5': 9, '10': 'packageImports'},
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'issues', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.AnalysisIssue', '10': 'issues'},
+    const {'1': 'packageImports', '3': 2, '4': 3, '5': 9, '10': 'packageImports'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const AnalysisIssue$json = {
+/// Descriptor for `AnalysisResults`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List analysisResultsDescriptor = $convert.base64Decode('Cg9BbmFseXNpc1Jlc3VsdHMSOAoGaXNzdWVzGAEgAygLMiAuZGFydF9zZXJ2aWNlcy5hcGkuQW5hbHlzaXNJc3N1ZVIGaXNzdWVzEiYKDnBhY2thZ2VJbXBvcnRzGAIgAygJUg5wYWNrYWdlSW1wb3J0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+@$core.Deprecated('Use analysisIssueDescriptor instead')
+const AnalysisIssue$json = const {
   '1': 'AnalysisIssue',
-  '2': [
-    {'1': 'kind', '3': 1, '4': 1, '5': 9, '10': 'kind'},
-    {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
-    {'1': 'message', '3': 3, '4': 1, '5': 9, '10': 'message'},
-    {'1': 'sourceName', '3': 4, '4': 1, '5': 9, '10': 'sourceName'},
-    {'1': 'hasFixes', '3': 5, '4': 1, '5': 8, '10': 'hasFixes'},
-    {'1': 'charStart', '3': 6, '4': 1, '5': 5, '10': 'charStart'},
-    {'1': 'charLength', '3': 7, '4': 1, '5': 5, '10': 'charLength'},
+  '2': const [
+    const {'1': 'kind', '3': 1, '4': 1, '5': 9, '10': 'kind'},
+    const {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
+    const {'1': 'message', '3': 3, '4': 1, '5': 9, '10': 'message'},
+    const {'1': 'sourceName', '3': 4, '4': 1, '5': 9, '10': 'sourceName'},
+    const {'1': 'hasFixes', '3': 5, '4': 1, '5': 8, '10': 'hasFixes'},
+    const {'1': 'charStart', '3': 6, '4': 1, '5': 5, '10': 'charStart'},
+    const {'1': 'charLength', '3': 7, '4': 1, '5': 5, '10': 'charLength'},
+    const {'1': 'url', '3': 8, '4': 1, '5': 9, '10': 'url'},
+    const {'1': 'diagnosticMessages', '3': 9, '4': 3, '5': 11, '6': '.dart_services.api.DiagnosticMessage', '10': 'diagnosticMessages'},
   ],
 };
 
-const VersionRequest$json = {
+/// Descriptor for `AnalysisIssue`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List analysisIssueDescriptor = $convert.base64Decode('Cg1BbmFseXNpc0lzc3VlEhIKBGtpbmQYASABKAlSBGtpbmQSEgoEbGluZRgCIAEoBVIEbGluZRIYCgdtZXNzYWdlGAMgASgJUgdtZXNzYWdlEh4KCnNvdXJjZU5hbWUYBCABKAlSCnNvdXJjZU5hbWUSGgoIaGFzRml4ZXMYBSABKAhSCGhhc0ZpeGVzEhwKCWNoYXJTdGFydBgGIAEoBVIJY2hhclN0YXJ0Eh4KCmNoYXJMZW5ndGgYByABKAVSCmNoYXJMZW5ndGgSEAoDdXJsGAggASgJUgN1cmwSVAoSZGlhZ25vc3RpY01lc3NhZ2VzGAkgAygLMiQuZGFydF9zZXJ2aWNlcy5hcGkuRGlhZ25vc3RpY01lc3NhZ2VSEmRpYWdub3N0aWNNZXNzYWdlcw==');
+@$core.Deprecated('Use diagnosticMessageDescriptor instead')
+const DiagnosticMessage$json = const {
+  '1': 'DiagnosticMessage',
+  '2': const [
+    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+    const {'1': 'line', '3': 2, '4': 1, '5': 5, '10': 'line'},
+    const {'1': 'charStart', '3': 3, '4': 1, '5': 5, '10': 'charStart'},
+    const {'1': 'charLength', '3': 4, '4': 1, '5': 5, '10': 'charLength'},
+  ],
+};
+
+/// Descriptor for `DiagnosticMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List diagnosticMessageDescriptor = $convert.base64Decode('ChFEaWFnbm9zdGljTWVzc2FnZRIYCgdtZXNzYWdlGAEgASgJUgdtZXNzYWdlEhIKBGxpbmUYAiABKAVSBGxpbmUSHAoJY2hhclN0YXJ0GAMgASgFUgljaGFyU3RhcnQSHgoKY2hhckxlbmd0aBgEIAEoBVIKY2hhckxlbmd0aA==');
+@$core.Deprecated('Use versionRequestDescriptor instead')
+const VersionRequest$json = const {
   '1': 'VersionRequest',
 };
 
-const CompileResponse$json = {
+/// Descriptor for `VersionRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List versionRequestDescriptor = $convert.base64Decode('Cg5WZXJzaW9uUmVxdWVzdA==');
+@$core.Deprecated('Use compileResponseDescriptor instead')
+const CompileResponse$json = const {
   '1': 'CompileResponse',
-  '2': [
-    {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
-    {'1': 'sourceMap', '3': 2, '4': 1, '5': 9, '10': 'sourceMap'},
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
+    const {'1': 'sourceMap', '3': 2, '4': 1, '5': 9, '10': 'sourceMap'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const CompileDDCResponse$json = {
+/// Descriptor for `CompileResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List compileResponseDescriptor = $convert.base64Decode('Cg9Db21waWxlUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSHAoJc291cmNlTWFwGAIgASgJUglzb3VyY2VNYXASNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
+@$core.Deprecated('Use compileDDCResponseDescriptor instead')
+const CompileDDCResponse$json = const {
   '1': 'CompileDDCResponse',
-  '2': [
-    {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
-    {'1': 'modulesBaseUrl', '3': 2, '4': 1, '5': 9, '10': 'modulesBaseUrl'},
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'result', '3': 1, '4': 1, '5': 9, '10': 'result'},
+    const {'1': 'modulesBaseUrl', '3': 2, '4': 1, '5': 9, '10': 'modulesBaseUrl'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const DocumentResponse$json = {
+/// Descriptor for `CompileDDCResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List compileDDCResponseDescriptor = $convert.base64Decode('ChJDb21waWxlRERDUmVzcG9uc2USFgoGcmVzdWx0GAEgASgJUgZyZXN1bHQSJgoObW9kdWxlc0Jhc2VVcmwYAiABKAlSDm1vZHVsZXNCYXNlVXJsEjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
+@$core.Deprecated('Use documentResponseDescriptor instead')
+const DocumentResponse$json = const {
   '1': 'DocumentResponse',
-  '2': [
-    {
-      '1': 'info',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.DocumentResponse.InfoEntry',
-      '10': 'info'
-    },
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'info', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.DocumentResponse.InfoEntry', '10': 'info'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
-  '3': [DocumentResponse_InfoEntry$json],
+  '3': const [DocumentResponse_InfoEntry$json],
 };
 
-const DocumentResponse_InfoEntry$json = {
+@$core.Deprecated('Use documentResponseDescriptor instead')
+const DocumentResponse_InfoEntry$json = const {
   '1': 'InfoEntry',
-  '2': [
-    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': {'7': true},
+  '7': const {'7': true},
 };
 
-const CompleteResponse$json = {
+/// Descriptor for `DocumentResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List documentResponseDescriptor = $convert.base64Decode('ChBEb2N1bWVudFJlc3BvbnNlEkEKBGluZm8YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Eb2N1bWVudFJlc3BvbnNlLkluZm9FbnRyeVIEaW5mbxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3IaNwoJSW5mb0VudHJ5EhAKA2tleRgBIAEoCVIDa2V5EhQKBXZhbHVlGAIgASgJUgV2YWx1ZToCOAE=');
+@$core.Deprecated('Use completeResponseDescriptor instead')
+const CompleteResponse$json = const {
   '1': 'CompleteResponse',
-  '2': [
-    {
-      '1': 'replacementOffset',
-      '3': 1,
-      '4': 1,
-      '5': 5,
-      '10': 'replacementOffset'
-    },
-    {
-      '1': 'replacementLength',
-      '3': 2,
-      '4': 1,
-      '5': 5,
-      '10': 'replacementLength'
-    },
-    {
-      '1': 'completions',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.Completion',
-      '10': 'completions'
-    },
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'replacementOffset', '3': 1, '4': 1, '5': 5, '10': 'replacementOffset'},
+    const {'1': 'replacementLength', '3': 2, '4': 1, '5': 5, '10': 'replacementLength'},
+    const {'1': 'completions', '3': 3, '4': 3, '5': 11, '6': '.dart_services.api.Completion', '10': 'completions'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const Completion$json = {
+/// Descriptor for `CompleteResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List completeResponseDescriptor = $convert.base64Decode('ChBDb21wbGV0ZVJlc3BvbnNlEiwKEXJlcGxhY2VtZW50T2Zmc2V0GAEgASgFUhFyZXBsYWNlbWVudE9mZnNldBIsChFyZXBsYWNlbWVudExlbmd0aBgCIAEoBVIRcmVwbGFjZW1lbnRMZW5ndGgSPwoLY29tcGxldGlvbnMYAyADKAsyHS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uUgtjb21wbGV0aW9ucxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+@$core.Deprecated('Use completionDescriptor instead')
+const Completion$json = const {
   '1': 'Completion',
-  '2': [
-    {
-      '1': 'completion',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.Completion.CompletionEntry',
-      '10': 'completion'
-    },
+  '2': const [
+    const {'1': 'completion', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.Completion.CompletionEntry', '10': 'completion'},
   ],
-  '3': [Completion_CompletionEntry$json],
+  '3': const [Completion_CompletionEntry$json],
 };
 
-const Completion_CompletionEntry$json = {
+@$core.Deprecated('Use completionDescriptor instead')
+const Completion_CompletionEntry$json = const {
   '1': 'CompletionEntry',
-  '2': [
-    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 9, '10': 'value'},
   ],
-  '7': {'7': true},
+  '7': const {'7': true},
 };
 
-const FixesResponse$json = {
+/// Descriptor for `Completion`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List completionDescriptor = $convert.base64Decode('CgpDb21wbGV0aW9uEk0KCmNvbXBsZXRpb24YASADKAsyLS5kYXJ0X3NlcnZpY2VzLmFwaS5Db21wbGV0aW9uLkNvbXBsZXRpb25FbnRyeVIKY29tcGxldGlvbho9Cg9Db21wbGV0aW9uRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+@$core.Deprecated('Use fixesResponseDescriptor instead')
+const FixesResponse$json = const {
   '1': 'FixesResponse',
-  '2': [
-    {
-      '1': 'fixes',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.ProblemAndFixes',
-      '10': 'fixes'
-    },
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'fixes', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.ProblemAndFixes', '10': 'fixes'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const ProblemAndFixes$json = {
+/// Descriptor for `FixesResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List fixesResponseDescriptor = $convert.base64Decode('Cg1GaXhlc1Jlc3BvbnNlEjgKBWZpeGVzGAEgAygLMiIuZGFydF9zZXJ2aWNlcy5hcGkuUHJvYmxlbUFuZEZpeGVzUgVmaXhlcxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+@$core.Deprecated('Use problemAndFixesDescriptor instead')
+const ProblemAndFixes$json = const {
   '1': 'ProblemAndFixes',
-  '2': [
-    {
-      '1': 'fixes',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.CandidateFix',
-      '10': 'fixes'
-    },
-    {'1': 'problemMessage', '3': 2, '4': 1, '5': 9, '10': 'problemMessage'},
-    {'1': 'offset', '3': 3, '4': 1, '5': 5, '10': 'offset'},
-    {'1': 'length', '3': 4, '4': 1, '5': 5, '10': 'length'},
+  '2': const [
+    const {'1': 'fixes', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.CandidateFix', '10': 'fixes'},
+    const {'1': 'problemMessage', '3': 2, '4': 1, '5': 9, '10': 'problemMessage'},
+    const {'1': 'offset', '3': 3, '4': 1, '5': 5, '10': 'offset'},
+    const {'1': 'length', '3': 4, '4': 1, '5': 5, '10': 'length'},
   ],
 };
 
-const CandidateFix$json = {
+/// Descriptor for `ProblemAndFixes`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List problemAndFixesDescriptor = $convert.base64Decode('Cg9Qcm9ibGVtQW5kRml4ZXMSNQoFZml4ZXMYASADKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5DYW5kaWRhdGVGaXhSBWZpeGVzEiYKDnByb2JsZW1NZXNzYWdlGAIgASgJUg5wcm9ibGVtTWVzc2FnZRIWCgZvZmZzZXQYAyABKAVSBm9mZnNldBIWCgZsZW5ndGgYBCABKAVSBmxlbmd0aA==');
+@$core.Deprecated('Use candidateFixDescriptor instead')
+const CandidateFix$json = const {
   '1': 'CandidateFix',
-  '2': [
-    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
-    {
-      '1': 'edits',
-      '3': 2,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.SourceEdit',
-      '10': 'edits'
-    },
-    {'1': 'selectionOffset', '3': 3, '4': 1, '5': 5, '10': 'selectionOffset'},
-    {
-      '1': 'linkedEditGroups',
-      '3': 4,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.LinkedEditGroup',
-      '10': 'linkedEditGroups'
-    },
+  '2': const [
+    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+    const {'1': 'edits', '3': 2, '4': 3, '5': 11, '6': '.dart_services.api.SourceEdit', '10': 'edits'},
+    const {'1': 'selectionOffset', '3': 3, '4': 1, '5': 5, '10': 'selectionOffset'},
+    const {'1': 'linkedEditGroups', '3': 4, '4': 3, '5': 11, '6': '.dart_services.api.LinkedEditGroup', '10': 'linkedEditGroups'},
   ],
 };
 
-const SourceEdit$json = {
+/// Descriptor for `CandidateFix`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List candidateFixDescriptor = $convert.base64Decode('CgxDYW5kaWRhdGVGaXgSGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZRIzCgVlZGl0cxgCIAMoCzIdLmRhcnRfc2VydmljZXMuYXBpLlNvdXJjZUVkaXRSBWVkaXRzEigKD3NlbGVjdGlvbk9mZnNldBgDIAEoBVIPc2VsZWN0aW9uT2Zmc2V0Ek4KEGxpbmtlZEVkaXRHcm91cHMYBCADKAsyIi5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0R3JvdXBSEGxpbmtlZEVkaXRHcm91cHM=');
+@$core.Deprecated('Use sourceEditDescriptor instead')
+const SourceEdit$json = const {
   '1': 'SourceEdit',
-  '2': [
-    {'1': 'offset', '3': 1, '4': 1, '5': 5, '10': 'offset'},
-    {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
-    {'1': 'replacement', '3': 3, '4': 1, '5': 9, '10': 'replacement'},
+  '2': const [
+    const {'1': 'offset', '3': 1, '4': 1, '5': 5, '10': 'offset'},
+    const {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
+    const {'1': 'replacement', '3': 3, '4': 1, '5': 9, '10': 'replacement'},
   ],
 };
 
-const LinkedEditGroup$json = {
+/// Descriptor for `SourceEdit`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List sourceEditDescriptor = $convert.base64Decode('CgpTb3VyY2VFZGl0EhYKBm9mZnNldBgBIAEoBVIGb2Zmc2V0EhYKBmxlbmd0aBgCIAEoBVIGbGVuZ3RoEiAKC3JlcGxhY2VtZW50GAMgASgJUgtyZXBsYWNlbWVudA==');
+@$core.Deprecated('Use linkedEditGroupDescriptor instead')
+const LinkedEditGroup$json = const {
   '1': 'LinkedEditGroup',
-  '2': [
-    {'1': 'positions', '3': 1, '4': 3, '5': 5, '10': 'positions'},
-    {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
-    {
-      '1': 'suggestions',
-      '3': 3,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.LinkedEditSuggestion',
-      '10': 'suggestions'
-    },
+  '2': const [
+    const {'1': 'positions', '3': 1, '4': 3, '5': 5, '10': 'positions'},
+    const {'1': 'length', '3': 2, '4': 1, '5': 5, '10': 'length'},
+    const {'1': 'suggestions', '3': 3, '4': 3, '5': 11, '6': '.dart_services.api.LinkedEditSuggestion', '10': 'suggestions'},
   ],
 };
 
-const LinkedEditSuggestion$json = {
+/// Descriptor for `LinkedEditGroup`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List linkedEditGroupDescriptor = $convert.base64Decode('Cg9MaW5rZWRFZGl0R3JvdXASHAoJcG9zaXRpb25zGAEgAygFUglwb3NpdGlvbnMSFgoGbGVuZ3RoGAIgASgFUgZsZW5ndGgSSQoLc3VnZ2VzdGlvbnMYAyADKAsyJy5kYXJ0X3NlcnZpY2VzLmFwaS5MaW5rZWRFZGl0U3VnZ2VzdGlvblILc3VnZ2VzdGlvbnM=');
+@$core.Deprecated('Use linkedEditSuggestionDescriptor instead')
+const LinkedEditSuggestion$json = const {
   '1': 'LinkedEditSuggestion',
-  '2': [
-    {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
-    {'1': 'kind', '3': 2, '4': 1, '5': 9, '10': 'kind'},
+  '2': const [
+    const {'1': 'value', '3': 1, '4': 1, '5': 9, '10': 'value'},
+    const {'1': 'kind', '3': 2, '4': 1, '5': 9, '10': 'kind'},
   ],
 };
 
-const FormatResponse$json = {
+/// Descriptor for `LinkedEditSuggestion`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List linkedEditSuggestionDescriptor = $convert.base64Decode('ChRMaW5rZWRFZGl0U3VnZ2VzdGlvbhIUCgV2YWx1ZRgBIAEoCVIFdmFsdWUSEgoEa2luZBgCIAEoCVIEa2luZA==');
+@$core.Deprecated('Use formatResponseDescriptor instead')
+const FormatResponse$json = const {
   '1': 'FormatResponse',
-  '2': [
-    {'1': 'newString', '3': 1, '4': 1, '5': 9, '10': 'newString'},
-    {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'newString', '3': 1, '4': 1, '5': 9, '10': 'newString'},
+    const {'1': 'offset', '3': 2, '4': 1, '5': 5, '10': 'offset'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const AssistsResponse$json = {
+/// Descriptor for `FormatResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List formatResponseDescriptor = $convert.base64Decode('Cg5Gb3JtYXRSZXNwb25zZRIcCgluZXdTdHJpbmcYASABKAlSCW5ld1N0cmluZxIWCgZvZmZzZXQYAiABKAVSBm9mZnNldBI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+@$core.Deprecated('Use assistsResponseDescriptor instead')
+const AssistsResponse$json = const {
   '1': 'AssistsResponse',
-  '2': [
-    {
-      '1': 'assists',
-      '3': 1,
-      '4': 3,
-      '5': 11,
-      '6': '.dart_services.api.CandidateFix',
-      '10': 'assists'
-    },
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'assists', '3': 1, '4': 3, '5': 11, '6': '.dart_services.api.CandidateFix', '10': 'assists'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const VersionResponse$json = {
+/// Descriptor for `AssistsResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List assistsResponseDescriptor = $convert.base64Decode('Cg9Bc3Npc3RzUmVzcG9uc2USOQoHYXNzaXN0cxgBIAMoCzIfLmRhcnRfc2VydmljZXMuYXBpLkNhbmRpZGF0ZUZpeFIHYXNzaXN0cxI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3I=');
+@$core.Deprecated('Use versionResponseDescriptor instead')
+const VersionResponse$json = const {
   '1': 'VersionResponse',
-  '2': [
-    {'1': 'sdkVersion', '3': 1, '4': 1, '5': 9, '10': 'sdkVersion'},
-    {'1': 'sdkVersionFull', '3': 2, '4': 1, '5': 9, '10': 'sdkVersionFull'},
-    {'1': 'runtimeVersion', '3': 3, '4': 1, '5': 9, '10': 'runtimeVersion'},
-    {'1': 'appEngineVersion', '3': 4, '4': 1, '5': 9, '10': 'appEngineVersion'},
-    {'1': 'servicesVersion', '3': 5, '4': 1, '5': 9, '10': 'servicesVersion'},
-    {'1': 'flutterVersion', '3': 6, '4': 1, '5': 9, '10': 'flutterVersion'},
-    {
-      '1': 'flutterDartVersion',
-      '3': 7,
-      '4': 1,
-      '5': 9,
-      '10': 'flutterDartVersion'
-    },
-    {
-      '1': 'flutterDartVersionFull',
-      '3': 8,
-      '4': 1,
-      '5': 9,
-      '10': 'flutterDartVersionFull'
-    },
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'sdkVersion', '3': 1, '4': 1, '5': 9, '10': 'sdkVersion'},
+    const {'1': 'sdkVersionFull', '3': 2, '4': 1, '5': 9, '10': 'sdkVersionFull'},
+    const {'1': 'runtimeVersion', '3': 3, '4': 1, '5': 9, '10': 'runtimeVersion'},
+    const {'1': 'appEngineVersion', '3': 4, '4': 1, '5': 9, '10': 'appEngineVersion'},
+    const {'1': 'servicesVersion', '3': 5, '4': 1, '5': 9, '10': 'servicesVersion'},
+    const {'1': 'flutterVersion', '3': 6, '4': 1, '5': 9, '10': 'flutterVersion'},
+    const {'1': 'flutterDartVersion', '3': 7, '4': 1, '5': 9, '10': 'flutterDartVersion'},
+    const {'1': 'flutterDartVersionFull', '3': 8, '4': 1, '5': 9, '10': 'flutterDartVersionFull'},
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const BadRequest$json = {
+/// Descriptor for `VersionResponse`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List versionResponseDescriptor = $convert.base64Decode('Cg9WZXJzaW9uUmVzcG9uc2USHgoKc2RrVmVyc2lvbhgBIAEoCVIKc2RrVmVyc2lvbhImCg5zZGtWZXJzaW9uRnVsbBgCIAEoCVIOc2RrVmVyc2lvbkZ1bGwSJgoOcnVudGltZVZlcnNpb24YAyABKAlSDnJ1bnRpbWVWZXJzaW9uEioKEGFwcEVuZ2luZVZlcnNpb24YBCABKAlSEGFwcEVuZ2luZVZlcnNpb24SKAoPc2VydmljZXNWZXJzaW9uGAUgASgJUg9zZXJ2aWNlc1ZlcnNpb24SJgoOZmx1dHRlclZlcnNpb24YBiABKAlSDmZsdXR0ZXJWZXJzaW9uEi4KEmZsdXR0ZXJEYXJ0VmVyc2lvbhgHIAEoCVISZmx1dHRlckRhcnRWZXJzaW9uEjYKFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwYCCABKAlSFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwSNQoFZXJyb3IYYyABKAsyHy5kYXJ0X3NlcnZpY2VzLmFwaS5FcnJvck1lc3NhZ2VSBWVycm9y');
+@$core.Deprecated('Use badRequestDescriptor instead')
+const BadRequest$json = const {
   '1': 'BadRequest',
-  '2': [
-    {
-      '1': 'error',
-      '3': 99,
-      '4': 1,
-      '5': 11,
-      '6': '.dart_services.api.ErrorMessage',
-      '10': 'error'
-    },
+  '2': const [
+    const {'1': 'error', '3': 99, '4': 1, '5': 11, '6': '.dart_services.api.ErrorMessage', '10': 'error'},
   ],
 };
 
-const ErrorMessage$json = {
+/// Descriptor for `BadRequest`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List badRequestDescriptor = $convert.base64Decode('CgpCYWRSZXF1ZXN0EjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvcg==');
+@$core.Deprecated('Use errorMessageDescriptor instead')
+const ErrorMessage$json = const {
   '1': 'ErrorMessage',
-  '2': [
-    {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
+  '2': const [
+    const {'1': 'message', '3': 1, '4': 1, '5': 9, '10': 'message'},
   ],
 };
+
+/// Descriptor for `ErrorMessage`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List errorMessageDescriptor = $convert.base64Decode('CgxFcnJvck1lc3NhZ2USGAoHbWVzc2FnZRgBIAEoCVIHbWVzc2FnZQ==');

--- a/lib/src/protos/dart_services.pbserver.dart
+++ b/lib/src/protos/dart_services.pbserver.dart
@@ -6,4 +6,3 @@
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 export 'dart_services.pb.dart';
-

--- a/lib/src/protos/dart_services.pbserver.dart
+++ b/lib/src/protos/dart_services.pbserver.dart
@@ -2,7 +2,8 @@
 //  Generated code. Do not modify.
 //  source: protos/dart_services.proto
 //
-// @dart = 2.3
-// ignore_for_file: camel_case_types,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type
+// @dart = 2.7
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 export 'dart_services.pb.dart';
+

--- a/protos/dart_services.proto
+++ b/protos/dart_services.proto
@@ -47,6 +47,7 @@ message AnalysisIssue {
   int32 charLength = 7;
   string url = 8;
   repeated DiagnosticMessage diagnosticMessages = 9;
+  string correction = 10;
 }
 
 message DiagnosticMessage {

--- a/protos/dart_services.proto
+++ b/protos/dart_services.proto
@@ -14,6 +14,11 @@ message CompileRequest {
   bool returnSourceMap = 2;
 }
 
+message CompileDDCRequest {
+  // The Dart source.
+  string source = 1;
+}
+
 message SourceRequest {
   // The Dart source.
   string source = 1;
@@ -40,6 +45,15 @@ message AnalysisIssue {
   bool hasFixes = 5;
   int32 charStart = 6;
   int32 charLength = 7;
+  string url = 8;
+  repeated DiagnosticMessage diagnosticMessages = 9;
+}
+
+message DiagnosticMessage {
+  string message = 1;
+  int32 line = 2;
+  int32 charStart = 3;
+  int32 charLength = 4;
 }
 
 message VersionRequest {}

--- a/third_party/pkg/route.dart/lib/click_handler.dart
+++ b/third_party/pkg/route.dart/lib/click_handler.dart
@@ -5,12 +5,12 @@ import 'dart:html';
 import 'link_matcher.dart';
 import 'client.dart';
 
-typedef String _HashNormalizer(String s);
+typedef _HashNormalizer = String Function(String s);
 
 /// WindowClickHandler can be used as a hook into [Router] to
 /// modify behavior right after user clicks on an element, and
 /// before the URL in the browser changes.
-typedef WindowClickHandler(Event e);
+typedef WindowClickHandler = Function(Event e);
 
 /// This is default behavior used by [Router] to handle clicks on elements.
 ///

--- a/third_party/pkg/route.dart/lib/client.dart
+++ b/third_party/pkg/route.dart/lib/client.dart
@@ -23,10 +23,10 @@ part 'route_handle.dart';
 final _logger = Logger('route');
 const _PATH_SEPARATOR = '.';
 
-typedef void RoutePreEnterEventHandler(RoutePreEnterEvent event);
-typedef void RouteEnterEventHandler(RouteEnterEvent event);
-typedef void RoutePreLeaveEventHandler(RoutePreLeaveEvent event);
-typedef void RouteLeaveEventHandler(RouteLeaveEvent event);
+typedef RoutePreEnterEventHandler = void Function(RoutePreEnterEvent event);
+typedef RouteEnterEventHandler = void Function(RouteEnterEvent event);
+typedef RoutePreLeaveEventHandler = void Function(RoutePreLeaveEvent event);
+typedef RouteLeaveEventHandler = void Function(RouteLeaveEvent event);
 
 /// [Route] represents a node in the route tree.
 abstract class Route {

--- a/third_party/pkg/route.dart/test/client_test.dart
+++ b/third_party/pkg/route.dart/test/client_test.dart
@@ -216,12 +216,11 @@ main() {
         'fooLeave': 0,
         'fooEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++);
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++);
 
       return router.reload().then((_) {
         expect(counters, {
@@ -239,17 +238,16 @@ main() {
         'barLeave': 0,
         'barEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++,
-            mount: (r) => r.addRoute(
-                name: 'bar',
-                path: '/:bar',
-                leave: (_) => counters['barLeave']++,
-                enter: (_) => counters['barEnter']++));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++,
+          mount: (r) => r.addRoute(
+              name: 'bar',
+              path: '/:bar',
+              leave: (_) => counters['barLeave']++,
+              enter: (_) => counters['barEnter']++));
 
       return router.route('/123').then((_) {
         expect(counters, {
@@ -278,17 +276,16 @@ main() {
         'barLeave': 0,
         'barEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++,
-            mount: (r) => r.addRoute(
-                name: 'bar',
-                path: '/:bar',
-                leave: (_) => counters['barLeave']++,
-                enter: (_) => counters['barEnter']++));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++,
+          mount: (r) => r.addRoute(
+              name: 'bar',
+              path: '/:bar',
+              leave: (_) => counters['barLeave']++,
+              enter: (_) => counters['barEnter']++));
 
       return router.route('/123/321').then((_) {
         expect(counters, {
@@ -318,17 +315,16 @@ main() {
         'barLeave': 0,
         'barEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++,
-            mount: (r) => r.addRoute(
-                name: 'bar',
-                path: '/:bar',
-                leave: (_) => counters['barLeave']++,
-                enter: (_) => counters['barEnter']++));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++,
+          mount: (r) => r.addRoute(
+              name: 'bar',
+              path: '/:bar',
+              leave: (_) => counters['barLeave']++,
+              enter: (_) => counters['barEnter']++));
 
       return router.route('/123/321').then((_) {
         expect(counters, {
@@ -356,12 +352,11 @@ main() {
         'fooLeave': 0,
         'fooEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++);
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++);
 
       return router.route('/123?foo=bar&blah=blah').then((_) {
         expect(counters, {
@@ -389,17 +384,16 @@ main() {
         'barLeave': 0,
         'barEnter': 0,
       };
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            leave: (_) => counters['fooLeave']++,
-            enter: (_) => counters['fooEnter']++,
-            mount: (r) => r.addRoute(
-                name: 'bar',
-                path: '/:bar',
-                leave: (_) => counters['barLeave']++,
-                enter: (_) => counters['barEnter']++));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          leave: (_) => counters['fooLeave']++,
+          enter: (_) => counters['fooEnter']++,
+          mount: (r) => r.addRoute(
+              name: 'bar',
+              path: '/:bar',
+              leave: (_) => counters['barLeave']++,
+              enter: (_) => counters['barEnter']++));
 
       return router.route('/123/321?foo=bar&blah=blah').then((_) {
         expect(counters, {
@@ -447,31 +441,30 @@ main() {
         'bazLeave': 0
       };
       var router = Router();
-      router.root
-        ..addRoute(
-            path: '/foo',
-            name: 'foo',
-            preEnter: (_) => counters['fooPreEnter']++,
-            preLeave: (_) => counters['fooPreLeave']++,
-            enter: (_) => counters['fooEnter']++,
-            leave: (_) => counters['fooLeave']++,
-            watchQueryParameters: [],
-            mount: (Route route) => route
-              ..addRoute(
-                  path: '/bar',
-                  name: 'bar',
-                  preEnter: (_) => counters['barPreEnter']++,
-                  preLeave: (_) => counters['barPreLeave']++,
-                  enter: (_) => counters['barEnter']++,
-                  leave: (_) => counters['barLeave']++)
-              ..addRoute(
-                  path: '/baz',
-                  name: 'baz',
-                  preEnter: (_) => counters['bazPreEnter']++,
-                  preLeave: (_) => counters['bazPreLeave']++,
-                  enter: (_) => counters['bazEnter']++,
-                  leave: (_) => counters['bazLeave']++,
-                  watchQueryParameters: ['baz.blah']));
+      router.root.addRoute(
+          path: '/foo',
+          name: 'foo',
+          preEnter: (_) => counters['fooPreEnter']++,
+          preLeave: (_) => counters['fooPreLeave']++,
+          enter: (_) => counters['fooEnter']++,
+          leave: (_) => counters['fooLeave']++,
+          watchQueryParameters: [],
+          mount: (Route route) => route
+            ..addRoute(
+                path: '/bar',
+                name: 'bar',
+                preEnter: (_) => counters['barPreEnter']++,
+                preLeave: (_) => counters['barPreLeave']++,
+                enter: (_) => counters['barEnter']++,
+                leave: (_) => counters['barLeave']++)
+            ..addRoute(
+                path: '/baz',
+                name: 'baz',
+                preEnter: (_) => counters['bazPreEnter']++,
+                preLeave: (_) => counters['bazPreLeave']++,
+                enter: (_) => counters['bazEnter']++,
+                leave: (_) => counters['bazLeave']++,
+                watchQueryParameters: ['baz.blah']));
 
       expect(counters, {
         'fooPreEnter': 0,
@@ -550,21 +543,18 @@ main() {
       ;
 
       var router = Router();
-      router.root
-        ..addRoute(
-            path: '/foo',
-            name: 'foo',
-            leave: loggingLeaveHandler,
-            mount: (Route route) => route
-              ..addRoute(
-                  path: '/bar',
-                  name: 'bar',
-                  leave: loggingLeaveHandler,
-                  mount: (Route route) => route
-                    ..addRoute(
-                        path: '/baz',
-                        name: 'baz',
-                        leave: loggingLeaveHandler)));
+      router.root.addRoute(
+          path: '/foo',
+          name: 'foo',
+          leave: loggingLeaveHandler,
+          mount: (Route route) => route
+            ..addRoute(
+                path: '/bar',
+                name: 'bar',
+                leave: loggingLeaveHandler,
+                mount: (Route route) => route
+                  ..addRoute(
+                      path: '/baz', name: 'baz', leave: loggingLeaveHandler)));
 
       router.route('/foo/bar/baz').then(expectAsync1((_) {
         expect(log, []);
@@ -578,11 +568,10 @@ main() {
     test('should leave active child route when routed to parent route only',
         () {
       var router = Router();
-      router.root
-        ..addRoute(
-            path: '/foo',
-            name: 'foo',
-            mount: (Route route) => route..addRoute(path: '/bar', name: 'bar'));
+      router.root.addRoute(
+          path: '/foo',
+          name: 'foo',
+          mount: (Route route) => route..addRoute(path: '/bar', name: 'bar'));
 
       return router.route('/foo/bar').then((_) {
         expect(router.activePath.map((r) => r.name), ['foo', 'bar']);
@@ -598,21 +587,20 @@ main() {
       bool bazEntered = false;
 
       var router = Router();
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            mount: (Route child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  enter: (RouteEnterEvent e) => barEntered = true,
-                  preLeave: (RoutePreLeaveEvent e) =>
-                      e.allowLeave(completer.future))
-              ..addRoute(
-                  name: 'baz',
-                  path: '/baz',
-                  enter: (RouteEnterEvent e) => bazEntered = true));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          mount: (Route child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                enter: (RouteEnterEvent e) => barEntered = true,
+                preLeave: (RoutePreLeaveEvent e) =>
+                    e.allowLeave(completer.future))
+            ..addRoute(
+                name: 'baz',
+                path: '/baz',
+                enter: (RouteEnterEvent e) => bazEntered = true));
 
       router.route('/foo/bar').then(expectAsync1((_) {
         expect(barEntered, true);
@@ -639,17 +627,16 @@ main() {
       bool barEntered = false;
 
       var router = Router();
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            mount: (Route child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  enter: (RouteEnterEvent e) => barEntered = true,
-                  preEnter: (RoutePreEnterEvent e) =>
-                      e.allowEnter(completer.future)));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          mount: (Route child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                enter: (RouteEnterEvent e) => barEntered = true,
+                preEnter: (RoutePreEnterEvent e) =>
+                    e.allowEnter(completer.future)));
 
       router.route('/foo/bar').then(expectAsync1((_) {
         expect(barEntered, allowEnter);
@@ -929,21 +916,20 @@ main() {
   group('Default route', () {
     void _testHeadTail(String path, String expectFoo, String expectBar) {
       var router = Router();
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            defaultRoute: true,
-            enter: expectAsync1((RouteEvent e) {
-              expect(e.path, expectFoo);
-            }),
-            mount: (child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  defaultRoute: true,
-                  enter: expectAsync1(
-                      (RouteEvent e) => expect(e.path, expectBar))));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          defaultRoute: true,
+          enter: expectAsync1((RouteEvent e) {
+            expect(e.path, expectFoo);
+          }),
+          mount: (child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                defaultRoute: true,
+                enter:
+                    expectAsync1((RouteEvent e) => expect(e.path, expectBar))));
 
       router.route(path);
     }
@@ -1121,11 +1107,10 @@ main() {
       when((mockWindow.document as HtmlDocument).title)
           .thenReturn('page title');
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'a',
-            path: '/:foo',
-            mount: (child) => child..addRoute(name: 'b', path: '/:bar'));
+      router.root.addRoute(
+          name: 'a',
+          path: '/:foo',
+          mount: (child) => child..addRoute(name: 'b', path: '/:bar'));
 
       var routeA = router.root.findRoute('a');
 
@@ -1165,18 +1150,17 @@ main() {
       when((mockWindow.document as HtmlDocument).title)
           .thenReturn('page title');
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'a',
-            defaultRoute: true,
-            path: '/:foo',
-            enter: (_) => counters['aEnter']++,
-            mount: (child) => child
-              ..addRoute(
-                  name: 'b',
-                  defaultRoute: true,
-                  path: '/:bar',
-                  enter: (_) => counters['bEnter']++));
+      router.root.addRoute(
+          name: 'a',
+          defaultRoute: true,
+          path: '/:foo',
+          enter: (_) => counters['aEnter']++,
+          mount: (child) => child
+            ..addRoute(
+                name: 'b',
+                defaultRoute: true,
+                path: '/:bar',
+                enter: (_) => counters['bEnter']++));
 
       expect(counters, {'aEnter': 0, 'bEnter': 0});
 
@@ -1202,14 +1186,13 @@ main() {
       when((mockWindow.document as HtmlDocument).title)
           .thenReturn('page title');
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'a',
-            path: '/foo',
-            enter: (_) => counters['aEnter']++,
-            mount: (child) => child
-              ..addRoute(
-                  name: 'b', path: '/bar', enter: (_) => counters['bEnter']++));
+      router.root.addRoute(
+          name: 'a',
+          path: '/foo',
+          enter: (_) => counters['aEnter']++,
+          mount: (child) => child
+            ..addRoute(
+                name: 'b', path: '/bar', enter: (_) => counters['bEnter']++));
 
       expect(counters, {'aEnter': 0, 'bEnter': 0});
 
@@ -1255,13 +1238,12 @@ main() {
     test('should reconstruct url', () {
       var mockWindow = MockWindow();
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'a',
-            defaultRoute: true,
-            path: '/:foo',
-            mount: (child) =>
-                child..addRoute(name: 'b', defaultRoute: true, path: '/:bar'));
+      router.root.addRoute(
+          name: 'a',
+          defaultRoute: true,
+          path: '/:foo',
+          mount: (child) =>
+              child..addRoute(name: 'b', defaultRoute: true, path: '/:bar'));
 
       var routeA = router.root.findRoute('a');
 
@@ -1300,27 +1282,26 @@ main() {
       Route routeFoo, routeBar, routeBaz, routeQux, routeAux;
 
       var router = Router();
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/:foo',
-            mount: (child) => routeFoo = child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/:bar',
-                  mount: (child) => routeBar = child
-                    ..addRoute(
-                        name: 'baz',
-                        path: '/:baz',
-                        mount: (child) => routeBaz = child))
-              ..addRoute(
-                  name: 'qux',
-                  path: '/:qux',
-                  mount: (child) => routeQux = child
-                    ..addRoute(
-                        name: 'aux',
-                        path: '/:aux',
-                        mount: (child) => routeAux = child)));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/:foo',
+          mount: (child) => routeFoo = child
+            ..addRoute(
+                name: 'bar',
+                path: '/:bar',
+                mount: (child) => routeBar = child
+                  ..addRoute(
+                      name: 'baz',
+                      path: '/:baz',
+                      mount: (child) => routeBaz = child))
+            ..addRoute(
+                name: 'qux',
+                path: '/:qux',
+                mount: (child) => routeQux = child
+                  ..addRoute(
+                      name: 'aux',
+                      path: '/:aux',
+                      mount: (child) => routeAux = child)));
 
       expect(router.root.findRoute('foo'), same(routeFoo));
       expect(router.root.findRoute('foo.bar'), same(routeBar));
@@ -1340,16 +1321,15 @@ main() {
     group('query params', () {
       test('should parse query', () {
         var router = Router();
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/:foo',
-              enter: expectAsync1((RouteEvent e) {
-                expect(e.parameters, {
-                  'foo': '123',
-                });
-                expect(e.queryParameters, {'a': 'b', 'b': '', 'c': 'foo bar'});
-              }));
+        router.root.addRoute(
+            name: 'foo',
+            path: '/:foo',
+            enter: expectAsync1((RouteEvent e) {
+              expect(e.parameters, {
+                'foo': '123',
+              });
+              expect(e.queryParameters, {'a': 'b', 'b': '', 'c': 'foo bar'});
+            }));
 
         router.route('/123?a=b&b=&c=foo%20bar');
       });
@@ -1360,13 +1340,12 @@ main() {
           'fooLeave': 0,
           'fooEnter': 0,
         };
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/:foo',
-              watchQueryParameters: ['bar'],
-              leave: (_) => counters['fooLeave']++,
-              enter: (_) => counters['fooEnter']++);
+        router.root.addRoute(
+            name: 'foo',
+            path: '/:foo',
+            watchQueryParameters: ['bar'],
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++);
 
         return router.route('/123').then((_) {
           expect(counters, {
@@ -1388,13 +1367,12 @@ main() {
           'fooLeave': 0,
           'fooEnter': 0,
         };
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/:foo',
-              watchQueryParameters: ['foo'],
-              leave: (_) => counters['fooLeave']++,
-              enter: (_) => counters['fooEnter']++);
+        router.root.addRoute(
+            name: 'foo',
+            path: '/:foo',
+            watchQueryParameters: ['foo'],
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++);
 
         return router.route('/123').then((_) {
           expect(counters, {
@@ -1416,13 +1394,12 @@ main() {
           'fooLeave': 0,
           'fooEnter': 0,
         };
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/:foo',
-              watchQueryParameters: [RegExp(r'^foo$')],
-              leave: (_) => counters['fooLeave']++,
-              enter: (_) => counters['fooEnter']++);
+        router.root.addRoute(
+            name: 'foo',
+            path: '/:foo',
+            watchQueryParameters: [RegExp(r'^foo$')],
+            leave: (_) => counters['fooLeave']++,
+            enter: (_) => counters['fooEnter']++);
 
         return router.route('/123').then((_) {
           expect(counters, {
@@ -1442,23 +1419,22 @@ main() {
     group('isActive', () {
       test('should currectly identify active/inactive routes', () {
         var router = Router();
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/foo',
-              mount: (child) => child
-                ..addRoute(
-                    name: 'bar',
-                    path: '/bar',
-                    mount: (child) => child
-                      ..addRoute(
-                          name: 'baz', path: '/baz', mount: (child) => child))
-                ..addRoute(
-                    name: 'qux',
-                    path: '/qux',
-                    mount: (child) => child
-                      ..addRoute(
-                          name: 'aux', path: '/aux', mount: (child) => child)));
+        router.root.addRoute(
+            name: 'foo',
+            path: '/foo',
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/bar',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'baz', path: '/baz', mount: (child) => child))
+              ..addRoute(
+                  name: 'qux',
+                  path: '/qux',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'aux', path: '/aux', mount: (child) => child)));
 
         expect(r(router, 'foo').isActive, false);
         expect(r(router, 'foo.bar').isActive, false);
@@ -1491,19 +1467,16 @@ main() {
     group('parameters', () {
       test('should return path parameters for routes', () {
         var router = Router();
-        router.root
-          ..addRoute(
-              name: 'foo',
-              path: '/:foo',
-              mount: (child) => child
-                ..addRoute(
-                    name: 'bar',
-                    path: '/:bar',
-                    mount: (child) => child
-                      ..addRoute(
-                          name: 'baz',
-                          path: '/:baz',
-                          mount: (child) => child)));
+        router.root.addRoute(
+            name: 'foo',
+            path: '/:foo',
+            mount: (child) => child
+              ..addRoute(
+                  name: 'bar',
+                  path: '/:bar',
+                  mount: (child) => child
+                    ..addRoute(
+                        name: 'baz', path: '/:baz', mount: (child) => child)));
 
         expect(r(router, 'foo').parameters, isNull);
         expect(r(router, 'foo.bar').parameters, isNull);
@@ -1533,23 +1506,22 @@ main() {
   group('activePath', () {
     test('should currectly identify active path', () {
       var router = Router();
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            mount: (child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'baz', path: '/baz', mount: (child) => child))
-              ..addRoute(
-                  name: 'qux',
-                  path: '/qux',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'aux', path: '/aux', mount: (child) => child)));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          mount: (child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'baz', path: '/baz', mount: (child) => child))
+            ..addRoute(
+                name: 'qux',
+                path: '/qux',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'aux', path: '/aux', mount: (child) => child)));
 
       var strPath =
           (List<Route> path) => path.map((Route r) => r.name).join('.');
@@ -1572,23 +1544,22 @@ main() {
     test('should currectly identify active path after relative go', () {
       var mockWindow = MockWindow();
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            mount: (child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'baz', path: '/baz', mount: (child) => child))
-              ..addRoute(
-                  name: 'qux',
-                  path: '/qux',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'aux', path: '/aux', mount: (child) => child)));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          mount: (child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'baz', path: '/baz', mount: (child) => child))
+            ..addRoute(
+                name: 'qux',
+                path: '/qux',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'aux', path: '/aux', mount: (child) => child)));
 
       var strPath =
           (List<Route> path) => path.map((Route r) => r.name).join('.');
@@ -1610,23 +1581,22 @@ main() {
         () {
       var mockWindow = MockWindow();
       var router = Router(windowImpl: mockWindow);
-      router.root
-        ..addRoute(
-            name: 'foo',
-            path: '/foo',
-            mount: (child) => child
-              ..addRoute(
-                  name: 'bar',
-                  path: '/bar',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'baz', path: '/baz', mount: (child) => child))
-              ..addRoute(
-                  name: 'qux',
-                  path: '/qux',
-                  mount: (child) => child
-                    ..addRoute(
-                        name: 'aux', path: '/aux', mount: (child) => child)));
+      router.root.addRoute(
+          name: 'foo',
+          path: '/foo',
+          mount: (child) => child
+            ..addRoute(
+                name: 'bar',
+                path: '/bar',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'baz', path: '/baz', mount: (child) => child))
+            ..addRoute(
+                name: 'qux',
+                path: '/qux',
+                mount: (child) => child
+                  ..addRoute(
+                      name: 'aux', path: '/aux', mount: (child) => child)));
 
       var strPath =
           (List<Route> path) => path.map((Route r) => r.name).join('.');

--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -65,6 +65,10 @@ a {
   color: $dark-issue-label-color;
 }
 
+.issue:hover {
+  background-color: darken($dark-issues-background-color, 3%);
+}
+
 .issue .message {
   color: $dark-issue-label-color;
 }

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -52,6 +52,10 @@ a {
   color: $light-label-color;
 }
 
+.issue:hover {
+  background-color: darken($light-secondary-background-color, 5%);
+}
+
 .issue .message {
   color: $light-label-color;
 }

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -453,12 +453,23 @@ a {
   color: $dark-issue-label-color;
 }
 
+.issue:hover {
+  background-color: darken($dark-issues-background-color, 3%);
+}
+
 .issue .message {
   color: $dark-issue-label-color;
 }
 
-#issues-toggle {
+#issues-toggle, .issue-anchor {
   color: $mdc-theme-primary;
+  &:visited {
+    color: $mdc-theme-primary;
+  }
+
+  &:hover {
+    color: darken($mdc-theme-primary, 12%);
+  }
 }
 
 #issues-message {

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -104,9 +104,6 @@ body>footer {
 
 
 a {
-  text-decoration: none;
-  cursor: pointer;
-
   color: $playground-link-color;
   fill: $playground-text-color;
 


### PR DESCRIPTION
Adds "Open Documentation" links, diagnostic messages, and corrections in the analysis panel

<img width="1041" alt="Screen Shot 2021-02-18 at 4 03 57 PM" src="https://user-images.githubusercontent.com/1145719/108437848-f290a980-7202-11eb-9638-3756b3acd207.png">

Diagnostic messages often show line numbers, so #317 would be nice to have soon.

depends on https://github.com/dart-lang/dart-services/pull/663
fixes https://github.com/dart-lang/dart-pad/issues/1676