### PR TITLE
some minor changes to the error toast UI

### DIFF
--- a/lib/elements/elements.css
+++ b/lib/elements/elements.css
@@ -221,7 +221,7 @@ button.close:hover {
 }
 
 .issue + .issue {
-  margin-top: 4px;
+  padding-top: 6px;
 }
 
 .issue .issuelabel {

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -15,10 +15,6 @@ a {
   margin-top: 8px;
 }
 
-#issues-container > div + div {
-  margin-top: 8px;
-}
-
 .flash {
   border-radius: 0;
   border: none;
@@ -26,15 +22,11 @@ a {
 }
 
 #flash-container {
-  width: 380px;
+  width: 420px;
   z-index: 10;
   bottom: 40px;
   right: 8px;
   position: fixed;
-}
-
-#issues-container {
-  width: 380px;
 }
 
 .message-container {
@@ -83,7 +75,6 @@ a {
   display: flex;
   flex-direction: row;
   align-items: start;
-  line-height: 20px;
   border-radius: 3px;
   padding: 4px;
   margin: 0;
@@ -140,6 +131,10 @@ a {
   padding-left: 5px;
   line-height: 20px;
   font-family: 'Roboto', sans-serif;
+}
+
+.message + .message {
+  padding-top: 4px;
 }
 
 // Keys dialog


### PR DESCRIPTION
some minor changes to the error toast UI:
- removed some code to eliminate trailing periods from a message
- normalized padding between the elements in an issue
- removed some unused css selectors
- restructured where the line no and docs link are

<img width="435" alt="Screen Shot 2021-02-23 at 4 43 37 PM" src="https://user-images.githubusercontent.com/1269969/108928449-08cda980-75f7-11eb-91eb-7003073c4e9d.png">

@johnpryan 