### PR TITLE
Fix a few problems in instructions and setup for running a custom backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,12 +57,12 @@ cd dart-services
 dart pub get
 # Change the SDK version dart-services serves to the one you currently have installed
 grind update-docker-version
-# Begin serving the backend locally on port 8002.
+# Begin serving the backend locally on port 8082.
 grind serve &
 
 cd ../dart-pad
 # Begin serving the front-end locally on port 8000, with the given backend
-export DARTPAD_BACKEND=http://localhost:8002 
+export DARTPAD_BACKEND=http://localhost:8082
 grind serve-custom-backend
 ```
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -79,7 +79,7 @@ serveLocalAppEngine() async {
 const String backendVariable = 'DARTPAD_BACKEND';
 
 @Task(
-    'Serve locally on port 8002 and use backend from $backendVariable environment variable')
+    'Serve locally on port 8082 and use backend from $backendVariable environment variable')
 @Depends(build)
 serveCustomBackend() async {
   if (!Platform.environment.containsKey(backendVariable)) {
@@ -88,7 +88,7 @@ serveCustomBackend() async {
   }
 
   final serverUrl =
-      Platform.environment[backendVariable] ?? 'http://localhost:8002';
+      Platform.environment[backendVariable] ?? 'http://localhost:8082';
 
   // In all files *.dart.js in build/scripts/, replace
   // 'https://v1.api.dartpad.dev' with serverUrl.

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -91,7 +91,7 @@ serveCustomBackend() async {
       Platform.environment[backendVariable] ?? 'http://localhost:8002';
 
   // In all files *.dart.js in build/scripts/, replace
-  // 'https://dart-services.appspot.com' with serverUrl.
+  // 'https://v1.api.dartpad.dev' with serverUrl.
   final files = <FileSystemEntity>[];
   files.addAll(_buildDir.join('scripts').asDirectory.listSync());
   for (var entity in files) {
@@ -104,7 +104,7 @@ serveCustomBackend() async {
 
     var fileContents = file.readAsStringSync();
     fileContents =
-        fileContents.replaceAll('https://dart-services.appspot.com', serverUrl);
+        fileContents.replaceAll('https://v1.api.dartpad.dev', serverUrl);
     file.writeAsStringSync(fileContents);
   }
 


### PR DESCRIPTION
This evening I tried following the instructions in [CONTRIBUTING.md](https://github.com/dart-lang/dart-pad/blob/master/CONTRIBUTING.md) for running dart-pad with a local [dart-services](https://github.com/dart-lang/dart-services) backend and found two small problems:

1. The substitution that replaced the official server address with the user-specified address didn't work because it [referred to an obsolete host](https://github.com/dart-lang/dart-pad/blob/91ff579e394e81695534715ed1590028639c0497/tool/grind.dart#L107) - the current host is [here](https://github.com/dart-lang/dart-pad/blob/f1bd3cf47b9954ebd815508c8e3312e16e32f0dd/lib/services/common.dart#L8) (though there may be some problems related to the new null-safe host).

2. The instructions in [CONTRIBUTING.md](https://github.com/dart-lang/dart-pad/blob/master/CONTRIBUTING.md) indicated that the backend server would start on port 8002 when actually it was configured for [port 8082](https://github.com/dart-lang/dart-services/search?q=8082).