### PR TITLE
Enable Line Numbers in Dart Playground

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -456,8 +456,6 @@ class Playground implements GistContainer, GistController {
   void _initLayout() {
     editorPanelHeader = DElement(_editorPanelHeader);
     editorPanelFooter = DElement(_editorPanelFooter);
-    var editor = querySelector('#editor-host');
-    editor.setAttribute('style', 'margin:0;');
     _changeLayout(Layout.dart);
   }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -503,7 +503,8 @@ class Playground implements GistContainer, GistController {
     editor = (editorFactory as CodeMirrorFactory)
         .createFromElement(_editorHost, options: codeMirrorOptions)
           ..theme = 'darkpad'
-          ..mode = 'dart';
+          ..mode = 'dart'
+          ..showLineNumbers = true;
 
     // set up key bindings
     keys.bind(['ctrl-s'], _handleSave, 'Save', hidden: true);

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -456,6 +456,8 @@ class Playground implements GistContainer, GistController {
   void _initLayout() {
     editorPanelHeader = DElement(_editorPanelHeader);
     editorPanelFooter = DElement(_editorPanelFooter);
+    var editor = querySelector('#editor-host');
+    editor.setAttribute('style', 'margin:0;');
     _changeLayout(Layout.dart);
   }
 

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -148,7 +148,7 @@ a {
 #editor-host {
   @include layout-vertical;
   @include layout-flex;
-  margin: 8px 0 0 16px;
+  margin: 8px 0 0 0;
   padding: 0 8px;
 
   .CodeMirror {


### PR DESCRIPTION
As mentioned in issue #317, The embedded DartPad editor has had the line numbers for a long time. This Pull Request enables the same option on the Playground side.