### PR TITLE
Remove tuneup

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,13 +8,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "14.0.0"
-  analysis_server_lib:
-    dependency: transitive
-    description:
-      name: analysis_server_lib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.10"
   analyzer:
     dependency: transitive
     description:
@@ -603,13 +596,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.1+3"
-  tuneup:
-    dependency: "direct dev"
-    description:
-      name: tuneup
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.7"
   tuple:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,4 +33,3 @@ dev_dependencies:
   shelf: ^0.7.5
   shelf_static: ^0.2.8
   test: ^1.15.7
-  tuneup: any

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -37,11 +37,6 @@ updateThirdParty() {
 }
 
 @Task()
-analyze() {
-  PubApp.local('tuneup').run(['check']);
-}
-
-@Task()
 testCli() async => await TestRunner().testAsync(platformSelector: 'vm');
 
 // This task require a frame buffer to run.
@@ -201,7 +196,7 @@ coverage() {
 }
 
 @DefaultTask()
-@Depends(analyze, testCli, testWeb, coverage, build)
+@Depends(testCli, testWeb, coverage, build)
 void buildbot() {}
 
 @Task('Prepare the app for deployment')


### PR DESCRIPTION
I'm not seeing a large benefit of pulling in this dev dependency anymore. We run the analyzer with fatal information enable in Github actions and as for the tools, if someone wants to use them they can globally activate the package.