### PR TITLE
Switch grind script to use dart pub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,6 @@ This serves the DartPad frontend locally on port 8000.
 
 * To run DartPad against a local version of the dart-services backend:
 ```bash
-
 cd ..
 git clone git@github.com:dart-lang/dart-services.git
 cd dart-services

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -49,9 +49,9 @@ testCli() async => await TestRunner().testAsync(platformSelector: 'vm');
 testWeb() async {
   await TestRunner().testAsync(platformSelector: 'chrome');
   log('Running route.dart tests...');
-  run('pub', arguments: ['get'], workingDirectory: _routeDir.path);
-  run('pub',
-      arguments: ['run', 'test:test', '--platform=chrome'],
+  run('dart', arguments: ['pub', 'get'], workingDirectory: _routeDir.path);
+  run('dart',
+      arguments: ['pub', 'run', 'test:test', '--platform=chrome'],
       workingDirectory: _routeDir.path);
 }
 


### PR DESCRIPTION
Switch to using the pub subcommand as it is becoming less common to have `pub` on your path directly.