### PR TITLE
enable null safety switch by default

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -253,12 +253,15 @@ class Playground implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => _showKeyboardDialog());
-    nullSafetyEnabled = window.localStorage.containsKey('null_safety') &&
-        window.localStorage['null_safety'] == 'true';
 
-    // Override if a query parameter is provided
+    // Query params have higher precedence than local storage
     if (queryParams.hasNullSafety) {
       nullSafetyEnabled = queryParams.nullSafety;
+    } else if (window.localStorage.containsKey('null_safety')) {
+      nullSafetyEnabled = window.localStorage['null_safety'] == 'true';
+    } else {
+      // Default to null safety
+      nullSafetyEnabled = true;
     }
 
     nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))


### PR DESCRIPTION
Enables the null safety switch if no query parameter is provided and the user has not used it before (nothing is stored in local storage)

Closes #1814 

fyi @mit-mit @RedBrogdon 