### PR TITLE
Make the back-end URLs configurable via grind and build_runner

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,6 +16,8 @@ targets:
           dart2js_args:
           - --minify
           - --fast-startup
+          - -DPRE_NULL_SAFETY_SERVER_URL=https://v1.api.dartpad.dev/
+          - -DNULL_SAFETY_SERVER_URL=https://nullsafety.api.dartpad.dev/
 
       json_serializable:
         # Ignore codelab samples.

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -542,7 +542,7 @@ class Embed {
       api.rootUrl = nullSafetyServerUrl;
       window.localStorage['null_safety'] = 'true';
     } else {
-      api.rootUrl = serverUrl;
+      api.rootUrl = preNullSafetyServerUrl;
       window.localStorage['null_safety'] = 'false';
     }
     _performAnalysis();

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -61,7 +61,8 @@ class DartServicesModule extends Module {
   @override
   Future init() {
     var client = SanitizingBrowserClient();
-    deps[DartservicesApi] = DartservicesApi(client, rootUrl: serverUrl);
+    deps[DartservicesApi] =
+        DartservicesApi(client, rootUrl: preNullSafetyServerUrl);
     return Future.value();
   }
 }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1006,7 +1006,7 @@ class Playground implements GistContainer, GistController {
       window.localStorage['null_safety'] = 'true';
       nullSafetySwitch.root.title = 'Null safety is currently enabled';
     } else {
-      api.rootUrl = serverUrl;
+      api.rootUrl = preNullSafetyServerUrl;
       window.localStorage['null_safety'] = 'false';
       nullSafetySwitch.root.title = 'Null safety is currently disabled';
     }

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -4,15 +4,27 @@
 
 library dart_pad.common;
 
-// The endpoint running dart-services.
-const serverUrl = 'https://v1.api.dartpad.dev/';
+/// The environment variable name which specifies the URL of the pre-null safety
+/// back-end server.
+///
+/// This typically is specified in `dart2js_args` passed via a build_runner
+/// option. The `grind build` task specifies this option.
+const preNullSafetyServerUrlEnvironmentVar = 'PRE_NULL_SAFETY_SERVER_URL';
 
-// Used when null safety is enabled in the UI.
-const nullSafetyServerUrl = 'https://nullsafety.api.dartpad.dev/';
+/// The URL of the pre-null safety back-end server.
+const preNullSafetyServerUrl =
+    String.fromEnvironment(preNullSafetyServerUrlEnvironmentVar);
 
-// A URL to use while debugging.
-// const serverUrl = 'http://127.0.0.1:8082/';
-// const nullSafetyServerUrl = 'http://127.0.0.1:8084/';
+/// The environment variable name which specifies the URL of the null safety
+/// back-end server.
+///
+/// This typically is specified in `dart2js_args` passed via a build_runner
+/// option. The `grind build` task specifies this option.
+const nullSafetyServerUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';
+
+/// The URL of the null safety back-end server.
+const nullSafetyServerUrl =
+    String.fromEnvironment(nullSafetyServerUrlEnvironmentVar);
 
 // Alternate versions for development purposes
 // const serverUrl = 'https://old.api.dartpad.dev/';


### PR DESCRIPTION
Currently a grinder task allows serving dart-pad with a custom dart-services back-end via editing the compiled JavaScript that dart2js produces. This has proven fragile, and figuring out where the expected URLs are is not very discoverable. Changing the local URLs while developing involves editing `common.dart`, risking accidentally checking in the changes every time you change them to do some development.

Well this ended up being a lot more complicated than originally hoped. :/ Since build_runner and build_web_compilers and dart2js are black boxes to grinder, this idea requires both grinder task options (and patches to compensate for https://github.com/google/grinder.dart/issues/318) and dart2js args.

I'm not married to this. I think that the custom URLs are safer than the current method, and more discoverable. I like the idea of moving the standard URLs to build.yaml, since they are just configuration, not code. And I like the local URLs being in the grinder script as well. All that being said, what a limbo dance we must do... I wonder if I'm holding build_runner/web_build_compilers/dart2js/grinder wrong. :(