### PR TITLE
Minor cleanup in playground code

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -931,10 +931,10 @@ class Playground implements GistContainer, GistController {
     _leftConsole.showOutput(message, error: error);
     _rightConsole.showOutput(message, error: error);
 
-    // If there's no tabs visible or the console is not being displayed,
-    // increment the counter
+    // If there are no tabs visible or the console is not being displayed,
+    // increment the counter.
     if (tabExpandController == null ||
-        tabExpandController?.state != TabState.console) {
+        tabExpandController.state != TabState.console) {
       unreadConsoleCounter.increment();
     }
   }
@@ -962,39 +962,43 @@ class Playground implements GistContainer, GistController {
 
     _layout = layout;
 
-    if (layout == Layout.dart) {
-      _frame.hidden = true;
-      editorPanelFooter.setAttr('hidden');
-      _disposeOutputPanelTabs();
-      _rightDocPanel.attributes.remove('hidden');
-      _rightConsoleElement.attributes.remove('hidden');
-      webTabBar.setAttr('hidden');
-      webLayoutTabController.selectTab('dart');
-      _initRightSplitter();
-      editorPanelHeader.setAttr('hidden');
-      webOutputLabel.setAttr('hidden');
-    } else if (layout == Layout.html) {
-      _disposeRightSplitter();
-      _frame.hidden = false;
-      editorPanelFooter.clearAttr('hidden');
-      _initOutputPanelTabs();
-      _rightDocPanel.setAttribute('hidden', '');
-      _rightConsoleElement.setAttribute('hidden', '');
-      webTabBar.toggleAttr('hidden', false);
-      webLayoutTabController.selectTab('dart');
-      editorPanelHeader.clearAttr('hidden');
-      webOutputLabel.setAttr('hidden');
-    } else if (layout == Layout.flutter) {
-      _disposeRightSplitter();
-      _frame.hidden = false;
-      editorPanelFooter.clearAttr('hidden');
-      _initOutputPanelTabs();
-      _rightDocPanel.setAttribute('hidden', '');
-      _rightConsoleElement.setAttribute('hidden', '');
-      webTabBar.setAttr('hidden');
-      webLayoutTabController.selectTab('dart');
-      editorPanelHeader.setAttr('hidden');
-      webOutputLabel.clearAttr('hidden');
+    switch (layout) {
+      case Layout.dart:
+        _frame.hidden = true;
+        editorPanelFooter.setAttr('hidden');
+        _disposeOutputPanelTabs();
+        _rightDocPanel.attributes.remove('hidden');
+        _rightConsoleElement.attributes.remove('hidden');
+        webTabBar.setAttr('hidden');
+        webLayoutTabController.selectTab('dart');
+        _initRightSplitter();
+        editorPanelHeader.setAttr('hidden');
+        webOutputLabel.setAttr('hidden');
+        break;
+      case Layout.html:
+        _disposeRightSplitter();
+        _frame.hidden = false;
+        editorPanelFooter.clearAttr('hidden');
+        _initOutputPanelTabs();
+        _rightDocPanel.setAttribute('hidden', '');
+        _rightConsoleElement.setAttribute('hidden', '');
+        webTabBar.toggleAttr('hidden', false);
+        webLayoutTabController.selectTab('dart');
+        editorPanelHeader.clearAttr('hidden');
+        webOutputLabel.setAttr('hidden');
+        break;
+      case Layout.flutter:
+        _disposeRightSplitter();
+        _frame.hidden = false;
+        editorPanelFooter.clearAttr('hidden');
+        _initOutputPanelTabs();
+        _rightDocPanel.setAttribute('hidden', '');
+        _rightConsoleElement.setAttribute('hidden', '');
+        webTabBar.setAttr('hidden');
+        webLayoutTabController.selectTab('dart');
+        editorPanelHeader.setAttr('hidden');
+        webOutputLabel.clearAttr('hidden');
+        break;
     }
   }
 


### PR DESCRIPTION
* Using a switch over enum cases allows static analysis checks to make sure we don't miss anything.
* Minor comment grammar.

Just a few things while reading playground.dart. I really like how this file is laid out. It's long but every piece of functionality is relatively isolated in its own short method.