### PR TITLE
List web/third_party as a static directory in app.yaml

### DIFF
--- a/web/app.yaml
+++ b/web/app.yaml
@@ -47,6 +47,9 @@ handlers:
   - url: /packages/mdc_web
     static_dir: packages/mdc_web
 
+  - url: /third_party
+    static_dir: third_party
+
   - url: .*
     script: auto
 


### PR DESCRIPTION
This makes sure the `hljs` files are hosted for the Workshop UI (https://github.com/dart-lang/dart-pad/pull/1829)