### PR TITLE
Update pedantic, disable unsafe_html, and sort directives

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,6 +18,7 @@ linter:
 
     # Extra enabled rules
     camel_case_types: true
+    directives_ordering: true
     file_names: true
     hash_and_equals: true
     iterable_contains_unrelated_type: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:pedantic/analysis_options.1.11.0.yaml
 
 analyzer:
   strong-mode:
@@ -13,44 +13,44 @@ analyzer:
     - 'web/example/codelabs/**'
 linter:
   rules:
-    - await_only_futures
-    - camel_case_types
-    - file_names
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - non_constant_identifier_names
-    - package_prefixed_library_names
-    - prefer_typing_uninitialized_variables
-    - provide_deprecation_message
-    - unawaited_futures
-    - unnecessary_overrides
-    - unrelated_type_equality_checks
-    - valid_regexps
-    - void_checks
-    - avoid_function_literals_in_foreach_calls
-    - avoid_private_typedef_functions
-    - avoid_renaming_method_parameters
-    - avoid_returning_null_for_void
-    - avoid_single_cascade_in_expression_statements
-    - constant_identifier_names
-    - control_flow_in_finally
-    - empty_constructor_bodies
-    - empty_statements
-    - exhaustive_cases
-    - implementation_imports
-    - overridden_fields
-    - package_names
-    - prefer_function_declarations_over_variables
-    - prefer_initializing_formals
-    - prefer_inlined_adds
-    - prefer_is_not_operator
-    - prefer_mixin
-    - prefer_null_aware_operators
-    - prefer_void_to_null
-    - slash_for_doc_comments
-    - type_init_formals
-    - unnecessary_brace_in_string_interps
-    - unnecessary_getters_setters
-    - unnecessary_string_escapes
-    - unnecessary_string_interpolations
+    # Disabled as we really on quite a few uses of these currently
+    unsafe_html: false
+
+    # Extra enabled rules
+    camel_case_types: true
+    file_names: true
+    hash_and_equals: true
+    iterable_contains_unrelated_type: true
+    list_remove_unrelated_type: true
+    non_constant_identifier_names: true
+    package_prefixed_library_names: true
+    prefer_typing_uninitialized_variables: true
+    provide_deprecation_message: true
+    unawaited_futures: true
+    unnecessary_overrides: true
+    unrelated_type_equality_checks: true
+    valid_regexps: true
+    void_checks: true
+    avoid_function_literals_in_foreach_calls: true
+    avoid_private_typedef_functions: true
+    avoid_renaming_method_parameters: true
+    avoid_returning_null_for_void: true
+    avoid_single_cascade_in_expression_statements: true
+    constant_identifier_names: true
+    control_flow_in_finally: true
+    empty_constructor_bodies: true
+    empty_statements: true
+    exhaustive_cases: true
+    implementation_imports: true
+    overridden_fields: true
+    package_names: true
+    prefer_function_declarations_over_variables: true
+    prefer_initializing_formals: true
+    prefer_is_not_operator: true
+    prefer_mixin: true
+    prefer_null_aware_operators: true
+    prefer_void_to_null: true
+    slash_for_doc_comments: true
+    type_init_formals: true
+    unnecessary_string_escapes: true
+    unnecessary_string_interpolations: true

--- a/lib/codelab.dart
+++ b/lib/codelab.dart
@@ -25,6 +25,7 @@ import 'elements/counter.dart';
 import 'elements/dialog.dart';
 import 'elements/elements.dart';
 import 'elements/material_tab_controller.dart';
+import 'hljs.dart' as hljs;
 import 'modules/codemirror_module.dart';
 import 'modules/dart_pad_module.dart';
 import 'modules/dartservices_module.dart';
@@ -33,7 +34,6 @@ import 'services/dartservices.dart';
 import 'services/execution.dart';
 import 'services/execution_iframe.dart';
 import 'src/ga.dart';
-import 'hljs.dart' as hljs;
 import 'util/keymap.dart';
 
 CodelabUi _codelabUi;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   git: ^2.0.0
   grinder: ^0.8.0
   json_serializable: ^3.5.0
-  pedantic: ^1.9.0
+  pedantic: ^1.11.0
   shelf: ^0.7.5
   shelf_static: ^0.2.8
   test: ^1.15.7

--- a/test/inject/inject_embed_test.dart
+++ b/test/inject/inject_embed_test.dart
@@ -5,8 +5,8 @@
 @TestOn('browser')
 import 'dart:html';
 
-import 'package:test/test.dart';
 import 'package:dart_pad/inject/inject_embed.dart' as inject_embed;
+import 'package:test/test.dart';
 
 // todo (ryjohn): determine how to load embed-flutter.html and other assets.
 //

--- a/test/sharing/gist_loader_test.dart
+++ b/test/sharing/gist_loader_test.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
 import 'package:dart_pad/sharing/gists.dart';
-import 'package:test/test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:test/test.dart';
 
 void main() => defineTests();
 

--- a/test/sharing/gists_test.dart
+++ b/test/sharing/gists_test.dart
@@ -5,8 +5,8 @@
 @TestOn('browser')
 library dart_pad.gists_test;
 
-import 'package:dart_pad/sharing/gists.dart';
 import 'package:dart_pad/sharing/gist_storage.dart';
+import 'package:dart_pad/sharing/gists.dart';
 import 'package:test/test.dart';
 
 void main() => defineTests();


### PR DESCRIPTION
Would be good to eventually not ignore `unsafe_html` or only ignore on an individual basis, but we use affected calls around our iFrame handling and similar quite a lot.

To disable it, had to switch to a map listing of the rules. I also removed duplicate rules that now exist in the newer versions of pedantic.

I also enabled `directives_ordering` and fixed the few cases of it triggering.