### PR TITLE
Fix typo in main.py

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
 # Files that the server is allowed to serve. Additional static files are
 # served via directives in app.yaml.
 VALID_FILES = [
-    'workshop.html',
+    'workshops.html',
     'dark_mode.js',
     'dart-192.png',
     'embed-dart.html',


### PR DESCRIPTION
I think this could have been caught by running `grind serve-local-app-engine` but I don't typically do that...