### PR TITLE
Fix workshops UI title

### DIFF
--- a/lib/workshops/src/fetcher_impl.dart
+++ b/lib/workshops/src/fetcher_impl.dart
@@ -12,7 +12,7 @@ abstract class WorkshopFetcherImpl implements WorkshopFetcher {
   Future<Workshop> fetch() async {
     var metadata = await fetchMeta();
     var steps = await fetchSteps(metadata);
-    return Workshop('Example workshop', metadata.type, steps);
+    return Workshop(metadata.name, metadata.type, steps);
   }
 
   Future<Meta> fetchMeta() async {

--- a/web/example/workshops/dart/meta.yaml
+++ b/web/example/workshops/dart/meta.yaml
@@ -1,4 +1,4 @@
-name: Example codelab
+name: Example workshop
 type: dart
 steps:
   - name: Step 1


### PR DESCRIPTION
The string 'Example workshop' was being used instead of the metadata field.