### PR TITLE
Share performAnalysis method

### DIFF
--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -5,10 +5,10 @@
 library dartpad.completion;
 
 import 'dart:convert' show jsonDecode;
+import 'package:async/async.dart';
 
 import 'editing/editor.dart';
 import 'services/dartservices.dart' as ds;
-import 'src/util.dart';
 
 // TODO: For CodeMirror, we get a request each time the user hits a key when the
 // completion popup is open. We need to cache the results when appropriate.
@@ -17,7 +17,7 @@ class DartCompleter extends CodeCompleter {
   final ds.DartservicesApi servicesApi;
   final Document document;
 
-  CancellableCompleter _lastCompleter;
+  CancelableCompleter _lastCompleter;
 
   DartCompleter(this.servicesApi, this.document);
 
@@ -27,7 +27,7 @@ class DartCompleter extends CodeCompleter {
     bool onlyShowFixes = false,
   }) {
     // Cancel any open completion request.
-    if (_lastCompleter != null) _lastCompleter.cancel();
+    if (_lastCompleter != null) _lastCompleter.operation.cancel();
 
     var offset = editor.document.indexFromPos(editor.document.cursor);
 
@@ -35,7 +35,7 @@ class DartCompleter extends CodeCompleter {
       ..source = editor.document.value
       ..offset = offset;
 
-    var completer = CancellableCompleter<CompletionResult>();
+    var completer = CancelableCompleter<CompletionResult>();
     _lastCompleter = completer;
 
     if (onlyShowFixes) {
@@ -99,7 +99,7 @@ class DartCompleter extends CodeCompleter {
       });
     } else {
       servicesApi.complete(request).then((ds.CompleteResponse response) {
-        if (completer.isCancelled) return;
+        if (completer.isCanceled) return;
 
         var replaceOffset = response.replacementOffset;
         var replaceLength = response.replacementLength;
@@ -175,7 +175,7 @@ class DartCompleter extends CodeCompleter {
       });
     }
 
-    return completer.future;
+    return completer.operation.value;
   }
 }
 

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -27,7 +27,7 @@ class DartCompleter extends CodeCompleter {
     bool onlyShowFixes = false,
   }) {
     // Cancel any open completion request.
-    if (_lastCompleter != null) _lastCompleter.operation.cancel();
+    _lastCompleter?.operation?.cancel();
 
     var offset = editor.document.indexFromPos(editor.document.cursor);
 

--- a/lib/context.dart
+++ b/lib/context.dart
@@ -6,12 +6,12 @@ library context;
 
 import 'services/dartservices.dart';
 
-abstract class DartSourceProvider {
+abstract class ContextBase {
   bool get isFocused;
   String get dartSource;
 }
 
-abstract class Context implements DartSourceProvider {
+abstract class Context implements ContextBase {
   final List<AnalysisIssue> issues = [];
 
   String get focusedEditor;
@@ -29,14 +29,4 @@ abstract class Context implements DartSourceProvider {
   String get activeMode;
   Stream<String> get onModeChange;
   void switchTo(String name);
-}
-
-abstract class ContextProvider {
-  Context get context;
-}
-
-class BaseContextProvider extends ContextProvider {
-  @override
-  final Context context;
-  BaseContextProvider(this.context);
 }

--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -26,7 +26,7 @@ class DocHandler {
   };
 
   final Editor _editor;
-  final DartSourceProvider _sourceProvider;
+  final ContextBase _sourceProvider;
 
   final NodeValidator _htmlValidator = PermissiveNodeValidator();
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -14,6 +14,7 @@ import 'package:split/split.dart';
 
 import 'check_localstorage.dart';
 import 'completion.dart';
+import 'context.dart';
 import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
@@ -103,6 +104,7 @@ class Embed extends EditorUi {
   Editor htmlEditor;
   Editor cssEditor;
 
+  @override
   EmbedContext context;
 
   Splitter splitter;
@@ -1259,7 +1261,7 @@ class ConsoleExpandController extends Console {
   }
 }
 
-class EmbedContext {
+class EmbedContext implements ContextBase {
   final Editor userCodeEditor;
   final Editor htmlEditor;
   final Editor cssEditor;
@@ -1302,6 +1304,7 @@ class EmbedContext {
 
   Document get dartDocument => _dartDoc;
 
+  @override
   String get dartSource => _dartDoc.value;
 
   String get htmlSource => _htmlDoc?.value;
@@ -1346,6 +1349,9 @@ class EmbedContext {
     // TODO(DomesticMouse): implement with CodeMirror integration
     return false;
   }
+
+  @override
+  bool get isFocused => userCodeEditor.hasFocus;
 }
 
 final RegExp _flutterUrlExp =

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -30,6 +30,7 @@ import 'modules/dartservices_module.dart';
 import 'services/common.dart';
 import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
+import 'sharing/editor_ui.dart';
 import 'sharing/gists.dart';
 import 'src/util.dart';
 import 'util/keymap.dart';
@@ -55,7 +56,7 @@ class EmbedOptions {
 
 /// An embeddable DartPad UI that provides the ability to test the user's code
 /// snippet against a desired result.
-class Embed {
+class Embed extends EditorUi {
   final EmbedOptions options;
 
   var _executionButtonCount = 0;

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -39,6 +39,7 @@ import 'services/common.dart';
 import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/editor_doc_property.dart';
+import 'sharing/editor_ui.dart';
 import 'sharing/gist_file_property.dart';
 import 'sharing/gist_storage.dart';
 import 'sharing/gists.dart';
@@ -59,7 +60,7 @@ void init() {
   _playground = Playground();
 }
 
-class Playground implements GistContainer, GistController {
+class Playground extends EditorUi implements GistContainer, GistController {
   final MutableGist editableGist = MutableGist(Gist());
   GistStorage _gistStorage;
   MDCButton newButton;

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -1,0 +1,3 @@
+abstract class EditorUi {
+
+}

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -14,7 +14,7 @@ abstract class EditorUi {
   final Logger logger = Logger('dartpad');
   ContextBase get context;
 
-  Future analysisRequest;
+  Future<AnalysisResults> analysisRequest;
   DBusyLight busyLight;
   AnalysisResultsController analysisResultsController;
   Editor editor;

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -1,3 +1,5 @@
-abstract class EditorUi {
+import '../context.dart';
 
+abstract class EditorUi {
+  ContextBase get context;
 }

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -1,5 +1,3 @@
-
-
 import 'dart:async';
 
 import 'package:logging/logging.dart';
@@ -25,7 +23,7 @@ abstract class EditorUi {
     analysisResultsController.display(issues);
   }
 
-    /// Perform static analysis of the source code. Return whether the code
+  /// Perform static analysis of the source code. Return whether the code
   /// analyzed cleanly (had no errors or warnings).
   Future<bool> performAnalysis() {
     var input = SourceRequest()..source = context.dartSource;
@@ -49,7 +47,7 @@ abstract class EditorUi {
       editor.document.setAnnotations(result.issues.map((AnalysisIssue issue) {
         var startLine = lines.getLineForOffset(issue.charStart);
         var endLine =
-        lines.getLineForOffset(issue.charStart + issue.charLength);
+            lines.getLineForOffset(issue.charStart + issue.charLength);
 
         var start = Position(
             startLine, issue.charStart - lines.offsetForLine(startLine));

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -1,5 +1,88 @@
+
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
 import '../context.dart';
+import '../dart_pad.dart';
+import '../editing/editor.dart';
+import '../elements/analysis_results_controller.dart';
+import '../elements/elements.dart';
+import '../services/common.dart';
+import '../services/dartservices.dart';
 
 abstract class EditorUi {
+  final Logger logger = Logger('dartpad');
   ContextBase get context;
+
+  Future analysisRequest;
+  DBusyLight busyLight;
+  AnalysisResultsController analysisResultsController;
+  Editor editor;
+
+  void displayIssues(List<AnalysisIssue> issues) {
+    analysisResultsController.display(issues);
+  }
+
+    /// Perform static analysis of the source code. Return whether the code
+  /// analyzed cleanly (had no errors or warnings).
+  Future<bool> performAnalysis() {
+    var input = SourceRequest()..source = context.dartSource;
+
+    var lines = Lines(input.source);
+
+    var request = dartServices.analyze(input).timeout(serviceCallTimeout);
+    analysisRequest = request;
+
+    return request.then((AnalysisResults result) {
+      // Discard if we requested another analysis.
+      if (analysisRequest != request) return false;
+
+      // Discard if the document has been mutated since we requested analysis.
+      if (input.source != context.dartSource) return false;
+
+      busyLight.reset();
+
+      displayIssues(result.issues);
+
+      editor.document.setAnnotations(result.issues.map((AnalysisIssue issue) {
+        var startLine = lines.getLineForOffset(issue.charStart);
+        var endLine =
+        lines.getLineForOffset(issue.charStart + issue.charLength);
+
+        var start = Position(
+            startLine, issue.charStart - lines.offsetForLine(startLine));
+        var end = Position(
+            endLine,
+            issue.charStart +
+                issue.charLength -
+                lines.offsetForLine(startLine));
+
+        return Annotation(issue.kind, issue.message, issue.line,
+            start: start, end: end);
+      }).toList());
+
+      var hasErrors = result.issues.any((issue) => issue.kind == 'error');
+      var hasWarnings = result.issues.any((issue) => issue.kind == 'warning');
+
+      return hasErrors == false && hasWarnings == false;
+    }).catchError((e) {
+      if (e is! TimeoutException) {
+        final message = e is ApiRequestError ? e.message : '$e';
+
+        displayIssues([
+          AnalysisIssue()
+            ..kind = 'error'
+            ..line = 1
+            ..message = message
+        ]);
+      } else {
+        logger.severe(e);
+      }
+
+      editor.document.setAnnotations([]);
+      busyLight.reset();
+    });
+  }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -4,9 +4,7 @@
 
 library dart_pad.util;
 
-import 'dart:async';
 import 'dart:html';
-import 'package:meta/meta.dart';
 
 /// Return whether we are running on a mobile device.
 bool isMobile() {
@@ -45,52 +43,6 @@ We look forward to your
 Made with &lt;3 by Google.
 ''';
 
-/// Thrown when a cancellation occurs whilst waiting for a result.
-class CancellationException implements Exception {
-  final String reason;
-
-  const CancellationException(this.reason);
-
-  @override
-  String toString() {
-    var result = 'Request cancelled';
-    if (reason != null) result = '$result due to: $reason';
-    return result;
-  }
-}
-
-class CancellableCompleter<T> implements Completer {
-  final _completer = Completer<T>();
-  bool _cancelled = false;
-
-  CancellableCompleter();
-
-  @override
-  void complete([value]) {
-    if (!_cancelled) _completer.complete(value as FutureOr<T>);
-  }
-
-  @override
-  void completeError(Object error, [StackTrace stackTrace]) {
-    if (!_cancelled) _completer.completeError(error, stackTrace);
-  }
-
-  @override
-  Future<T> get future => _completer.future;
-
-  @override
-  bool get isCompleted => _completer.isCompleted;
-
-  void cancel({String reason = 'cancelled'}) {
-    if (!_cancelled) {
-      if (!isCompleted) completeError(CancellationException(reason));
-      _cancelled = true;
-    }
-  }
-
-  bool get isCancelled => _cancelled;
-}
-
 String capitalize(String s) {
   if (s == null) {
     return null;
@@ -98,67 +50,5 @@ String capitalize(String s) {
     return s.toUpperCase();
   } else {
     return '${s[0].toUpperCase()}${s.substring(1)}';
-  }
-}
-
-/// Wait [duration] time after an event to fire on the returned stream, and
-/// reset that time if a new event arrives.
-Stream<T> debounceStream<T>(Stream<T> stream, Duration duration) {
-  var controller = StreamController<T>.broadcast();
-
-  Timer timer;
-
-  stream.listen((T event) {
-    timer?.cancel();
-    timer = Timer(duration, () {
-      controller.add(event);
-    });
-  });
-
-  return controller.stream;
-}
-
-/// A typedef to represent a function taking no arguments and with no return
-/// value.
-typedef VoidFunction = void Function();
-
-/// Batch up calls to the given closure. Repeated calls to [invoke] will
-/// overwrite the closure to be called. We'll delay at least [minDelay] before
-/// calling the closure, but will not delay more than [maxDelay].
-class DelayedTimer {
-  final Duration minDelay;
-  final Duration maxDelay;
-
-  VoidFunction _closure;
-
-  Timer _minTimer;
-  Timer _maxTimer;
-
-  DelayedTimer({
-    @required this.minDelay,
-    @required this.maxDelay,
-  });
-
-  void invoke(VoidFunction closure) {
-    _closure = closure;
-
-    if (_minTimer == null) {
-      _minTimer = Timer(minDelay, _fire);
-      _maxTimer = Timer(maxDelay, _fire);
-    } else {
-      _minTimer.cancel();
-      _minTimer = Timer(minDelay, _fire);
-    }
-  }
-
-  void _fire() {
-    _minTimer?.cancel();
-    _minTimer = null;
-
-    _maxTimer?.cancel();
-    _maxTimer = null;
-
-    _closure();
-    _closure = null;
   }
 }

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -31,6 +31,7 @@ import 'modules/dartservices_module.dart';
 import 'services/common.dart';
 import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
+import 'sharing/editor_ui.dart';
 import 'src/ga.dart';
 import 'util/keymap.dart';
 import 'workshops/workshops.dart';
@@ -45,7 +46,7 @@ void init() {
   _workshopUi = WorkshopUi();
 }
 
-class WorkshopUi {
+class WorkshopUi extends EditorUi {
   WorkshopState _workshopState;
   Splitter splitter;
   Splitter rightSplitter;

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -62,7 +62,8 @@ class WorkshopUi extends EditorUi {
   Dialog dialog;
   DocHandler docHandler;
   Future _analysisRequest;
-  DartSourceProvider sourceProvider;
+  @override
+  ContextBase context;
   MDCButton formatButton;
   DBusyLight busyLight;
   AnalysisResultsController analysisResultsController;
@@ -127,8 +128,8 @@ class WorkshopUi extends EditorUi {
           ..mode = 'dart'
           ..showLineNumbers = true;
 
-    sourceProvider = WorkshopDartSourceProvider(editor);
-    docHandler = DocHandler(editor, sourceProvider);
+    context = WorkshopDartSourceProvider(editor);
+    docHandler = DocHandler(editor, context);
 
     editor.document.onChange.listen((_) => busyLight.on());
     editor.document.onChange
@@ -454,7 +455,7 @@ class WorkshopUi extends EditorUi {
   /// Perform static analysis of the source code. Return whether the code
   /// analyzed cleanly (had no errors or warnings).
   Future<bool> _performAnalysis() {
-    var input = SourceRequest()..source = sourceProvider.dartSource;
+    var input = SourceRequest()..source = context.dartSource;
 
     var lines = Lines(input.source);
 
@@ -466,7 +467,7 @@ class WorkshopUi extends EditorUi {
       if (_analysisRequest != request) return false;
 
       // Discard if the document has been mutated since we requested analysis.
-      if (input.source != sourceProvider.dartSource) return false;
+      if (input.source != context.dartSource) return false;
 
       busyLight.reset();
 
@@ -513,7 +514,7 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _format() {
-    var originalSource = sourceProvider.dartSource;
+    var originalSource = context.dartSource;
     var input = SourceRequest()..source = originalSource;
     formatButton.disabled = true;
 
@@ -624,7 +625,7 @@ class WorkshopState {
   bool get hasPreviousStep => _currentStepIndex > 0;
 }
 
-class WorkshopDartSourceProvider implements DartSourceProvider {
+class WorkshopDartSourceProvider implements ContextBase {
   final Editor editor;
 
   WorkshopDartSourceProvider(this.editor);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -574,7 +574,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "1.2.0"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   yaml: ^2.2.0
   checked_yaml: ^1.0.0
   js: ^0.6.0
-  stream_transform: any
+  stream_transform: ^1.2.0
 
 dev_dependencies:
   build_runner: any


### PR DESCRIPTION
Parent issue: https://github.com/dart-lang/dart-pad/issues/1845

This moves the `performAnalysis` methods for each editor into a new superclass, `EditorUi`. 

I also removed some classes from `util.dart`. The `CancellableCompleter` class is provided in `package:async` and the `debounceStream` function is implemented in [package:stream_transform](https://pub.dev/packages/stream_transform). 

I also removed the `DelayedTimer` class from `util.dart`, since it was only being used in the Embed class. We could re-add debouncing to the shared version of this method at some point.