### PR TITLE
Destroy the iframe between executions if null safety was toggled

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -518,6 +518,7 @@ class Embed extends EditorUi {
     }
   }
 
+  @override
   set nullSafetyEnabled(bool enabled) {
     _nullSafetyEnabled = enabled;
     _handleNullSafetySwitched(enabled);
@@ -526,6 +527,7 @@ class Embed extends EditorUi {
     nullSafetyCheckmark.toggleClass('hide', !enabled);
   }
 
+  @override
   bool get nullSafetyEnabled {
     return _nullSafetyEnabled;
   }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -102,8 +102,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
   Console _rightConsole;
   Counter unreadConsoleCounter;
 
-  bool nullSafetyEnabled;
-
   Playground() {
     _initDialogs();
     _checkLocalStorage();
@@ -891,10 +889,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
     if (enabled) {
       api.rootUrl = nullSafetyServerUrl;
       window.localStorage['null_safety'] = 'true';
+      nullSafetyEnabled = true;
       nullSafetySwitch.root.title = 'Null safety is currently enabled';
     } else {
       api.rootUrl = preNullSafetyServerUrl;
       window.localStorage['null_safety'] = 'false';
+      nullSafetyEnabled = false;
       nullSafetySwitch.root.title = 'Null safety is currently disabled';
     }
 

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -24,13 +24,17 @@ abstract class ExecutionService {
   ///
   /// [addFirebaseJs] should be `true` when the script imports any Firebase
   /// libraries. Firebase JS SDKs will then be added to the iframe.
-  Future execute(
+  ///
+  /// If [destroyFrame] is `true`, this method destroys and rebuilds the
+  /// execution frame, instead of just replacing its contents.
+  Future<void> execute(
     String html,
     String css,
     String javaScript, {
     String /*?*/ modulesBaseUrl,
     bool addRequireJs = false,
     bool addFirebaseJs = false,
+    bool destroyFrame = false,
   });
 
   void replaceHtml(String html);
@@ -39,7 +43,7 @@ abstract class ExecutionService {
 
   /// Destroy the iframe; stop any currently running scripts. The iframe will be
   /// available to be re-used again.
-  Future tearDown();
+  Future<void> tearDown();
 
   Stream<String> get onStdout;
 


### PR DESCRIPTION
Work towards https://github.com/dart-lang/dart-pad/issues/1817

* Move `nullSafetyEnabled` to EditorUi
* Add type arguments to `Future` return types for `execute`, `tearDown`
* Add `destroyIframe` parameter to `execute`