### PR TITLE
Speed up workshop UI start-up

### DIFF
--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -218,7 +218,7 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _loadWorkshop() async {
-    var fetcher = await _getFetcher();
+    var fetcher = _createWorkshopFetcher();
     _workshopState = WorkshopState(await fetcher.fetch());
   }
 
@@ -355,7 +355,7 @@ class WorkshopUi extends EditorUi {
     nextStepButton.toggleAttr('disabled', !_workshopState.hasNextStep);
   }
 
-  Future<WorkshopFetcher> _getFetcher() async {
+  WorkshopFetcher _createWorkshopFetcher() {
     var webServer = queryParams.webServer;
     if (webServer != null && webServer.isNotEmpty) {
       var uri = Uri.parse(webServer);

--- a/lib/workshops/src/fetcher_impl.dart
+++ b/lib/workshops/src/fetcher_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:checked_yaml/checked_yaml.dart';
 
 import 'fetcher.dart';
@@ -20,21 +22,43 @@ abstract class WorkshopFetcherImpl implements WorkshopFetcher {
     return checkedYamlDecode(contents, (Map m) => Meta.fromJson(m));
   }
 
-  Future<List<Step>> fetchSteps(Meta metadata) async {
-    var steps = <Step>[];
-    for (var stepConfig in metadata.steps) {
-      steps.add(await fetchStep(stepConfig));
+  Future<Iterable<Step>> fetchSteps(Meta metadata) async {
+    // The unnamed list constructor was removed in Dart 2.12, so use a map to
+    // fetch each step in parallel and place the results in the original order.
+    var map = <int, Step>{};
+    var futures = <Future>[];
+    for (var i = 0; i < metadata.steps.length; i++) {
+      var config = metadata.steps[i];
+      var future = fetchStep(config).then((step) => map[i] = step);
+      futures.add(future);
     }
-    return steps;
+    await Future.wait(futures);
+
+    // Return the fetched step objects in the same order that they appeared in
+    // the configuration metadata
+    return List<Step>.generate(metadata.steps.length, (idx) => map[idx]);
   }
 
   Future<Step> fetchStep(StepConfiguration config) async {
     var directory = config.directory;
-    var instructions = await loadFileContents([directory, 'instructions.md']);
-    var snippet = await loadFileContents([directory, 'snippet.dart']);
-    var solution = config.hasSolution
-        ? await loadFileContents([directory, 'solution.dart'])
-        : null;
+    String instructions;
+    String snippet;
+    String /*?*/ solution;
+
+    var futures = <Future>[];
+
+    futures.add(loadFileContents([directory, 'instructions.md'])
+        .then((e) => instructions = e));
+    futures.add(
+        loadFileContents([directory, 'snippet.dart']).then((e) => snippet = e));
+
+    if (config.hasSolution) {
+      futures.add(loadFileContents([directory, 'solution.dart'])
+          .then((e) => solution = e));
+    }
+
+    await Future.wait(futures);
+
     return Step(config.name, instructions, snippet, solution: solution);
   }
 }

--- a/lib/workshops/src/fetcher_impl.dart
+++ b/lib/workshops/src/fetcher_impl.dart
@@ -23,8 +23,9 @@ abstract class WorkshopFetcherImpl implements WorkshopFetcher {
   }
 
   Future<Iterable<Step>> fetchSteps(Meta metadata) async {
-    // The unnamed list constructor was removed in Dart 2.12, so use a map to
-    // fetch each step in parallel and place the results in the original order.
+    // The unnamed list constructor was removed in Dart 2.12, so use a map
+    // instead of a list to fetch each step in parallel and place the results in
+    // the original order.
     var map = <int, Step>{};
     var futures = <Future>[];
     for (var i = 0; i < metadata.steps.length; i++) {

--- a/lib/workshops/src/fetcher_impl.dart
+++ b/lib/workshops/src/fetcher_impl.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:checked_yaml/checked_yaml.dart';
 
 import 'fetcher.dart';
@@ -14,7 +12,7 @@ abstract class WorkshopFetcherImpl implements WorkshopFetcher {
   Future<Workshop> fetch() async {
     var metadata = await fetchMeta();
     var steps = await fetchSteps(metadata);
-    return Workshop(metadata.name, metadata.type, steps);
+    return Workshop(metadata.name, metadata.type, steps.toList());
   }
 
   Future<Meta> fetchMeta() async {


### PR DESCRIPTION
This speeds up the GitHub and web server WorkshopFetcher implementations by making the requests in parallel and combining the results