### PR TITLE
Move Keyboard shortcuts into superclass, EditorUI.

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -34,7 +34,6 @@ import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/editor_ui.dart';
 import 'sharing/gists.dart';
-import 'util/keymap.dart';
 import 'util/query_params.dart' show queryParams;
 
 const int defaultSplitterWidth = 6;
@@ -111,7 +110,6 @@ class Embed extends EditorUi {
   DElement featureMessage;
 
   MDCLinearProgress linearProgress;
-  Dialog dialog;
   Map<String, String> lastInjectedSourceCode = <String, String>{};
 
   bool _editorIsBusy = true;
@@ -140,7 +138,6 @@ class Embed extends EditorUi {
 
   Embed(this.options) {
     _initHostListener();
-    dialog = Dialog();
 
     if (!checkLocalStorage()) {
       dialog.showOk(
@@ -574,25 +571,7 @@ class Embed extends EditorUi {
     context.onDartDirty.listen((_) => busyLight.on());
     context.onDartReconcile.listen((_) => performAnalysis());
 
-    keys.bind(['ctrl-space', 'macctrl-space'], () {
-      if (userCodeEditor.hasFocus) {
-        userCodeEditor.showCompletions();
-      }
-    }, 'Completion');
-
-    keys.bind(['alt-enter'], () {
-      userCodeEditor.showCompletions(onlyShowFixes: true);
-    }, 'Quick fix');
-
-    keys.bind(['ctrl-enter', 'macctrl-enter'], handleRun, 'Run');
-    keys.bind(['shift-ctrl-/', 'shift-macctrl-/'], () {
-      _showKeyboardDialog();
-    }, 'Keyboard Shortcuts');
-    keys.bind(['shift-ctrl-f', 'shift-macctrl-f'], () {
-      _format();
-    }, 'Format');
-
-    document.onKeyUp.listen(_handleAutoCompletion);
+    initKeyBindings();
 
     var horizontal = true;
     var webOutput = querySelector('#web-output');
@@ -634,6 +613,26 @@ class Embed extends EditorUi {
 
     // set enabled/disabled state of various buttons
     editorIsBusy = false;
+  }
+
+  @override
+  void initKeyBindings() {
+    keys.bind(['ctrl-space', 'macctrl-space'], () {
+      if (userCodeEditor.hasFocus) {
+        userCodeEditor.showCompletions();
+      }
+    }, 'Completion');
+
+    keys.bind(['alt-enter'], () {
+      userCodeEditor.showCompletions(onlyShowFixes: true);
+    }, 'Quick fix');
+
+    keys.bind(['shift-ctrl-f', 'shift-macctrl-f'], () {
+      _format();
+    }, 'Format');
+
+    document.onKeyUp.listen(_handleAutoCompletion);
+    super.initKeyBindings();
   }
 
   Future<void> _loadAndShowGist({bool analyze = true}) async {
@@ -840,10 +839,6 @@ class Embed extends EditorUi {
     testResultBox.hide();
     hintBox.hide();
     analysisResultsController.display(issues);
-  }
-
-  void _showKeyboardDialog() {
-    dialog.showOk('Keyboard shortcuts', keyMapToHtml(keys.inverseBindings));
   }
 
   WindowBase get _hostWindow {

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -2,9 +2,12 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:dart_pad/elements/button.dart';
+import 'package:dart_pad/elements/dialog.dart';
 import 'package:dart_pad/services/execution.dart';
+import 'package:dart_pad/util/keymap.dart';
 import 'package:logging/logging.dart';
 import 'package:mdc_web/mdc_web.dart';
+import 'package:meta/meta.dart';
 
 import '../context.dart';
 import '../dart_pad.dart';
@@ -26,6 +29,9 @@ abstract class EditorUi {
   MDCButton runButton;
   ExecutionService executionService;
 
+  /// The dialog box for information like Keyboard shortcuts.
+  final Dialog dialog = Dialog();
+
   /// The source-of-truth for whether null safety is enabled.
   ///
   /// On page load, this may be originally derived from local storage.
@@ -46,6 +52,18 @@ abstract class EditorUi {
 
   void displayIssues(List<AnalysisIssue> issues) {
     analysisResultsController.display(issues);
+  }
+
+  @mustCallSuper
+  void initKeyBindings() {
+    keys.bind(['ctrl-enter', 'macctrl-enter'], handleRun, 'Run');
+    keys.bind(['shift-ctrl-/', 'shift-macctrl-/'], () {
+      showKeyboardDialog();
+    }, 'Keyboard Shortcuts');
+  }
+
+  void showKeyboardDialog() {
+    dialog.showOk('Keyboard shortcuts', keyMapToHtml(keys.inverseBindings));
   }
 
   void showSnackbar(String message) {

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -32,7 +32,6 @@ import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/editor_ui.dart';
 import 'src/ga.dart';
-import 'util/keymap.dart';
 import 'workshops/workshops.dart';
 
 WorkshopUi _workshopUi;
@@ -55,7 +54,6 @@ class WorkshopUi extends EditorUi {
   Console _console;
   MDCButton showSolutionButton;
   Counter unreadConsoleCounter;
-  Dialog dialog;
   DocHandler docHandler;
   @override
   ContextBase context;
@@ -95,14 +93,13 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _init() async {
-    _initDialogs();
     await _loadWorkshop();
     _initBusyLights();
     _initHeader();
     _updateInstructions();
     await _initModules();
     _initWorkshopUi();
-    _initKeyBindings();
+    initKeyBindings();
     _initEditor();
     _initSplitters();
     _initStepButtons();
@@ -122,10 +119,6 @@ class WorkshopUi extends EditorUi {
     modules.register(CodeMirrorModule());
 
     await modules.start();
-  }
-
-  void _initDialogs() {
-    dialog = Dialog();
   }
 
   void _initBusyLights() {
@@ -185,12 +178,11 @@ class WorkshopUi extends EditorUi {
 
     querySelector('#keyboard-button')
         .onClick
-        .listen((_) => _showKeyboardDialog());
+        .listen((_) => showKeyboardDialog());
   }
 
-  void _initKeyBindings() {
-    // set up key bindings
-    keys.bind(['ctrl-enter'], handleRun, 'Run');
+  @override
+  void initKeyBindings() {
     keys.bind(['f1'], () {
       ga.sendEvent('main', 'help');
       docHandler.generateDoc([_documentationElement]);
@@ -204,9 +196,6 @@ class WorkshopUi extends EditorUi {
       editor.showCompletions();
     }, 'Completion');
 
-    keys.bind(['shift-ctrl-/', 'shift-macctrl-/'], () {
-      _showKeyboardDialog();
-    }, 'Keyboard Shortcuts');
     keys.bind(['shift-ctrl-f', 'shift-macctrl-f'], () {
       _format();
     }, 'Format');
@@ -218,6 +207,8 @@ class WorkshopUi extends EditorUi {
       }
       _handleAutoCompletion(e);
     });
+
+    super.initKeyBindings();
   }
 
   void _handleAutoCompletion(KeyboardEvent e) {
@@ -368,10 +359,6 @@ class WorkshopUi extends EditorUi {
     }
     throw ('Invalid parameters provided. Use either "webserver" or '
         '"gh_owner", "gh_repo", "gh_ref", and "gh_path"');
-  }
-
-  void _showKeyboardDialog() {
-    dialog.showOk('Keyboard shortcuts', keyMapToHtml(keys.inverseBindings));
   }
 
   Future<void> _format() {


### PR DESCRIPTION
With this new superclass, we can move the `Dialog dialog` field, the common
key bindings, and showKeyboardDialog all up.

Each editor has some private implementation work with the remaining key bindings
(like `_format()` or `userCodeEditor` or "Save"). While these may be deduplicated in the
future, it seemed a bit much for this change.

The superclass method `initKeyBindings` is `@mustCallSuper` to ensure that the
subclasses init the common keybindings as well as their custom ones.