### PR TITLE
Fix instructions page width

### DIFF
--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -113,6 +113,10 @@ section.main-section {
     margin-left: 12px;
     margin-right: 12px;
   }
+
+  img {
+    width: 100%;
+  }
 }
 
 #step-button-container {


### PR DESCRIPTION
`<img>` elements are now 100% width so that they don't affect the width of the instructions panel.

fixes #1859