### PR TITLE
use 500px max width for instructions panel

### DIFF
--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -102,6 +102,7 @@ section.main-section {
 #steps-panel {
   @include layout-vertical();
   @include layout-center();
+  min-width: 500px;
 }
 
 #markdown-content {


### PR DESCRIPTION
Follow up to https://github.com/dart-lang/dart-pad/pull/1891
fixes #1859