### PR TITLE
remove duplicate canvaskit.js files

### DIFF
--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -5,6 +5,11 @@
  */
 
 replaceJavaScript = function (value) {
+    // Remove canvaskit from this page, This can be removed when this PR lands
+    // in dart-services:
+    // https://github.com/flutter/engine/pull/26059
+    removeCanvaskit();
+
     // Remove the old node.
     var oldNode = document.getElementById('compiledJsScript');
     if (oldNode && oldNode.parentNode) {
@@ -55,6 +60,21 @@ removeFirebase = function () {
     removeScript('firebase-app');
     removeScript('firebase-auth');
     removeScript('firestore');
+}
+
+removeCanvaskit = function () {
+    var scripts = document.head.querySelectorAll('script');
+    var existingScript;
+    for (var i = 0; i < scripts.length; i++) {
+        if (scripts[i].src.includes('canvaskit.js')) {
+            existingScript = scripts[i];
+            break;
+        }
+    }
+
+    if (existingScript != null) {
+        existingScript.parentNode.removeChild(existingScript);
+    }
 }
 
 messageHandler = function (e) {

--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -64,16 +64,12 @@ removeFirebase = function () {
 
 removeCanvaskit = function () {
     var scripts = document.head.querySelectorAll('script');
-    var existingScript;
     for (var i = 0; i < scripts.length; i++) {
-        if (scripts[i].src.includes('canvaskit.js')) {
-            existingScript = scripts[i];
-            break;
+        var script = scripts[i];
+        if (script.src.includes('canvaskit.js')) {
+            script.parentNode.removeChild(script);
+            return;
         }
-    }
-
-    if (existingScript != null) {
-        existingScript.parentNode.removeChild(existingScript);
     }
 }
 
@@ -104,5 +100,5 @@ messageHandler = function (e) {
 
 window.addEventListener('load', function () {
     window.addEventListener('message', messageHandler, false);
-    parent.postMessage({ 'sender': 'frame', 'type': 'ready' }, '*');
+    parent.postMessage({'sender': 'frame', 'type': 'ready'}, '*');
 });


### PR DESCRIPTION
This will keep DartPad's memory usage around 70mb. Without this change multiple `canvaskit.js` files remain on the page and memory can shoot up to 100MB+. 

This is a workaround for #1860 until https://github.com/flutter/engine/pull/26059 lands or we can switch to the HTML renderer in dart-services

FYI @hterkelsen 