### PR TITLE
Link to flutter docs if using Flutter

### DIFF
--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -114,7 +114,7 @@ class DocHandler {
     var hasDartdoc = info['dartdoc'] != null;
     var isVariable = kind.contains('variable');
 
-    var apiLink = libraryName == null ? '' : _dartApiLink(libraryName);
+    var apiLink = _dartApiLink(libraryName);
 
     var propagatedType = info['propagatedType'];
     var _mdDocs = '''# `${info['description']}`\n\n
@@ -133,7 +133,11 @@ $apiLink\n\n''';
     return _DocResult(_htmlDocs, kind.replaceAll(' ', '_'));
   }
 
-  String _dartApiLink(String /*!*/ libraryName) {
+  String _dartApiLink(String /*?*/ libraryName) {
+    if (libraryName == null) {
+      return '';
+    }
+
     final usingFlutter = hasFlutterContent(_sourceProvider.dartSource);
     if (libraryName.contains('dart:') || usingFlutter) {
       if (usingFlutter) {
@@ -164,6 +168,7 @@ $apiLink\n\n''';
 
       return apiLink.toString();
     }
+
     return libraryName;
   }
 }


### PR DESCRIPTION
If the user is using Flutter at all, we will instead use the Flutter API docs(https://api.flutter.dev/) which also include the `dart:` libraries. This enables linking to the pre-existing SDK libraries in addition to `dart:ui`. 

On top of that, if the library is one of those exported as `package:flutter/`, we will link to its library docs if available.

Fixes #1903