### PR TITLE
Add back external icon class implemenetation

### DIFF
--- a/web/styles/shared.scss
+++ b/web/styles/shared.scss
@@ -79,3 +79,12 @@ $doc-console-padding: 8px 24px 8px 24px;
     font-style: normal;
   }
 }
+
+.launch-icon {
+  display: inline-block;
+  background: url('../../pictures/launch.svg') center no-repeat;
+  background-size: 100%;
+  width: 12px;
+  height: 12px;
+  margin-bottom: -1px;
+}


### PR DESCRIPTION
At some point this class was removed, I've added back a modified implementation of it. 

![image](https://user-images.githubusercontent.com/18372958/119560825-0b60ac00-bd6a-11eb-8e7d-0f9d3152dd9d.png)
