### PR TITLE
Use Material Font Icons for version "info" icon and "keyboard" icon

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -223,7 +223,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => showKeyboardDialog());
-    querySelector('#dartpad-version')
+    querySelector('#dartpad-package-versions')
         .onClick
         .listen((_) => showPackageVersionsDialog());
 

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -82,13 +82,7 @@ a {
 }
 
 // Keyboard button
-.keyboard {
-  display: inline-block;
-  background: url('../../pictures/keyboard.svg') center no-repeat;
-  background-size: 100%;
-  width: 22px;
-  height: 18px;
-  margin-top: 1px;
+#keyboard-button {
   cursor: pointer;
   opacity: 0.7;
 
@@ -140,6 +134,7 @@ a {
   cursor: pointer;
 }
 
+// Issues
 .issue + .issue {
   margin-top: 4px;
 }
@@ -189,6 +184,27 @@ a {
 
 .message + .message {
   padding-top: 4px;
+}
+
+// Styles for footer items on the right
+@mixin footer-item-right {
+  margin-left: 12px;
+}
+
+// Versions
+#dartpad-version {
+  @include footer-item-right;
+}
+
+#dartpad-package-versions {
+  @include footer-item-right;
+  cursor: pointer;
+  font-size: 18px;
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+  }
 }
 
 // Keys dialog

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -179,7 +179,7 @@ class WorkshopUi extends EditorUi {
     querySelector('#keyboard-button')
         .onClick
         .listen((_) => showKeyboardDialog());
-    querySelector('#dartpad-version')
+    querySelector('#dartpad-package-versions')
         .onClick
         .listen((_) => showPackageVersionsDialog());
   }

--- a/web/index.html
+++ b/web/index.html
@@ -245,7 +245,7 @@
 </section>
 
 <footer>
-    <div id="keyboard-button" class="keyboard footer-item"></div>
+    <i id="keyboard-button" class="material-icons footer-item" aria-hidden="true">keyboard</i>
     <div class="footer-item">
         <a href="https://dart.dev/tools/dartpad/privacy"
            target="repo" class="footer-item">Privacy notice</a>
@@ -266,6 +266,7 @@
     <div id="issues-message" class="info-message"></div>
     <a id="issues-toggle" hidden></a>
     <div id="dartpad-version"></div>
+    <i id="dartpad-package-versions" class="material-icons" aria-hidden="true">info</i>
 </footer>
 
 <div class="mdc-dialog"

--- a/web/pictures/keyboard.svg
+++ b/web/pictures/keyboard.svg
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
-        "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg"
-     xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" 
-     width="24" height="24" viewBox="0 0 24 24">
-    <path fill="#fff" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"/>
-</svg>

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -96,10 +96,6 @@ body>footer {
   * {
     margin-right: 4px;
   }
-
-  #dartpad-version {
-    margin-left: 12px;
-  }
 }
 
 
@@ -288,11 +284,11 @@ a {
 }
 
 #issues-message {
+  @include footer-item-right;
   font-family: $normal-font;
   font-size: $playground-editor-font-size;
   cursor: default;
   margin-right: 0px;
-  margin-left: 12px;
 }
 
 

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -272,10 +272,6 @@ body>footer {
   * {
     margin-right: 4px;
   }
-
-  #dartpad-version {
-    margin-left: 12px;
-  }
 }
 
 // Issues

--- a/web/workshops.html
+++ b/web/workshops.html
@@ -178,7 +178,7 @@
 </section>
 
 <footer>
-    <div id="keyboard-button" class="keyboard footer-item"></div>
+    <i id="keyboard-button" class="material-icons footer-item" aria-hidden="true">keyboard</i>
     <div class="footer-item">
         <a href="https://dart.dev/tools/dartpad/privacy"
            target="repo" class="footer-item">Privacy notice</a>
@@ -189,6 +189,7 @@
     <div id="issues-message" class="info-message"></div>
     <a id="issues-toggle" hidden></a>
     <div id="dartpad-version"></div>
+    <i id="dartpad-package-versions" class="material-icons" aria-hidden="true">info</i>
 </footer>
 
 <div class="mdc-dialog"


### PR DESCRIPTION
This helps to standardize on using this icon font for icons. I moved some
styles around a bit as well.