### PR TITLE
Disable line wrapping

### DIFF
--- a/lib/editing/codemirror_options.dart
+++ b/lib/editing/codemirror_options.dart
@@ -4,7 +4,7 @@ const codeMirrorOptions = {
   'autoCloseBrackets': true,
   'matchBrackets': true,
   'tabSize': 2,
-  'lineWrapping': true,
+  'lineWrapping': false,
   'indentUnit': 2,
   'cursorHeight': 0.85,
   'viewportMargin': 100,

--- a/lib/elements/console.dart
+++ b/lib/elements/console.dart
@@ -22,7 +22,7 @@ class Console {
   /// The CSS class name to apply to error messages.
   final String errorClass;
 
-  final _bufferedOutput = <SpanElement>[];
+  final _bufferedOutput = <DivElement>[];
 
   Console(
     this.element, {
@@ -37,12 +37,12 @@ class Console {
       message = filter(message);
     }
 
-    var span = SpanElement()..text = '$message\n';
-    span.classes.add(error ? errorClass : 'normal');
+    var div = DivElement()..text = '$message\n';
+    div.classes.add(error ? errorClass : 'normal');
 
     // Buffer the console output so that heavy writing to stdout does not starve
     // the DOM thread.
-    _bufferedOutput.add(span);
+    _bufferedOutput.add(div);
     if (_bufferedOutput.length == 1) {
       Timer(bufferDuration, () {
         element.element.children.addAll(_bufferedOutput);

--- a/lib/elements/tab_expand_controller.dart
+++ b/lib/elements/tab_expand_controller.dart
@@ -4,6 +4,7 @@ import 'dart:html';
 import 'package:meta/meta.dart';
 import 'package:split/split.dart';
 
+import '../sharing/editor_ui.dart';
 import 'button.dart';
 import 'counter.dart';
 import 'elements.dart';
@@ -25,6 +26,7 @@ class TabExpandController {
   final DElement docs;
   final Counter unreadCounter;
   final DElement iframe;
+  final EditorUi editorUi;
 
   /// The element to give the top half of the split when this panel
   /// opens
@@ -52,6 +54,7 @@ class TabExpandController {
     @required this.topSplit,
     @required this.bottomSplit,
     @required this.unreadCounter,
+    @required this.editorUi,
   })  : console = DElement(consoleElement),
         docs = DElement(docsElement),
         iframe = iframeElement == null ? null : DElement(iframeElement) {
@@ -195,6 +198,9 @@ class TabExpandController {
       sizes: [70, 30],
       minSize: [100, 100],
     );
+
+    editorUi.listenForResize(topSplit);
+
     _splitterConfigured = true;
   }
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -117,6 +117,9 @@ class Embed extends EditorUi {
   bool get editorIsBusy => _editorIsBusy;
 
   @override
+  Editor get editor => userCodeEditor;
+
+  @override
   Document get currentDocument => userCodeEditor.document;
 
   /// Toggles the state of several UI components based on whether the editor is

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -386,6 +386,7 @@ class Embed extends EditorUi {
           expandIcon: querySelector('#console-expand-icon'),
           unreadCounter: unreadConsoleCounter,
           consoleElement: querySelector('#console-output-container'),
+          editorUi: this,
           onSizeChanged: () {
             userCodeEditor.resize();
             testEditor.resize();
@@ -602,6 +603,8 @@ class Embed extends EditorUi {
       // set the minimum sizes (in pixels)
       minSize: [100, 100],
     );
+
+    listenForResize(splitterElements[0]);
 
     if (gistId.isNotEmpty || sampleId.isNotEmpty || githubParamsPresent) {
       _loadAndShowGist(analyze: false);
@@ -1086,6 +1089,7 @@ class ConsoleExpandController extends Console {
   final DElement expandIcon;
   final Counter unreadCounter;
   final Function onSizeChanged;
+  final EditorUi editorUi;
   Splitter _splitter;
   bool _expanded;
 
@@ -1096,6 +1100,7 @@ class ConsoleExpandController extends Console {
     Element consoleElement,
     this.unreadCounter,
     this.onSizeChanged,
+    this.editorUi,
   })  : expandButton = DElement(expandButton),
         footer = DElement(footer),
         expandIcon = DElement(expandIcon),
@@ -1169,6 +1174,7 @@ class ConsoleExpandController extends Console {
       sizes: [60, 40],
       minSize: [32, 32],
     );
+    editorUi.listenForResize(splitterElements[0]);
   }
 }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -367,6 +367,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
       sizes: const [50, 50],
       minSize: const [100, 100],
     );
+
+    listenForResize(editorPanel);
   }
 
   void _initRightSplitter() {
@@ -383,6 +385,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
       minSize: const [100, 100],
     );
     rightSplitterConfigured = true;
+
+    listenForResize(outputHost);
   }
 
   void _disposeRightSplitter() {
@@ -408,6 +412,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       topSplit: _editorHost,
       bottomSplit: _editorPanelFooter,
       unreadCounter: unreadConsoleCounter,
+      editorUi: this,
     );
   }
 

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -276,7 +276,6 @@ a {
   }
 }
 
-// TODO (ryjohn): is this doing anything?
 .editor-tab {
   text-transform: none !important;
   letter-spacing: normal;

--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -277,6 +277,7 @@ a {
   }
 }
 
+// TODO (ryjohn): is this doing anything?
 .editor-tab {
   text-transform: none !important;
   letter-spacing: normal;

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -259,4 +259,12 @@ abstract class EditorUi {
       milliseconds,
     );
   }
+
+  /// Resize Codemirror when the size of the panel changes. This keeps the
+  /// virtual scrollbar in sync with the size of the panel.
+  void listenForResize(Element element) {
+    ResizeObserver((entries, observer) {
+      editor.resize();
+    }).observe(element);
+  }
 }

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -240,11 +240,7 @@ class WorkshopUi extends EditorUi {
       minSize: [100, 100],
     );
 
-    // Resize Codemirror when the size of the panel changes. This keeps the
-    // virtual scrollbar in sync with the size of the panel.
-    ResizeObserver((entries, observer) {
-      editor.resize();
-    }).observe(editorPanel);
+    listenForResize(editorPanel);
   }
 
   void _initHeader() {
@@ -401,6 +397,7 @@ class WorkshopUi extends EditorUi {
       topSplit: _editorPanel,
       bottomSplit: _editorPanelFooter,
       unreadCounter: unreadConsoleCounter,
+      editorUi: this,
     );
   }
 

--- a/test/embed/embed_test.html
+++ b/test/embed/embed_test.html
@@ -162,7 +162,7 @@ BSD-style license that can be found in the LICENSE file. -->
                     </button>
                 </div>
             </div>
-            <div id="console-output-container" class="custom-scrollbar" hidden></div>
+            <div id="console-output-container" class="console custom-scrollbar" hidden></div>
         </div>
     </div>
     <div id="web-output">

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -151,7 +151,7 @@ BSD-style license that can be found in the LICENSE file. -->
         <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
-        <div id="console-output-container" class="custom-scrollbar"></div>
+        <div id="console-output-container" class="console custom-scrollbar"></div>
     </div>
     <div id="web-output" hidden>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -159,7 +159,7 @@ BSD-style license that can be found in the LICENSE file. -->
                     </button>
                 </div>
             </div>
-            <div id="console-output-container" class="custom-scrollbar" hidden></div>
+            <div id="console-output-container" class="console custom-scrollbar" hidden></div>
         </div>
     </div>
     <div id="web-output">

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -183,7 +183,7 @@ BSD-style license that can be found in the LICENSE file. -->
                     </button>
                 </div>
             </div>
-            <div id="console-output-container" class="custom-scrollbar" hidden></div>
+            <div id="console-output-container" class="console custom-scrollbar" hidden></div>
         </div>
     </div>
     <div id="web-output">

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -151,7 +151,7 @@ BSD-style license that can be found in the LICENSE file. -->
         <div id="console-output-header">
             <span class="view-label">Console <span id="unread-console-counter" class="Counter" hidden></span></span>
         </div>
-        <div id="console-output-container" class="custom-scrollbar"></div>
+        <div id="console-output-container" class="console custom-scrollbar"></div>
     </div>
     <div id="web-output" hidden>
         <iframe id="frame" sandbox="allow-scripts" class="flex-auto">

--- a/web/styles/cm-dartpad-light.scss
+++ b/web/styles/cm-dartpad-light.scss
@@ -36,7 +36,7 @@
 .cm-s-dartpad span.cm-property { color: $light-red; }
 
 .CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div {
-  background: $dark-scrollbar-color;
+  background: $light-scrollbar-color;
 }
 
 .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -58,8 +58,7 @@ body {
 // Code Editor
 
 #user-code-editor, #solution-editor, #test-editor, #html-editor, #solution-editor {
-  flex: 1;
-  width: 100%;
+  @include layout-fit;
 }
 
 .CodeMirror-hints {
@@ -107,6 +106,7 @@ body {
 // Styling specifically for CodeMirror editor
 
 .CodeMirror {
+  width: 100%;
   height: 100%;
   font-family: $editor-font;
   font-size: $embed-editor-font-size;
@@ -126,6 +126,8 @@ body {
 
 .no-overflow {
   height: 100%;
+  width: 100%;
+  overflow-x: hidden;
   overflow-y: hidden;
 }
 

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -75,7 +75,6 @@ body {
   font-family: $editor-font;
   font-size: $embed-editor-font-size;
   overflow-y: auto;
-  height: 100%;
   white-space: pre-wrap;
   display: flex;
   flex-direction: column;
@@ -325,4 +324,8 @@ body {
 
 .flex-column {
   flex-direction: column !important;
+}
+
+.console .normal {
+  white-space: nowrap !important;
 }

--- a/web/styles/embed/styles_light.scss
+++ b/web/styles/embed/styles_light.scss
@@ -148,4 +148,3 @@ a {
 #console-expand-icon, .close-flash-container .close-flash-button {
   color: $light-label-color;
 }
-

--- a/web/styles/shared.scss
+++ b/web/styles/shared.scss
@@ -25,6 +25,7 @@ $doc-console-padding: 8px 24px 8px 24px;
   * {
     color: $dark-editor-text;
   }
+
   h1 {
     margin-top: 0;
     font-size: 12pt;
@@ -40,43 +41,54 @@ $doc-console-padding: 8px 24px 8px 24px;
     font-size: inherit;
     color: #cdcdcd; /* little bit brigher than normal text*/
   }
+
   p {
     margin-top: 0;
   }
+
   a {
     color: #66d9ef;
   }
+
   a:hover {
     color: #66d9ef;
     text-decoration: underline;
   }
+
   a {
     color: #66d9ef;
   }
+
   a:hover {
     color: #66d9ef;
     text-decoration: underline;
   }
+
   pre {
     overflow-x: auto;
     margin: 1em;
   }
+
   pre code {
     white-space: inherit;
     word-wrap: normal;
   }
+
   code, .parameter-hints code {
     font-family: $editor-font;
     font-size: 12pt;
     color: $dark-blue;
   }
+
   code em {
     color: $dark-orange;
     font-style: normal;
   }
+
   .parameter-hints code {
     color: $dark-orange;
   }
+
   code em {
     color: $dark-orange;
     font-style: normal;
@@ -108,7 +120,12 @@ button#run-button {
 .editor-tab {
   @include mdc-button-ink-color($button-text-color);
   color: $button-text-color;
+
   &.active {
     color: $dark-blue;
   }
+}
+
+.console .normal {
+  white-space: nowrap !important;
 }

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -137,16 +137,18 @@ a {
 
 // Editor panel
 #editor-panel {
+  @include layout-vertical;
   @include layout-relative;
 }
 
 #editor-host {
-  @include layout-fit;
+  @include layout-flex;
+  @include layout-relative;
   margin: 8px 0 0 0;
   padding: 0 8px;
 
   .CodeMirror {
-    width: 100%;
+    @include layout-fit;
     height: 100%;
     font-family: $editor-font;
     font-size: $playground-editor-font-size;

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -176,6 +176,9 @@ a {
   @include layout-vertical;
   @include layout-relative;
 
+  // Constrain the width of #console-panel
+  width: 0;
+
   iframe {
     @include layout-flex;
     border: none;
@@ -185,6 +188,8 @@ a {
 #right-output-panel {
   @include layout;
   @include layout-vertical;
+  @include layout-relative;
+
   #right-output-panel-content {
     @include layout-flex;
   }
@@ -204,7 +209,7 @@ a {
   font-size: 14px;
   line-height: 20px;
   min-height: 50px;
-  overflow-y: auto;
+  overflow: auto;
   white-space: pre-wrap;
   padding: $doc-console-padding;
 
@@ -401,6 +406,13 @@ a {
 .view-label {
   color: $dark-label-color;
 }
+
+// Scrollbars
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: $dark-scrollbar-color;
+}
+
+.custom-scrollbar::-webkit-scrollbar-corner { background: transparent; }
 
 // Misc
 .hide {

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -137,18 +137,17 @@ a {
 
 // Editor panel
 #editor-panel {
-  @include layout-vertical;
   @include layout-relative;
 }
 
 #editor-host {
-  @include layout-vertical;
-  @include layout-flex;
+  @include layout-fit;
   margin: 8px 0 0 0;
   padding: 0 8px;
 
   .CodeMirror {
-    @include layout-flex;
+    width: 100%;
+    height: 100%;
     font-family: $editor-font;
     font-size: $playground-editor-font-size;
   }

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -179,6 +179,7 @@ section.main-section {
 #editor-panel {
   @include layout-vertical;
   @include layout-relative;
+  @include layout-self-stretch;
 }
 #editor-host {
   @include layout-fit;

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -82,6 +82,9 @@ section.main-section {
 // Panels
 #right-panel {
   @include layout-vertical();
+
+  // Constrain the width of #console-panel
+  width: 0;
 }
 
 #editor-panel, #output-panel {
@@ -346,3 +349,10 @@ button#show-solution-btn {
 #editor-panel-close-button {
   @include mdc-icon-button-size(16px, 16px, 8px);
 }
+
+// Scrollbars
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background-color: $dark-scrollbar-color;
+}
+
+.custom-scrollbar::-webkit-scrollbar-corner { background: transparent; }

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -181,13 +181,13 @@ section.main-section {
   @include layout-relative;
 }
 #editor-host {
-  @include layout-vertical;
-  @include layout-flex;
+  @include layout-fit;
   margin: 8px 0 0 0;
   padding: 0 8px;
 
   .CodeMirror {
-    @include layout-flex;
+    width: 100%;
+    height: 100%;
     font-family: $editor-font;
     font-size: $playground-editor-font-size;
   }

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -179,15 +179,16 @@ section.main-section {
 #editor-panel {
   @include layout-vertical;
   @include layout-relative;
-  @include layout-self-stretch;
 }
+
 #editor-host {
-  @include layout-fit;
+  @include layout-flex;
+  @include layout-relative;
   margin: 8px 0 0 0;
   padding: 0 8px;
 
   .CodeMirror {
-    width: 100%;
+    @include layout-fit;
     height: 100%;
     font-family: $editor-font;
     font-size: $playground-editor-font-size;


### PR DESCRIPTION
This disables `lineWrapping` in the CodeMirror configuration and fixes up some layout code

Staging link: https://20210615t190904-dot-dart-pad.appspot.com/

fixes #1342