### PR TITLE
Add null check for #dartpad-package-versions query

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -221,11 +221,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
         moreMenu.open = !moreMenu.open;
       });
     querySelector('#keyboard-button')
-        .onClick
-        .listen((_) => showKeyboardDialog());
+        ?.onClick
+        ?.listen((_) => showKeyboardDialog());
     querySelector('#dartpad-package-versions')
-        .onClick
-        .listen((_) => showPackageVersionsDialog());
+        ?.onClick
+        ?.listen((_) => showPackageVersionsDialog());
 
     // Query params have higher precedence than local storage
     if (queryParams.hasNullSafety) {

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -177,11 +177,11 @@ class WorkshopUi extends EditorUi {
     updateVersions();
 
     querySelector('#keyboard-button')
-        .onClick
-        .listen((_) => showKeyboardDialog());
+        ?.onClick
+        ?.listen((_) => showKeyboardDialog());
     querySelector('#dartpad-package-versions')
-        .onClick
-        .listen((_) => showPackageVersionsDialog());
+        ?.onClick
+        ?.listen((_) => showPackageVersionsDialog());
   }
 
   @override


### PR DESCRIPTION
This is a workaround for a caching issue in AppEngine (#1683)