### PR TITLE
clear "id" query parameter when a new pad is created

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -930,6 +930,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     ga.sendEvent('main', 'new');
 
+    queryParams.gistId = '';
+
     await showNew(layout);
     showSnackbar('New pad created');
   }


### PR DESCRIPTION
This was happening because we set the current gist using the `id` query param now (https://github.com/dart-lang/dart-pad/pull/1937). If it's not cleared it will just show the same gist.