### PR TITLE
Fix text color in console

### DIFF
--- a/web/styles/embed/styles_dark.scss
+++ b/web/styles/embed/styles_dark.scss
@@ -38,7 +38,7 @@ a {
 }
 
 #console-output-container {
-  span.normal {
+  div.normal {
     color: #dddddd;
   }
 


### PR DESCRIPTION
The embedded editors were displaying black text with the dark theme.