### PR TITLE
Fix special characters not working in print

### DIFF
--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -327,5 +327,5 @@ body {
 }
 
 .console .normal {
-  white-space: nowrap !important;
+  white-space: pre !important;
 }

--- a/web/styles/shared.scss
+++ b/web/styles/shared.scss
@@ -127,7 +127,7 @@ button#run-button {
 }
 
 .console .normal {
-  white-space: nowrap !important;
+  white-space: pre !important;
 }
 
 // Small icon buttons


### PR DESCRIPTION
Using `nowrap` led to spaces being compressed and line breaks(\n) being lost.

Originally this snippet(https://dartpad.dev/?id=bfb985ef3fdde329c29ca5bacd11e449&null_safety=true):

```dart
void main() {
  print('Hello! \t My name is \\parlough\\. What is your name?Hello! \t My name is \\parlough\\. \nWhat is your name?');
  print('Hello! \t My name is \\parlough\\. What is your name?Hello! \t My name is \\parlough\\. \nWhat is your name?');
}
```

Would print this:

![Screenshot from 2021-07-24 21-01-56](https://user-images.githubusercontent.com/18372958/126885229-72fc7d31-ae7a-466a-910f-49e49abb7c85.png)

After this change:
![Screenshot from 2021-07-24 21-02-19](https://user-images.githubusercontent.com/18372958/126885234-e1708895-cef4-4432-ad50-fb97c930f630.png)


I didn't know a lot about `white-space` so I referred to this article(https://css-tricks.com/almanac/properties/w/whitespace/) for clarifications.

Fixes https://github.com/dart-lang/site-www/issues/3421

