### PR TITLE
Fix library doc link generation

### DIFF
--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -134,23 +134,33 @@ $apiLink\n\n''';
   }
 
   String _dartApiLink(String? libraryName) {
-    if (libraryName == null) {
+    if (libraryName == null ||
+        libraryName.isEmpty ||
+        libraryName == 'main.dart') {
       return '';
     }
 
     final usingFlutter = hasFlutterContent(_sourceProvider.dartSource);
-    if (libraryName.contains('dart:') || usingFlutter) {
+    final isDartLibrary = libraryName.contains('dart:');
+
+    // Only can link to library docs for dart libraries or `package:flutter`.
+    if (isDartLibrary || usingFlutter) {
       if (usingFlutter) {
         final splitFlutter = libraryName.split('/');
+
         if (splitFlutter[0] == 'package:flutter') {
-          // If this part of the path is not present, we cannot link to the
-          // documentation currently.
+          splitFlutter.removeAt(0);
+          // Find library name, either after package declaration or `src`.
+          libraryName = splitFlutter
+              .firstWhere((element) => element != 'src')
+              .replaceAll('.dart', '');
+        } else if (!isDartLibrary) {
+          // If it's not a Flutter or Dart library, return just the name.
           return libraryName;
         }
       }
 
-      final apiLink = StringBuffer();
-      apiLink.write('[Open library docs](');
+      final apiLink = StringBuffer('[Open library docs](');
 
       if (usingFlutter) {
         apiLink.write('https://api.flutter.dev/flutter');


### PR DESCRIPTION
There's a few issues this fixes:

- Fixes #1973 - Items declared in the class have a libraryName of `main.dart` and we have no documentation to link to, so just return an empty string. We don't have the necessary information on the frontend to link to parent method's library from the libraryName, so to do so would take some larger restructuring. 
- Fixes improper check on when we can return Flutter links
- Supports more types of Flutter library name's, including ones with and without `/src/`.
- Doesn't try to improperly link to pub package links such as Firebase anymore.

I recommend testing locally with complex examples like "Sunflower" and verify multiple Dart and Flutter links generate as you expect.