### PR TITLE
Make a few embed elements nullable

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -73,8 +73,8 @@ class Embed extends EditorUi {
   late final TabView editorTabView;
   late final TabView testTabView;
   late final TabView solutionTabView;
-  late final TabView htmlTabView;
-  late final TabView cssTabView;
+  TabView? htmlTabView;
+  TabView? cssTabView;
   late final DElement solutionTab;
   late final MDCMenu menu;
 
@@ -105,7 +105,7 @@ class Embed extends EditorUi {
   late final Splitter splitter;
 
   late final Console consoleExpandController;
-  late final DElement webOutputLabel;
+  DElement? webOutputLabel;
   late final DElement featureMessage;
 
   late final MDCLinearProgress linearProgress;
@@ -163,8 +163,8 @@ class Embed extends EditorUi {
           editorTabView.setSelected(name == 'editor');
           testTabView.setSelected(name == 'test');
           solutionTabView.setSelected(name == 'solution');
-          htmlTabView.setSelected(name == 'html');
-          cssTabView.setSelected(name == 'css');
+          htmlTabView?.setSelected(name == 'html');
+          cssTabView?.setSelected(name == 'css');
 
           if (name == 'editor') {
             userCodeEditor.resize();
@@ -819,7 +819,7 @@ class Embed extends EditorUi {
 
     // The iframe will show Flutter output for the rest of the lifetime of the
     // app, so hide the label.
-    webOutputLabel.setAttr('hidden');
+    webOutputLabel?.setAttr('hidden');
 
     return success;
   }


### PR DESCRIPTION
They are not present on every embed causing late initialization errors and the solution tabs to not work by switching.

We could still make them `late final` but it gets a little awkward with setting values `= null`. Let me know if you'd like me to go that direction though. There's other structures that would work better as well, but would take a larger set of refactoring.

Supersedes https://github.com/dart-lang/dart-pad/pull/1970