### PR TITLE
Make most of the fields in Playground private

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -59,44 +59,38 @@ void init() {
 }
 
 class Playground extends EditorUi implements GistContainer, GistController {
-  final MutableGist editableGist = MutableGist(Gist());
+  final MutableGist _editableGist = MutableGist(Gist());
   late GistStorage _gistStorage;
-  late MDCButton newButton;
-  late MDCButton resetButton;
-  late MDCButton formatButton;
-  late MDCButton installButton;
-  late MDCButton samplesButton;
-  late MDCButton editorConsoleTab;
-  late MDCButton editorDocsTab;
-  late MDCButton closePanelButton;
-  late MDCButton moreMenuButton;
+  late MDCButton _formatButton;
+  late MDCButton _editorConsoleTab;
+  late MDCButton _editorDocsTab;
+  late MDCButton _closePanelButton;
   late DElement editorPanelHeader;
   late DElement editorPanelFooter;
-  late MDCMenu samplesMenu;
-  late MDCMenu moreMenu;
-  late NewPadDialog newPadDialog;
-  late DElement titleElement;
-  late MaterialTabController webLayoutTabController;
-  late DElement webTabBar;
-  late DElement webOutputLabel;
-  late MDCSwitch nullSafetySwitch;
+  late MDCMenu _samplesMenu;
+  late MDCMenu _moreMenu;
+  late NewPadDialog _newPadDialog;
+  late DElement _titleElement;
+  late MaterialTabController _webLayoutTabController;
+  late DElement _webTabBar;
+  late DElement _webOutputLabel;
+  late MDCSwitch _nullSafetySwitch;
 
-  late Splitter splitter;
-  late Splitter rightSplitter;
-  bool rightSplitterConfigured = false;
-  TabExpandController? tabExpandController;
+  late Splitter _rightSplitter;
+  bool _rightSplitterConfigured = false;
+  TabExpandController? _tabExpandController;
 
   @override
   late PlaygroundContext context;
-  Layout? _layout;
+  late Layout _layout;
 
   // The last returned shared gist used to update the url.
   Gist? _overrideNextRouteGist;
-  late DocHandler docHandler;
+  late DocHandler _docHandler;
 
   late Console _leftConsole;
   late Console _rightConsole;
-  late Counter unreadConsoleCounter;
+  late Counter _unreadConsoleCounter;
 
   Playground() {
     _initDialogs();
@@ -152,7 +146,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   bool get _isCompletionActive => editor.completionActive;
 
   void _initDialogs() {
-    newPadDialog = NewPadDialog();
+    _newPadDialog = NewPadDialog();
   }
 
   void _initBusyLights() {
@@ -161,8 +155,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _initGistNameHeader() {
     // Update the title on changes.
-    titleElement = DElement(querySelector('header .header-gist-name')!);
-    bind(editableGist.property('description'), titleElement.textProperty);
+    _titleElement = DElement(querySelector('header .header-gist-name')!);
+    bind(_editableGist.property('description'), _titleElement.textProperty);
   }
 
   void _initGistStorage() {
@@ -187,38 +181,39 @@ class Playground extends EditorUi implements GistContainer, GistController {
     });
   }
 
+  static void _toggleMenu(MDCMenu menu) => menu.open = !menu.open!;
+
   void _initButtons() {
-    newButton = MDCButton(querySelector('#new-button') as ButtonElement)
-      ..onClick.listen((_) => _showCreateGistDialog());
-    resetButton = MDCButton(querySelector('#reset-button') as ButtonElement)
-      ..onClick.listen((_) => _showResetDialog());
-    formatButton = MDCButton(querySelector('#format-button') as ButtonElement)
+    MDCButton(querySelector('#new-button') as ButtonElement)
+        .onClick
+        .listen((_) => _showCreateGistDialog());
+    MDCButton(querySelector('#reset-button') as ButtonElement)
+        .onClick
+        .listen((_) => _showResetDialog());
+    _formatButton = MDCButton(querySelector('#format-button') as ButtonElement)
       ..onClick.listen((_) => _format());
-    installButton = MDCButton(querySelector('#install-button') as ButtonElement)
-      ..onClick.listen((_) => _showInstallPage());
-    samplesButton =
-        MDCButton(querySelector('#samples-dropdown-button') as ButtonElement)
-          ..onClick.listen((e) {
-            samplesMenu.open = !samplesMenu.open!;
-          });
+    MDCButton(querySelector('#install-button') as ButtonElement)
+        .onClick
+        .listen((_) => _showInstallPage());
+
+    MDCButton(querySelector('#samples-dropdown-button') as ButtonElement)
+        .onClick
+        .listen((e) => _toggleMenu(_samplesMenu));
 
     runButton = MDCButton(querySelector('#run-button') as ButtonElement)
       ..onClick.listen((_) {
         handleRun();
       });
-    editorConsoleTab =
+    _editorConsoleTab =
         MDCButton(querySelector('#editor-panel-console-tab') as ButtonElement);
-    editorDocsTab =
+    _editorDocsTab =
         MDCButton(querySelector('#editor-panel-docs-tab') as ButtonElement);
-    closePanelButton = MDCButton(
+    _closePanelButton = MDCButton(
         querySelector('#editor-panel-close-button') as ButtonElement,
         isIcon: true);
-    moreMenuButton = MDCButton(
-        querySelector('#more-menu-button') as ButtonElement,
-        isIcon: true)
-      ..onClick.listen((_) {
-        moreMenu.open = !moreMenu.open!;
-      });
+    MDCButton(querySelector('#more-menu-button') as ButtonElement, isIcon: true)
+        .onClick
+        .listen((_) => _toggleMenu(_moreMenu));
     querySelector('#keyboard-button')
         ?.onClick
         .listen((_) => showKeyboardDialog());
@@ -236,10 +231,10 @@ class Playground extends EditorUi implements GistContainer, GistController {
       nullSafetyEnabled = true;
     }
 
-    nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
+    _nullSafetySwitch = MDCSwitch(querySelector('#null-safety-switch'))
       ..checked = nullSafetyEnabled
       ..listen('change', (event) {
-        _handleNullSafetySwitched(nullSafetySwitch.checked!);
+        _handleNullSafetySwitched(_nullSafetySwitch.checked!);
       });
     _handleNullSafetySwitched(nullSafetyEnabled);
   }
@@ -247,7 +242,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   void _initLabels() {
     var webOutputLabelElement = querySelector('#web-output-label');
     if (webOutputLabelElement != null) {
-      webOutputLabel = DElement(webOutputLabelElement);
+      _webOutputLabel = DElement(webOutputLabelElement);
     }
   }
 
@@ -318,12 +313,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
       listElement.children.add(_menuElement(sample));
     }
 
-    samplesMenu = MDCMenu(element)
+    _samplesMenu = MDCMenu(element)
       ..setAnchorCorner(AnchorCorner.bottomLeft)
       ..setAnchorElement(querySelector('#samples-dropdown-button')!)
       ..hoistMenuToBody();
 
-    samplesMenu.listen('MDCMenu:selected', (e) {
+    _samplesMenu.listen('MDCMenu:selected', (e) {
       var index = (e as CustomEvent).detail['index'] as int;
       var gistId = samples.elementAt(index).gistId;
       showGist(gistId);
@@ -331,11 +326,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   void _initMoreMenu() {
-    moreMenu = MDCMenu(querySelector('#more-menu'))
+    _moreMenu = MDCMenu(querySelector('#more-menu'))
       ..setAnchorCorner(AnchorCorner.bottomLeft)
       ..setAnchorElement(querySelector('#more-menu-button')!)
       ..hoistMenuToBody();
-    moreMenu.listen('MDCMenu:selected', (e) {
+    _moreMenu.listen('MDCMenu:selected', (e) {
       var idx = (e as CustomEvent).detail['index'] as int?;
       switch (idx) {
         case 0:
@@ -356,10 +351,10 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _initSplitters() {
     var editorPanel = querySelector('#editor-panel')!;
-    var outputPanel = querySelector('#output-panel');
+    var outputPanel = querySelector('#output-panel')!;
 
-    splitter = flexSplit(
-      [editorPanel, outputPanel!],
+    flexSplit(
+      [editorPanel, outputPanel],
       horizontal: true,
       gutterSize: 6,
       sizes: const [50, 50],
@@ -370,61 +365,61 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   void _initRightSplitter() {
-    if (rightSplitterConfigured) {
+    if (_rightSplitterConfigured) {
       return;
     }
 
     var outputHost = querySelector('#right-output-panel')!;
-    rightSplitter = flexSplit(
+    _rightSplitter = flexSplit(
       [outputHost, _rightDocPanel],
       horizontal: false,
       gutterSize: 6,
       sizes: const [50, 50],
       minSize: const [100, 100],
     );
-    rightSplitterConfigured = true;
+    _rightSplitterConfigured = true;
 
     listenForResize(outputHost);
   }
 
   void _disposeRightSplitter() {
-    if (!rightSplitterConfigured) {
+    if (!_rightSplitterConfigured) {
       // The right splitter might already be destroyed.
       return;
     }
-    rightSplitter.destroy();
-    rightSplitterConfigured = false;
+    _rightSplitter.destroy();
+    _rightSplitterConfigured = false;
   }
 
   void _initOutputPanelTabs() {
-    if (tabExpandController != null) {
+    if (_tabExpandController != null) {
       return;
     }
 
-    tabExpandController = TabExpandController(
-      consoleButton: editorConsoleTab,
-      docsButton: editorDocsTab,
-      closeButton: closePanelButton,
+    _tabExpandController = TabExpandController(
+      consoleButton: _editorConsoleTab,
+      docsButton: _editorDocsTab,
+      closeButton: _closePanelButton,
       docsElement: _leftDocPanel,
       consoleElement: _leftConsoleElement,
       topSplit: _editorHost,
       bottomSplit: _editorPanelFooter,
-      unreadCounter: unreadConsoleCounter,
+      unreadCounter: _unreadConsoleCounter,
       editorUi: this,
     );
   }
 
   void _disposeOutputPanelTabs() {
-    tabExpandController?.dispose();
-    tabExpandController = null;
+    _tabExpandController?.dispose();
+    _tabExpandController = null;
   }
 
   void _initTabs() {
-    webTabBar = DElement(querySelector('#web-tab-bar')!);
-    webLayoutTabController =
-        MaterialTabController(MDCTabBar(webTabBar.element));
+    _webTabBar = DElement(querySelector('#web-tab-bar')!);
+    _webLayoutTabController =
+        MaterialTabController(MDCTabBar(_webTabBar.element));
     for (var name in ['dart', 'html', 'css']) {
-      webLayoutTabController.registerTab(
+      _webLayoutTabController.registerTab(
           TabElement(querySelector('#$name-tab')!, name: name, onSelect: () {
         ga.sendEvent('edit', name);
         context.switchTo(name);
@@ -440,7 +435,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   void _initConsoles() {
     _leftConsole = Console(DElement(_leftConsoleElement));
     _rightConsole = Console(DElement(_rightConsoleContentElement));
-    unreadConsoleCounter =
+    _unreadConsoleCounter =
         Counter(querySelector('#unread-console-counter') as SpanElement);
   }
 
@@ -480,9 +475,9 @@ class Playground extends EditorUi implements GistContainer, GistController {
     // Set up CodeMirror
     editor = (editorFactory as CodeMirrorFactory)
         .createFromElement(_editorHost, options: codeMirrorOptions)
-      ..theme = 'darkpad'
-      ..mode = 'dart'
-      ..showLineNumbers = true;
+          ..theme = 'darkpad'
+          ..mode = 'dart'
+          ..showLineNumbers = true;
 
     initKeyBindings();
 
@@ -496,19 +491,19 @@ class Playground extends EditorUi implements GistContainer, GistController {
     context.onDartReconcile.listen((_) => performAnalysis());
 
     Property htmlFile =
-        GistFileProperty(editableGist.getGistFile('index.html')!);
+        GistFileProperty(_editableGist.getGistFile('index.html')!);
     Property htmlDoc = EditorDocumentProperty(context.htmlDocument, 'html');
     bind(htmlDoc, htmlFile);
     bind(htmlFile, htmlDoc);
 
     Property cssFile =
-        GistFileProperty(editableGist.getGistFile('styles.css')!);
+        GistFileProperty(_editableGist.getGistFile('styles.css')!);
     Property cssDoc = EditorDocumentProperty(context.cssDocument, 'css');
     bind(cssDoc, cssFile);
     bind(cssFile, cssDoc);
 
     Property dartFile =
-        GistFileProperty(editableGist.getGistFile('main.dart')!);
+        GistFileProperty(_editableGist.getGistFile('main.dart')!);
     Property dartDoc = EditorDocumentProperty(context.dartDocument, 'dart');
     bind(dartDoc, dartFile);
     bind(dartFile, dartDoc);
@@ -518,12 +513,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
       // Delay to give codemirror time to process the mouse event.
       Timer.run(() {
         if (!context.cursorPositionIsWhitespace()) {
-          docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
+          _docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
         }
       });
     });
 
-    docHandler = DocHandler(editor, context);
+    _docHandler = DocHandler(editor, context);
 
     updateVersions();
 
@@ -543,7 +538,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     keys.bind(['ctrl-s'], _handleSave, 'Save', hidden: true);
     keys.bind(['f1'], () {
       ga.sendEvent('main', 'help');
-      docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
+      _docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
     }, 'Documentation');
 
     keys.bind(['alt-enter'], () {
@@ -561,7 +556,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     document.onKeyUp.listen((e) {
       if (editor.completionActive ||
           DocHandler.cursorKeys.contains(e.keyCode)) {
-        docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
+        _docHandler.generateDoc([_rightDocContentElement, _leftDocPanel]);
       }
       _handleAutoCompletion(e);
     });
@@ -602,11 +597,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     // If no gist was loaded, use a new Dart gist.
     if (loadResult == LoadGistResult.none) {
-      editableGist.setBackingGist(_createGist(layout));
+      _editableGist.setBackingGist(_createGist(layout));
 
       // Store the gist so that the same sample is loaded when the page is
       // refreshed.
-      _gistStorage.setStoredGist(editableGist.createGist());
+      _gistStorage.setStoredGist(_editableGist.createGist());
     }
 
     // Clear console output and update the layout if necessary.
@@ -648,17 +643,17 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
       var blankGist = Gist();
-      editableGist.setBackingGist(blankGist);
+      _editableGist.setBackingGist(blankGist);
 
       var storedGist = _gistStorage.getStoredGist()!;
 
       // Set the editable gist's backing gist so that the route handler can
       // detect the project type.
-      editableGist.setBackingGist(storedGist);
+      _editableGist.setBackingGist(storedGist);
 
-      editableGist.description = storedGist.description;
+      _editableGist.description = storedGist.description;
       for (var file in storedGist.files!) {
-        editableGist.getGistFile(file.name)!.content = file.content;
+        _editableGist.getGistFile(file.name)!.content = file.content;
       }
       return LoadGistResult.storage;
     }
@@ -672,7 +667,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     if (!isLegalGistId(gistId)) {
       showHome();
       return;
-    } else if (editableGist.backingGist!.id == gistId) {
+    } else if (_editableGist.backingGist!.id == gistId) {
       return;
     }
 
@@ -689,7 +684,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     // routing library to update the url properly.
     if (_overrideNextRouteGist != null &&
         _overrideNextRouteGist!.id == gistId) {
-      editableGist.setBackingGist(_overrideNextRouteGist);
+      _editableGist.setBackingGist(_overrideNextRouteGist);
       _overrideNextRouteGist = null;
       return;
     }
@@ -697,15 +692,15 @@ class Playground extends EditorUi implements GistContainer, GistController {
     _overrideNextRouteGist = null;
 
     gistLoader.loadGist(gistId).then((Gist gist) {
-      editableGist.setBackingGist(gist);
+      _editableGist.setBackingGist(gist);
 
       if (_gistStorage.hasStoredGist && _gistStorage.storedId == gistId) {
         loadedFromSaved = true;
 
         var storedGist = _gistStorage.getStoredGist()!;
-        editableGist.description = storedGist.description;
+        _editableGist.description = storedGist.description;
         for (var file in storedGist.files!) {
-          editableGist.getGistFile(file.name)!.content = file.content;
+          _editableGist.getGistFile(file.name)!.content = file.content;
         }
       }
 
@@ -731,7 +726,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   Future<bool> handleRun() async {
     var success = await super.handleRun();
     if (success) {
-      webOutputLabel.setAttr('hidden');
+      _webOutputLabel.setAttr('hidden');
     }
     return success;
   }
@@ -739,12 +734,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
   Future<void> _format() {
     var originalSource = context.dartSource;
     var input = SourceRequest()..source = originalSource;
-    formatButton.disabled = true;
+    _formatButton.disabled = true;
 
     var request = dartServices.format(input).timeout(serviceCallTimeout);
     return request.then((FormatResponse result) {
       busyLight.reset();
-      formatButton.disabled = false;
+      _formatButton.disabled = false;
 
       if (result.newString.isEmpty) {
         _logger.fine('Format returned null/empty result');
@@ -759,7 +754,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       }
     }).catchError((e) {
       busyLight.reset();
-      formatButton.disabled = false;
+      _formatButton.disabled = false;
       _logger.severe(e);
     });
   }
@@ -776,7 +771,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   void clearOutput() {
     _rightConsole.clear();
     _leftConsole.clear();
-    unreadConsoleCounter.clear();
+    _unreadConsoleCounter.clear();
   }
 
   @override
@@ -786,9 +781,9 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     // If there are no tabs visible or the console is not being displayed,
     // increment the counter.
-    if (tabExpandController == null ||
-        tabExpandController!.state != TabState.console) {
-      unreadConsoleCounter.increment();
+    if (_tabExpandController == null ||
+        _tabExpandController!.state != TabState.console) {
+      _unreadConsoleCounter.increment();
     }
   }
 
@@ -806,11 +801,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
         _disposeOutputPanelTabs();
         _rightDocPanel.attributes.remove('hidden');
         _rightConsoleElement.attributes.remove('hidden');
-        webTabBar.setAttr('hidden');
-        webLayoutTabController.selectTab('dart');
+        _webTabBar.setAttr('hidden');
+        _webLayoutTabController.selectTab('dart');
         _initRightSplitter();
         editorPanelHeader.setAttr('hidden');
-        webOutputLabel.setAttr('hidden');
+        _webOutputLabel.setAttr('hidden');
         break;
       case Layout.html:
         _disposeRightSplitter();
@@ -819,10 +814,10 @@ class Playground extends EditorUi implements GistContainer, GistController {
         _initOutputPanelTabs();
         _rightDocPanel.setAttribute('hidden', '');
         _rightConsoleElement.setAttribute('hidden', '');
-        webTabBar.toggleAttr('hidden', false);
-        webLayoutTabController.selectTab('dart');
+        _webTabBar.toggleAttr('hidden', false);
+        _webLayoutTabController.selectTab('dart');
         editorPanelHeader.clearAttr('hidden');
-        webOutputLabel.setAttr('hidden');
+        _webOutputLabel.setAttr('hidden');
         break;
       case Layout.flutter:
         _disposeRightSplitter();
@@ -831,10 +826,10 @@ class Playground extends EditorUi implements GistContainer, GistController {
         _initOutputPanelTabs();
         _rightDocPanel.setAttribute('hidden', '');
         _rightConsoleElement.setAttribute('hidden', '');
-        webTabBar.setAttr('hidden');
-        webLayoutTabController.selectTab('dart');
+        _webTabBar.setAttr('hidden');
+        _webLayoutTabController.selectTab('dart');
         editorPanelHeader.setAttr('hidden');
-        webOutputLabel.clearAttr('hidden');
+        _webOutputLabel.clearAttr('hidden');
         break;
     }
   }
@@ -846,12 +841,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
       api!.rootUrl = nullSafetyServerUrl;
       window.localStorage['null_safety'] = 'true';
       nullSafetyEnabled = true;
-      nullSafetySwitch.root.title = 'Null safety is currently enabled';
+      _nullSafetySwitch.root.title = 'Null safety is currently enabled';
     } else {
       api!.rootUrl = preNullSafetyServerUrl;
       window.localStorage['null_safety'] = 'false';
       nullSafetyEnabled = false;
-      nullSafetySwitch.root.title = 'Null safety is currently disabled';
+      _nullSafetySwitch.root.title = 'Null safety is currently disabled';
     }
 
     updateVersions();
@@ -864,7 +859,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   // GistContainer interface
   @override
-  MutableGist get mutableGist => editableGist;
+  MutableGist get mutableGist => _editableGist;
 
   @override
   void overrideNextRoute(Gist gist) {
@@ -875,7 +870,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     var result = await dialog.showOkCancel(
         'Create New Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
-      final layout = await newPadDialog.show();
+      final layout = await _newPadDialog.show();
       if (layout == null) return;
       await createGistForLayout(layout);
     }
@@ -938,7 +933,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _resetGists() {
     _gistStorage.clearStoredGist();
-    editableGist.reset();
+    _editableGist.reset();
     // Delay to give time for the model change event to propagate through
     // to the editor component (which is where `_performAnalysis()` pulls
     // the Dart source from).

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -475,9 +475,9 @@ class Playground extends EditorUi implements GistContainer, GistController {
     // Set up CodeMirror
     editor = (editorFactory as CodeMirrorFactory)
         .createFromElement(_editorHost, options: codeMirrorOptions)
-          ..theme = 'darkpad'
-          ..mode = 'dart'
-          ..showLineNumbers = true;
+      ..theme = 'darkpad'
+      ..mode = 'dart'
+      ..showLineNumbers = true;
 
     initKeyBindings();
 


### PR DESCRIPTION
One immediate benefit of making fields private is that analyzer's unused_field analysis triggers, detecting a few unused fields. These are generally buttons which need a listener, but the MDCButton object does not need to be long-lived.

I also make a few nullable fields late instead of nullable. Just tidying post-null safety migration.