### PR TITLE
Initialize most Playground fields at declaration

### DIFF
--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -7,7 +7,6 @@ import 'dart:html';
 
 import 'package:dart_pad/elements/button.dart';
 import 'package:dart_pad/elements/elements.dart';
-import 'package:dart_pad/playground.dart';
 import 'package:dart_pad/services/dartservices.dart';
 import 'package:mdc_web/mdc_web.dart';
 
@@ -25,6 +24,7 @@ class AnalysisResultsController {
   final DElement flash;
   final DElement message;
   final DElement toggle;
+  final MDCSnackbar snackbar;
   late bool _flashHidden;
 
   final StreamController<Location> _onClickController =
@@ -32,7 +32,8 @@ class AnalysisResultsController {
 
   Stream<Location> get onItemClicked => _onClickController.stream;
 
-  AnalysisResultsController(this.flash, this.message, this.toggle) {
+  AnalysisResultsController(
+      this.flash, this.message, this.toggle, this.snackbar) {
     // Show issues by default, but hide the flash element (otherwise an empty
     // flash container will be shown). display() will un-hide the element when
     // there are issues to display.
@@ -125,12 +126,13 @@ class AnalysisResultsController {
       ..toggleClass('mdc-button-small', true)
       ..toggleClass('material-icons', true);
 
-    copyButton.onClick.listen((event) {
-      window.navigator.clipboard
-          ?.writeText(message)
-          .then((_) =>
-              {playground?.showSnackbar('Copied to clipboard successfully!')})
-          .catchError((_) => {playground?.showSnackbar('Failed to copy')});
+    copyButton.onClick.listen((event) async {
+      try {
+        await window.navigator.clipboard?.writeText(message);
+        snackbar.showMessage('Copied to clipboard successfully!');
+      } catch (_) {
+        snackbar.showMessage('Failed to copy');
+      }
     });
 
     elem.children.add(copyButton.element);

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -199,3 +199,10 @@ class Location {
     required this.charLength,
   });
 }
+
+extension SnackbarExtension on MDCSnackbar {
+  void showMessage(String message) {
+    labelText = message;
+    open();
+  }
+}

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -350,11 +350,10 @@ class Embed extends EditorUi {
       cssTabView = TabView(DElement(querySelector('#css-view')!));
     }
 
-    executionService =
-        ExecutionServiceIFrame(querySelector('#frame') as IFrameElement)
-          ..frameSrc = isDarkMode
-              ? '../scripts/frame_dark.html'
-              : '../scripts/frame.html';
+    executionService = ExecutionServiceIFrame(
+        querySelector('#frame') as IFrameElement)
+      ..frameSrc =
+          isDarkMode ? '../scripts/frame_dark.html' : '../scripts/frame.html';
 
     executionService.onStderr.listen((err) {
       consoleExpandController.showOutput(err, error: true);

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -350,10 +350,11 @@ class Embed extends EditorUi {
       cssTabView = TabView(DElement(querySelector('#css-view')!));
     }
 
-    executionService = ExecutionServiceIFrame(
-        querySelector('#frame') as IFrameElement)
-      ..frameSrc =
-          isDarkMode ? '../scripts/frame_dark.html' : '../scripts/frame.html';
+    executionService =
+        ExecutionServiceIFrame(querySelector('#frame') as IFrameElement)
+          ..frameSrc = isDarkMode
+              ? '../scripts/frame_dark.html'
+              : '../scripts/frame.html';
 
     executionService.onStderr.listen((err) {
       consoleExpandController.showOutput(err, error: true);
@@ -377,10 +378,11 @@ class Embed extends EditorUi {
     });
 
     analysisResultsController = AnalysisResultsController(
-        DElement(querySelector('#issues')!),
-        DElement(querySelector('#issues-message')!),
-        DElement(querySelector('#issues-toggle')!))
-      ..onItemClicked.listen((item) {
+      DElement(querySelector('#issues')!),
+      DElement(querySelector('#issues-message')!),
+      DElement(querySelector('#issues-toggle')!),
+      snackbar,
+    )..onItemClicked.listen((item) {
         _jumpTo(item.line, item.charStart, item.charLength, focus: true);
       });
 

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -92,17 +92,14 @@ abstract class EditorUi {
         treeSanitizer: NodeTreeSanitizer.trusted);
 
     var div = DivElement()
-      ..children.add(DivElement()
-        ..children.add(dl)
-        ..classes.add('keys-dialog'));
+      ..children
+          .add(DivElement()..children.add(dl)..classes.add('keys-dialog'));
     dialog.showOk('Pub package versions', div.innerHtml);
   }
 
-  void showSnackbar(String message) {
-    var div = querySelector('.mdc-snackbar')!;
-    var snackbar = MDCSnackbar(div)..labelText = message;
-    snackbar.open();
-  }
+  void showSnackbar(String message) => snackbar.showMessage(message);
+
+  MDCSnackbar get snackbar => MDCSnackbar(querySelector('.mdc-snackbar')!);
 
   Document get currentDocument => editor.document;
 

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -92,8 +92,9 @@ abstract class EditorUi {
         treeSanitizer: NodeTreeSanitizer.trusted);
 
     var div = DivElement()
-      ..children
-          .add(DivElement()..children.add(dl)..classes.add('keys-dialog'));
+      ..children.add(DivElement()
+        ..children.add(dl)
+        ..classes.add('keys-dialog'));
     dialog.showOk('Pub package versions', div.innerHtml);
   }
 

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -129,9 +129,9 @@ class WorkshopUi extends EditorUi {
     // Set up CodeMirror
     editor = (editorFactory as CodeMirrorFactory)
         .createFromElement(_editorHost, options: codeMirrorOptions)
-          ..theme = 'darkpad'
-          ..mode = 'dart'
-          ..showLineNumbers = true;
+      ..theme = 'darkpad'
+      ..mode = 'dart'
+      ..showLineNumbers = true;
 
     context = WorkshopDartSourceProvider(editor);
     docHandler = DocHandler(editor, context);

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -129,9 +129,9 @@ class WorkshopUi extends EditorUi {
     // Set up CodeMirror
     editor = (editorFactory as CodeMirrorFactory)
         .createFromElement(_editorHost, options: codeMirrorOptions)
-      ..theme = 'darkpad'
-      ..mode = 'dart'
-      ..showLineNumbers = true;
+          ..theme = 'darkpad'
+          ..mode = 'dart'
+          ..showLineNumbers = true;
 
     context = WorkshopDartSourceProvider(editor);
     docHandler = DocHandler(editor, context);
@@ -167,10 +167,11 @@ class WorkshopUi extends EditorUi {
     (deps[DartservicesApi] as DartservicesApi).rootUrl = nullSafetyServerUrl;
 
     analysisResultsController = AnalysisResultsController(
-        DElement(querySelector('#issues')!),
-        DElement(querySelector('#issues-message')!),
-        DElement(querySelector('#issues-toggle')!))
-      ..onItemClicked.listen((item) {
+      DElement(querySelector('#issues')!),
+      DElement(querySelector('#issues-message')!),
+      DElement(querySelector('#issues-toggle')!),
+      snackbar,
+    )..onItemClicked.listen((item) {
         _jumpTo(item.line, item.charStart, item.charLength, focus: true);
       });
 

--- a/web/scripts/playground.dart
+++ b/web/scripts/playground.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dart_pad/playground.dart' as playground;
+import 'package:dart_pad/playground.dart';
 import 'package:logging/logging.dart';
 
-void main() {
+void main() async {
   Logger.root.onRecord.listen(print);
 
-  playground.init();
+  await Playground.initialize();
 }


### PR DESCRIPTION
* The only reference to `playground.dart`'s top-level `playground` was in AnalysisResultsController. I've refactored the snackbar to remove that singular usage.
* `playground.dart`'s top-level `init` function is replaced by a static function on `Playground`.
* Change Future.then to async/await with try/catch.
* Initialize simple fields with a simple initializer and make the field `final`.
* Initialize complex fields with a function and make the field `late final`. In this way, the function is allowed to be an instance function.