### PR TITLE
Make _layout nullable to fix late initialization error

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -83,7 +83,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   @override
   late PlaygroundContext context;
-  late Layout _layout;
+  Layout? _layout;
 
   // The last returned shared gist used to update the url.
   Gist? _overrideNextRouteGist;


### PR DESCRIPTION
Making this field nullable gives it a null type until the first call to _changeLayout() occurs. This is important because _changeLayout accesses the field for an equality check, which results in a late initialization error.