### PR TITLE
Share mdc-button-small styles between all editors

### DIFF
--- a/lib/scss/material_shared.scss
+++ b/lib/scss/material_shared.scss
@@ -1,0 +1,16 @@
+// Styles shared between all editors that use material components mixins.
+//
+// This file must be imported after material-components-web to avoid overwriting
+// the color theme. For example:
+//
+// @import "package:mdc_web/material-components-web";
+// @import 'package:dart_pad/scss/material_shared';
+
+@import "package:mdc_web/material-components-web";
+
+// Small icon buttons
+.mdc-button-small {
+  @include mdc-icon-button-size(14px);
+  font-size: 14px !important;
+  margin: -2px 0 0 12px
+}

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -8,6 +8,7 @@
 @import 'package:dart_pad/scss/variables';
 
 @import "package:mdc_web/material-components-web";
+@import 'package:dart_pad/scss/material_shared';
 
 * {
   box-sizing: border-box;

--- a/web/styles/shared.scss
+++ b/web/styles/shared.scss
@@ -1,10 +1,15 @@
-@import 'package:mdc_web/material-components-web';
+// This file contains styles shared between the Workshop UI (workshops.html) and
+// the Playground UI (index.html).
+//
+// Styles shared between all editors are located in
+// package:dart_pad/scss/shared.scss
 
+@import 'package:mdc_web/material-components-web';
 @import 'package:dart_pad/scss/colors';
 @import 'package:dart_pad/scss/layout';
 @import 'package:dart_pad/scss/shared';
 @import 'package:dart_pad/scss/variables';
-
+@import 'package:dart_pad/scss/material_shared';
 
 // Layout constants
 $doc-console-padding: 8px 24px 8px 24px;
@@ -128,11 +133,4 @@ button#run-button {
 
 .console .normal {
   white-space: pre !important;
-}
-
-// Small icon buttons
-.mdc-button-small {
-  @include mdc-icon-button-size(14px);
-  font-size: 14px !important;
-  margin: -2px 0 0 12px
 }


### PR DESCRIPTION
I created a new SCSS file that can be used for shared styles that depend on the styles in `package:mdc_web/material-components-web`. They can't be part of `shared.scss` since that is expected to be imported *before* material-components-web.  I added some comments to explain. 

Before and after:

<img width="897" alt="Screen Shot 2021-08-24 at 4 00 20 PM" src="https://user-images.githubusercontent.com/1145719/130701328-e332dd2d-d4a6-466e-a4bb-c3f67a67be31.png">
<img width="897" alt="Screen Shot 2021-08-24 at 4 02 26 PM" src="https://user-images.githubusercontent.com/1145719/130701342-fc763491-a0e0-4d9e-912b-95820d84dd83.png">


