### PR TITLE
Prepare playground and dartservices for Channel Switcher

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -18,6 +18,10 @@ targets:
           - --fast-startup
           - -DPRE_NULL_SAFETY_SERVER_URL=https://v1.api.dartpad.dev/
           - -DNULL_SAFETY_SERVER_URL=https://nullsafety.api.dartpad.dev/
+          - -DSTABLE_SERVER_URL=https://v1.api.dartpad.dev/
+          - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
+          - -DDEV_SERVER_URL=https://dev.api.dartpad.dev/
+          - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
 
       json_serializable:
         # Ignore workshop samples.
@@ -31,3 +35,7 @@ global_options:
       environment:
         PRE_NULL_SAFETY_SERVER_URL: https://v1.api.dartpad.dev/
         NULL_SAFETY_SERVER_URL: https://nullsafety.api.dartpad.dev/
+        STABLE_SERVER_URL: https://nullsafety.api.dartpad.dev/
+        BETA_SERVER_URL: https://beta.api.dartpad.dev/
+        DEV_SERVER_URL: https://dev.api.dartpad.dev/
+        OLD_SERVER_URL: https://old.api.dartpad.dev/

--- a/lib/dart_pad.dart
+++ b/lib/dart_pad.dart
@@ -4,6 +4,8 @@
 
 library dart_pad;
 
+import 'package:http/browser_client.dart';
+
 import 'context.dart';
 import 'core/dependencies.dart';
 import 'core/keys.dart';
@@ -26,3 +28,5 @@ GistLoader get gistLoader => deps[GistLoader] as GistLoader;
 Keys get keys => deps[Keys] as Keys;
 
 State get state => deps[State] as State;
+
+BrowserClient get browserClient => deps[BrowserClient] as BrowserClient;

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -61,6 +61,7 @@ class DartServicesModule extends Module {
   @override
   Future init() {
     var client = SanitizingBrowserClient();
+    deps[BrowserClient] = client;
     deps[DartservicesApi] =
         DartservicesApi(client, rootUrl: preNullSafetyServerUrl);
     return Future.value();

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -2,13 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// Common constants.
+///
+/// The `*EnvironmentVar` constants specify environment variable names, which
+/// are typically specified in `dart2js_args` passed via a build_runner option.
+/// The `grind build` task specifies each of these options.
 library dart_pad.common;
 
 /// The environment variable name which specifies the URL of the pre-null safety
 /// back-end server.
-///
-/// This typically is specified in `dart2js_args` passed via a build_runner
-/// option. The `grind build` task specifies this option.
 const preNullSafetyServerUrlEnvironmentVar = 'PRE_NULL_SAFETY_SERVER_URL';
 
 /// The URL of the pre-null safety back-end server.
@@ -17,20 +19,39 @@ const preNullSafetyServerUrl =
 
 /// The environment variable name which specifies the URL of the null safety
 /// back-end server.
-///
-/// This typically is specified in `dart2js_args` passed via a build_runner
-/// option. The `grind build` task specifies this option.
 const nullSafetyServerUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';
 
 /// The URL of the null safety back-end server.
 const nullSafetyServerUrl =
     String.fromEnvironment(nullSafetyServerUrlEnvironmentVar);
 
-// Alternate versions for development purposes
-// const serverUrl = 'https://old.api.dartpad.dev/';
-// const serverUrl = 'https://stable.api.dartpad.dev/';
-// const serverUrl = 'https://beta.api.dartpad.dev/';
-// const serverUrl = 'https://dev.api.dartpad.dev/';
+/// The environment variable name which specifies the URL of the back-end
+/// server serving "Flutter stable".
+const stableServerUrlEnvironmentVar = 'STABLE_SERVER_URL';
+
+/// The URL of the "Flutter stable" back-end server.
+const stableServerUrl = String.fromEnvironment(stableServerUrlEnvironmentVar);
+
+/// The environment variable name which specifies the URL of the back-end
+/// server serving "Flutter beta".
+const betaServerUrlEnvironmentVar = 'BETA_SERVER_URL';
+
+/// The URL of the "Flutter beta" back-end server.
+const betaServerUrl = String.fromEnvironment(betaServerUrlEnvironmentVar);
+
+/// The environment variable name which specifies the URL of the back-end
+/// server serving "Flutter dev".
+const devServerUrlEnvironmentVar = 'DEV_SERVER_URL';
+
+/// The URL of the "Flutter dev" back-end server.
+const devServerUrl = String.fromEnvironment(devServerUrlEnvironmentVar);
+
+/// The environment variable name which specifies the URL of the back-end
+/// server serving "Flutter old" (stable -1).
+const oldServerUrlEnvironmentVar = 'OLD_SERVER_URL';
+
+/// The URL of the "Flutter old" back-end server.
+const oldServerUrl = String.fromEnvironment(oldServerUrlEnvironmentVar);
 
 const Duration serviceCallTimeout = Duration(seconds: 10);
 const Duration longServiceCallTimeout = Duration(seconds: 60);


### PR DESCRIPTION
All features here are non-breaking; some Channel concepts are introduced, but UI is not altered. https://github.com/dart-lang/dart-pad/issues/774

* STABLE|BETA|DEV|OLD_SERVER_URL variables added to common.dart and build.yaml. STABLE is the same as nullsafety, but the duplication is minor and will make the transition clearer.
* Add BrowserClient to the dependency modules. I really don't understand the dependency modules, wrt use of Zones, etc. But adding this means we keep just one for poking each of the `/version` endpoints.
* Refactor the Samples button and menu a bit, to simplify and align with upcoming Channels button and menu.
* Add a Channel class with an async static method to construct, which pings a given `/version` endpoint and returns a Channel with version info.