### PR TITLE
Enable channel switch on non-stable URLs

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -260,7 +260,14 @@
                 <input type="checkbox" id="basic-switch" class="mdc-switch__native-control" role="switch" aria-checked="false">
             </div>
         </div>
-        <label for="basic-switch">Null Safety</label>
+        <label id="null-safety-switch-label" for="null-safety-switch">Null Safety</label>
+        <div id="channel-switch">
+            <button type="button" id="channels-dropdown-button" class="mdc-button">
+                <span class="mdc-button__label">Channel</span>
+                <i class="material-icons mdc-button__icon" aria-hidden="true">expand_more</i>
+            </button>
+            <div id="channels-menu" class="mdc-menu mdc-menu-surface"></div>
+        </div>
     </div>
     <div class="flex"></div>
     <div id="issues-message" class="info-message"></div>

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -353,6 +353,21 @@ a {
     margin-right: 14px;
 }
 
+.channel-item {
+  display: list-item;
+  height: auto;
+}
+
+.mdc-list-item__title {
+  font-weight: bold;
+  margin-bottom: 0;
+}
+
+p.mdc-list-item__details {
+  font-size: 14px;
+  margin-top: 0;
+}
+
 // Editor Tabs
 .editor-tab {
   @include mdc-button-ink-color($button-text-color);


### PR DESCRIPTION
When the URL does not contain a `channel` query parameter, or when such a query parameter is not `stable`, enable the channel switcher, and disable the null safety toggle.

Channel switch may need some different styling, but landing this will allow folk to experiment, and give feedback.