### PR TITLE
Change the root url based on the initial channel query parameter

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -408,6 +408,9 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     var element = _buildChannelsMenu(channels);
     _configureChannelsMenu(element);
+
+    // Set the initial channel from the current query parameter
+    _handleChannelSwitched(queryParams.channel);
   }
 
   void _configureChannelsMenu(Element menuElement) {


### PR DESCRIPTION
Call _handleChannelSwitched when channels menu component is initialized. This makes sure that the root url in `DartServicesApi` is set to the initial value of the query parameter.