### PR TITLE
Add allow-same-origin policy to pad iframes

### DIFF
--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -155,7 +155,9 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
     <div id="web-output" hidden>
         <!-- allow-popups allows plugins like url_launcher to open popups. -->
-        <iframe id="frame" sandbox="allow-scripts allow-popups" class="flex-auto">
+        <iframe id="frame"
+		sandbox="allow-scripts allow-popups allow-same-origin"
+		class="flex-auto">
         </iframe>
     </div>
     <div class="mdc-snackbar">

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -165,7 +165,9 @@ BSD-style license that can be found in the LICENSE file. -->
     <div id="web-output">
         <span id="web-output-label" class="view-label">UI Output</span>
         <!-- allow-popups allows plugins like url_launcher to open popups. -->
-        <iframe id="frame" sandbox="allow-scripts allow-popups" class="flex-auto">
+        <iframe id="frame"
+		sandbox="allow-scripts allow-popups allow-same-origin"
+		class="flex-auto">
         </iframe>
     </div>
     <div class="mdc-snackbar">

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -189,7 +189,9 @@ BSD-style license that can be found in the LICENSE file. -->
     <div id="web-output">
         <span id="web-output-label" class="view-label">UI Output</span>
         <!-- allow-popups allows plugins like url_launcher to open popups. -->
-        <iframe id="frame" sandbox="allow-scripts allow-popups" class="flex-auto">
+        <iframe id="frame"
+		sandbox="allow-scripts allow-popups allow-same-origin"
+		class="flex-auto">
         </iframe>
     </div>
     <div class="mdc-snackbar">

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -155,7 +155,9 @@ BSD-style license that can be found in the LICENSE file. -->
     </div>
     <div id="web-output" hidden>
         <!-- allow-popups allows plugins like url_launcher to open popups. -->
-        <iframe id="frame" sandbox="allow-scripts allow-popups" class="flex-auto">
+        <iframe id="frame"
+		sandbox="allow-scripts allow-popups allow-same-origin"
+		class="flex-auto">
         </iframe>
     </div>
     <div class="mdc-snackbar">

--- a/web/index.html
+++ b/web/index.html
@@ -208,7 +208,7 @@
         <div id="output-panel">
             <span id="web-output-label" class="view-label absolute">UI Output</span>
 	    <!-- allow-popups allows plugins like url_launcher to open popups. -->
-            <iframe id="frame" sandbox="allow-scripts allow-popups" flex
+            <iframe id="frame" sandbox="allow-scripts allow-popups allow-same-origin" flex
                     src="scripts/frame_dark.html"></iframe>
             <div id="right-output-panel">
                 <span class="view-label">Console</span>

--- a/web/workshops.html
+++ b/web/workshops.html
@@ -139,7 +139,7 @@
                 </div>
                 <div id="editor-panel-tab-host">
                     <!-- allow-popups allows plugins like url_launcher to open popups. -->
-                    <iframe id="frame" sandbox="allow-scripts allow-popups" flex
+                    <iframe id="frame" sandbox="allow-scripts allow-popups allow-same-origin" flex
                             src="scripts/frame_dark.html"></iframe>
                     <div id="console-panel" class="console custom-scrollbar">
                     </div>


### PR DESCRIPTION
Work towards https://github.com/dart-lang/dart-pad/issues/1946.

My only concern is running with this in embedded pads. Security concern?

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/sandbox

I don't... think so?