### PR TITLE
Remove all  pre-null safety switch code

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,9 +16,8 @@ targets:
           dart2js_args:
           - --minify
           - --fast-startup
-          - -DPRE_NULL_SAFETY_SERVER_URL=https://v1.api.dartpad.dev/
-          - -DNULL_SAFETY_SERVER_URL=https://nullsafety.api.dartpad.dev/
-          - -DSTABLE_SERVER_URL=https://v1.api.dartpad.dev/
+          - -DSERVER_URL=https://nullsafety.api.dartpad.dev/
+          - -DSTABLE_SERVER_URL=https://nullsafety.api.dartpad.dev/
           - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
           - -DDEV_SERVER_URL=https://dev.api.dartpad.dev/
           - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
@@ -33,8 +32,7 @@ global_options:
   build_web_compilers:ddc:
     options:
       environment:
-        PRE_NULL_SAFETY_SERVER_URL: https://v1.api.dartpad.dev/
-        NULL_SAFETY_SERVER_URL: https://nullsafety.api.dartpad.dev/
+        SERVER_URL: https://nullsafety.api.dartpad.dev/
         STABLE_SERVER_URL: https://nullsafety.api.dartpad.dev/
         BETA_SERVER_URL: https://beta.api.dartpad.dev/
         DEV_SERVER_URL: https://dev.api.dartpad.dev/

--- a/build.yaml
+++ b/build.yaml
@@ -16,8 +16,8 @@ targets:
           dart2js_args:
           - --minify
           - --fast-startup
-          - -DSERVER_URL=https://nullsafety.api.dartpad.dev/
-          - -DSTABLE_SERVER_URL=https://nullsafety.api.dartpad.dev/
+          - -DSERVER_URL=https://stable.api.dartpad.dev/
+          - -DSTABLE_SERVER_URL=https://stable.api.dartpad.dev/
           - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
           - -DDEV_SERVER_URL=https://dev.api.dartpad.dev/
           - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
@@ -32,8 +32,8 @@ global_options:
   build_web_compilers:ddc:
     options:
       environment:
-        SERVER_URL: https://nullsafety.api.dartpad.dev/
-        STABLE_SERVER_URL: https://nullsafety.api.dartpad.dev/
+        SERVER_URL: https://stable.api.dartpad.dev/
+        STABLE_SERVER_URL: https://stable.api.dartpad.dev/
         BETA_SERVER_URL: https://beta.api.dartpad.dev/
         DEV_SERVER_URL: https://dev.api.dartpad.dev/
         OLD_SERVER_URL: https://old.api.dartpad.dev/

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -508,41 +508,6 @@ class Embed extends EditorUi {
   bool get githubParamsPresent =>
       githubOwner.isNotEmpty && githubRepo.isNotEmpty && githubPath.isNotEmpty;
 
-<<<<<<< HEAD
-=======
-  void _initNullSafety() {
-    if (queryParams.hasNullSafety && queryParams.nullSafety) {
-      nullSafetyEnabled = true;
-    }
-  }
-
-  @override
-  set nullSafetyEnabled(bool enabled) {
-    _nullSafetyEnabled = enabled;
-    _handleNullSafetySwitched(enabled);
-    featureMessage.text = 'Null safety';
-    featureMessage.toggleAttr('hidden', !enabled);
-    nullSafetyCheckmark.toggleClass('hide', !enabled);
-  }
-
-  @override
-  bool get nullSafetyEnabled {
-    return _nullSafetyEnabled;
-  }
-
-  void _handleNullSafetySwitched(bool enabled) {
-    final api = deps[DartservicesApi] as DartservicesApi?;
-    if (enabled) {
-      api!.rootUrl = nullSafetyServerUrl;
-      window.localStorage['null_safety'] = 'true';
-    } else {
-      api!.rootUrl = preNullSafetyServerUrl;
-      window.localStorage['null_safety'] = 'false';
-    }
-    unawaited(performAnalysis());
-  }
-
->>>>>>> master
   Future<void> _initModules() async {
     final modules = ModuleManager();
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -84,7 +84,6 @@ class Embed extends EditorUi {
   bool _showTestCode = false;
 
   late final DElement nullSafetyCheckmark;
-  bool _nullSafetyEnabled = false;
 
   late final Counter unreadConsoleCounter;
 
@@ -259,10 +258,6 @@ class Embed extends EditorUi {
           testEditor.readOnly =
               solutionEditor.readOnly = !_editableTestSolution;
           break;
-        case 2:
-          // Null safety
-          nullSafetyEnabled = !nullSafetyEnabled;
-          break;
       }
     });
 
@@ -422,10 +417,7 @@ class Embed extends EditorUi {
 
     _initBusyLights();
 
-    _initModules()
-        .then((_) => _init())
-        .then((_) => _emitReady())
-        .then((_) => _initNullSafety());
+    _initModules().then((_) => _init()).then((_) => _emitReady());
   }
 
   /// Initializes a listener for messages from the parent window. Allows this
@@ -519,38 +511,6 @@ class Embed extends EditorUi {
 
   bool get githubParamsPresent =>
       githubOwner.isNotEmpty && githubRepo.isNotEmpty && githubPath.isNotEmpty;
-
-  void _initNullSafety() {
-    if (queryParams.hasNullSafety && queryParams.nullSafety) {
-      nullSafetyEnabled = true;
-    }
-  }
-
-  @override
-  set nullSafetyEnabled(bool enabled) {
-    _nullSafetyEnabled = enabled;
-    _handleNullSafetySwitched(enabled);
-    featureMessage.text = 'Null safety';
-    featureMessage.toggleAttr('hidden', !enabled);
-    nullSafetyCheckmark.toggleClass('hide', !enabled);
-  }
-
-  @override
-  bool get nullSafetyEnabled {
-    return _nullSafetyEnabled;
-  }
-
-  void _handleNullSafetySwitched(bool enabled) {
-    var api = deps[DartservicesApi] as DartservicesApi?;
-    if (enabled) {
-      api!.rootUrl = nullSafetyServerUrl;
-      window.localStorage['null_safety'] = 'true';
-    } else {
-      api!.rootUrl = preNullSafetyServerUrl;
-      window.localStorage['null_safety'] = 'false';
-    }
-    unawaited(performAnalysis());
-  }
 
   Future<void> _initModules() async {
     var modules = ModuleManager();

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -83,8 +83,6 @@ class Embed extends EditorUi {
   bool _editableTestSolution = false;
   bool _showTestCode = false;
 
-  late final DElement nullSafetyCheckmark;
-
   late final Counter unreadConsoleCounter;
 
   late final FlashBox testResultBox;
@@ -230,8 +228,6 @@ class Embed extends EditorUi {
     showTestCodeCheckmark = DElement(querySelector('#show-test-checkmark')!);
     editableTestSolutionCheckmark =
         DElement(querySelector('#editable-test-solution-checkmark')!);
-    nullSafetyCheckmark =
-        DElement(querySelector('#toggle-null-safety-checkmark')!);
 
     menuButton =
         MDCButton(querySelector('#menu-button') as ButtonElement, isIcon: true)

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -63,7 +63,7 @@ class DartServicesModule extends Module {
     var client = SanitizingBrowserClient();
     deps[BrowserClient] = client;
     deps[DartservicesApi] =
-        DartservicesApi(client, rootUrl: preNullSafetyServerUrl);
+        DartservicesApi(client, rootUrl: nullSafetyServerUrl);
     return Future.value();
   }
 }

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -62,8 +62,7 @@ class DartServicesModule extends Module {
   Future init() {
     final client = SanitizingBrowserClient();
     deps[BrowserClient] = client;
-    deps[DartservicesApi] =
-        DartservicesApi(client, rootUrl: nullSafetyServerUrl);
+    deps[DartservicesApi] = DartservicesApi(client, rootUrl: serverUrl);
     return Future.value();
   }
 }

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -73,7 +73,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
   final DElement _webTabBar = DElement(querySelector('#web-tab-bar')!);
   final DElement _webOutputLabel =
       DElement(querySelector('#web-output-label')!);
-  final Element? _channelSwitch = querySelector('#channel-switch');
   MDCMenu? _channelsMenu;
 
   late Splitter _rightSplitter;
@@ -208,25 +207,12 @@ class Playground extends EditorUi implements GistContainer, GistController {
         ?.onClick
         .listen((_) => showPackageVersionsDialog());
 
-    var channel = queryParams.channel;
-    if (channel == 'stable') {
-      // Disable the channel switcher.
-      var channelSwitch = _channelSwitch;
-      if (channelSwitch != null) {
-        channelSwitch.setAttribute('hidden', '');
-      }
-      var channelSwitchLabel = querySelector('#channel-switch-label');
-      if (channelSwitchLabel != null) {
-        channelSwitchLabel.setAttribute('hidden', '');
-      }
-    } else {
-      _initChannelsMenu();
-      var channelsButton = _channelsDropdownButton;
-      if (channelsButton is ButtonElement) {
-        MDCButton(channelsButton)
-            .onClick
-            .listen((e) => _toggleMenu(_channelsMenu));
-      }
+    _initChannelsMenu();
+    var channelsButton = _channelsDropdownButton;
+    if (channelsButton is ButtonElement) {
+      MDCButton(channelsButton)
+          .onClick
+          .listen((e) => _toggleMenu(_channelsMenu));
     }
   }
 

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -9,14 +9,6 @@
 /// The `grind build` task specifies each of these options.
 library dart_pad.common;
 
-/// The environment variable name which specifies the URL of the pre-null safety
-/// back-end server.
-const preNullSafetyServerUrlEnvironmentVar = 'PRE_NULL_SAFETY_SERVER_URL';
-
-/// The URL of the pre-null safety back-end server.
-const preNullSafetyServerUrl =
-    String.fromEnvironment(preNullSafetyServerUrlEnvironmentVar);
-
 /// The environment variable name which specifies the URL of the null safety
 /// back-end server.
 const nullSafetyServerUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -9,13 +9,12 @@
 /// The `grind build` task specifies each of these options.
 library dart_pad.common;
 
-/// The environment variable name which specifies the URL of the null safety
-/// back-end server.
-const nullSafetyServerUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';
+/// The environment variable name which specifies the URL of the back-end
+/// server.
+const serverUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';
 
-/// The URL of the null safety back-end server.
-const nullSafetyServerUrl =
-    String.fromEnvironment(nullSafetyServerUrlEnvironmentVar);
+/// The URL of the back-end server.
+const serverUrl = String.fromEnvironment(serverUrlEnvironmentVar);
 
 /// The environment variable name which specifies the URL of the back-end
 /// server serving "Flutter stable".

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -9,9 +9,9 @@
 /// The `grind build` task specifies each of these options.
 library dart_pad.common;
 
-/// The environment variable name which specifies the URL of the back-end
+/// The environment variable name which specifies the URL of the base back-end
 /// server.
-const serverUrlEnvironmentVar = 'NULL_SAFETY_SERVER_URL';
+const serverUrlEnvironmentVar = 'SERVER_URL';
 
 /// The URL of the back-end server.
 const serverUrl = String.fromEnvironment(serverUrlEnvironmentVar);

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -32,14 +32,6 @@ abstract class EditorUi {
   /// The dialog box for information like Keyboard shortcuts.
   final Dialog dialog = Dialog();
 
-  /// The source-of-truth for whether null safety is enabled.
-  ///
-  /// On page load, this may be originally derived from local storage.
-  late bool nullSafetyEnabled;
-
-  /// Whether null safety was enabled for the previous execution.
-  bool nullSafetyWasPreviouslyEnabled = false;
-
   String get fullDartSource => context.dartSource;
 
   bool get shouldCompileDDC;
@@ -185,10 +177,6 @@ abstract class EditorUi {
 
     final compilationTimer = Stopwatch()..start();
     final compileRequest = CompileRequest()..source = fullDartSource;
-    // If the null safety toggle has changed from the last execution to this
-    // one, destroy the frame.
-    final shouldDestroyFrame =
-        nullSafetyWasPreviouslyEnabled == !nullSafetyEnabled;
 
     try {
       if (shouldCompileDDC) {
@@ -206,7 +194,9 @@ abstract class EditorUi {
           modulesBaseUrl: response.modulesBaseUrl,
           addRequireJs: true,
           addFirebaseJs: shouldAddFirebaseJs,
-          destroyFrame: shouldDestroyFrame,
+          // TODO(srawlins): Determine if we need to destroy the frame when
+          // changing channels.
+          destroyFrame: false,
         );
       } else {
         final response = await dartServices
@@ -220,14 +210,9 @@ abstract class EditorUi {
           context.htmlSource,
           context.cssSource,
           response.result,
-          destroyFrame: shouldDestroyFrame,
+          destroyFrame: false,
         );
       }
-      // Only after successful execution can we safely set the "previous" null
-      // safety state. If compilation or execution threw, we leave the previous
-      // null safety state so that we know to still destroy the frame on the
-      // next attempt.
-      nullSafetyWasPreviouslyEnabled = nullSafetyEnabled;
       return true;
     } catch (e) {
       ga.sendException('${e.runtimeType}');

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -12,31 +12,6 @@ class _QueryParams {
     return Uri.parse(window.location.toString()).queryParameters;
   }
 
-  /// Whether or not null safety is enabled through query parameters.
-  bool get nullSafety {
-    final nullSafety = _queryParam('null_safety');
-
-    return nullSafety == 'true';
-  }
-
-  set nullSafety(bool enabled) {
-    _replaceQueryParameters((params) {
-      if (enabled) {
-        params['null_safety'] = 'true';
-      } else {
-        params.remove('null_safety');
-      }
-      return params;
-    });
-  }
-
-  /// Whether the `null_safety` query parameter is defined or not.
-  bool get hasNullSafety {
-    final nullSafety = _queryParam('null_safety');
-
-    return nullSafety != null;
-  }
-
   set gistId(String? gistId) {
     var url = Uri.parse(window.location.toString());
     var params = Map<String, String?>.from(url.queryParameters);

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -159,7 +159,7 @@ class WorkshopUi extends EditorUi {
     deps[Analytics] = Analytics();
 
     // Use null safety for workshops
-    (deps[DartservicesApi] as DartservicesApi).rootUrl = nullSafetyServerUrl;
+    (deps[DartservicesApi] as DartservicesApi).rootUrl = serverUrl;
 
     analysisResultsController = AnalysisResultsController(
       DElement(querySelector('#issues')!),

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -83,18 +83,6 @@ class WorkshopUi extends EditorUi {
   DivElement get _editorPanelFooter =>
       querySelector('#editor-panel-footer') as DivElement;
 
-  @override
-  bool get nullSafetyEnabled => true;
-
-  /// Whether null safety was enabled for the previous execution.
-  @override
-  bool get nullSafetyWasPreviouslyEnabled => true;
-
-  @override
-  set nullSafetyEnabled(bool v) {
-    throw Exception('setting null safety in workshops is not supported.');
-  }
-
   Future<void> _init() async {
     await _loadWorkshop();
     _initBusyLights();

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,7 +50,6 @@ serveLocalAppEngine() async {
   ConstTaskArgs('build', flags: {
     _debugFlag: true,
   }, options: {
-    _preNullSafetyServerUrlOption: 'http://127.0.0.1:8082/',
     _nullSafetyServerUrlOption: 'http://127.0.0.1:8084/',
   }),
 ))
@@ -66,9 +65,7 @@ serveLocalBackend() async {
 @Task('Serve locally on port 8000 and use beta server URL for pre null-safe')
 @Depends(ConstTaskInvocation(
   'build',
-  ConstTaskArgs('build', options: {
-    _preNullSafetyServerUrlOption: 'http://beta.api.dartpad.dev/',
-  }),
+  ConstTaskArgs('build', options: {}),
 ))
 serveBetaBackend() async {
   log('\nServing dart-pad on http://localhost:8000');
@@ -82,9 +79,7 @@ serveBetaBackend() async {
 @Task('Serve locally on port 8000 and use dev server URL for pre null-safe')
 @Depends(ConstTaskInvocation(
   'build',
-  ConstTaskArgs('build', options: {
-    _preNullSafetyServerUrlOption: 'http://dev.api.dartpad.dev/',
-  }),
+  ConstTaskArgs('build', options: {}),
 ))
 serveDevBackend() async {
   log('\nServing dart-pad on http://localhost:8000');
@@ -99,10 +94,6 @@ serveDevBackend() async {
 /// use DDC instead of dart2js.
 const _debugFlag = 'debug';
 
-/// A grinder option which specifies the URL of the pre-null safety back-end
-/// server.
-const _preNullSafetyServerUrlOption = 'pre-null-safety-server-url';
-
 /// A grinder option which specifies the URL of the null safety back-end
 /// server.
 const _nullSafetyServerUrlOption = 'null-safety-server-url';
@@ -112,9 +103,6 @@ const _nullSafetyServerUrlOption = 'null-safety-server-url';
 build() {
   var args = context.invocation.arguments;
   var compilerArgs = {
-    if (args.hasOption(_preNullSafetyServerUrlOption))
-      preNullSafetyServerUrlEnvironmentVar:
-          args.getOption(_preNullSafetyServerUrlOption),
     if (args.hasOption(_nullSafetyServerUrlOption))
       nullSafetyServerUrlEnvironmentVar:
           args.getOption(_nullSafetyServerUrlOption),

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -51,7 +51,7 @@ serveLocalAppEngine() async {
   ConstTaskArgs('build', flags: {
     _debugFlag: true,
   }, options: {
-    _nullSafetyServerUrlOption: 'http://127.0.0.1:8084/',
+    _serverUrlOption: 'http://127.0.0.1:8084/',
   }),
 ))
 serveLocalBackend() async {
@@ -95,18 +95,16 @@ serveDevBackend() async {
 /// use DDC instead of dart2js.
 const _debugFlag = 'debug';
 
-/// A grinder option which specifies the URL of the null safety back-end
-/// server.
-const _nullSafetyServerUrlOption = 'null-safety-server-url';
+/// A grinder option which specifies the URL of the back-end server.
+const _serverUrlOption = 'server-url';
 
 @Task('Build the `web/index.html` entrypoint')
 @Depends(generateProtos)
 build() {
   final args = context.invocation.arguments;
   final compilerArgs = {
-    if (args.hasOption(_nullSafetyServerUrlOption))
-      nullSafetyServerUrlEnvironmentVar:
-          args.getOption(_nullSafetyServerUrlOption),
+    if (args.hasOption(_serverUrlOption))
+      serverUrlEnvironmentVar: args.getOption(_serverUrlOption),
   };
   PubApp.local('build_runner').run([
     'build',

--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -119,12 +119,6 @@ BSD-style license that can be found in the LICENSE file. -->
                         </span>
                         <span class="mdc-list-item__text">Editable test/solution</span>
                     </li>
-                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                        <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                            <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                        </span>
-                        <span class="mdc-list-item__text">Null Safety</span>
-                    </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -119,12 +119,6 @@ BSD-style license that can be found in the LICENSE file. -->
                       </span>
                       <span class="mdc-list-item__text">Editable test/solution</span>
                   </li>
-                  <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                      <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                    </span>
-                    <span class="mdc-list-item__text">Null Safety</span>
-                  </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -137,12 +137,6 @@ BSD-style license that can be found in the LICENSE file. -->
                       </span>
                       <span class="mdc-list-item__text">Editable test/solution</span>
                   </li>
-                  <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                        <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                    </span>
-                    <span class="mdc-list-item__text">Null Safety</span>
-                  </li>
                 </ul>
             </div>
         </div>

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -119,12 +119,6 @@ BSD-style license that can be found in the LICENSE file. -->
                       </span>
                         <span class="mdc-list-item__text">Editable test/solution</span>
                     </li>
-                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                        <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                            <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                        </span>
-                        <span class="mdc-list-item__text">Null Safety</span>
-                    </li>
                 </ul>
             </div>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -254,14 +254,6 @@
            target="repo">Send feedback</a>
     </div>
     <div class="footer-item">
-        <div id="null-safety-switch" class="mdc-switch" title="Null safety is currently disabled">
-            <div class="mdc-switch__track"></div>
-            <div class="mdc-switch__thumb-underlay">
-                <div class="mdc-switch__thumb"></div>
-                <input type="checkbox" id="basic-switch" class="mdc-switch__native-control" role="switch" aria-checked="false">
-            </div>
-        </div>
-        <label id="null-safety-switch-label" for="null-safety-switch">Null Safety</label>
         <div id="channel-switch">
             <button type="button" id="channels-dropdown-button" class="mdc-button mdc-button-footer">
                 <span class="mdc-button__label">Channel</span>


### PR DESCRIPTION
Removes all code that references a pre-null safe backend, or the toggle between pre-null safe and null safe:

* remove null safety checkmark in embed
* remove null safety switch in playground
* remove pre-null safe samples
* enable the channel switcher always, instead of null safety switch
* no more destroying the iframe
* remove null safety switch in workshops
* remove grind option to specify a local pre-null safety backend
* remove HTML for the null safety toggles