### PR TITLE
Prefer final locals

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,6 +16,7 @@ linter:
     - always_declare_return_types
     - avoid_private_typedef_functions
     - directives_ordering
+    - prefer_final_locals
     - prefer_mixin
     - prefer_single_quotes
     - unawaited_futures

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -29,22 +29,22 @@ class DartCompleter extends CodeCompleter {
     // Cancel any open completion request.
     _lastCompleter?.operation.cancel();
 
-    var offset = editor.document.indexFromPos(editor.document.cursor);
+    final offset = editor.document.indexFromPos(editor.document.cursor);
 
-    var request = ds.SourceRequest()
+    final request = ds.SourceRequest()
       ..source = editor.document.value
       ..offset = offset;
 
-    var completer = CancelableCompleter<CompletionResult>();
+    final completer = CancelableCompleter<CompletionResult>();
     _lastCompleter = completer;
 
     if (onlyShowFixes) {
-      var completions = <Completion>[];
-      var fixesFuture =
+      final completions = <Completion>[];
+      final fixesFuture =
           servicesApi.fixes(request).then((ds.FixesResponse response) {
         for (var problemFix in response.fixes) {
           for (var fix in problemFix.fixes) {
-            var fixes = fix.edits.map((edit) {
+            final fixes = fix.edits.map((edit) {
               return SourceEdit(edit.length, edit.offset, edit.replacement);
             }).toList();
 
@@ -57,10 +57,10 @@ class DartCompleter extends CodeCompleter {
           }
         }
       });
-      var assistsFuture =
+      final assistsFuture =
           servicesApi.assists(request).then((ds.AssistsResponse response) {
         for (var assist in response.assists) {
-          var sourceEdits = assist.edits
+          final sourceEdits = assist.edits
               .map((edit) =>
                   SourceEdit(edit.length, edit.offset, edit.replacement))
               .toList();
@@ -80,7 +80,7 @@ class DartCompleter extends CodeCompleter {
             absoluteCursorPosition = assist.selectionOffset;
           }
 
-          var completion = Completion(
+          final completion = Completion(
             '',
             displayString: assist.message,
             type: 'type-quick_fix',
@@ -100,14 +100,14 @@ class DartCompleter extends CodeCompleter {
       servicesApi.complete(request).then((ds.CompleteResponse response) {
         if (completer.isCanceled) return;
 
-        var replaceOffset = response.replacementOffset;
-        var replaceLength = response.replacementLength;
+        final replaceOffset = response.replacementOffset;
+        final replaceLength = response.replacementLength;
 
-        var responses = response.completions.map((completion) {
+        final responses = response.completions.map((completion) {
           return AnalysisCompletion(replaceOffset, replaceLength, completion);
         });
 
-        var completions = responses.map((completion) {
+        final completions = responses.map((completion) {
           // TODO: Move to using a LabelProvider; decouple the data and rendering.
           var displayString = completion.isMethod
               ? '${completion.text}${completion.parameters}'
@@ -126,7 +126,7 @@ class DartCompleter extends CodeCompleter {
             displayString += '()';
           }
 
-          var deprecatedClass = completion.isDeprecated ? ' deprecated' : '';
+          final deprecatedClass = completion.isDeprecated ? ' deprecated' : '';
 
           if (completion.type == null) {
             return Completion(
@@ -205,7 +205,7 @@ class AnalysisCompletion implements Comparable {
   String? get kind => _map['kind'] as String?;
 
   bool get isMethod {
-    var element = _map['element'];
+    final element = _map['element'];
     return element is Map
         ? (element['kind'] == 'FUNCTION' || element['kind'] == 'METHOD')
         : false;
@@ -220,7 +220,7 @@ class AnalysisCompletion implements Comparable {
       isMethod ? _map['parameterNames'].length as int? : null;
 
   String get text {
-    var str = _map['completion'] as String;
+    final str = _map['completion'] as String;
     if (str.startsWith('(') && str.endsWith(')')) {
       return str.substring(1, str.length - 1);
     } else {

--- a/lib/core/dependencies.dart
+++ b/lib/core/dependencies.dart
@@ -47,7 +47,7 @@ class Dependencies {
   /// Get the current logical instance. This is the instance associated with the
   /// current Zone, parent Zones, or the global instance.
   static Dependencies get instance {
-    var deps = Zone.current['dependencies'] as Dependencies?;
+    final deps = Zone.current['dependencies'] as Dependencies?;
     return deps ?? _global;
   }
 
@@ -62,7 +62,7 @@ class Dependencies {
       return _instances[type];
     }
 
-    var parent = _calcParent(Zone.current);
+    final parent = _calcParent(Zone.current);
     return parent?.getDependency(type);
   }
 
@@ -83,7 +83,7 @@ class Dependencies {
   /// satisfied with this [Dependencies] object, and then delegate up to
   /// [Dependencies] for parent Zones.
   void runInZone(VoidFunc function) {
-    var zone = Zone.current.fork(zoneValues: {'dependencies': this});
+    final zone = Zone.current.fork(zoneValues: {'dependencies': this});
     zone.run(function);
   }
 
@@ -92,10 +92,10 @@ class Dependencies {
   Dependencies? _calcParent(Zone zone) {
     if (this == _global) return null;
 
-    var parentZone = zone.parent;
+    final parentZone = zone.parent;
     if (parentZone == null) return _global;
 
-    var deps = parentZone['dependencies'] as Dependencies?;
+    final deps = parentZone['dependencies'] as Dependencies?;
     if (deps == this) {
       return _calcParent(parentZone);
     } else {

--- a/lib/core/keys.dart
+++ b/lib/core/keys.dart
@@ -38,7 +38,7 @@ class Keys {
 
   void _handleKeyEvent(KeyboardEvent event) {
     try {
-      var k = event;
+      final k = event;
 
       if (!k.altKey &&
           !k.ctrlKey &&
@@ -62,7 +62,7 @@ class Keys {
   }
 
   bool _handleKey(String key) {
-    var action = _bindings[key];
+    final action = _bindings[key];
     if (action != null) {
       Timer.run(() => action());
       return true;
@@ -99,7 +99,7 @@ class Action {
 
 /// Convert [event] into a string (e.g., `ctrl-s`).
 String printKeyEvent(KeyboardEvent event) {
-  var buf = StringBuffer();
+  final buf = StringBuffer();
 
   // shift ctrl alt
   if (event.shiftKey) buf.write('shift-');

--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -135,8 +135,10 @@ class SharingDialog extends DDialog {
       ..flex()
       ..element.style.paddingLeft = '16px');
     final _rightArea = _embedArea.add(DElement.tag('div'));
-    final _embedDartArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
-    final _embedHtmlArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
+    final _embedDartArea =
+        _leftArea.add(DElement.tag('div')..layoutHorizontal());
+    final _embedHtmlArea =
+        _leftArea.add(DElement.tag('div')..layoutHorizontal());
     _embedDartRadio = _embedDartArea.add(RadioButtonInputElement()
       ..name = 'embed'
       ..id = 'dart-radio');

--- a/lib/dialogs.dart
+++ b/lib/dialogs.dart
@@ -20,11 +20,11 @@ class OkCancelDialog extends DDialog {
     element.classes.toggle('sharing-dialog', true);
     content.add(ParagraphElement()).text = message;
 
-    var cancelButton = buttonArea.add(DButton.button(text: cancelText));
+    final cancelButton = buttonArea.add(DButton.button(text: cancelText));
     buttonArea.add(SpanElement()..attributes['flex'] = '');
     cancelButton.onClick.listen((_) => hide());
 
-    var okButton =
+    final okButton =
         buttonArea.add(DButton.button(text: okText, classes: 'default'));
     okButton.onClick.listen((_) {
       okAction();
@@ -35,13 +35,13 @@ class OkCancelDialog extends DDialog {
 
 class AboutDialog extends DDialog {
   AboutDialog([String? versionText]) : super(title: 'About DartPad') {
-    var p = content.add(ParagraphElement());
+    final p = content.add(ParagraphElement());
     var text = privacyText;
     if (versionText != null) text += ' Based on Dart SDK $versionText.';
     p.setInnerHtml(text, validator: PermissiveNodeValidator());
 
     buttonArea.add(SpanElement()..attributes['flex'] = '');
-    var okButton =
+    final okButton =
         buttonArea.add(DButton.button(text: 'OK', classes: 'default'));
     okButton.onClick.listen((_) => hide());
   }
@@ -130,13 +130,13 @@ class SharingDialog extends DDialog {
     _embedArea = div.add(DElement.tag('div'))
       ..layoutHorizontal()
       ..flex();
-    var _leftArea = _embedArea.add(DElement.tag('div')
+    final _leftArea = _embedArea.add(DElement.tag('div')
       ..layoutVertical()
       ..flex()
       ..element.style.paddingLeft = '16px');
-    var _rightArea = _embedArea.add(DElement.tag('div'));
-    var _embedDartArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
-    var _embedHtmlArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
+    final _rightArea = _embedArea.add(DElement.tag('div'));
+    final _embedDartArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
+    final _embedHtmlArea = _leftArea.add(DElement.tag('div')..layoutHorizontal());
     _embedDartRadio = _embedDartArea.add(RadioButtonInputElement()
       ..name = 'embed'
       ..id = 'dart-radio');
@@ -224,7 +224,7 @@ class SharingDialog extends DDialog {
       _text.text =
           'Share the DartPad link or view the source at gist.github.com:';
       _textArea.style.display = 'none';
-      var gist = gistContainer.mutableGist;
+      final gist = gistContainer.mutableGist;
       content.add(_div);
       _padUrl.value = 'https://dartpad.dev/${gist.id}';
       _gistUrl.value = gist.htmlUrl;
@@ -246,7 +246,7 @@ class KeysDialog extends DDialog {
   }
 
   DListElement get keyMapToHtml {
-    var dl = DListElement();
+    final dl = DListElement();
     keyMap.forEach((Action action, Set<String> keys) {
       if (!action.hidden) {
         var string = '';

--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -93,31 +93,31 @@ class DocHandler {
   }
 
   String _sourceWithCompletionInserted(String source, int offset) {
-    var completionText = querySelector('.CodeMirror-hint-active')!.text!;
-    var lastSpace = source.substring(0, offset).lastIndexOf(' ') + 1;
-    var lastDot = source.substring(0, offset).lastIndexOf('.') + 1;
-    var insertOffset = math.max(lastSpace, lastDot);
+    final completionText = querySelector('.CodeMirror-hint-active')!.text!;
+    final lastSpace = source.substring(0, offset).lastIndexOf(' ') + 1;
+    final lastDot = source.substring(0, offset).lastIndexOf('.') + 1;
+    final insertOffset = math.max(lastSpace, lastDot);
     return _sourceProvider.dartSource.substring(0, insertOffset) +
         completionText +
         _sourceProvider.dartSource.substring(offset);
   }
 
   _DocResult _getHtmlTextFor(DocumentResponse result) {
-    var info = result.info;
+    final info = result.info;
 
     if (info['description'] == null && info['dartdoc'] == null) {
       return _DocResult('');
     }
 
-    var libraryName = info['libraryName'];
-    var kind = info['kind']!;
-    var hasDartdoc = info['dartdoc'] != null;
-    var isVariable = kind.contains('variable');
+    final libraryName = info['libraryName'];
+    final kind = info['kind']!;
+    final hasDartdoc = info['dartdoc'] != null;
+    final isVariable = kind.contains('variable');
 
-    var apiLink = _dartApiLink(libraryName);
+    final apiLink = _dartApiLink(libraryName);
 
-    var propagatedType = info['propagatedType'];
-    var _mdDocs = '''# `${info['description']}`\n\n
+    final propagatedType = info['propagatedType'];
+    final _mdDocs = '''# `${info['description']}`\n\n
 ${hasDartdoc ? "${info['dartdoc']}\n\n" : ''}
 ${isVariable ? "$kind\n\n" : ''}
 ${(isVariable && propagatedType != null) ? "**Propagated type:** $propagatedType\n\n" : ''}
@@ -192,7 +192,7 @@ class InlineBracketsColon extends markdown.InlineSyntax {
 
   @override
   bool onMatch(markdown.InlineParser parser, Match match) {
-    var element = markdown.Element.text('code', htmlEscape(match[1]!));
+    final element = markdown.Element.text('code', htmlEscape(match[1]!));
     parser.addNode(element);
     return true;
   }
@@ -212,7 +212,7 @@ class InlineBrackets extends markdown.InlineSyntax {
 
   @override
   bool onMatch(markdown.InlineParser parser, Match match) {
-    var element =
+    final element =
         markdown.Element.text('code', '<em>${htmlEscape(match[1]!)}</em>');
     parser.addNode(element);
     return true;

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -58,7 +58,7 @@ class CodeMirrorFactory extends EditorFactory {
       'theme': 'zenburn' // ambiance, vibrant-ink, monokai, zenburn
     };
 
-    var editor = CodeMirror.fromElement(element, options: options);
+    final editor = CodeMirror.fromElement(element, options: options);
     CodeMirror.addCommand('goLineLeft', _handleGoLineLeft);
     return _CodeMirrorEditor._(this, editor);
   }
@@ -78,15 +78,15 @@ class CodeMirrorFactory extends EditorFactory {
 
   Future<HintResults> _completionHelper(
       CodeMirror editor, CodeCompleter completer, HintsOptions? options) {
-    var ed = _CodeMirrorEditor._fromExisting(this, editor);
+    final ed = _CodeMirrorEditor._fromExisting(this, editor);
 
     return completer
         .complete(ed, onlyShowFixes: ed._lookingForQuickFix)
         .then((CompletionResult result) {
-      var doc = editor.getDoc()!;
-      var from = doc.posFromIndex(result.replaceOffset);
-      var to = doc.posFromIndex(result.replaceOffset + result.replaceLength);
-      var stringToReplace = doc.getValue()!.substring(
+      final doc = editor.getDoc()!;
+      final from = doc.posFromIndex(result.replaceOffset);
+      final to = doc.posFromIndex(result.replaceOffset + result.replaceLength);
+      final stringToReplace = doc.getValue()!.substring(
           result.replaceOffset, result.replaceOffset + result.replaceLength);
 
       var hints = result.completions.map((completion) {
@@ -108,13 +108,13 @@ class CodeMirrorFactory extends EditorFactory {
               doc.setCursor(
                   doc.posFromIndex(completion.absoluteCursorPosition!));
             } else if (completion.cursorOffset != null) {
-              var diff = hint.text!.length - completion.cursorOffset!;
+              final diff = hint.text!.length - completion.cursorOffset!;
               doc.setCursor(pos.Position(
                   editor.getCursor().line, editor.getCursor().ch! - diff));
             }
           },
           hintRenderer: (html.Element element, HintResult hint) {
-            var escapeHtml = HtmlEscape().convert as String Function(String?);
+            final escapeHtml = HtmlEscape().convert as String Function(String?);
             if (completion.type != 'type-quick_fix') {
               element.innerHtml = escapeHtml(completion.displayString)
                   .replaceFirst(escapeHtml(stringToReplace),

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -74,23 +74,23 @@ class AnalysisResultsController {
 
     flash.clearChildren();
     for (var issue in issues) {
-      var elem = _createIssueElement(issue);
+      final elem = _createIssueElement(issue);
       flash.add(elem);
     }
   }
 
   Element _createIssueElement(AnalysisIssue issue) {
-    var message = issue.message;
+    final message = issue.message;
 
-    var elem = DivElement()..classes.addAll(['issue', 'clickable']);
+    final elem = DivElement()..classes.addAll(['issue', 'clickable']);
 
     elem.children.add(SpanElement()
       ..text = issue.kind
       ..classes.addAll(_classesForType[issue.kind]!));
 
-    var columnElem = DivElement()..classes.add('issue-column');
+    final columnElem = DivElement()..classes.add('issue-column');
 
-    var messageSpan = DivElement()
+    final messageSpan = DivElement()
       ..text = 'line ${issue.line} • $message'
       ..classes.add('message');
     columnElem.children.add(messageSpan);
@@ -113,13 +113,13 @@ class AnalysisResultsController {
 
     // TODO: This should likely be named contextMessages.
     for (var diagnostic in issue.diagnosticMessages) {
-      var diagnosticElement = _createDiagnosticElement(diagnostic);
+      final diagnosticElement = _createDiagnosticElement(diagnostic);
       columnElem.children.add(diagnosticElement);
     }
 
     elem.children.add(columnElem);
 
-    var copyButton = MDCButton(ButtonElement(), isIcon: true);
+    final copyButton = MDCButton(ButtonElement(), isIcon: true);
     copyButton.buttonElement.setInnerHtml('content_copy');
     copyButton
       ..toggleClass('mdc-icon-button', true)
@@ -150,7 +150,7 @@ class AnalysisResultsController {
   Element _createDiagnosticElement(DiagnosticMessage diagnosticMessage) {
     final message = diagnosticMessage.message;
 
-    var elem = DivElement()..classes.addAll(['message', 'clickable']);
+    final elem = DivElement()..classes.addAll(['message', 'clickable']);
     elem.text = message;
     elem.onClick.listen((event) {
       // Stop the mouse event so the outer issue mouse handler doesn't process

--- a/lib/elements/bind.dart
+++ b/lib/elements/bind.dart
@@ -102,7 +102,7 @@ class _PropertyBinding implements Binding {
   StreamSubscription? _sub;
 
   _PropertyBinding(this.property, this.target) {
-    var stream = property.onChanged;
+    final stream = property.onChanged;
     if (stream != null) _sub = stream.listen(_handleEvent);
   }
 

--- a/lib/elements/console.dart
+++ b/lib/elements/console.dart
@@ -38,7 +38,7 @@ class Console {
       message = filter(message);
     }
 
-    var div = DivElement()..text = '$message\n';
+    final div = DivElement()..text = '$message\n';
     div.classes.add(error ? errorClass : 'normal');
 
     // Buffer the console output so that heavy writing to stdout does not starve
@@ -49,7 +49,7 @@ class Console {
         element.element.children.addAll(_bufferedOutput);
         // Using scrollIntoView(ScrollAlignment.BOTTOM) causes the parent page
         // to scroll, so set the scrollTop instead.
-        var last = element.element.children.last;
+        final last = element.element.children.last;
         element.element.scrollTop = last.offsetTop;
         _bufferedOutput.clear();
       });

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -169,7 +169,7 @@ class DSplitter extends DElement {
     if (!horizontal && !vertical) horizontal = true;
 
     if (element.querySelector('div.inner') == null) {
-      Element e = DivElement();
+      final Element e = DivElement();
       e.classes.add('inner');
       element.children.add(e);
     }
@@ -234,12 +234,12 @@ class DSplitter extends DElement {
   }
 
   Element get _target {
-    var children = element.parent!.children;
+    final children = element.parent!.children;
     return children[children.indexOf(element) - 1];
   }
 
   num _minSize(Element e) {
-    var style = e.getComputedStyle();
+    final style = e.getComputedStyle();
     var str = vertical ? style.minWidth : style.minHeight;
     if (str.endsWith('px')) {
       str = str.substring(0, str.length - 2);
@@ -250,7 +250,7 @@ class DSplitter extends DElement {
   }
 
   num get _targetSize {
-    var style = _target.getComputedStyle();
+    final style = _target.getComputedStyle();
     var str = vertical ? style.width : style.height;
     if (str.endsWith('px')) {
       str = str.substring(0, str.length - 2);
@@ -276,7 +276,7 @@ class DSplitter extends DElement {
     }
 
     if (_controller.hasListener) {
-      var newPos = position;
+      final newPos = position;
       if (currentPos != newPos) _controller.add(newPos);
     }
   }
@@ -566,7 +566,7 @@ class TabController {
 
   /// This method will throw if the tabName is not the name of a current tab.
   void selectTab(String? tabName) {
-    var tab = tabs.firstWhere((t) => t.name == tabName);
+    final tab = tabs.firstWhere((t) => t.name == tabName);
 
     for (var t in tabs) {
       t.toggleAttr('selected', t == tab);

--- a/lib/elements/material_tab_controller.dart
+++ b/lib/elements/material_tab_controller.dart
@@ -13,8 +13,8 @@ class MaterialTabController extends TabController {
 
   @override
   Future selectTab(String? tabName) async {
-    var tab = tabs.firstWhere((t) => t.name == tabName);
-    var idx = tabs.indexOf(tab);
+    final tab = tabs.firstWhere((t) => t.name == tabName);
+    final idx = tabs.indexOf(tab);
 
     tabBar.activateTab(idx);
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -215,8 +215,8 @@ class Embed extends EditorUi {
 
     showHintButton = MDCButton(querySelector('#show-hint') as ButtonElement)
       ..onClick.listen((_) {
-        var hintElement = DivElement()..text = context.hint;
-        var showSolutionButton = AnchorElement()
+        final hintElement = DivElement()..text = context.hint;
+        final showSolutionButton = AnchorElement()
           ..style.cursor = 'pointer'
           ..text = 'Show solution';
         showSolutionButton.onClick.listen((_) {
@@ -277,7 +277,7 @@ class Embed extends EditorUi {
 
     testResultBox = FlashBox(querySelector('#test-result-box') as DivElement);
     hintBox = FlashBox(querySelector('#hint-box') as DivElement);
-    var editorTheme = isDarkMode ? 'darkpad' : 'dartpad';
+    final editorTheme = isDarkMode ? 'darkpad' : 'dartpad';
 
     userCodeEditor = editorFactory.createFromElement(
         querySelector('#user-code-editor')!,
@@ -325,27 +325,27 @@ class Embed extends EditorUi {
       querySelector('#install-button')!.setAttribute('hidden', '');
     }
 
-    var editorTabViewElement = querySelector('#user-code-view');
+    final editorTabViewElement = querySelector('#user-code-view');
     if (editorTabViewElement != null) {
       editorTabView = TabView(DElement(editorTabViewElement));
     }
 
-    var testTabViewElement = querySelector('#test-view');
+    final testTabViewElement = querySelector('#test-view');
     if (testTabViewElement != null) {
       testTabView = TabView(DElement(testTabViewElement));
     }
 
-    var solutionTabViewElement = querySelector('#solution-view');
+    final solutionTabViewElement = querySelector('#solution-view');
     if (solutionTabViewElement != null) {
       solutionTabView = TabView(DElement(solutionTabViewElement));
     }
 
-    var htmlTabViewElement = querySelector('#html-view');
+    final htmlTabViewElement = querySelector('#html-view');
     if (htmlTabViewElement != null) {
       htmlTabView = TabView(DElement(htmlTabViewElement));
     }
 
-    var cssTabViewElement = querySelector('#css-view');
+    final cssTabViewElement = querySelector('#css-view');
     if (cssTabViewElement != null) {
       cssTabView = TabView(DElement(querySelector('#css-view')!));
     }
@@ -386,7 +386,7 @@ class Embed extends EditorUi {
       });
 
     if (options.mode == EmbedMode.flutter || options.mode == EmbedMode.html) {
-      var controller = ConsoleExpandController(
+      final controller = ConsoleExpandController(
           expandButton: querySelector('#console-output-header')!,
           footer: querySelector('#console-output-footer')!,
           expandIcon: querySelector('#console-expand-icon')!,
@@ -409,7 +409,7 @@ class Embed extends EditorUi {
           Console(DElement(querySelector('#console-output-container')!));
     }
 
-    var webOutputLabelElement = querySelector('#web-output-label');
+    final webOutputLabelElement = querySelector('#web-output-label');
     if (webOutputLabelElement != null) {
       webOutputLabel = DElement(webOutputLabelElement);
     }
@@ -432,13 +432,13 @@ class Embed extends EditorUi {
   /// embedded iframe to display and run arbitrary Dart code.
   void _initHostListener() {
     window.addEventListener('message', (dynamic event) {
-      var data = event.data;
+      final data = event.data;
       if (data is! Map) {
         // Ignore unexpected messages
         return;
       }
 
-      var type = data['type'];
+      final type = data['type'];
 
       if (type == 'sourceCode') {
         lastInjectedSourceCode =
@@ -541,7 +541,7 @@ class Embed extends EditorUi {
   }
 
   void _handleNullSafetySwitched(bool enabled) {
-    var api = deps[DartservicesApi] as DartservicesApi?;
+    final api = deps[DartservicesApi] as DartservicesApi?;
     if (enabled) {
       api!.rootUrl = nullSafetyServerUrl;
       window.localStorage['null_safety'] = 'true';
@@ -553,7 +553,7 @@ class Embed extends EditorUi {
   }
 
   Future<void> _initModules() async {
-    var modules = ModuleManager();
+    final modules = ModuleManager();
 
     modules.register(DartPadModule());
     modules.register(DartServicesModule());
@@ -569,7 +569,7 @@ class Embed extends EditorUi {
     deps[GistLoader] = GistLoader.defaultFilters();
     deps[Analytics] = Analytics();
 
-    var channel = queryParams.channel;
+    final channel = queryParams.channel;
     if (Channel.urlMapping.keys.contains(channel)) {
       dartServices.rootUrl = Channel.urlMapping[channel]!;
     }
@@ -586,21 +586,21 @@ class Embed extends EditorUi {
     initKeyBindings();
 
     var horizontal = true;
-    var webOutput = querySelector('#web-output')!;
+    final webOutput = querySelector('#web-output')!;
     List<Element> splitterElements;
     if (options.mode == EmbedMode.flutter || options.mode == EmbedMode.html) {
-      var editorAndConsoleContainer =
+      final editorAndConsoleContainer =
           querySelector('#editor-and-console-container')!;
       splitterElements = [editorAndConsoleContainer, webOutput];
     } else if (options.mode == EmbedMode.inline) {
-      var editorContainer = querySelector('#editor-container')!;
-      var consoleView = querySelector('#console-view')!;
+      final editorContainer = querySelector('#editor-container')!;
+      final consoleView = querySelector('#console-view')!;
       consoleView.removeAttribute('hidden');
       splitterElements = [editorContainer, consoleView];
       horizontal = false;
     } else {
-      var editorContainer = querySelector('#editor-container')!;
-      var consoleView = querySelector('#console-view')!;
+      final editorContainer = querySelector('#editor-container')!;
+      final consoleView = querySelector('#console-view')!;
       consoleView.removeAttribute('hidden');
       splitterElements = [editorContainer, consoleView];
     }
@@ -739,7 +739,7 @@ class Embed extends EditorUi {
   }
 
   void _handleCopyCode() {
-    var textElement = document.createElement('textarea') as TextAreaElement;
+    final textElement = document.createElement('textarea') as TextAreaElement;
     textElement.value = _getActiveSourceCode();
     document.body!.append(textElement);
     textElement.select();
@@ -757,7 +757,7 @@ class Embed extends EditorUi {
   }
 
   String _getActiveSourceCode() {
-    var activeTabName = tabController.selectedTab.name;
+    final activeTabName = tabController.selectedTab.name;
 
     switch (activeTabName) {
       case 'editor':
@@ -819,7 +819,7 @@ class Embed extends EditorUi {
     hintBox.hide();
     consoleExpandController.clear();
 
-    var success = await super.handleRun();
+    final success = await super.handleRun();
 
     editorIsBusy = false;
 
@@ -831,11 +831,11 @@ class Embed extends EditorUi {
   }
 
   void _sendVirtualPageView(String? id) {
-    var url = Uri.parse(window.location.toString());
-    var newParams = Map<String, String?>.from(url.queryParameters);
+    final url = Uri.parse(window.location.toString());
+    final newParams = Map<String, String?>.from(url.queryParameters);
     newParams['ga_id'] = id;
-    var pageName = url.replace(queryParameters: newParams);
-    var path = '${pageName.path}?${pageName.query}';
+    final pageName = url.replace(queryParameters: newParams);
+    final path = '${pageName.path}?${pageName.query}';
     ga.sendPage(pageName: path);
   }
 
@@ -865,12 +865,12 @@ class Embed extends EditorUi {
   }
 
   void _format() async {
-    var originalSource = userCodeEditor.document.value;
-    var input = SourceRequest()..source = originalSource;
+    final originalSource = userCodeEditor.document.value;
+    final input = SourceRequest()..source = originalSource;
 
     try {
       formatButton.disabled = true;
-      var result = await dartServices.format(input).timeout(serviceCallTimeout);
+      final result = await dartServices.format(input).timeout(serviceCallTimeout);
 
       busyLight.reset();
       formatButton.disabled = false;
@@ -908,7 +908,7 @@ class Embed extends EditorUi {
   }
 
   void _jumpTo(int line, int charStart, int charLength, {bool focus = false}) {
-    var doc = userCodeEditor.document;
+    final doc = userCodeEditor.document;
 
     doc.select(
         doc.posFromIndex(charStart), doc.posFromIndex(charStart + charLength));
@@ -959,7 +959,7 @@ class EmbedTabController extends MaterialTabController {
   Future selectTab(String? tabName, {bool force = false}) async {
     // Show a confirmation dialog if the solution tab is tapped
     if (tabName == 'solution' && !force) {
-      var result = await _dialog.showYesNo(
+      final result = await _dialog.showYesNo(
         'Show solution?',
         'If you just want a hint, click <span style="font-weight:bold">Cancel'
             '</span> and then <span style="font-weight:bold">Hint</span>.',
@@ -1164,7 +1164,7 @@ class ConsoleExpandController extends Console {
 
   void _initSplitter() {
     final editorContainer = querySelector('#editor-container')!;
-    var splitterElements = [
+    final splitterElements = [
       editorContainer,
       querySelector('#console-output-footer')!,
     ];

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -870,7 +870,8 @@ class Embed extends EditorUi {
 
     try {
       formatButton.disabled = true;
-      final result = await dartServices.format(input).timeout(serviceCallTimeout);
+      final result =
+          await dartServices.format(input).timeout(serviceCallTimeout);
 
       busyLight.reset();
       formatButton.disabled = false;

--- a/lib/inject/inject_embed.dart
+++ b/lib/inject/inject_embed.dart
@@ -20,14 +20,14 @@ var iframePrefix = 'https://dartpad.dev/';
 /// instance of DartPad.
 void main() {
   _logger.onRecord.listen(logToJsConsole);
-  var snippets = querySelectorAll('code');
+  final snippets = querySelectorAll('code');
   for (var snippet in snippets) {
     if (snippet.classes.isEmpty) {
       continue;
     }
 
-    var className = snippet.classes.first;
-    var parser = LanguageStringParser(className);
+    final className = snippet.classes.first;
+    final parser = LanguageStringParser(className);
     if (!parser.isValid) {
       continue;
     }
@@ -37,14 +37,14 @@ void main() {
 }
 
 String iframeSrc(Map<String, String> options) {
-  var prefix = 'embed-${_valueOr(options, 'mode', 'dart')}.html';
-  var theme = 'theme=${_valueOr(options, 'theme', 'light')}';
-  var run = 'run=${_valueOr(options, 'run', 'false')}';
-  var split = 'split=${_valueOr(options, 'split', 'false')}';
-  var nullSafety = 'null_safety=${_valueOr(options, 'null_safety', 'false')}';
+  final prefix = 'embed-${_valueOr(options, 'mode', 'dart')}.html';
+  final theme = 'theme=${_valueOr(options, 'theme', 'light')}';
+  final run = 'run=${_valueOr(options, 'run', 'false')}';
+  final split = 'split=${_valueOr(options, 'split', 'false')}';
+  final nullSafety = 'null_safety=${_valueOr(options, 'null_safety', 'false')}';
   // A unique ID used to distinguish between DartPad instances in an article or
   // codelab.
-  var analytics = 'ga_id=${_valueOr(options, 'ga_id', 'false')}';
+  final analytics = 'ga_id=${_valueOr(options, 'ga_id', 'false')}';
 
   return '$iframePrefix$prefix?$theme&$run&$split&$analytics&$nullSafety';
 }
@@ -67,7 +67,7 @@ String? _valueOr(Map<String, String> map, String value, String defaultValue) {
 ///   </code>
 /// </pre>
 void _injectEmbed(Element snippet, Map<String, String> options) {
-  var preElement = snippet.parent;
+  final preElement = snippet.parent;
   if (preElement is! PreElement) {
     _logUnexpectedHtml();
     return;
@@ -78,10 +78,10 @@ void _injectEmbed(Element snippet, Map<String, String> options) {
     return;
   }
 
-  var files = _parseFiles(HtmlUnescape().convert(snippet.innerHtml!));
+  final files = _parseFiles(HtmlUnescape().convert(snippet.innerHtml!));
 
-  var hostIndex = preElement.parent!.children.indexOf(preElement);
-  var host = DivElement();
+  final hostIndex = preElement.parent!.children.indexOf(preElement);
+  final host = DivElement();
   preElement.parent!.children[hostIndex] = host;
 
   InjectedEmbed(host, files, options);
@@ -105,7 +105,7 @@ class InjectedEmbed {
   Future _init() async {
     host.children.clear();
 
-    var iframe = IFrameElement()..attributes = {'src': iframeSrc(options)};
+    final iframe = IFrameElement()..attributes = {'src': iframeSrc(options)};
 
     if (options.containsKey('width')) {
       iframe.style.width = options['width'];
@@ -119,7 +119,7 @@ class InjectedEmbed {
 
     window.addEventListener('message', (dynamic e) {
       if (e.data['type'] == 'ready') {
-        var m = {'sourceCode': files, 'type': 'sourceCode'};
+        final m = {'sourceCode': files, 'type': 'sourceCode'};
         iframe.contentWindow!.postMessage(m, '*');
       }
     });
@@ -127,7 +127,7 @@ class InjectedEmbed {
 }
 
 void _logUnexpectedHtml() {
-  var message = '''Incorrect HTML for "dartpad-embed". Please use this format:
+  final message = '''Incorrect HTML for "dartpad-embed". Please use this format:
 <pre>
   <code class="run-dartpad">
     [code here]

--- a/lib/inject/inject_parser.dart
+++ b/lib/inject/inject_parser.dart
@@ -15,7 +15,7 @@ class InjectParser {
 
   /// Returns filenames and contents that were parsed from the input
   Map<String, String> read() {
-    var lines = input.split('\n');
+    final lines = input.split('\n');
     for (var i = 0; i < lines.length; i++) {
       _currentLine = i;
       _readLine(lines[i]);
@@ -39,7 +39,7 @@ class InjectParser {
       if (_currentFile == null) {
         _error('$_currentLine: unexpected end');
       } else {
-        var match = _endExp.firstMatch(line)![1];
+        final match = _endExp.firstMatch(line)![1];
         if (match != _currentFile) {
           _error('$_currentLine: end statement did not match begin statement');
         } else {
@@ -65,7 +65,7 @@ class InjectParser {
   }
 
   void _error(String message) {
-    var errorMessage =
+    final errorMessage =
         'error parsing DartPad scripts on line $_currentLine: $message';
     throw DartPadInjectException(errorMessage);
   }
@@ -92,12 +92,12 @@ class LanguageStringParser {
   }
 
   Map<String, String> get options {
-    var opts = <String, String>{};
+    final opts = <String, String>{};
     if (!isValid) {
       return opts;
     }
 
-    var matches = _optionsExp.allMatches(input);
+    final matches = _optionsExp.allMatches(input);
     for (var match in matches) {
       if (match.groupCount != 2) {
         continue;

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -60,7 +60,7 @@ class SanitizingBrowserClient extends BrowserClient {
 class DartServicesModule extends Module {
   @override
   Future init() {
-    var client = SanitizingBrowserClient();
+    final client = SanitizingBrowserClient();
     deps[BrowserClient] = client;
     deps[DartservicesApi] =
         DartservicesApi(client, rootUrl: preNullSafetyServerUrl);

--- a/lib/parameter_popup.dart
+++ b/lib/parameter_popup.dart
@@ -70,7 +70,7 @@ class ParameterPopup {
 
   void _lookupParameterInfo() {
     var offset = editor.document.indexFromPos(editor.document.cursor);
-    var source = editor.document.value;
+    final source = editor.document.value;
     var parInfo = _parameterInfo(source, offset);
 
     if (parInfo == null) {
@@ -78,12 +78,12 @@ class ParameterPopup {
       return;
     }
 
-    var openingParenIndex = parInfo['openingParenIndex']!;
-    var parameterIndex = parInfo['parameterIndex'];
+    final openingParenIndex = parInfo['openingParenIndex']!;
+    final parameterIndex = parInfo['parameterIndex'];
     offset = openingParenIndex - 1;
 
     // We request documentation info of what is before the parenthesis.
-    var input = SourceRequest()
+    final input = SourceRequest()
       ..source = source
       ..offset = offset;
 
@@ -96,7 +96,7 @@ class ParameterPopup {
         return;
       }
 
-      var parameterInfo = result.info['parameters']!;
+      final parameterInfo = result.info['parameters']!;
       var outputString = '';
       if (parameterInfo.isEmpty) {
         outputString += '<code>&lt;no parameters&gt;</code>';
@@ -131,43 +131,43 @@ class ParameterPopup {
   }
 
   void _showParameterPopup(String string, int methodOffset) {
-    var editorDiv = querySelector('#editpanel .CodeMirror') as DivElement;
-    var lineHeightStr =
+    final editorDiv = querySelector('#editpanel .CodeMirror') as DivElement;
+    final lineHeightStr =
         editorDiv.getComputedStyle().getPropertyValue('line-height');
-    var lineHeight =
+    final lineHeight =
         int.parse(lineHeightStr.substring(0, lineHeightStr.indexOf('px')));
     // var charWidth = editorDiv.getComputedStyle().getPropertyValue('letter-spacing');
-    var charWidth = 8;
+    final charWidth = 8;
 
-    var methodPosition = editor.document.posFromIndex(methodOffset);
-    var cursorCoords = editor.getCursorCoords();
-    var methodCoords = editor.getCursorCoords(position: methodPosition);
-    var heightOfMethod = (methodCoords.y - lineHeight - 5).round();
+    final methodPosition = editor.document.posFromIndex(methodOffset);
+    final cursorCoords = editor.getCursorCoords();
+    final methodCoords = editor.getCursorCoords(position: methodPosition);
+    final heightOfMethod = (methodCoords.y - lineHeight - 5).round();
 
     DivElement parameterPopup;
     if (parPopupActive) {
-      var parameterHint = querySelector('.parameter-hint')!;
+      final parameterHint = querySelector('.parameter-hint')!;
       parameterHint.innerHtml = string;
 
       //update popup position
-      var newLeft = math
+      final newLeft = math
           .max(
               cursorCoords.x - (parameterHint.text!.length * charWidth / 2), 22)
           .round();
 
       parameterPopup = querySelector('.parameter-hints') as DivElement
         ..style.top = '${heightOfMethod}px';
-      var oldLeftString = parameterPopup.style.left;
-      var oldLeft =
+      final oldLeftString = parameterPopup.style.left;
+      final oldLeft =
           int.parse(oldLeftString.substring(0, oldLeftString.indexOf('px')));
       if ((newLeft - oldLeft).abs() > 50) {
         parameterPopup.style.left = '${newLeft}px';
       }
     } else {
-      var parameterHint = SpanElement()
+      final parameterHint = SpanElement()
         ..innerHtml = string
         ..classes.add('parameter-hint');
-      var left = math
+      final left = math
           .max(
               cursorCoords.x - (parameterHint.text!.length * charWidth / 2), 22)
           .round();
@@ -180,7 +180,7 @@ class ParameterPopup {
       parameterPopup.append(parameterHint);
       document.body!.append(parameterPopup);
     }
-    var activeParameter = querySelector('.parameter-hints em');
+    final activeParameter = querySelector('.parameter-hints em');
     if (activeParameter != null &&
         activeParameter.previousElementSibling != null) {
       parameterPopup.scrollLeft =

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -210,25 +210,25 @@ class Playground extends EditorUi implements GistContainer, GistController {
         ?.onClick
         .listen((_) => showPackageVersionsDialog());
 
-    var channel = queryParams.channel;
+    final channel = queryParams.channel;
     if (channel == 'stable') {
       // Disable the channel switcher.
-      var channelSwitch = _channelSwitch;
+      final channelSwitch = _channelSwitch;
       if (channelSwitch != null) {
         channelSwitch.setAttribute('hidden', '');
       }
-      var channelSwitchLabel = querySelector('#channel-switch-label');
+      final channelSwitchLabel = querySelector('#channel-switch-label');
       if (channelSwitchLabel != null) {
         channelSwitchLabel.setAttribute('hidden', '');
       }
     } else {
       _initChannelsMenu();
       _nullSafetySwitch.root.setAttribute('hidden', '');
-      var nullSafetySwitchLabel = querySelector('#null-safety-switch-label');
+      final nullSafetySwitchLabel = querySelector('#null-safety-switch-label');
       if (nullSafetySwitchLabel != null) {
         nullSafetySwitchLabel.setAttribute('hidden', '');
       }
-      var channelsButton = _channelsDropdownButton;
+      final channelsButton = _channelsDropdownButton;
       if (channelsButton is ButtonElement) {
         MDCButton(channelsButton)
             .onClick
@@ -255,7 +255,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   MDCMenu _initSamplesMenu({bool nullSafe = false}) {
-    var element = querySelector('#samples-menu')!;
+    final element = querySelector('#samples-menu')!;
     element.children.clear();
 
     List<Sample> samples;
@@ -289,11 +289,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
       ];
     }
 
-    var listElement = _mdcList();
+    final listElement = _mdcList();
     element.children.add(listElement);
 
     for (var sample in samples) {
-      var menuElement = _mdcListItem(children: [
+      final menuElement = _mdcListItem(children: [
         ImageElement()
           ..classes.add('mdc-list-item__graphic')
           ..src = 'pictures/logo_${_layoutToString(sample.layout)}.png',
@@ -304,14 +304,14 @@ class Playground extends EditorUi implements GistContainer, GistController {
       listElement.children.add(menuElement);
     }
 
-    var samplesMenu = MDCMenu(element)
+    final samplesMenu = MDCMenu(element)
       ..setAnchorCorner(AnchorCorner.bottomLeft)
       ..setAnchorElement(_samplesDropdownButton)
       ..hoistMenuToBody();
 
     samplesMenu.listen('MDCMenu:selected', (e) {
-      var index = (e as CustomEvent).detail['index'] as int;
-      var gistId = samples.elementAt(index).gistId;
+      final index = (e as CustomEvent).detail['index'] as int;
+      final gistId = samples.elementAt(index).gistId;
       showGist(gistId);
     });
 
@@ -319,8 +319,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   void _initMoreMenu() {
-    var moreMenuButton = querySelector('#more-menu-button') as ButtonElement;
-    var moreMenu = MDCMenu(querySelector('#more-menu'))
+    final moreMenuButton = querySelector('#more-menu-button') as ButtonElement;
+    final moreMenu = MDCMenu(querySelector('#more-menu'))
       ..setAnchorCorner(AnchorCorner.bottomLeft)
       ..setAnchorElement(moreMenuButton)
       ..hoistMenuToBody();
@@ -328,7 +328,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
         .onClick
         .listen((_) => _toggleMenu(moreMenu));
     moreMenu.listen('MDCMenu:selected', (e) {
-      var idx = (e as CustomEvent).detail['index'] as int?;
+      final idx = (e as CustomEvent).detail['index'] as int?;
       switch (idx) {
         case 0:
           _showSharingPage();
@@ -347,16 +347,16 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   Element _buildChannelsMenu(List<Channel> channels) {
-    var element = querySelector('#channels-menu')!;
+    final element = querySelector('#channels-menu')!;
     element.children = [];
 
-    var listElement = _mdcList();
+    final listElement = _mdcList();
     element.children.add(listElement);
 
-    var currentChannel = queryParams.channel;
+    final currentChannel = queryParams.channel;
 
     for (var channel in channels) {
-      var checkmark = SpanElement()
+      final checkmark = SpanElement()
         ..id = ('${channel.name}-checkmark')
         ..classes.add('channel-menu-left')
         ..classes.add('mdc-list-item__graphic')
@@ -372,7 +372,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
         checkmark.classes.toggle('hide');
       }
 
-      var menuElement = _mdcListItem(children: [
+      final menuElement = _mdcListItem(children: [
         DivElement()
           ..classes.add('channel-item-group')
           ..children = [
@@ -406,7 +406,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       Channel.fromVersion('old'),
     ]);
 
-    var element = _buildChannelsMenu(channels);
+    final element = _buildChannelsMenu(channels);
     _configureChannelsMenu(element);
 
     // Set the initial channel from the current query parameter
@@ -424,8 +424,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   void _handleChannelsMenuSelected(e) {
-    var index = (e as CustomEvent).detail['index'] as int;
-    var channel = Channel.urlMapping.keys.toList()[index];
+    final index = (e as CustomEvent).detail['index'] as int;
+    final channel = Channel.urlMapping.keys.toList()[index];
     _handleChannelSwitched(channel);
   }
 
@@ -438,7 +438,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     });
 
   LIElement _mdcListItem({List<Element> children = const []}) {
-    var element = LIElement()
+    final element = LIElement()
       ..classes.add('mdc-list-item')
       ..classes.add('channel-menu-list')
       ..attributes.addAll({'role': 'menuitem'});
@@ -449,8 +449,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   void _initSplitters() {
-    var editorPanel = querySelector('#editor-panel')!;
-    var outputPanel = querySelector('#output-panel')!;
+    final editorPanel = querySelector('#editor-panel')!;
+    final outputPanel = querySelector('#output-panel')!;
 
     flexSplit(
       [editorPanel, outputPanel],
@@ -468,7 +468,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       return;
     }
 
-    var outputHost = querySelector('#right-output-panel')!;
+    final outputHost = querySelector('#right-output-panel')!;
     _rightSplitter = flexSplit(
       [outputHost, _rightDocPanel],
       horizontal: false,
@@ -514,7 +514,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   MaterialTabController _initTabs() {
-    var webLayoutTabController =
+    final webLayoutTabController =
         MaterialTabController(MDCTabBar(_webTabBar.element));
     for (var name in ['dart', 'html', 'css']) {
       webLayoutTabController.registerTab(
@@ -539,7 +539,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   static Future<void> _initModules() async {
-    var modules = ModuleManager();
+    final modules = ModuleManager();
 
     modules.register(DartPadModule());
     modules.register(DartServicesModule());
@@ -578,21 +578,21 @@ class Playground extends EditorUi implements GistContainer, GistController {
     context.onDartDirty.listen((_) => busyLight.on());
     context.onDartReconcile.listen((_) => performAnalysis());
 
-    Property htmlFile =
+    final Property htmlFile =
         GistFileProperty(_editableGist.getGistFile('index.html')!);
-    Property htmlDoc = EditorDocumentProperty(context.htmlDocument, 'html');
+    final Property htmlDoc = EditorDocumentProperty(context.htmlDocument, 'html');
     bind(htmlDoc, htmlFile);
     bind(htmlFile, htmlDoc);
 
-    Property cssFile =
+    final Property cssFile =
         GistFileProperty(_editableGist.getGistFile('styles.css')!);
-    Property cssDoc = EditorDocumentProperty(context.cssDocument, 'css');
+    final Property cssDoc = EditorDocumentProperty(context.cssDocument, 'css');
     bind(cssDoc, cssFile);
     bind(cssFile, cssDoc);
 
-    Property dartFile =
+    final Property dartFile =
         GistFileProperty(_editableGist.getGistFile('main.dart')!);
-    Property dartDoc = EditorDocumentProperty(context.dartDocument, 'dart');
+    final Property dartDoc = EditorDocumentProperty(context.dartDocument, 'dart');
     bind(dartDoc, dartFile);
     bind(dartFile, dartDoc);
 
@@ -655,7 +655,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _finishedInit() {
     // Clear the splash.
-    var splash = DSplash(querySelector('div.splash')!);
+    final splash = DSplash(querySelector('div.splash')!);
     splash.hide();
   }
 
@@ -682,7 +682,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   Future<void> showNew(Layout layout) async {
-    var loadResult = _loadGist();
+    final loadResult = _loadGist();
 
     // If no gist was loaded, use a new Dart gist.
     if (loadResult == LoadGistResult.none) {
@@ -731,10 +731,10 @@ class Playground extends EditorUi implements GistContainer, GistController {
     }
 
     if (_gistStorage.hasStoredGist && _gistStorage.storedId == null) {
-      var blankGist = Gist();
+      final blankGist = Gist();
       _editableGist.setBackingGist(blankGist);
 
-      var storedGist = _gistStorage.getStoredGist()!;
+      final storedGist = _gistStorage.getStoredGist()!;
 
       // Set the editable gist's backing gist so that the route handler can
       // detect the project type.
@@ -771,7 +771,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     // When sharing, we have to pipe the returned (created) gist through the
     // routing library to update the url properly.
-    var overrideNextRouteGist = _overrideNextRouteGist;
+    final overrideNextRouteGist = _overrideNextRouteGist;
     if (overrideNextRouteGist != null && overrideNextRouteGist.id == gistId) {
       _editableGist.setBackingGist(overrideNextRouteGist);
       _overrideNextRouteGist = null;
@@ -786,7 +786,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       if (_gistStorage.hasStoredGist && _gistStorage.storedId == gistId) {
         loadedFromSaved = true;
 
-        var storedGist = _gistStorage.getStoredGist()!;
+        final storedGist = _gistStorage.getStoredGist()!;
         _editableGist.description = storedGist.description;
         for (var file in storedGist.files) {
           _editableGist.getGistFile(file.name)!.content = file.content;
@@ -805,7 +805,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
         }).catchError((e) => null);
       });
     }).catchError((e) {
-      var message = 'Error loading gist $gistId.';
+      final message = 'Error loading gist $gistId.';
       showSnackbar(message);
       _logger.severe('$message: $e');
     });
@@ -813,7 +813,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   @override
   Future<bool> handleRun() async {
-    var success = await super.handleRun();
+    final success = await super.handleRun();
     if (success) {
       _webOutputLabel.setAttr('hidden');
     }
@@ -821,11 +821,11 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   Future<void> _format() {
-    var originalSource = context.dartSource;
-    var input = SourceRequest()..source = originalSource;
+    final originalSource = context.dartSource;
+    final input = SourceRequest()..source = originalSource;
     _formatButton.disabled = true;
 
-    var request = dartServices.format(input).timeout(serviceCallTimeout);
+    final request = dartServices.format(input).timeout(serviceCallTimeout);
     return request.then((FormatResponse result) {
       busyLight.reset();
       _formatButton.disabled = false;
@@ -973,7 +973,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     // Re-create the channels menu to show the correct checkmark
     for (var channelName in Channel.urlMapping.keys) {
-      var checkmark = document.querySelector('#$channelName-checkmark');
+      final checkmark = document.querySelector('#$channelName-checkmark');
       if (checkmark == null) {
         continue;
       }
@@ -995,7 +995,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   Future<void> _showCreateGistDialog() async {
-    var result = await dialog.showOkCancel(
+    final result = await dialog.showOkCancel(
         'Create New Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
       final layout = await _newPadDialog.show();
@@ -1005,7 +1005,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   }
 
   Future<void> _showResetDialog() async {
-    var result = await dialog.showOkCancel(
+    final result = await dialog.showOkCancel(
         'Reset Pad', 'Discard changes to the current pad?');
     if (result == DialogResult.ok) {
       _resetGists();
@@ -1147,8 +1147,8 @@ class NewPadDialog {
   Future<Layout?> show() {
     _createButton.toggleAttr('disabled', true);
 
-    var completer = Completer<Layout?>();
-    var dartSub = _dartButton.root.onClick.listen((_) {
+    final completer = Completer<Layout?>();
+    final dartSub = _dartButton.root.onClick.listen((_) {
       _flutterButton.root.classes.remove('selected');
       _dartButton.root.classes.add('selected');
       _createButton.toggleAttr('disabled', false);
@@ -1156,18 +1156,18 @@ class NewPadDialog {
       _htmlSwitch.disabled = false;
     });
 
-    var flutterSub = _flutterButton.root.onClick.listen((_) {
+    final flutterSub = _flutterButton.root.onClick.listen((_) {
       _dartButton.root.classes.remove('selected');
       _flutterButton.root.classes.add('selected');
       _createButton.toggleAttr('disabled', false);
       _htmlSwitchContainer.toggleClass('hide', true);
     });
 
-    var cancelSub = _cancelButton.onClick.listen((_) {
+    final cancelSub = _cancelButton.onClick.listen((_) {
       completer.complete(selectedLayout);
     });
 
-    var createSub = _createButton.onClick.listen((_) {
+    final createSub = _createButton.onClick.listen((_) {
       completer.complete(selectedLayout);
     });
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -580,7 +580,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     final Property htmlFile =
         GistFileProperty(_editableGist.getGistFile('index.html')!);
-    final Property htmlDoc = EditorDocumentProperty(context.htmlDocument, 'html');
+    final Property htmlDoc =
+        EditorDocumentProperty(context.htmlDocument, 'html');
     bind(htmlDoc, htmlFile);
     bind(htmlFile, htmlDoc);
 
@@ -592,7 +593,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     final Property dartFile =
         GistFileProperty(_editableGist.getGistFile('main.dart')!);
-    final Property dartDoc = EditorDocumentProperty(context.dartDocument, 'dart');
+    final Property dartDoc =
+        EditorDocumentProperty(context.dartDocument, 'dart');
     bind(dartDoc, dartFile);
     bind(dartFile, dartDoc);
 

--- a/lib/playground_context.dart
+++ b/lib/playground_context.dart
@@ -81,7 +81,7 @@ class PlaygroundContext extends Context {
 
   @override
   void switchTo(String name) {
-    var oldMode = activeMode;
+    final oldMode = activeMode;
 
     if (name == 'dart') {
       editor.swapDocument(_dartDoc);
@@ -136,11 +136,11 @@ class PlaygroundContext extends Context {
 
   /// Return true if the current cursor position is in a whitespace char.
   bool cursorPositionIsWhitespace() {
-    var document = editor.document;
-    var str = document.value;
-    var index = document.indexFromPos(document.cursor);
+    final document = editor.document;
+    final str = document.value;
+    final index = document.indexFromPos(document.cursor);
     if (index < 0 || index >= str.length) return false;
-    var char = str[index];
+    final char = str[index];
     return char != char.trim();
   }
 }

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -60,7 +60,7 @@ class Lines {
   final _starts = <int>[];
 
   Lines(String source) {
-    var units = source.codeUnits;
+    final units = source.codeUnits;
     var nextIsEol = true;
     for (var i = 0; i < units.length; i++) {
       if (nextIsEol) {

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -232,11 +232,11 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
     if (_frame.parent != null) {
       _readyCompleter = Completer();
 
-      var clone = _frame.clone(false) as IFrameElement;
+      final clone = _frame.clone(false) as IFrameElement;
       clone.src = _frameSrc;
 
-      var children = _frame.parent!.children;
-      var index = children.indexOf(_frame);
+      final children = _frame.parent!.children;
+      final index = children.indexOf(_frame);
       children.insert(index, clone);
       _frame.parent!.children.remove(_frame);
       _frame = clone;

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -71,22 +71,22 @@ abstract class EditorUi {
   /// Each package name links to its page at pub.dev; each package version
   /// links to the version page at pub.dev; Each link opens in a new tab.
   void showPackageVersionsDialog() {
-    var directlyImportableList = StringBuffer('<dl>');
-    var indirectList = StringBuffer('<dl>');
+    final directlyImportableList = StringBuffer('<dl>');
+    final indirectList = StringBuffer('<dl>');
     for (var package in _packageInfo) {
-      var packageUrl = 'https://pub.dev/packages/${package.name}';
-      var packageLink = AnchorElement()
+      final packageUrl = 'https://pub.dev/packages/${package.name}';
+      final packageLink = AnchorElement()
         ..href = packageUrl
         ..setAttribute('target', '_blank')
         ..text = package.name;
-      var dt = '<dt>${packageLink.outerHtml}</dt>';
-      var packageVersion = package.version;
-      var versionLink = SpanElement()
+      final dt = '<dt>${packageLink.outerHtml}</dt>';
+      final packageVersion = package.version;
+      final versionLink = SpanElement()
         ..children.add(AnchorElement()
           ..href = '$packageUrl/versions/$packageVersion'
           ..setAttribute('target', '_blank')
           ..text = packageVersion);
-      var dd = '<dd>${versionLink.outerHtml}</dd>';
+      final dd = '<dd>${versionLink.outerHtml}</dd>';
       if (package.supported) {
         directlyImportableList.write(dt);
         directlyImportableList.write(dd);
@@ -97,12 +97,12 @@ abstract class EditorUi {
     }
     directlyImportableList.write('</dl>');
     indirectList.write('</dl>');
-    var directDl = Element.html(directlyImportableList.toString(),
+    final directDl = Element.html(directlyImportableList.toString(),
         treeSanitizer: NodeTreeSanitizer.trusted);
-    var indirectDl = Element.html(indirectList.toString(),
+    final indirectDl = Element.html(indirectList.toString(),
         treeSanitizer: NodeTreeSanitizer.trusted);
 
-    var div = DivElement()
+    final div = DivElement()
       ..children.add(DivElement()
         ..children
             .add(ParagraphElement()..text = 'Directly importable packages')
@@ -123,15 +123,15 @@ abstract class EditorUi {
   /// Perform static analysis of the source code. Return whether the code
   /// analyzed cleanly (had no errors or warnings).
   Future<bool> performAnalysis() async {
-    var input = SourceRequest()..source = fullDartSource;
+    final input = SourceRequest()..source = fullDartSource;
 
-    var lines = Lines(input.source);
+    final lines = Lines(input.source);
 
-    var request = dartServices.analyze(input).timeout(serviceCallTimeout);
+    final request = dartServices.analyze(input).timeout(serviceCallTimeout);
     analysisRequest = request;
 
     try {
-      var result = await request;
+      final result = await request;
       // Discard if we requested another analysis.
       if (analysisRequest != request) return false;
 
@@ -143,21 +143,21 @@ abstract class EditorUi {
       displayIssues(result.issues);
 
       currentDocument.setAnnotations(result.issues.map((AnalysisIssue issue) {
-        var startLine = lines.getLineForOffset(issue.charStart);
-        var endLine =
+        final startLine = lines.getLineForOffset(issue.charStart);
+        final endLine =
             lines.getLineForOffset(issue.charStart + issue.charLength);
-        var offsetForStartLine = lines.offsetForLine(startLine);
+        final offsetForStartLine = lines.offsetForLine(startLine);
 
-        var start = Position(startLine, issue.charStart - offsetForStartLine);
-        var end = Position(
+        final start = Position(startLine, issue.charStart - offsetForStartLine);
+        final end = Position(
             endLine, issue.charStart + issue.charLength - offsetForStartLine);
 
         return Annotation(issue.kind, issue.message, issue.line,
             start: start, end: end);
       }).toList());
 
-      var hasErrors = result.issues.any((issue) => issue.kind == 'error');
-      var hasWarnings = result.issues.any((issue) => issue.kind == 'warning');
+      final hasErrors = result.issues.any((issue) => issue.kind == 'error');
+      final hasWarnings = result.issues.any((issue) => issue.kind == 'warning');
       return !hasErrors && !hasWarnings;
     } catch (e) {
       if (e is! TimeoutException) {
@@ -244,9 +244,9 @@ abstract class EditorUi {
   /// Updates the Flutter and Dart SDK versions in the bottom right.
   void updateVersions() async {
     try {
-      var response = await dartServices.version();
+      final response = await dartServices.version();
       // "Based on Flutter 1.19.0-4.1.pre Dart SDK 2.8.4"
-      var versionText = 'Based on Flutter ${response.flutterVersion}'
+      final versionText = 'Based on Flutter ${response.flutterVersion}'
           ' Dart SDK ${response.sdkVersionFull}';
       querySelector('#dartpad-version')!.text = versionText;
       if (response.packageVersions.isNotEmpty) {
@@ -292,8 +292,8 @@ class Channel {
     // default to the stable channel.
     rootUrl ??= stableServerUrl;
 
-    var dartservicesApi = DartservicesApi(browserClient, rootUrl: rootUrl);
-    var versionResponse = await dartservicesApi.version();
+    final dartservicesApi = DartservicesApi(browserClient, rootUrl: rootUrl);
+    final versionResponse = await dartservicesApi.version();
     return Channel._(
       name: name,
       dartVersion: versionResponse.sdkVersionFull,

--- a/lib/sharing/gist_storage.dart
+++ b/lib/sharing/gist_storage.dart
@@ -14,7 +14,7 @@ class GistStorage {
   String? _storedId;
 
   GistStorage() {
-    var gist = getStoredGist();
+    final gist = getStoredGist();
     if (gist != null) {
       _storedId = gist.id;
     }
@@ -28,7 +28,7 @@ class GistStorage {
       _storedId == null || _storedId!.isEmpty ? null : _storedId;
 
   Gist? getStoredGist() {
-    var data = window.localStorage[_key];
+    final data = window.localStorage[_key];
     return data == null
         ? null
         : Gist.fromMap(json.decode(data) as Map<String, dynamic>);

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -40,17 +40,17 @@ String? extractHtmlBody(String? html) {
   if (html == null || !html.contains('<html')) {
     return html;
   } else {
-    var body = r'body(?:\s[^>]*)?'; // Body tag with its attributes
-    var any = r'[\s\S]'; // Any character including new line
-    var bodyRegExp = RegExp('<$body>($any*)</$body>(?:(?!</$body>)$any)*',
+    final body = r'body(?:\s[^>]*)?'; // Body tag with its attributes
+    final any = r'[\s\S]'; // Any character including new line
+    final bodyRegExp = RegExp('<$body>($any*)</$body>(?:(?!</$body>)$any)*',
         multiLine: true, caseSensitive: false);
-    var match = bodyRegExp.firstMatch(html);
+    final match = bodyRegExp.firstMatch(html);
     return match == null ? '' : match.group(1)!.trim();
   }
 }
 
 Gist createSampleDartGist() {
-  var gist = Gist(description: phrases.generate());
+  final gist = Gist(description: phrases.generate());
   gist.files.add(GistFile(name: 'main.dart', content: sample.dartCode));
   gist.files.add(GistFile(
       name: 'readme.md',
@@ -60,7 +60,7 @@ Gist createSampleDartGist() {
 }
 
 Gist createSampleHtmlGist() {
-  var gist = Gist(description: phrases.generate());
+  final gist = Gist(description: phrases.generate());
   gist.files.add(GistFile(name: 'main.dart', content: sample.dartCodeHtml));
   gist.files.add(GistFile(name: 'index.html', content: sample.htmlCode));
   gist.files.add(GistFile(name: 'styles.css', content: sample.cssCode));
@@ -72,7 +72,7 @@ Gist createSampleHtmlGist() {
 }
 
 Gist createSampleFlutterGist() {
-  var gist = Gist(description: phrases.generate());
+  final gist = Gist(description: phrases.generate());
   gist.files.add(GistFile(name: 'main.dart', content: sample.flutterCode));
   gist.files.add(GistFile(
       name: 'readme.md',
@@ -84,10 +84,10 @@ Gist createSampleFlutterGist() {
 /// Find the best match for the given file names in the gist file info; return
 /// the file (or `null` if no match is found).
 GistFile? chooseGistFile(Gist gist, List<String> names, [Function? matcher]) {
-  var files = gist.files;
+  final files = gist.files;
 
   for (var name in names) {
-    var file = files.firstWhereOrNull((f) => f.name == name);
+    final file = files.firstWhereOrNull((f) => f.name == name);
     if (file != null) return file;
   }
 
@@ -129,26 +129,26 @@ class GistLoader {
     // Update files based on our preferred file names.
     if (gist.getFile('body.html') != null &&
         gist.getFile('index.html') == null) {
-      var file = gist.getFile('body.html')!;
+      final file = gist.getFile('body.html')!;
       file.name = 'index.html';
     }
 
     if (gist.getFile('style.css') != null &&
         gist.getFile('styles.css') == null) {
-      var file = gist.getFile('style.css')!;
+      final file = gist.getFile('style.css')!;
       file.name = 'styles.css';
     }
 
     if (gist.getFile('main.dart') == null &&
         gist.files.where((f) => f.name?.endsWith('.dart') ?? false).length ==
             1) {
-      var file =
+      final file =
           gist.files.firstWhere((f) => f.name?.endsWith('.dart') ?? false);
       file.name = 'main.dart';
     }
 
     // Extract the body out of the html file.
-    var htmlFile = gist.getFile('index.html');
+    final htmlFile = gist.getFile('index.html');
     if (htmlFile != null) {
       htmlFile.content = extractHtmlBody(htmlFile.content);
     }
@@ -156,16 +156,16 @@ class GistLoader {
 
   static void _defaultSaveHook(Gist gist) {
     // Create a full html file on save.
-    var hasStyles = gist.getFile('styles.css') != null;
-    var styleRef =
+    final hasStyles = gist.getFile('styles.css') != null;
+    final styleRef =
         hasStyles ? '    <link rel="stylesheet" href="styles.css">\n' : '';
 
-    var hasDart = gist.getFile('main.dart') != null;
-    var dartRef = hasDart
+    final hasDart = gist.getFile('main.dart') != null;
+    final dartRef = hasDart
         ? '    <script type="application/dart" src="main.dart"></script>\n'
         : '';
 
-    var htmlFile = gist.getFile('index.html');
+    final htmlFile = gist.getFile('index.html');
     if (htmlFile != null) {
       htmlFile.content = '''
 <!DOCTYPE html>
@@ -185,7 +185,7 @@ $styleRef$dartRef  </head>
     }
 
     // Update the readme for this gist.
-    var readmeFile = GistFile(
+    final readmeFile = GistFile(
         name: 'readme.md',
         content: _createReadmeContents(
             title: gist.description,
@@ -421,7 +421,7 @@ class Gist {
   }
 
   Map<String, dynamic> toMap() {
-    var m = <String, dynamic>{};
+    final m = <String, dynamic>{};
     if (id != null) m['id'] = id;
     if (description != null) m['description'] = description;
     if (public != null) m['public'] = public;

--- a/lib/sharing/mutable_gist.dart
+++ b/lib/sharing/mutable_gist.dart
@@ -55,7 +55,7 @@ class MutableGist implements PropertyOwner {
   Gist? get backingGist => _backingGist;
 
   void setBackingGist(Gist newGist, {bool wipeState = true}) {
-    var wasDirty = dirty;
+    final wasDirty = dirty;
     if (wipeState) _localValues.clear();
     _backingGist = newGist;
     if (wasDirty != dirty) _dirtyChangedController.add(dirty);
@@ -82,7 +82,7 @@ class MutableGist implements PropertyOwner {
   Property<String?> property(String? name) => _MutableGistProperty(this, name);
 
   Gist createGist({String? summary}) {
-    var gist = Gist(
+    final gist = Gist(
         description: description,
         id: id,
         public: public,
@@ -96,7 +96,7 @@ class MutableGist implements PropertyOwner {
   }
 
   void reset() {
-    var wasDirty = dirty;
+    final wasDirty = dirty;
     _localValues.clear();
     if (wasDirty != dirty) _dirtyChangedController.add(dirty);
     _changedController.add(null);
@@ -108,7 +108,7 @@ class MutableGist implements PropertyOwner {
   }
 
   void _setProperty(String? key, String? data) {
-    var wasDirty = dirty;
+    final wasDirty = dirty;
     _localValues[key] = data;
     if (_localValues[key] == _backingGist[key]) _localValues.remove(key);
     if (wasDirty != dirty) _dirtyChangedController.add(dirty);
@@ -154,7 +154,7 @@ class _MutableGistProperty implements Property<String?> {
   _MutableGistProperty(this.mutableGist, this.name) {
     _value = get();
     mutableGist.onChanged.listen((_) {
-      var newValue = get();
+      final newValue = get();
       if (newValue != _value) {
         _value = newValue;
         _changedController.add(_value);

--- a/lib/src/ga.dart
+++ b/lib/src/ga.dart
@@ -22,7 +22,7 @@ class Analytics {
   }
 
   void sendEvent(String category, String action, {String? label}) {
-    var m = <String, dynamic>{
+    final m = <String, dynamic>{
       'hitType': 'event',
       'eventCategory': category,
       'eventAction': action,
@@ -33,7 +33,7 @@ class Analytics {
 
   void sendTiming(String category, String variable, int valueMillis,
       {String? label}) {
-    var m = <String, dynamic>{
+    final m = <String, dynamic>{
       'hitType': 'timing',
       'timingCategory': category,
       'timingVar': variable,
@@ -44,7 +44,7 @@ class Analytics {
   }
 
   void sendException(String description, {bool? fatal}) {
-    var m = <String, dynamic>{
+    final m = <String, dynamic>{
       'exDescription': description,
     };
     if (fatal != null) m['exFatal'] = fatal;
@@ -53,7 +53,7 @@ class Analytics {
 
   void _ga(String method, [Map? args]) {
     if (isAvailable) {
-      var params = <dynamic>[method];
+      final params = <dynamic>[method];
       if (args != null) params.add(JsObject.jsify(args));
       _gaFunction!.apply(params);
     }
@@ -61,7 +61,7 @@ class Analytics {
 
   void _ga2(String method, String type, [Map? args]) {
     if (isAvailable) {
-      var params = <dynamic>[method, type];
+      final params = <dynamic>[method, type];
       if (args != null) params.add(JsObject.jsify(args));
       _gaFunction!.apply(params);
     }
@@ -69,7 +69,7 @@ class Analytics {
 
   void _ga3(String method, String type, String? arg, [Map? args]) {
     if (isAvailable) {
-      var params = <dynamic>[method, type, arg];
+      final params = <dynamic>[method, type, arg];
       if (args != null) params.add(JsObject.jsify(args));
       _gaFunction!.apply(params);
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -10,8 +10,8 @@ import 'dart:html';
 bool isMobile() {
   const mobileSize = 610;
 
-  var width = document.documentElement!.clientWidth;
-  var height = document.documentElement!.clientHeight;
+  final width = document.documentElement!.clientWidth;
+  final height = document.documentElement!.clientHeight;
 
   return width <= mobileSize || height <= mobileSize;
 }

--- a/lib/util/keymap.dart
+++ b/lib/util/keymap.dart
@@ -8,7 +8,7 @@ import 'package:dart_pad/core/keys.dart';
 
 // HTML for keyboard shortcuts dialog
 String? keyMapToHtml(Map<Action, Set<String>> keyMap) {
-  var dl = DListElement();
+  final dl = DListElement();
   keyMap.forEach((Action action, Set<String> keys) {
     if (!action.hidden) {
       var string = '';
@@ -21,10 +21,10 @@ String? keyMapToHtml(Map<Action, Set<String>> keyMap) {
     }
   });
 
-  var keysDialogDiv = DivElement()
+  final keysDialogDiv = DivElement()
     ..children.add(dl)
     ..classes.add('keys-dialog');
-  var div = DivElement()..children.add(keysDialogDiv);
+  final div = DivElement()..children.add(keysDialogDiv);
 
   return div.innerHtml;
 }

--- a/lib/util/query_params.dart
+++ b/lib/util/query_params.dart
@@ -39,7 +39,7 @@ class _QueryParams {
 
   set gistId(String? gistId) {
     var url = Uri.parse(window.location.toString());
-    var params = Map<String, String?>.from(url.queryParameters);
+    final params = Map<String, String?>.from(url.queryParameters);
     params['id'] = gistId;
     url = url.replace(queryParameters: params);
     window.history.replaceState({}, 'DartPad', url.toString());

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -115,7 +115,7 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _initModules() async {
-    var modules = ModuleManager();
+    final modules = ModuleManager();
 
     modules.register(DartPadModule());
     modules.register(DartServicesModule());
@@ -227,14 +227,14 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _loadWorkshop() async {
-    var fetcher = _createWorkshopFetcher();
+    final fetcher = _createWorkshopFetcher();
     _workshopState = WorkshopState(await fetcher.fetch());
   }
 
   void _initSplitters() {
-    var stepsPanel = querySelector('#steps-panel');
-    var rightPanel = querySelector('#right-panel');
-    var editorPanel = querySelector('#editor-panel')!;
+    final stepsPanel = querySelector('#steps-panel');
+    final rightPanel = querySelector('#right-panel');
+    final editorPanel = querySelector('#editor-panel')!;
 
     splitter = flexSplit(
       [stepsPanel!, rightPanel!],
@@ -316,7 +316,7 @@ class WorkshopUi extends EditorUi {
   }
 
   void _updateInstructions() {
-    var div = querySelector('#markdown-content')!;
+    final div = querySelector('#markdown-content')!;
     div.children.clear();
     div.setInnerHtml(
         markdown.markdownToHtml(_workshopState.currentStep.instructions,
@@ -333,15 +333,15 @@ class WorkshopUi extends EditorUi {
   }
 
   WorkshopFetcher _createWorkshopFetcher() {
-    var webServer = queryParams.webServer;
+    final webServer = queryParams.webServer;
     if (webServer != null && webServer.isNotEmpty) {
-      var uri = Uri.parse(webServer);
+      final uri = Uri.parse(webServer);
       return WebServerWorkshopFetcher(uri);
     }
-    var ghOwner = queryParams.githubOwner;
-    var ghRepo = queryParams.githubRepo;
-    var ghRef = queryParams.githubRef;
-    var ghPath = queryParams.githubPath;
+    final ghOwner = queryParams.githubOwner;
+    final ghRepo = queryParams.githubRepo;
+    final ghRef = queryParams.githubRef;
+    final ghPath = queryParams.githubPath;
     if (ghOwner != null &&
         ghOwner.isNotEmpty &&
         ghRepo != null &&
@@ -358,11 +358,11 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _format() {
-    var originalSource = context.dartSource;
-    var input = SourceRequest()..source = originalSource;
+    final originalSource = context.dartSource;
+    final input = SourceRequest()..source = originalSource;
     formatButton.disabled = true;
 
-    var request = dartServices.format(input).timeout(serviceCallTimeout);
+    final request = dartServices.format(input).timeout(serviceCallTimeout);
     return request.then((FormatResponse result) {
       busyLight.reset();
       formatButton.disabled = false;
@@ -427,7 +427,7 @@ class WorkshopUi extends EditorUi {
   }
 
   Future<void> _handleShowSolution() async {
-    var result = await dialog.showOkCancel(
+    final result = await dialog.showOkCancel(
         'Show solution',
         'Are you sure you want to show the solution? Your changes for this '
             'step will be lost.');
@@ -448,11 +448,11 @@ class WorkshopUi extends EditorUi {
 
   /// Return true if the current cursor position is in a whitespace char.
   bool _cursorPositionIsWhitespace() {
-    var document = editor.document;
-    var str = document.value;
-    var index = document.indexFromPos(document.cursor);
+    final document = editor.document;
+    final str = document.value;
+    final index = document.indexFromPos(document.cursor);
     if (index < 0 || index >= str.length) return false;
-    var char = str[index];
+    final char = str[index];
     return char != char.trim();
   }
 }

--- a/lib/workshops/src/fetcher_impl.dart
+++ b/lib/workshops/src/fetcher_impl.dart
@@ -10,33 +10,33 @@ abstract class WorkshopFetcherImpl implements WorkshopFetcher {
 
   @override
   Future<Workshop> fetch() async {
-    var metadata = await fetchMeta();
-    var steps = await fetchSteps(metadata);
+    final metadata = await fetchMeta();
+    final steps = await fetchSteps(metadata);
     return Workshop(metadata.name, metadata.type, steps);
   }
 
   Future<Meta> fetchMeta() async {
-    var contents = await loadFileContents(['meta.yaml']);
+    final contents = await loadFileContents(['meta.yaml']);
     return checkedYamlDecode(contents, (Map? m) => Meta.fromJson(m!));
   }
 
   Future<List<Step>> fetchSteps(Meta metadata) async {
     // Fetch each step in parallel and place the results in the original order.
-    var futures = <Future<Step>>[];
+    final futures = <Future<Step>>[];
     for (var i = 0; i < metadata.steps.length; i++) {
-      var config = metadata.steps[i];
+      final config = metadata.steps[i];
       futures.add(fetchStep(config));
     }
     return Future.wait(futures);
   }
 
   Future<Step> fetchStep(StepConfiguration config) async {
-    var directory = config.directory;
+    final directory = config.directory;
     late String instructions;
     late String snippet;
     String? solution;
 
-    var futures = <Future<String>>[];
+    final futures = <Future<String>>[];
 
     futures.add(loadFileContents([directory, 'instructions.md'])
         .then((e) => instructions = e));

--- a/lib/workshops/src/github.dart
+++ b/lib/workshops/src/github.dart
@@ -21,10 +21,10 @@ class GithubWorkshopFetcher extends WorkshopFetcherImpl {
 
   @override
   Future<String> loadFileContents(List<String> relativePath) async {
-    var url = _buildFileUrl(relativePath);
-    var res = await http.get(url);
+    final url = _buildFileUrl(relativePath);
+    final res = await http.get(url);
 
-    var statusCode = res.statusCode;
+    final statusCode = res.statusCode;
     if (statusCode == 404) {
       throw WorkshopFetchException(WorkshopFetchExceptionType.contentNotFound);
     } else if (statusCode == 403) {
@@ -38,8 +38,8 @@ class GithubWorkshopFetcher extends WorkshopFetcherImpl {
   }
 
   Uri _buildFileUrl(List<String> pathSegments) {
-    var p = path;
-    var filePath = <String>[if (p != null) p, ...pathSegments];
+    final p = path;
+    final filePath = <String>[if (p != null) p, ...pathSegments];
     return Uri(
       scheme: 'https',
       host: _apiHostname,

--- a/lib/workshops/src/web_server.dart
+++ b/lib/workshops/src/web_server.dart
@@ -9,9 +9,9 @@ class WebServerWorkshopFetcher extends WorkshopFetcherImpl {
 
   @override
   Future<String> loadFileContents(List<String> relativePath) async {
-    var fileUri =
+    final fileUri =
         uri.replace(pathSegments: [...uri.pathSegments, ...relativePath]);
-    var response = await http.get(fileUri);
+    final response = await http.get(fileUri);
     return response.body;
   }
 }

--- a/test/core/dependencies_test.dart
+++ b/test/core/dependencies_test.dart
@@ -12,7 +12,7 @@ void main() => defineTests();
 void defineTests() {
   group('dependencies', () {
     test('retrieve dependency', () {
-      var dependency = Dependencies();
+      final dependency = Dependencies();
       Dependencies.setGlobalInstance(dependency);
       expect(dependency[String], isNull);
       dependency[String] = 'foo';
@@ -21,7 +21,7 @@ void defineTests() {
     });
 
     test('runInZone', () {
-      var dependency = Dependencies();
+      final dependency = Dependencies();
       Dependencies.setGlobalInstance(dependency);
       expect(Dependencies.instance, isNotNull);
       dependency[String] = 'foo';

--- a/test/elements/bind_test.dart
+++ b/test/elements/bind_test.dart
@@ -14,8 +14,8 @@ void main() => defineTests();
 void defineTests() {
   group('bind', () {
     test('get stream changes', () {
-      var fromController = StreamController.broadcast();
-      var to = TestProperty();
+      final fromController = StreamController.broadcast();
+      final to = TestProperty();
       bind(fromController.stream, to);
       fromController.add('foo');
       return to.onChanged.first.then((_) {
@@ -24,8 +24,8 @@ void defineTests() {
     });
 
     test('get property changes', () {
-      var from = TestProperty('foo');
-      var to = TestProperty();
+      final from = TestProperty('foo');
+      final to = TestProperty();
       bind(from, to).flush();
       return to.onChanged.first.then((_) {
         expect(to.value, from.value);
@@ -33,15 +33,15 @@ void defineTests() {
     });
 
     test('target functions', () {
-      var from = TestProperty('foo');
+      final from = TestProperty('foo');
       Object? val;
       bind(from, (_val) => val = _val).flush();
       expect(val, from.value);
     });
 
     test('target properties', () {
-      var from = TestProperty('foo');
-      var to = TestProperty();
+      final from = TestProperty('foo');
+      final to = TestProperty();
       bind(from, to).flush();
       return to.onChanged.first.then((_) {
         expect(to.value, from.value);
@@ -49,9 +49,9 @@ void defineTests() {
     });
 
     test('can cancel', () {
-      var from = TestProperty();
-      var to = TestProperty();
-      var binding = bind(from, to);
+      final from = TestProperty();
+      final to = TestProperty();
+      final binding = bind(from, to);
       from.set('foo');
       binding.cancel();
       from.set('bar');

--- a/test/embed/embed_test.dart
+++ b/test/embed/embed_test.dart
@@ -43,12 +43,12 @@ void main() {
   });
   group('filterCloudUrls', () {
     test('cleans dart SDK urls', () {
-      var trace =
+      final trace =
           '(https://storage.googleapis.com/compilation_artifacts/2.2.0/dart_sdk.js:4537:11)';
       expect(embed.filterCloudUrls(trace), '([Dart SDK Source]:4537:11)');
     });
     test('cleans flutter SDK urls', () {
-      var trace =
+      final trace =
           '(https://storage.googleapis.com/compilation_artifacts/2.2.0/flutter_web.js:96550:21)';
       expect(embed.filterCloudUrls(trace), '([Flutter SDK Source]:96550:21)');
     });

--- a/test/inject/inject_embed_test.dart
+++ b/test/inject/inject_embed_test.dart
@@ -20,8 +20,8 @@ void main() {
     });
 
     test('injects a DartPad iframe with a correct code snippet', () async {
-      var iframes = querySelectorAll('iframe');
-      var iframe = iframes.first;
+      final iframes = querySelectorAll('iframe');
+      final iframe = iframes.first;
       expect(iframe, TypeMatcher<IFrameElement>());
       expect(iframe.attributes['src'],
           'embed-flutter.html?theme=dark&run=false&split=false&ga_id=example1&null_safety=false');

--- a/test/inject/inject_parser_test.dart
+++ b/test/inject/inject_parser_test.dart
@@ -8,8 +8,8 @@ import 'package:test/test.dart';
 void main() {
   group('InjectParser', () {
     test('can parse files', () {
-      var parser = InjectParser(_codelab);
-      var files = parser.read();
+      final parser = InjectParser(_codelab);
+      final files = parser.read();
       expect(files, isNotEmpty);
       expect(files['main.dart'], "String message = 'Hello, World!';\n");
       expect(files['solution.dart'], "String message = 'delete your code';\n");
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('can parse normal snippets', () {
-      var files = InjectParser(_normalSnippet).read();
+      final files = InjectParser(_normalSnippet).read();
       expect(files['main.dart'], equals("main() => print('Hello, World!');"));
     });
   });
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('supports options ', () {
-      var options = LanguageStringParser('run-dartpad:mode-html:theme-dark'
+      final options = LanguageStringParser('run-dartpad:mode-html:theme-dark'
               ':run-true:split-50:width-100%:height-400px:ga_id-example1:null_safety-true')
           .options;
       expect(options, isNotEmpty);

--- a/test/services/common_test.dart
+++ b/test/services/common_test.dart
@@ -12,7 +12,7 @@ void main() => defineTests();
 void defineTests() {
   group('Lines', () {
     test('empty string', () {
-      var lines = Lines('');
+      final lines = Lines('');
       expect(lines.getLineForOffset(0), 0);
       expect(lines.getLineForOffset(1), 0);
       expect(lines.offsetForLine(0), 0);
@@ -20,7 +20,7 @@ void defineTests() {
     });
 
     test('getLineForOffset', () {
-      var lines = Lines('one\ntwo\nthree');
+      final lines = Lines('one\ntwo\nthree');
       expect(lines.getLineForOffset(0), 0);
       expect(lines.getLineForOffset(1), 0);
       expect(lines.getLineForOffset(2), 0);
@@ -40,7 +40,7 @@ void defineTests() {
     });
 
     test('offsetForLine', () {
-      var lines = Lines('one\ntwo\nthree');
+      final lines = Lines('one\ntwo\nthree');
       expect(lines.offsetForLine(0), 0);
       expect(lines.offsetForLine(1), 4);
       expect(lines.offsetForLine(2), 8);

--- a/test/sharing/gists_test.dart
+++ b/test/sharing/gists_test.dart
@@ -49,8 +49,8 @@ void defineTests() {
       });
 
       test('should return body content with external scripts or resources', () {
-        var js = 'https://cdn.com/bootstrap.js';
-        var css = 'https://cdn.com/bootstrap.css';
+        final js = 'https://cdn.com/bootstrap.js';
+        final css = 'https://cdn.com/bootstrap.css';
         expect(extractHtmlBody('<link rel="stylesheet" href="$css">'),
             equals('<link rel="stylesheet" href="$css">'));
         expect(extractHtmlBody('<script src="$js"></script>'),
@@ -106,8 +106,8 @@ void defineTests() {
     });
 
     test('clone', () {
-      var gist = Gist(id: '2342jh2jh3g4', description: 'test gist');
-      var clone = gist.clone();
+      final gist = Gist(id: '2342jh2jh3g4', description: 'test gist');
+      final clone = gist.clone();
       expect(clone.id, gist.id);
       expect(clone.description, gist.description);
     });
@@ -115,7 +115,7 @@ void defineTests() {
 
   group('GistStorage', () {
     test('store', () {
-      var storage = GistStorage();
+      final storage = GistStorage();
       storage.setStoredGist(createSampleDartGist());
       expect(storage.hasStoredGist, true);
       expect(storage.getStoredGist(), isNotNull);
@@ -123,7 +123,7 @@ void defineTests() {
     });
 
     test('clear', () {
-      var storage = GistStorage();
+      final storage = GistStorage();
       storage.setStoredGist(createSampleDartGist());
       expect(storage.hasStoredGist, true);
       storage.clearStoredGist();

--- a/test/sharing/mutable_gist_test.dart
+++ b/test/sharing/mutable_gist_test.dart
@@ -14,16 +14,16 @@ void main() => defineTests();
 void defineTests() {
   group('MutableGist', () {
     test('mutation causes dirty', () {
-      var gist = Gist(description: 'foo');
-      var mgist = MutableGist(gist);
+      final gist = Gist(description: 'foo');
+      final mgist = MutableGist(gist);
       expect(mgist.dirty, false);
       mgist.description = 'bar';
       expect(mgist.dirty, true);
     });
 
     test('undoing mutation clear dirty', () {
-      var gist = Gist(description: 'foo');
-      var mgist = MutableGist(gist);
+      final gist = Gist(description: 'foo');
+      final mgist = MutableGist(gist);
       expect(mgist.dirty, false);
       mgist.description = 'bar';
       expect(mgist.dirty, true);
@@ -32,8 +32,8 @@ void defineTests() {
     });
 
     test('setBackingGist', () {
-      var gist = Gist(description: 'foo');
-      var mgist = MutableGist(gist);
+      final gist = Gist(description: 'foo');
+      final mgist = MutableGist(gist);
       expect(mgist.dirty, false);
       mgist.description = 'bar';
       expect(mgist.dirty, true);
@@ -42,10 +42,10 @@ void defineTests() {
     });
 
     test('createGist', () {
-      var gist = Gist(description: 'foo');
-      var mgist = MutableGist(gist);
+      final gist = Gist(description: 'foo');
+      final mgist = MutableGist(gist);
       mgist.description = 'bar';
-      var newGist = mgist.createGist();
+      final newGist = mgist.createGist();
       expect(newGist.description, 'bar');
     });
   });

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -110,8 +110,8 @@ const _nullSafetyServerUrlOption = 'null-safety-server-url';
 @Task('Build the `web/index.html` entrypoint')
 @Depends(generateProtos)
 build() {
-  var args = context.invocation.arguments;
-  var compilerArgs = {
+  final args = context.invocation.arguments;
+  final compilerArgs = {
     if (args.hasOption(_preNullSafetyServerUrlOption))
       preNullSafetyServerUrlEnvironmentVar:
           args.getOption(_preNullSafetyServerUrlOption),
@@ -133,24 +133,24 @@ build() {
     '--delete-conflicting-outputs',
   ]);
 
-  var mainFile = _buildDir.join('scripts/playground.dart.js');
+  final mainFile = _buildDir.join('scripts/playground.dart.js');
   log('$mainFile compiled to ${_printSize(mainFile)}');
 
-  var testFile = _buildDir.join('test', 'web.dart.js');
+  final testFile = _buildDir.join('test', 'web.dart.js');
   if (testFile.exists) {
     log('${testFile.path} compiled to ${_printSize(testFile)}');
   }
 
-  var newEmbedDartFile = _buildDir.join('scripts/embed_dart.dart.js');
+  final newEmbedDartFile = _buildDir.join('scripts/embed_dart.dart.js');
   log('$newEmbedDartFile compiled to ${_printSize(newEmbedDartFile)}');
 
-  var newEmbedFlutterFile = _buildDir.join('scripts/embed_flutter.dart.js');
+  final newEmbedFlutterFile = _buildDir.join('scripts/embed_flutter.dart.js');
   log('$newEmbedFlutterFile compiled to ${_printSize(newEmbedFlutterFile)}');
 
-  var newEmbedHtmlFile = _buildDir.join('scripts/embed_html.dart.js');
+  final newEmbedHtmlFile = _buildDir.join('scripts/embed_html.dart.js');
   log('$newEmbedHtmlFile compiled to ${_printSize(newEmbedHtmlFile)}');
 
-  var newEmbedInlineFile = _buildDir.join('scripts/embed_inline.dart.js');
+  final newEmbedInlineFile = _buildDir.join('scripts/embed_inline.dart.js');
   log('$newEmbedInlineFile compiled to ${_printSize(newEmbedInlineFile)}');
 
   // Remove .dart files.
@@ -170,14 +170,14 @@ build() {
 /// Formats a map of argument key and values to be passed as `dart2js_args` for
 /// webdev.
 String _formatDart2jsArgs(Map<String, String?> args) {
-  var values = args.entries.map((entry) => '"-D${entry.key}=${entry.value}"');
+  final values = args.entries.map((entry) => '"-D${entry.key}=${entry.value}"');
   return '[${values.join(',')}]';
 }
 
 /// Formats a map of argument key and values to be passed as DDC environment
 /// variables.
 String _formatDdcArgs(Map<String, String?> args) {
-  var values = args.entries.map((entry) => '"${entry.key}":"${entry.value}"');
+  final values = args.entries.map((entry) => '"${entry.key}":"${entry.value}"');
   return '{${values.join(',')}}';
 }
 
@@ -188,7 +188,7 @@ coverage() {
     return;
   }
 
-  var coveralls = PubApp.global('dart_coveralls');
+  final coveralls = PubApp.global('dart_coveralls');
   coveralls.run([
     'report',
     '--token',
@@ -212,9 +212,9 @@ deploy() async {
   // `dev` is served from dev.dart-pad.appspot.com
   // `prod` is served from prod.dart-pad.appspot.com and from dartpad.dartlang.org.
 
-  var app = yaml.loadYaml(File('web/app.yaml').readAsStringSync()) as Map;
+  final app = yaml.loadYaml(File('web/app.yaml').readAsStringSync()) as Map;
 
-  var handlers = app['handlers'];
+  final handlers = app['handlers'];
   var isSecure = false;
 
   for (var m in handlers) {

--- a/web/example/picker.dart
+++ b/web/example/picker.dart
@@ -20,8 +20,8 @@ String f() {
     ''';
 
 void main() {
-  var dartPadHost = querySelector('#dartpad-host')!;
-  var select = querySelector('#dartpad-select') as SelectElement;
+  final dartPadHost = querySelector('#dartpad-host')!;
+  final select = querySelector('#dartpad-select') as SelectElement;
 
   DartPadPicker(dartPadHost, select, snippets, dartPadUrl: '');
 }
@@ -65,8 +65,8 @@ class DartPadPicker {
 
   void _initSelectElement() {
     for (var i = 0; i < snippets.length; i++) {
-      var snippet = snippets[i];
-      var option = OptionElement(value: '$i')..text = snippet.name;
+      final snippet = snippets[i];
+      final option = OptionElement(value: '$i')..text = snippet.name;
       selectElement.children.add(option);
     }
     selectElement.onChange.listen((Event _) {


### PR DESCRIPTION
In order to eventually combine the dart-services and dart-pad repositories, it would be nice to align their analysis_options.yaml files, and then use a single analysis_options file.

This PR was generated by `dart fix`, making final-able locals final.

Towards https://github.com/dart-lang/dart-pad/issues/1350