### PR TITLE
Keep CanvasKit script cached on iframe

### DIFF
--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -5,11 +5,6 @@
  */
 
 replaceJavaScript = function (value) {
-    // Remove canvaskit from this page, This can be removed when this PR lands
-    // in dart-services:
-    // https://github.com/flutter/engine/pull/26059
-    removeCanvaskit();
-
     // Remove the old node.
     var oldNode = document.getElementById('compiledJsScript');
     if (oldNode && oldNode.parentNode) {


### PR DESCRIPTION
https://github.com/flutter/engine/pull/26059 is a fix that allows canvaskit to be cached on the page. The
Flutter SDK commit is https://github.com/flutter/flutter/commit/d9db3ea6e6b1cccda5838b11c156595f109df68c, which  is now available on the stable channel.

