### PR TITLE
Remove pedantic import

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -10,7 +10,6 @@ import 'package:dart_pad/elements/material_tab_controller.dart';
 import 'package:dart_pad/src/ga.dart';
 import 'package:dart_pad/util/detect_flutter.dart';
 import 'package:mdc_web/mdc_web.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:split/split.dart';
 
 import 'check_localstorage.dart';


### PR DESCRIPTION
This is no longer in the pubspec, so should not be in this file.

`unawaited` is no provided by `dart:async`.

I think the presence of this import is breaking a recent version of build_runner...