### PR TITLE
Bump Firebase JS SDKs to 8.6.1

### DIFF
--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -53,9 +53,9 @@ removeScript = function (id) {
 }
 
 addFirebase = function () {
-    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.4.1/firebase-app.js');
-    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.4.1/firebase-auth.js');
-    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.4.1/firebase-database.js',
+    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js');
+    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js');
+    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-database.js',
     function() {
         // To prevent poor interaction between a firebase iframe, and the
         // sandboxed render iframe, use this one weird trick. Otherwise, you
@@ -64,7 +64,7 @@ addFirebase = function () {
         // * https://github.com/firebase/firebase-js-sdk/issues/123.
         firebase.database.INTERNAL.forceWebSockets();
     });
-    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.4.1/firebase-firestore.js');
+    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js');
 }
 
 removeFirebase = function () {

--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -53,9 +53,9 @@ removeScript = function (id) {
 }
 
 addFirebase = function () {
-    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js');
-    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js');
-    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-database.js',
+    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js');
+    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-auth.js');
+    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-database.js',
     function() {
         // To prevent poor interaction between a firebase iframe, and the
         // sandboxed render iframe, use this one weird trick. Otherwise, you
@@ -64,7 +64,7 @@ addFirebase = function () {
         // * https://github.com/firebase/firebase-js-sdk/issues/123.
         firebase.database.INTERNAL.forceWebSockets();
     });
-    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.10.0/firebase-firestore.js');
+    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-firestore.js');
 }
 
 removeFirebase = function () {


### PR DESCRIPTION
Here are the recent changelogs starting at 8.6.1:

https://firebase.google.com/support/release-notes/js#version_861_-_may_12_2021