### PR TITLE
Prevent long lines of text from expanding the console panel

### DIFF
--- a/lib/elements/console.dart
+++ b/lib/elements/console.dart
@@ -39,6 +39,10 @@ class Console {
     }
 
     final div = DivElement()..text = '$message\n';
+
+    // Prevent long lines of text from expanding the console panel.
+    div.style.width = '0';
+
     div.classes.add(error ? errorClass : 'normal');
 
     // Buffer the console output so that heavy writing to stdout does not starve


### PR DESCRIPTION
This is a bit of a CSS hack, but I tested with the playground and embeds and it fixes the issue. We don't want the `div` elements to expand, so we set the width to zero. The text is still displayed and laid out normally.

fixes #2072