### PR TITLE
Use "white-space: pre" for error messages in the console.

### DIFF
--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -327,6 +327,6 @@ body {
   flex-direction: column !important;
 }
 
-.console .normal {
+.console {
   white-space: pre !important;
 }

--- a/web/styles/shared.scss
+++ b/web/styles/shared.scss
@@ -131,6 +131,6 @@ button#run-button {
   }
 }
 
-.console .normal {
+.console {
   white-space: pre !important;
 }


### PR DESCRIPTION
This is a follow up to https://github.com/dart-lang/dart-pad/pull/2073, which changed how error messages are displayed. If you run this snippet:

```dart
void main() {
  throw('This is a really long line... This is a really long line... This is a really long line... This is a really long line... This is a really long line... This is a really long line... This is a really long line... This is a really long line... This is a really long line... ');
}
```

it prints each word on a new line:

<img width="185" alt="Screen Shot 2021-11-10 at 2 52 02 PM" src="https://user-images.githubusercontent.com/1145719/141206641-6db283d1-c7bb-4152-a03a-8a38deb4a7a3.png">

This configures error messages to use the same CSS styles as normal print statements:

<img width="588" alt="Screen Shot 2021-11-10 at 2 53 03 PM" src="https://user-images.githubusercontent.com/1145719/141206699-76b1653d-458a-4f18-a89c-1f9e1c8593f4.png">


