### PR TITLE
Share more static analysis options with services

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -16,7 +16,10 @@ linter:
     - always_declare_return_types
     - avoid_private_typedef_functions
     - directives_ordering
+    - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_mixin
+    - prefer_relative_imports
     - prefer_single_quotes
+    - sort_pub_dependencies
     - unawaited_futures

--- a/lib/completion.dart
+++ b/lib/completion.dart
@@ -42,8 +42,8 @@ class DartCompleter extends CodeCompleter {
       final completions = <Completion>[];
       final fixesFuture =
           servicesApi.fixes(request).then((ds.FixesResponse response) {
-        for (var problemFix in response.fixes) {
-          for (var fix in problemFix.fixes) {
+        for (final problemFix in response.fixes) {
+          for (final fix in problemFix.fixes) {
             final fixes = fix.edits.map((edit) {
               return SourceEdit(edit.length, edit.offset, edit.replacement);
             }).toList();
@@ -59,7 +59,7 @@ class DartCompleter extends CodeCompleter {
       });
       final assistsFuture =
           servicesApi.assists(request).then((ds.AssistsResponse response) {
-        for (var assist in response.assists) {
+        for (final assist in response.assists) {
           final sourceEdits = assist.edits
               .map((edit) =>
                   SourceEdit(edit.length, edit.offset, edit.replacement))
@@ -155,8 +155,8 @@ class DartCompleter extends CodeCompleter {
         }).toList();
 
         // Removes duplicates when a completion is both a getter and a setter.
-        for (var completion in completions) {
-          for (var other in completions) {
+        for (final completion in completions) {
+          for (final other in completions) {
             if (completion.isSetterAndMatchesGetter(other)) {
               completions.removeWhere((c) => completion == c);
               other.type = 'type-getter_and_setter';

--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -8,7 +8,6 @@ import 'dart:convert' as convert show htmlEscape;
 import 'dart:html';
 import 'dart:math' as math;
 
-import 'package:dart_pad/util/detect_flutter.dart';
 import 'package:markdown/markdown.dart' as markdown;
 
 import 'context.dart';
@@ -17,6 +16,7 @@ import 'editing/editor.dart';
 import 'services/common.dart';
 import 'services/dartservices.dart';
 import 'src/util.dart';
+import 'util/detect_flutter.dart';
 
 class DocHandler {
   static const Set<int> cursorKeys = {

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -343,16 +343,16 @@ class _CodeMirrorDocument extends Document<_CodeMirrorEditor> {
 
   @override
   void setAnnotations(List<Annotation> annotations) {
-    for (var marker in doc!.getAllMarks()) {
+    for (final marker in doc!.getAllMarks()) {
       marker.clear();
     }
 
-    for (var widget in widgets) {
+    for (final widget in widgets) {
       widget.clear();
     }
     widgets.clear();
 
-    for (var e in nodes) {
+    for (final e in nodes) {
       e.parent!.children.remove(e);
     }
     nodes.clear();
@@ -362,7 +362,7 @@ class _CodeMirrorDocument extends Document<_CodeMirrorEditor> {
 
     var lastLine = -1;
 
-    for (var an in annotations) {
+    for (final an in annotations) {
       // Create in-line squiggles.
       doc!.markText(_posToPos(an.start), _posToPos(an.end),
           className: 'squiggle-${an.type}', title: an.message);

--- a/lib/elements/analysis_results_controller.dart
+++ b/lib/elements/analysis_results_controller.dart
@@ -5,10 +5,11 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart_pad/elements/button.dart';
-import 'package:dart_pad/elements/elements.dart';
-import 'package:dart_pad/services/dartservices.dart';
 import 'package:mdc_web/mdc_web.dart';
+
+import '../services/dartservices.dart';
+import 'button.dart';
+import 'elements.dart';
 
 class AnalysisResultsController {
   static const String _noIssuesMsg = 'no issues';
@@ -73,9 +74,8 @@ class AnalysisResultsController {
     message.text = '$amount ${amount == 1 ? 'issue' : 'issues'}';
 
     flash.clearChildren();
-    for (var issue in issues) {
-      final elem = _createIssueElement(issue);
-      flash.add(elem);
+    for (final issue in issues) {
+      flash.add(_createIssueElement(issue));
     }
   }
 
@@ -112,9 +112,8 @@ class AnalysisResultsController {
     }
 
     // TODO: This should likely be named contextMessages.
-    for (var diagnostic in issue.diagnosticMessages) {
-      final diagnosticElement = _createDiagnosticElement(diagnostic);
-      columnElem.children.add(diagnosticElement);
+    for (final diagnostic in issue.diagnosticMessages) {
+      columnElem.children.add(_createDiagnosticElement(diagnostic));
     }
 
     elem.children.add(columnElem);

--- a/lib/elements/button.dart
+++ b/lib/elements/button.dart
@@ -4,8 +4,9 @@
 
 import 'dart:html';
 
-import 'package:dart_pad/elements/elements.dart';
 import 'package:mdc_web/mdc_web.dart';
+
+import 'elements.dart';
 
 /// Adds a ripple effect to material design buttons
 class MDCButton extends DButton {

--- a/lib/elements/console.dart
+++ b/lib/elements/console.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart_pad/elements/elements.dart';
+import 'elements.dart';
 
 typedef ConsoleFilter = String Function(String line);
 

--- a/lib/elements/dialog.dart
+++ b/lib/elements/dialog.dart
@@ -5,8 +5,9 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart_pad/src/util.dart';
 import 'package:mdc_web/mdc_web.dart';
+
+import '../src/util.dart';
 
 enum DialogResult {
   yes,

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -568,7 +568,7 @@ class TabController {
   void selectTab(String? tabName) {
     final tab = tabs.firstWhere((t) => t.name == tabName);
 
-    for (var t in tabs) {
+    for (final t in tabs) {
       t.toggleAttr('selected', t == tab);
     }
 

--- a/lib/elements/material_tab_controller.dart
+++ b/lib/elements/material_tab_controller.dart
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:dart_pad/elements/elements.dart';
 import 'package:mdc_web/mdc_web.dart';
+
+import 'elements.dart';
 
 /// Implementation of [TabController] for usage with mdc_web tabs.
 class MaterialTabController extends TabController {
@@ -18,7 +19,7 @@ class MaterialTabController extends TabController {
 
     tabBar.activateTab(idx);
 
-    for (var t in tabs) {
+    for (final t in tabs) {
       t.toggleAttr('aria-selected', t == tab);
     }
 

--- a/lib/elements/tab_expand_controller.dart
+++ b/lib/elements/tab_expand_controller.dart
@@ -222,7 +222,7 @@ class TabExpandController {
     consoleButton.toggleClass('active', false);
 
     // Clear listeners
-    for (var s in _subscriptions) {
+    for (final s in _subscriptions) {
       s.cancel();
     }
     _subscriptions.clear();

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -6,9 +6,6 @@ import 'dart:async';
 import 'dart:html' hide Document, Console;
 import 'dart:math' as math;
 
-import 'package:dart_pad/elements/material_tab_controller.dart';
-import 'package:dart_pad/src/ga.dart';
-import 'package:dart_pad/util/detect_flutter.dart';
 import 'package:mdc_web/mdc_web.dart';
 import 'package:split/split.dart';
 
@@ -26,6 +23,7 @@ import 'elements/console.dart';
 import 'elements/counter.dart';
 import 'elements/dialog.dart';
 import 'elements/elements.dart';
+import 'elements/material_tab_controller.dart';
 import 'modules/dart_pad_module.dart';
 import 'modules/dartservices_module.dart';
 import 'services/common.dart';
@@ -33,6 +31,8 @@ import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/editor_ui.dart';
 import 'sharing/gists.dart';
+import 'src/ga.dart';
+import 'util/detect_flutter.dart';
 import 'util/query_params.dart' show queryParams;
 
 const int defaultSplitterWidth = 6;
@@ -156,7 +156,7 @@ class Embed extends EditorUi {
         ? const ['editor', 'html', 'css', 'solution', 'test']
         : const ['editor', 'solution', 'test'];
 
-    for (var name in tabNames) {
+    for (final name in tabNames) {
       tabController.registerTab(
         TabElement(querySelector('#$name-tab')!, name: name, onSelect: () {
           editorTabView.setSelected(name == 'editor');

--- a/lib/inject/inject_embed.dart
+++ b/lib/inject/inject_embed.dart
@@ -4,10 +4,10 @@
 
 import 'dart:html';
 
-import 'package:dart_pad/util/logging.dart';
 import 'package:html_unescape/html_unescape.dart';
 import 'package:logging/logging.dart';
 
+import '../util/logging.dart';
 import 'inject_parser.dart';
 
 Logger _logger = Logger('dartpad-embed');
@@ -21,7 +21,7 @@ var iframePrefix = 'https://dartpad.dev/';
 void main() {
   _logger.onRecord.listen(logToJsConsole);
   final snippets = querySelectorAll('code');
-  for (var snippet in snippets) {
+  for (final snippet in snippets) {
     if (snippet.classes.isEmpty) {
       continue;
     }

--- a/lib/inject/inject_parser.dart
+++ b/lib/inject/inject_parser.dart
@@ -98,7 +98,7 @@ class LanguageStringParser {
     }
 
     final matches = _optionsExp.allMatches(input);
-    for (var match in matches) {
+    for (final match in matches) {
       if (match.groupCount != 2) {
         continue;
       }

--- a/lib/modules/dartservices_module.dart
+++ b/lib/modules/dartservices_module.dart
@@ -44,7 +44,7 @@ class SanitizingBrowserClient extends BrowserClient {
   /// Strips all disallowed headers for an HTTP request before sending it.
   @override
   Future<StreamedResponse> send(BaseRequest request) {
-    for (var headerKey in disallowedHeaders) {
+    for (final headerKey in disallowedHeaders) {
       request.headers.remove(headerKey);
     }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -7,7 +7,6 @@ library playground;
 import 'dart:async';
 import 'dart:html' hide Console;
 
-import 'package:dart_pad/editing/editor_codemirror.dart';
 import 'package:logging/logging.dart';
 import 'package:mdc_web/mdc_web.dart';
 import 'package:split/split.dart';
@@ -22,6 +21,7 @@ import 'core/modules.dart';
 import 'dart_pad.dart';
 import 'documentation.dart';
 import 'editing/codemirror_options.dart';
+import 'editing/editor_codemirror.dart';
 import 'elements/analysis_results_controller.dart';
 import 'elements/bind.dart';
 import 'elements/button.dart';
@@ -293,7 +293,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     final listElement = _mdcList();
     element.children.add(listElement);
 
-    for (var sample in samples) {
+    for (final sample in samples) {
       final menuElement = _mdcListItem(children: [
         ImageElement()
           ..classes.add('mdc-list-item__graphic')
@@ -356,7 +356,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
     final currentChannel = queryParams.channel;
 
-    for (var channel in channels) {
+    for (final channel in channels) {
       final checkmark = SpanElement()
         ..id = ('${channel.name}-checkmark')
         ..classes.add('channel-menu-left')
@@ -443,7 +443,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       ..classes.add('mdc-list-item')
       ..classes.add('channel-menu-list')
       ..attributes.addAll({'role': 'menuitem'});
-    for (var child in children) {
+    for (final child in children) {
       element.children.add(child);
     }
     return element;
@@ -517,7 +517,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
   MaterialTabController _initTabs() {
     final webLayoutTabController =
         MaterialTabController(MDCTabBar(_webTabBar.element));
-    for (var name in ['dart', 'html', 'css']) {
+    for (final name in ['dart', 'html', 'css']) {
       webLayoutTabController.registerTab(
           TabElement(querySelector('#$name-tab')!, name: name, onSelect: () {
         ga.sendEvent('edit', name);
@@ -744,7 +744,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       _editableGist.setBackingGist(storedGist);
 
       _editableGist.description = storedGist.description;
-      for (var file in storedGist.files) {
+      for (final file in storedGist.files) {
         _editableGist.getGistFile(file.name)!.content = file.content;
       }
       return LoadGistResult.storage;
@@ -795,7 +795,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
         final storedGist = _gistStorage.getStoredGist()!;
         _editableGist.description = storedGist.description;
-        for (var file in storedGist.files) {
+        for (final file in storedGist.files) {
           _editableGist.getGistFile(file.name)!.content = file.content;
         }
       }
@@ -981,7 +981,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     performAnalysis();
 
     // Re-create the channels menu to show the correct checkmark
-    for (var channelName in Channel.urlMapping.keys) {
+    for (final channelName in Channel.urlMapping.keys) {
       final checkmark = document.querySelector('#$channelName-checkmark');
       if (checkmark == null) {
         continue;

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -1,10 +1,6 @@
 import 'dart:async';
 import 'dart:html';
 
-import 'package:dart_pad/elements/button.dart';
-import 'package:dart_pad/elements/dialog.dart';
-import 'package:dart_pad/services/execution.dart';
-import 'package:dart_pad/util/keymap.dart';
 import 'package:logging/logging.dart';
 import 'package:mdc_web/mdc_web.dart';
 import 'package:meta/meta.dart';
@@ -13,9 +9,13 @@ import '../context.dart';
 import '../dart_pad.dart';
 import '../editing/editor.dart';
 import '../elements/analysis_results_controller.dart';
+import '../elements/button.dart';
+import '../elements/dialog.dart';
 import '../elements/elements.dart';
 import '../services/common.dart';
 import '../services/dartservices.dart';
+import '../services/execution.dart';
+import '../util/keymap.dart';
 
 abstract class EditorUi {
   final Logger logger = Logger('dartpad');
@@ -73,7 +73,7 @@ abstract class EditorUi {
   void showPackageVersionsDialog() {
     final directlyImportableList = StringBuffer('<dl>');
     final indirectList = StringBuffer('<dl>');
-    for (var package in _packageInfo) {
+    for (final package in _packageInfo) {
       final packageUrl = 'https://pub.dev/packages/${package.name}';
       final packageLink = AnchorElement()
         ..href = packageUrl

--- a/lib/sharing/gist_storage.dart
+++ b/lib/sharing/gist_storage.dart
@@ -5,7 +5,7 @@
 import 'dart:convert' show json;
 import 'dart:convert';
 import 'dart:html';
-import 'package:dart_pad/sharing/gists.dart';
+import 'gists.dart';
 
 /// A class to store gists in html's localStorage.
 class GistStorage {

--- a/lib/sharing/gists.dart
+++ b/lib/sharing/gists.dart
@@ -8,13 +8,14 @@ import 'dart:convert' show json;
 import 'dart:convert';
 
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:dart_pad/sharing/exercise_metadata.dart';
-import 'package:dart_pad/src/sample.dart' as sample;
 import 'package:fluttering_phrases/fluttering_phrases.dart' as phrases;
 import 'package:http/http.dart' as http;
 import 'package:yaml/yaml.dart' as yaml;
+
+import '../src/sample.dart' as sample;
 import '../util/detect_flutter.dart' as detect_flutter;
 import '../util/github.dart';
+import 'exercise_metadata.dart';
 
 final String _dartpadLink = '[dartpad.dev](https://dartpad.dev)';
 
@@ -86,7 +87,7 @@ Gist createSampleFlutterGist() {
 GistFile? chooseGistFile(Gist gist, List<String> names, [Function? matcher]) {
   final files = gist.files;
 
-  for (var name in names) {
+  for (final name in names) {
     final file = files.firstWhereOrNull((f) => f.name == name);
     if (file != null) return file;
   }
@@ -391,7 +392,7 @@ class Gist {
     if (key == 'html_url') return htmlUrl;
     if (key == 'public') return public;
     if (key == 'summary') return summary;
-    for (var file in files) {
+    for (final file in files) {
       if (file.name == key) return file.content;
     }
     return null;
@@ -427,7 +428,7 @@ class Gist {
     if (public != null) m['public'] = public;
     if (summary != null) m['summary'] = summary;
     m['files'] = {};
-    for (var file in files) {
+    for (final file in files) {
       if (file.hasContent) {
         m['files'][file.name] = {'content': file.content};
       }

--- a/lib/util/keymap.dart
+++ b/lib/util/keymap.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html';
 
-import 'package:dart_pad/core/keys.dart';
+import '../core/keys.dart';
 
 // HTML for keyboard shortcuts dialog
 String? keyMapToHtml(Map<Action, Set<String>> keyMap) {

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -1,15 +1,16 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:html' hide Console;
 
-import 'package:dart_pad/context.dart';
-import 'package:dart_pad/src/util.dart';
-import 'package:dart_pad/util/detect_flutter.dart';
-import 'package:dart_pad/util/query_params.dart';
 import 'package:markdown/markdown.dart' as markdown;
 import 'package:split/split.dart';
 import 'package:stream_transform/stream_transform.dart';
 
 import 'completion.dart';
+import 'context.dart';
 import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
@@ -32,6 +33,9 @@ import 'services/dartservices.dart';
 import 'services/execution_iframe.dart';
 import 'sharing/editor_ui.dart';
 import 'src/ga.dart';
+import 'src/util.dart';
+import 'util/detect_flutter.dart';
+import 'util/query_params.dart';
 import 'workshops/workshops.dart';
 
 WorkshopUi? _workshopUi;

--- a/lib/workshops/src/github.dart
+++ b/lib/workshops/src/github.dart
@@ -1,6 +1,10 @@
-import 'package:dart_pad/util/github.dart';
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:http/http.dart' as http;
 
+import '../../util/github.dart';
 import 'exceptions.dart';
 import 'fetcher_impl.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,24 +5,24 @@ environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
+  checked_yaml: ^2.0.0
   codemirror: ^0.6.0-0
   collection: ^1.15.0
   fluttering_phrases: ^0.3.1
+  html_unescape: ^2.0.0
   http: ^0.13.0
+  js: ^0.6.0
   json_annotation: ^4.3.0
   logging: ^1.0.0
   markdown: ^4.0.0
+  mdc_web: ^0.6.0
   meta: ^1.2.4
   protobuf: ^2.0.0
+  sass_builder: ^2.1.0
   split:
     path: third_party/pkg/split/
-  html_unescape: ^2.0.0
-  sass_builder: ^2.1.0
-  mdc_web: ^0.6.0
-  yaml: ^3.0.0
-  checked_yaml: ^2.0.0
-  js: ^0.6.0
   stream_transform: ^2.0.0
+  yaml: ^3.0.0
 
 dev_dependencies:
   build_runner: ^2.0.0
@@ -42,7 +42,7 @@ dev_dependencies:
 #
 # https://github.com/material-components/material-components-web/pull/7158
 dependency_overrides:
-  sass: 1.32.10
   # `pub downgrade` will choose 8.0.0 but this conflicts in nullability with some
   # other dependency...
   built_value: ^8.1.0
+  sass: 1.32.10

--- a/test/e2e/playground_test.dart
+++ b/test/e2e/playground_test.dart
@@ -46,7 +46,7 @@ void main() async {
     // Start the Chromedriver process
     chromedriverProcess = await startChromedriver();
 
-    await for (String browserOut in const LineSplitter()
+    await for (final browserOut in const LineSplitter()
         .bind(utf8.decoder.bind(chromedriverProcess.stdout))) {
       if (browserOut.contains('Starting ChromeDriver')) {
         break;

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -157,7 +157,7 @@ build() {
   // Remove .dart files.
   var count = 0;
 
-  for (var entity in getDir('build/packages')
+  for (final entity in getDir('build/packages')
       .listSync(recursive: true, followLinks: false)) {
     if (entity is! File) continue;
     if (!entity.path.endsWith('.dart')) continue;
@@ -218,7 +218,7 @@ deploy() async {
   final handlers = app['handlers'];
   var isSecure = false;
 
-  for (var m in handlers) {
+  for (final m in handlers) {
     if (m['url'] == '.*') {
       isSecure = m['secure'] == 'always';
     }


### PR DESCRIPTION
Most fixes were made with `dart fix`, and then I had to manually sort the imports.

I don't have strong feelings about these three lint rules, but they are used in dart-services, so we should either add them here, or drop them there.