### PR TITLE
Stable is now null safe

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,8 +16,8 @@ targets:
           dart2js_args:
           - --minify
           - --fast-startup
-          - -DSERVER_URL=https://nullsafety.api.dartpad.dev/
-          - -DSTABLE_SERVER_URL=https://nullsafety.api.dartpad.dev/
+          - -DSERVER_URL=https://stable.api.dartpad.dev/
+          - -DSTABLE_SERVER_URL=https://stable.api.dartpad.dev/
           - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
           - -DDEV_SERVER_URL=https://dev.api.dartpad.dev/
           - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
@@ -32,8 +32,8 @@ global_options:
   build_web_compilers:ddc:
     options:
       environment:
-        SERVER_URL: https://nullsafety.api.dartpad.dev/
-        STABLE_SERVER_URL: https://nullsafety.api.dartpad.dev/
+        SERVER_URL: https://stable.api.dartpad.dev/
+        STABLE_SERVER_URL: https://stable.api.dartpad.dev/
         BETA_SERVER_URL: https://beta.api.dartpad.dev/
         DEV_SERVER_URL: https://dev.api.dartpad.dev/
         OLD_SERVER_URL: https://old.api.dartpad.dev/


### PR DESCRIPTION
With https://github.com/dart-lang/dart-services/pull/777 landed, stable.api.dartpad.dev is now serving null safety.