### PR TITLE
[Update frame.js] Error due to firebase version in DartPad

### DIFF
--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -53,9 +53,9 @@ removeScript = function (id) {
 }
 
 addFirebase = function () {
-    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js');
-    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-auth.js');
-    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-database.js',
+    addScript('firebase-app', 'https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js');
+    addScript('firebase-auth', 'https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js');
+    addScript('firebase-database', 'https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js',
     function() {
         // To prevent poor interaction between a firebase iframe, and the
         // sandboxed render iframe, use this one weird trick. Otherwise, you
@@ -64,7 +64,7 @@ addFirebase = function () {
         // * https://github.com/firebase/firebase-js-sdk/issues/123.
         firebase.database.INTERNAL.forceWebSockets();
     });
-    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.6.1/firebase-firestore.js');
+    addScript('firestore', 'https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js');
 }
 
 removeFirebase = function () {


### PR DESCRIPTION
When connecting to firebase with dartpad in firebase nanochat tutorial, we had an issue because of dartpad's firebase version.

We would like you to accept our pull request and update frame.js for update in firebase's version.

Thank you.

