### PR TITLE
added style for autocomplete menu

### DIFF
--- a/web/embed-dart.html
+++ b/web/embed-dart.html
@@ -24,6 +24,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
+    <link href="styles/cm-hints.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
 

--- a/web/embed-flutter.html
+++ b/web/embed-flutter.html
@@ -24,6 +24,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
+    <link href="styles/cm-hints.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
 

--- a/web/embed-html.html
+++ b/web/embed-html.html
@@ -24,6 +24,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
+    <link href="styles/cm-hints.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
 

--- a/web/embed-inline.html
+++ b/web/embed-inline.html
@@ -24,6 +24,7 @@ BSD-style license that can be found in the LICENSE file. -->
     <link href="packages/codemirror/addon/lint/lint.css" rel="stylesheet" media="screen">
     <link href="packages/codemirror/addon/hint/show-hint.css" rel="stylesheet" media="screen">
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
+    <link href="styles/cm-hints.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
 

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,7 @@
 
     <!-- codemirror themes -->
     <link href="styles/cm-scrollbars.css" rel="stylesheet" media="screen">
+    <link href="styles/cm-hints.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
     <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
 

--- a/web/styles/cm-hints.scss
+++ b/web/styles/cm-hints.scss
@@ -1,4 +1,3 @@
-@import 'package:dart_pad/scss/colors';
 
 .CodeMirror-hints {
   max-width: min(80%, 80em);

--- a/web/styles/cm-hints.scss
+++ b/web/styles/cm-hints.scss
@@ -1,0 +1,17 @@
+@import 'package:dart_pad/scss/colors';
+
+.CodeMirror-hints {
+  max-width: min(80%, 80em);
+}
+  
+.CodeMirror-hint {
+  padding-right: 5px !important;
+  list-style-position: inside;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;   
+}
+  
+.CodeMirror-hint:hover:not(.CodeMirror-hint-active) {
+  background-color: aliceblue;
+}


### PR DESCRIPTION
This addresses #2122.

The updated menu looks like this:

![autocomplete-css-update](https://user-images.githubusercontent.com/5104543/148519527-b6c65cfe-fa23-4966-8c98-c89dfa4cd7bf.png)

