### PR TITLE
Initialize the solution button in WorkshopUi

### DIFF
--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -102,6 +102,7 @@ class WorkshopUi extends EditorUi {
     _initConsoles();
     _initButtons();
     _updateCode();
+    _updateSolutionButton();
     _focusEditor();
     _initOutputPanelTabs();
   }


### PR DESCRIPTION
The WorkshopState doesn't emit an onStepChanged event when the app is
initialized, so _updateSolutionButton isn't called.

Fixes #2129