### PR TITLE
Properly cleanup when closing 'New Pad' dialog

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1098,13 +1098,20 @@ class NewPadDialog {
 
     _mdcDialog.open();
 
-    return completer.future.then((v) {
+    void handleClosing(Event _) {
       _flutterButton.root.classes.remove('selected');
       _dartButton.root.classes.remove('selected');
+      _htmlSwitchContainer.toggleClass('hide', true);
       dartSub.cancel();
       flutterSub.cancel();
       cancelSub.cancel();
       createSub.cancel();
+      _mdcDialog.unlisten('MDCDialog:closing', handleClosing);
+    }
+
+    _mdcDialog.listen('MDCDialog:closing', handleClosing);
+
+    return completer.future.then((v) {
       _mdcDialog.close();
       return v;
     });


### PR DESCRIPTION
- Hide the "HTML" switch on close so it's not present when the dialog reopened. Maintains previous selection still.
- Run cleanup logic when closing with 'esc' or clicking outside element. This was causing the subscriptions to be duplicated every time someone opened the dialog. Generally users don't open this too many times in one session but it could lead to an issue over time or with new logic introduced.