### PR TITLE
Remove obsolete channel grinder tasks

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -63,35 +63,6 @@ serveLocalBackend() async {
   });
 }
 
-@Task('Serve locally on port 8000 and use beta server URL for pre null-safe')
-@Depends(ConstTaskInvocation(
-  'build',
-  ConstTaskArgs('build', options: {}),
-))
-serveBetaBackend() async {
-  log('\nServing dart-pad on http://localhost:8000');
-
-  await Process.start(Platform.executable, ['bin/serve.dart'])
-      .then((Process process) {
-    process.stdout.transform(utf8.decoder).listen(stdout.write);
-  });
-}
-
-// TODO(srawlins): Remove this task if the 'dev' channel becomes unsupported.
-@Task('Serve locally on port 8000 and use dev server URL for pre null-safe')
-@Depends(ConstTaskInvocation(
-  'build',
-  ConstTaskArgs('build', options: {}),
-))
-serveDevBackend() async {
-  log('\nServing dart-pad on http://localhost:8000');
-
-  await Process.start(Platform.executable, ['bin/serve.dart'])
-      .then((Process process) {
-    process.stdout.transform(utf8.decoder).listen(stdout.write);
-  });
-}
-
 /// A grinder flag which directs build_runner to use the non-release mode, and
 /// use DDC instead of dart2js.
 const _debugFlag = 'debug';


### PR DESCRIPTION
As far as I can tell, these tasks have no differences remaining from the normal `serve` task and are not used anywhere.