### PR TITLE
Fix double error when switching from HTML layout

### DIFF
--- a/lib/sharing/editor_doc_property.dart
+++ b/lib/sharing/editor_doc_property.dart
@@ -15,8 +15,8 @@ class EditorDocumentProperty implements Property<String> {
   String get() => document.value;
 
   @override
-  void set(String str) {
-    document.value = str;
+  void set(String? str) {
+    document.value = str ?? '';
   }
 
   @override


### PR DESCRIPTION
Previously when switching from HTML layout to Dart or Flutter layouts, there were two errors in the console. This was due to the underlying mutable gist propagating the `null` value for the `styles.css` and `index.html` file properties.

<img width="529" alt="image" src="https://user-images.githubusercontent.com/18372958/149706437-344e8299-54fe-4254-9350-c88653cafbb6.png">
