### PR TITLE
Remove unused `removeCanvasKit` function

### DIFF
--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -45,17 +45,6 @@ addScript = function (id, url, onload) {
     document.head.appendChild(scriptNode);
 }
 
-removeCanvaskit = function () {
-    var scripts = document.head.querySelectorAll('script');
-    for (var i = 0; i < scripts.length; i++) {
-        var script = scripts[i];
-        if (script.src.includes('canvaskit.js')) {
-            script.parentNode.removeChild(script);
-            return;
-        }
-    }
-}
-
 /**
  * Executes userJs, a user script, after first loading RequireJS.
  */


### PR DESCRIPTION
We no longer use it as of https://github.com/dart-lang/dart-pad/commit/c6d0cd66e637b41ea5f70c418b12c5a97d11bb10 since Flutter Web now uses the cached CanvasKit if it is available.

Closes https://github.com/dart-lang/dart-pad/issues/1897