### PR TITLE
added style to show block cursor in editor overwrite mode - resolves #1792

### DIFF
--- a/web/styles/cm-dartpad-dark.scss
+++ b/web/styles/cm-dartpad-dark.scss
@@ -16,6 +16,7 @@
 .cm-s-darkpad .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: $dark-gutter-line-number-color; }
 .cm-s-darkpad .CodeMirror-linenumber { color: $dark-gutter-line-number-color; }
 .cm-s-darkpad .CodeMirror-cursor { border-left: 1px solid white; }
+.cm-s-darkpad .CodeMirror-cursors.CodeMirror-overwrite .CodeMirror-cursor { margin-top: 2px; width: 0.6em; border-left: none; background-color: rgba(255,255,255,0.7); }
 .cm-s-darkpad { background-color: $dark-code-background-color; color: $dark-editor-text; }
 .cm-s-darkpad span.cm-builtin { color: $dark-editor-text; }
 .cm-s-darkpad span.cm-comment { color: $dark-comment; }

--- a/web/styles/cm-dartpad-light.scss
+++ b/web/styles/cm-dartpad-light.scss
@@ -16,6 +16,7 @@
 .cm-s-dartpad .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded { color: $light-gutter-line-number-color; }
 .cm-s-dartpad .CodeMirror-linenumber { color: $light-gutter-line-number-color; }
 .cm-s-dartpad .CodeMirror-cursor { border-left: 1px solid $light-editor-text; }
+.cm-s-dartpad .CodeMirror-cursors.CodeMirror-overwrite .CodeMirror-cursor { margin-top: 2px; width: 0.6em; border-left: none; background-color: rgba($light-editor-text,0.7); }
 .cm-s-dartpad { background-color: $light-code-background-color; color: $light-editor-text; }
 .cm-s-dartpad span.cm-builtin { color: $light-editor-text; }
 .cm-s-dartpad span.cm-comment { color: $light-comment; }


### PR DESCRIPTION
Added style to change editor cursor to a block style cursor when editor is placed in overwrite mode.
A block cursor is an often used standard in editors to indicate overwrite vs. insert mode (Android Studio for example).