### PR TITLE
Update markdown to 5.0.0 release

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       name: markdown
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   js: ^0.6.0
   json_annotation: ^4.3.0
   logging: ^1.0.0
-  markdown: ^4.0.0
+  markdown: ^5.0.0
   mdc_web: ^0.6.0
   meta: ^1.2.4
   protobuf: ^2.0.0


### PR DESCRIPTION
The [5.0.0 release](https://pub.dev/packages/markdown/changelog#500) has some bug fixes related to table and blockquote parsing/rendering. 

The breaking changes don't affect DartPad's usage of Markdown. 