### PR TITLE
Tweaking window open mechanism in embed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,4 @@ web/scripts/codemirror.js
 
 last_prod/
 
-# IDE-specific files
 .idea/
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ web/scripts/codemirror.js
 
 last_prod/
 
+# IDE-specific files
 .idea/
+.vscode

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -802,10 +802,10 @@ class Embed extends EditorUi {
   void _showInstallPage() {
     if (_modeName == 'dart' || _modeName == 'html') {
       ga.sendEvent('main', 'install-dart');
-      _hostWindow!.location.href = 'https://dart.dev/get-dart';
+      window.open('https://dart.dev/get-dart', '_blank');
     } else {
       ga.sendEvent('main', 'install-flutter');
-      _hostWindow!.location.href = 'https://flutter.dev/get-started/install';
+      window.open('https://flutter.dev/get-started/install', '_blank');
     }
   }
 

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -791,14 +791,6 @@ class Embed extends EditorUi {
     analysisResultsController.display(issues);
   }
 
-  WindowBase? get _hostWindow {
-    if (window.parent != null) {
-      return window.parent;
-    }
-
-    return window;
-  }
-
   void _showInstallPage() {
     if (_modeName == 'dart' || _modeName == 'html') {
       ga.sendEvent('main', 'install-dart');


### PR DESCRIPTION
Changes the method used to open a new window when the "Install SDK" button is clicked. The SDK download page will be opened in a new window/tab rather than the one containing the embed.

Also adds `.vscode` to gitignore, as I've begun experimenting with the powers of the dark side.