### PR TITLE
Contributing Guide update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,15 @@ Contributions made by corporations are covered by a different agreement than the
 2) If you are updating an existing sample, create your own gist based on the existing samples.
    Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
    Fork the gist, if necessary, then update the contents with the new version from dartpad_examples.
-
+ 
    Otherwise, use the same gist layout as the samples to make sure that DartPad recognizes it:
      * `index.html` for the HTML snippet used to build the output page
      * `styles.css` for the style sheet
-     * `main.dart` for the Dart code.
-
+     * `main.dart` for the Dart code. 
+ 
    You can test your gist after updating or creating it by appending the gist ID to the URL for
    dartpad.
-
+ 
 3) Add or change sample Gist IDs to the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54),
    and submit a PR for review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,15 +26,15 @@ Contributions made by corporations are covered by a different agreement than the
 2) If you are updating an existing sample, create your own gist based on the existing samples.
    Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
    Fork the gist, if necessary, then update the contents with the new version from dartpad_examples.
- 
+
    Otherwise, use the same gist layout as the samples to make sure that DartPad recognizes it:
      * `index.html` for the HTML snippet used to build the output page
      * `styles.css` for the style sheet
-     * `main.dart` for the Dart code. 
- 
+     * `main.dart` for the Dart code.
+
    You can test your gist after updating or creating it by appending the gist ID to the URL for
    dartpad.
- 
+
 3) Add or change sample Gist IDs to the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54),
    and submit a PR for review.
 
@@ -43,8 +43,7 @@ Contributions made by corporations are covered by a different agreement than the
 * To run the DartPad against the regular serving backend:
 
 ```bash
-dart pub global activate grinder
-grind serve
+dart run build_runner serve
 ```
 This serves the DartPad frontend locally on port 8000.
 


### PR DESCRIPTION
Updated instructions to run DartPad locally to no longer use grind, which was both slow and required an extra undocumented step. New instructions use build_runner, which additionally watches for file changes and restarts the local server when files are saved.

(take 2)