### PR TITLE
Revert "Bump codemirror from 0.7.3+5.65.2 to 0.7.4+5.65.3"

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -168,7 +168,7 @@ packages:
       name: codemirror
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4+5.65.3"
+    version: "0.7.3+5.65.2"
   collection:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 
 dependencies:
   checked_yaml: ^2.0.0
-  codemirror: ^0.7.4+5.65.3
+  codemirror: ^0.7.3+5.65.2
   collection: ^1.16.0
   fluttering_phrases: ^0.3.1
   html_unescape: ^2.0.0


### PR DESCRIPTION
Reverts dart-lang/dart-pad#2256

This appears to be causing CodeMirror JS not to show up in the built version of the site, which is causing DartPad to fail on init in the browser.

