### PR TITLE
Refactor TabExpandController

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -25,6 +25,8 @@ class ExecutionServiceIFrame implements ExecutionService {
   late String _frameSrc;
   Completer<void> _readyCompleter = Completer();
 
+  IFrameElement get frame => _frame;
+
   ExecutionServiceIFrame(this._frame) {
     final src = _frame.src;
     if (src == null) {

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -309,13 +309,13 @@ class WorkshopUi extends EditorUi {
 
   void _initButtons() {
     runButton = MDCButton(querySelector('#run-button') as ButtonElement)
-      ..onClick.listen((_) {
-        tabExpandController.showUI();
-        handleRun().then((success) {
-          if (!success) {
-            tabExpandController.toggleConsole();
-          }
-        });
+      ..onClick.listen((_) async {
+        await handleRun();
+        if (_workshopState.workshop.type == WorkshopType.dart) {
+          tabExpandController.state = TabState.console;
+        } else {
+          tabExpandController.state = TabState.ui;
+        }
       });
 
     showSolutionButton =
@@ -356,7 +356,7 @@ class WorkshopUi extends EditorUi {
   }
 
   void _clearUIOutput() {
-    tabExpandController.showCode();
+    tabExpandController.hidePanel();
     executionService.replaceHtml('');
   }
 
@@ -452,7 +452,7 @@ class WorkshopUi extends EditorUi {
       docsButton: editorDocsTab,
       clearConsoleButton: clearConsoleButton,
       closeButton: closePanelButton,
-      iframeElement: _frame,
+      iFrameProvider: () => _frame,
       docsElement: _documentationElement,
       consoleElement: _consoleElement,
       topSplit: _editorPanel,
@@ -482,9 +482,6 @@ class WorkshopUi extends EditorUi {
   @override
   void showOutput(String message, {bool error = false}) {
     _console.showOutput(message, error: error);
-    if (tabExpandController.state != TabState.console) {
-      unreadConsoleCounter.increment();
-    }
   }
 
   Future<void> _handleShowSolution() async {


### PR DESCRIPTION
This makes `TabExpandController` display the correct tab based on the _current_ state, not the previous state. This also changes the API so that you call `TabExpandController.state =` instead of `toggle*()`.

closes #2247