### PR TITLE
Simpler two-click Create Pad dialog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,17 @@ Contributions made by corporations are covered by a different agreement than the
 
 * To run the DartPad against the regular serving backend:
 
+Install the [`protoc` compiler](https://grpc.io/docs/protoc-installation/).
+
+Run these commands:
+
 ```bash
+# Get all Dart dependencies
+dart pub get
+# Install the Dart protobuf compiler & grinder tool
+dart pub global activate protoc_plugin
 dart pub global activate grinder
+# Serve
 grind serve
 ```
 This serves the DartPad frontend locally on port 8000.

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -1062,10 +1062,8 @@ class NewPadDialog {
   final MDCDialog _mdcDialog;
   final MDCRipple _dartButton;
   final MDCRipple _flutterButton;
-  final MDCButton _createButton;
   final MDCButton _cancelButton;
   final MDCSwitch _htmlSwitch;
-  final DElement _htmlSwitchContainer;
 
   NewPadDialog()
       : assert(querySelector('#new-pad-dialog') != null),
@@ -1073,70 +1071,34 @@ class NewPadDialog {
         assert(querySelector('#new-pad-select-flutter') != null),
         assert(querySelector('#new-pad-cancel-button') != null),
         assert(querySelector('#new-pad-create-button') != null),
-        assert(querySelector('#new-pad-html-switch-container') != null),
-        assert(querySelector('#new-pad-html-switch-container .mdc-switch') !=
-            null),
+        assert(querySelector('#new-pad-html-switch') != null),
         _mdcDialog = MDCDialog(querySelector('#new-pad-dialog')!),
         _dartButton = MDCRipple(querySelector('#new-pad-select-dart')!),
         _flutterButton = MDCRipple(querySelector('#new-pad-select-flutter')!),
         _cancelButton =
             MDCButton(querySelector('#new-pad-cancel-button') as ButtonElement),
-        _createButton =
-            MDCButton(querySelector('#new-pad-create-button') as ButtonElement),
-        _htmlSwitchContainer =
-            DElement(querySelector('#new-pad-html-switch-container')!),
-        _htmlSwitch = MDCSwitch(
-            querySelector('#new-pad-html-switch-container .mdc-switch'));
-
-  Layout? get selectedLayout {
-    if (_dartButton.root.classes.contains('selected')) {
-      return _htmlSwitch.checked! ? Layout.html : Layout.dart;
-    }
-
-    if (_flutterButton.root.classes.contains('selected')) {
-      return Layout.flutter;
-    }
-
-    return null;
-  }
+        _htmlSwitch = MDCSwitch(querySelector('#new-pad-html-switch'));
 
   Future<Layout?> show() {
-    _createButton.toggleAttr('disabled', true);
-
     final completer = Completer<Layout?>();
     final dartSub = _dartButton.root.onClick.listen((_) {
-      _flutterButton.root.classes.remove('selected');
-      _dartButton.root.classes.add('selected');
-      _createButton.toggleAttr('disabled', false);
-      _htmlSwitchContainer.toggleClass('hide', false);
-      _htmlSwitch.disabled = false;
+      completer.complete(_htmlSwitch.checked! ? Layout.html : Layout.dart);
     });
 
     final flutterSub = _flutterButton.root.onClick.listen((_) {
-      _dartButton.root.classes.remove('selected');
-      _flutterButton.root.classes.add('selected');
-      _createButton.toggleAttr('disabled', false);
-      _htmlSwitchContainer.toggleClass('hide', true);
+      completer.complete(Layout.flutter);
     });
 
     final cancelSub = _cancelButton.onClick.listen((_) {
       completer.complete(null);
     });
 
-    final createSub = _createButton.onClick.listen((_) {
-      completer.complete(selectedLayout);
-    });
-
     _mdcDialog.open();
 
     void handleClosing(Event _) {
-      _flutterButton.root.classes.remove('selected');
-      _dartButton.root.classes.remove('selected');
-      _htmlSwitchContainer.toggleClass('hide', true);
       dartSub.cancel();
       flutterSub.cancel();
       cancelSub.cancel();
-      createSub.cancel();
       _mdcDialog.unlisten('MDCDialog:closing', handleClosing);
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -362,20 +362,18 @@
                         <img src="/pictures/logo_dart.png"/>
                         <span>Dart</span>
                     </div>
-                    <div id="new-pad-html-switch-container" class="hide">
-                        <div class="mdc-switch mdc-switch--disabled">
-                            <div class="mdc-switch__track"></div>
-                            <div class="mdc-switch__thumb-underlay">
-                                <div class="mdc-switch__thumb">
-                                    <input type="checkbox"
-                                           id="new-pad-html-switch"
-                                           class="mdc-switch__native-control"
-                                           role="switch">
-                                </div>
+                    <div id="new-pad-html-switch" class="mdc-switch">
+                        <div class="mdc-switch__track"></div>
+                        <div class="mdc-switch__thumb-underlay">
+                            <div class="mdc-switch__thumb">
+                                <input type="checkbox"
+                                        id="new-pad-html-switch"
+                                        class="mdc-switch__native-control"
+                                        role="switch">
                             </div>
                         </div>
-                        <label for="new-pad-html-switch">HTML</label>
                     </div>
+                    <label for="new-pad-html-switch">HTML</label>
                 </div>
                 <div class="divider"></div>
                 <div id="new-pad-select-flutter" class="select-project-button mdc-ripple-surface mdc-ripple-surface--primary">
@@ -385,14 +383,9 @@
             </div>
 
             <footer class="mdc-dialog__actions">
-
                 <button type="button" id="new-pad-cancel-button"
                         class="mdc-button mdc-dialog__button">
                     <span class="mdc-button__label">Cancel</span>
-                </button>
-                <button type="button" id="new-pad-create-button"
-                        class="mdc-button mdc-dialog__button">
-                    <span class="mdc-button__label">Create</span>
                 </button>
             </footer>
         </div>


### PR DESCRIPTION
Simplifies the Create Pad dialog by only requiring two steps:

1. Click New
1. Click Dart or Flutter (or optionally enable HTML and then Dart)

Today this is:

1. Click New
2. Click Dart or Flutter
3. Click Create