### PR TITLE
Fix embed solution tab switching and cancellation

### DIFF
--- a/lib/elements/dialog.dart
+++ b/lib/elements/dialog.dart
@@ -99,11 +99,18 @@ class Dialog {
       completer.complete(rightButtonResult);
     });
 
+    void handleClosing(Event _) {
+      completer.complete(DialogResult.cancel);
+    }
+
+    _mdcDialog.listen('MDCDialog:closing', handleClosing);
+
     _mdcDialog.open();
 
     return completer.future.then((v) {
       leftSub?.cancel();
       rightSub.cancel();
+      _mdcDialog.unlisten('MDCDialog:closing', handleClosing);
       _mdcDialog.close();
       return v;
     });

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -396,11 +396,11 @@ class TabController {
       tabs.firstWhere((tab) => tab.hasAttr('selected'));
 
   /// This method will throw if the tabName is not the name of a current tab.
-  void selectTab(String? tabName) {
+  void selectTab(String tabName) {
     final tab = tabs.firstWhere((t) => t.name == tabName);
 
     for (final t in tabs) {
-      t.toggleAttr('selected', t == tab);
+      t.toggleAttr('selected', t.name == tab.name);
     }
 
     tab.handleSelected();

--- a/lib/elements/material_tab_controller.dart
+++ b/lib/elements/material_tab_controller.dart
@@ -13,14 +13,14 @@ class MaterialTabController extends TabController {
   MaterialTabController(this.tabBar);
 
   @override
-  Future selectTab(String? tabName) async {
-    final tab = tabs.firstWhere((t) => t.name == tabName);
-    final idx = tabs.indexOf(tab);
+  Future<void> selectTab(String tabName) async {
+    final idx = tabs.indexWhere((t) => t.name == tabName);
+    final tab = tabs[idx];
 
     tabBar.activateTab(idx);
 
     for (final t in tabs) {
-      t.toggleAttr('aria-selected', t == tab);
+      t.toggleAttr('aria-selected', t.name == tab.name);
     }
 
     super.selectTab(tabName);

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -900,7 +900,7 @@ class EmbedTabController extends MaterialTabController {
 
   /// This method will throw if the tabName is not the name of a current tab.
   @override
-  Future selectTab(String? tabName, {bool force = false}) async {
+  Future<void> selectTab(String tabName, {bool force = false}) async {
     // Show a confirmation dialog if the solution tab is tapped
     if (tabName == 'solution' && !force) {
       final result = await _dialog.showYesNo(
@@ -911,8 +911,8 @@ class EmbedTabController extends MaterialTabController {
         noText: 'Cancel',
       );
       // Go back to the editor tab
-      if (result == DialogResult.no) {
-        tabName = 'editor';
+      if (result == DialogResult.no || result == DialogResult.cancel) {
+        tabName = 'dart';
       }
     }
 


### PR DESCRIPTION
- Fixes exception when saying "No" to "Show solution?" prompt
- Hooks up cancelling the "Show solution?" tab to switching back to editor
- Cleans up leaked listeners from cancelling the "Show solution?" tab
- Removes some unnecessary nullability
- Some minor cleanup