### PR TITLE
Speed up grinder tasks

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -218,8 +218,6 @@ void generateProtos() {
     throw 'Error generating the Protobuf classes\n${result.stderr}';
   }
 
-  // generate common_server_proto.g.dart
-  Pub.run('build_runner', arguments: ['build', '--delete-conflicting-outputs']);
   Process.runSync('dart', ['format', 'lib/src/protos']);
 }
 


### PR DESCRIPTION
This removes the build_runner build that happens after generating protos - that build doesn't do anything (any more at least, the comment looks to be outdated).

Since the build task also runs build_runner but with different flags (in particular enabling release mode), there was lots of throwaway work happening in the first (non-release) build.

For me this takes the `grind serve` task from 165 seconds down to 95 seconds.