### PR TITLE
fix _handleChannelsMenuSelected to get channel name from menu source array

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -394,7 +394,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _handleChannelsMenuSelected(e) {
     final index = (e as CustomEvent).detail['index'] as int;
-    final channel = Channel.urlMapping.keys.toList()[index];
+    final channel = channels[index]
+        .name; // Use menu index BACK into channels array it was created from to get channel name.
     _handleChannelSwitched(channel);
   }
 

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -394,8 +394,8 @@ class Playground extends EditorUi implements GistContainer, GistController {
 
   void _handleChannelsMenuSelected(e) {
     final index = (e as CustomEvent).detail['index'] as int;
-    final channel = channels[index]
-        .name; // Use menu index BACK into channels array it was created from to get channel name.
+    // Use menu index BACK into channels array it was created from to get channel name.
+    final channel = channels[index].name;
     _handleChannelSwitched(channel);
   }
 


### PR DESCRIPTION
This PR changes _handleChannelsMenuSelected() to get the channel name from using the menu index to index into the `channels` array that was used to create the menu in the first place. 

The existing code uses the menu index to index into the keys array of an entirely different map's keys to get the channel name.  This is error prone as it requires knowledge of this implicit relationship between the `channels` array and the `Channels.urlMapping` map's key ordering.

(more detail:)
The previous code used the menu index to index into `Channels.urlMapping` keys array.  This was error prone in that changes to the channels menu required these two arrays (`channels` in playground,dart and `urlMapping` in editor_ui.dart) to 'line up'.    This can easily lead to errors and confusion as illustrated by development of https://github.com/dart-lang/dart-pad/pull/2355 (see discussion).
I originally noticed the potential for this error to occur months ago and if I had followed my intuition then (and made this fix) it would have avoided Brett's wasting time when he stumbled up this in developing PR #2355.
