### PR TITLE
Add a delay for page-load in e2e tests

### DIFF
--- a/test/e2e/playground_test.dart
+++ b/test/e2e/playground_test.dart
@@ -85,6 +85,8 @@ void main() async {
         uri: Uri.parse('http://localhost:4444/wd/hub/'),
         desired: Capabilities.chrome);
 
+    await Future.delayed(Duration(milliseconds: 2000));
+
     // Go to your page
     await driver.get('http://localhost:8000/');
     await waitForPageToStabilize();


### PR DESCRIPTION
@srawlins this is a hacky fix for #2360 until we can figure out what's going on here...