### PR TITLE
Properly reserve format keybindings and release unused replace

### DIFF
--- a/lib/editing/codemirror_options.dart
+++ b/lib/editing/codemirror_options.dart
@@ -34,6 +34,9 @@ const codeMirrorOptions = {
     'Shift-Cmd-G': 'weHandleElsewhere',
     'F4': 'weHandleElsewhere',
     'Shift-F4': 'weHandleElsewhere',
+    'Shift-Ctrl-F': 'weHandleElsewhere',
+    'Shift-Cmd-F': 'weHandleElsewhere',
+    'Cmd-Alt-F': false,
     // vscode folding key combos (pc/mac)
     'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
     'Cmd-Alt-[': 'ourFoldWithCursorToStart',

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -74,6 +74,9 @@ class CodeMirrorFactory extends EditorFactory {
         'Shift-Cmd-G': 'weHandleElsewhere',
         'F4': 'weHandleElsewhere',
         'Shift-F4': 'weHandleElsewhere',
+        'Shift-Ctrl-F': 'weHandleElsewhere',
+        'Shift-Cmd-F': 'weHandleElsewhere',
+        'Cmd-Alt-F': false,
         // vscode folding key combos (pc/mac)
         'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
         'Cmd-Alt-[': 'ourFoldWithCursorToStart',


### PR DESCRIPTION
Now reserve **Shift-Ctrl-F** and **Shift-Cmd-F** as we use these for formatting. Also disables **Cmd-Alt-F** as we instead use custom replace functionality under **Ctrl-H** and **Cmd-H**, allowing the browser to handle it like users may expect.



Fixes the issue defined in the comment https://github.com/dart-lang/dart-pad/issues/2112#issuecomment-1007950916