### PR TITLE
Make playground issue hide/show keyboard accessible

### DIFF
--- a/lib/scss/shared.scss
+++ b/lib/scss/shared.scss
@@ -56,16 +56,6 @@ a {
   font-weight: bolder;
 }
 
-#issues-toggle {
-  cursor: pointer;
-
-  // Prevent the layout from changing when toggling between show and hide
-  width: 48px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
 // Issues
 #issues {
   overflow-y: auto;

--- a/web/index.html
+++ b/web/index.html
@@ -398,7 +398,8 @@
     </div>
     <div class="flex"></div>
     <div id="issues-message" class="info-message"></div>
-    <a id="issues-toggle" hidden></a>
+    <button type="button" id="issues-toggle" class="mdc-button mdc-button-footer" hidden>
+    </button>
     <div id="dartpad-version"></div>
     <i id="dartpad-package-versions" class="material-icons" aria-hidden="true">info</i>
 </footer>

--- a/web/styles/embed/styles.scss
+++ b/web/styles/embed/styles.scss
@@ -601,4 +601,14 @@ body {
   margin-top: 4px;
 }
 
+#issues-toggle {
+  cursor: pointer;
+
+  // Prevent the layout from changing when toggling between show and hide
+  width: 48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 

--- a/web/styles/styles.scss
+++ b/web/styles/styles.scss
@@ -343,6 +343,7 @@ a {
 
 #issues-toggle, .issue-anchor {
   color: $mdc-theme-primary;
+  margin-right: 0;
   &:visited {
     color: $mdc-theme-primary;
   }
@@ -357,7 +358,6 @@ a {
   font-family: $normal-font;
   font-size: $playground-editor-font-size;
   cursor: default;
-  margin-right: 0px;
 }
 
 

--- a/web/styles/workshops.scss
+++ b/web/styles/workshops.scss
@@ -338,6 +338,7 @@ body>footer {
 
 #issues-toggle, .issue-anchor {
   color: $mdc-theme-primary;
+  margin-right: 0;
   &:visited {
     color: $mdc-theme-primary;
   }

--- a/web/workshops.html
+++ b/web/workshops.html
@@ -264,7 +264,8 @@
     </div>
     <div class="flex"></div>
     <div id="issues-message" class="info-message"></div>
-    <a id="issues-toggle" hidden></a>
+    <button type="button" id="issues-toggle" class="mdc-button mdc-button-footer" hidden>
+    </button>
     <div id="dartpad-version"></div>
     <i id="dartpad-package-versions" class="material-icons" aria-hidden="true">info</i>
 </footer>


### PR DESCRIPTION
Can now focus and use the button with the keyboard: 
<img width="162" alt="keyboard accessible hide/show button" src="https://user-images.githubusercontent.com/18372958/192365758-1dd2146d-0c20-48a3-a176-42cc5d040305.png">
