### PR TITLE
Restrict sass_builder to v2.1.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   mdc_web: ^0.6.0
   meta: ^1.8.0
   protobuf: ^2.0.0
-  sass_builder: ^2.1.0
+  sass_builder: 2.1.4
   shelf: ^1.3.0
   shelf_static: ^1.1.0
   split:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   meta: ^1.8.0
   protobuf: ^2.0.0
   # ^2.1.5 is no longer compatible with our overridden sass version
+  # https://github.com/dart-lang/dart-pad/issues/2388
   sass_builder: 2.1.4
   shelf: ^1.3.0
   shelf_static: ^1.1.0
@@ -45,5 +46,6 @@ dev_dependencies:
 # Once released, it will need to be rolled into package:mdc_web.
 #
 # https://github.com/material-components/material-components-web/pull/7158
+# https://github.com/dart-lang/dart-pad/issues/2388
 dependency_overrides:
   sass: 1.32.10

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   mdc_web: ^0.6.0
   meta: ^1.8.0
   protobuf: ^2.0.0
+  # ^2.1.5 is no longer compatible with our overridden sass version
   sass_builder: 2.1.4
   shelf: ^1.3.0
   shelf_static: ^1.1.0


### PR DESCRIPTION
The [2.1.5](https://pub.dev/packages/sass_builder/changelog#215) release has a change that was required by newer versions of the `sass` package. Since we still override the `sass` version due to `mdc_web` needing to be updated, our version of `sass` is no longer compatible with new versions of `sass_builder`, resulting in errors if we upgrade. This PR solves this for now, by limiting `sass_builder` to v2.14. In the long run, we should investigate getting `mdc_web` updated so we can upgrade sass as well.