### PR TITLE
Allow Esc Tab or Esc Shift-Tab to escape editor focus

### DIFF
--- a/lib/editing/codemirror_options.dart
+++ b/lib/editing/codemirror_options.dart
@@ -20,6 +20,9 @@ const codeMirrorOptions = {
   'cursorHeight': 0.85,
   'viewportMargin': 100,
   'extraKeys': {
+    'Esc': '...',
+    'Esc Tab': false,
+    'Esc Shift-Tab': false,
     'Cmd-/': 'toggleComment',
     'Ctrl-/': 'toggleComment',
     'Shift-Tab': 'indentLess',

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -60,6 +60,9 @@ class CodeMirrorFactory extends EditorFactory {
       'viewportMargin': 100,
       //'gutters': [_gutterId],
       'extraKeys': {
+        'Esc': '...',
+        'Esc Tab': false,
+        'Esc Shift-Tab': false,
         'Cmd-/': 'toggleComment',
         'Ctrl-/': 'toggleComment',
         'Shift-Tab': 'indentLess',


### PR DESCRIPTION
This follows the behavior in CodeMirror 6 as well as other playgrounds like Svelte's.

I tested a few ways of implementing this and this seemed the most reliable and didn't require any extra changes to `package:codemirror.dart`.

Tested and confirmed to still work with Vim mode's extra Esc behavior.

Fixes #2112