### PR TITLE
Fix escape in vim-insert mode

### DIFF
--- a/lib/editing/codemirror_options.dart
+++ b/lib/editing/codemirror_options.dart
@@ -19,38 +19,7 @@ const codeMirrorOptions = {
   'indentUnit': 2,
   'cursorHeight': 0.85,
   'viewportMargin': 100,
-  'extraKeys': {
-    'Esc': '...',
-    'Esc Tab': false,
-    'Esc Shift-Tab': false,
-    'Cmd-/': 'toggleComment',
-    'Ctrl-/': 'toggleComment',
-    'Shift-Tab': 'indentLess',
-    'Tab': 'indentIfMultiLineSelectionElseInsertSoftTab',
-    'Cmd-F': 'weHandleElsewhere',
-    'Cmd-H': 'weHandleElsewhere',
-    'Ctrl-F': 'weHandleElsewhere',
-    'Ctrl-H': 'weHandleElsewhere',
-    'Cmd-G': 'weHandleElsewhere',
-    'Shift-Ctrl-G': 'weHandleElsewhere',
-    'Ctrl-G': 'weHandleElsewhere',
-    'Shift-Cmd-G': 'weHandleElsewhere',
-    'F4': 'weHandleElsewhere',
-    'Shift-F4': 'weHandleElsewhere',
-    'Shift-Ctrl-F': 'weHandleElsewhere',
-    'Shift-Cmd-F': 'weHandleElsewhere',
-    'Cmd-Alt-F': false,
-    // vscode folding key combos (pc/mac)
-    'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
-    'Cmd-Alt-[': 'ourFoldWithCursorToStart',
-    'Shift-Ctrl-]': 'unfold',
-    'Cmd-Alt-]': 'unfold',
-    'Shift-Ctrl-Alt-[':
-        'foldAll', // made our own keycombo since VSCode and AndroidStudio's
-    'Shift-Cmd-Alt-[': 'foldAll', //  are taken by browser
-    'Shift-Ctrl-Alt-]': 'unfoldAll',
-    'Shift-Cmd-Alt-]': 'unfoldAll',
-  },
+  'extraKeys': extraKeysWithEscapeTab,
   'foldGutter': true,
   'foldOptions': {
     'minFoldSize': 1,
@@ -67,4 +36,41 @@ const codeMirrorOptions = {
   },
   'hintOptions': {'completeSingle': false},
   'scrollbarStyle': 'simple',
+};
+
+const extraKeysWithoutEscapeTab = {
+  'Cmd-/': 'toggleComment',
+  'Ctrl-/': 'toggleComment',
+  'Shift-Tab': 'indentLess',
+  'Tab': 'indentIfMultiLineSelectionElseInsertSoftTab',
+  'Cmd-F': 'weHandleElsewhere',
+  'Cmd-H': 'weHandleElsewhere',
+  'Ctrl-F': 'weHandleElsewhere',
+  'Ctrl-H': 'weHandleElsewhere',
+  'Cmd-G': 'weHandleElsewhere',
+  'Shift-Ctrl-G': 'weHandleElsewhere',
+  'Ctrl-G': 'weHandleElsewhere',
+  'Shift-Cmd-G': 'weHandleElsewhere',
+  'F4': 'weHandleElsewhere',
+  'Shift-F4': 'weHandleElsewhere',
+  'Shift-Ctrl-F': 'weHandleElsewhere',
+  'Shift-Cmd-F': 'weHandleElsewhere',
+  'Cmd-Alt-F': false,
+  // vscode folding key combos (pc/mac)
+  'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
+  'Cmd-Alt-[': 'ourFoldWithCursorToStart',
+  'Shift-Ctrl-]': 'unfold',
+  'Cmd-Alt-]': 'unfold',
+  'Shift-Ctrl-Alt-[':
+      'foldAll', // made our own keycombo since VSCode and AndroidStudio's
+  'Shift-Cmd-Alt-[': 'foldAll', //  are taken by browser
+  'Shift-Ctrl-Alt-]': 'unfoldAll',
+  'Shift-Cmd-Alt-]': 'unfoldAll',
+};
+
+const extraKeysWithEscapeTab = {
+  'Esc': '...',
+  'Esc Tab': false,
+  'Esc Shift-Tab': false,
+  ...extraKeysWithoutEscapeTab
 };

--- a/lib/editing/editor.dart
+++ b/lib/editing/editor.dart
@@ -77,6 +77,9 @@ abstract class Editor {
   /// that the editor should do no further handling.
   Stream<html.MouseEvent> get onMouseDown;
 
+  /// Fired when the current current vim mode changes.
+  Stream get onVimModeChange;
+
   void resize();
 
   void focus();

--- a/lib/editing/editor_codemirror.dart
+++ b/lib/editing/editor_codemirror.dart
@@ -13,6 +13,7 @@ import 'package:codemirror/codemirror.dart' hide Position;
 import 'package:codemirror/codemirror.dart' as pos show Position;
 import 'package:codemirror/hints.dart';
 
+import 'codemirror_options.dart';
 import 'editor.dart' hide Position;
 import 'editor.dart' as ed show Position;
 
@@ -34,83 +35,8 @@ class CodeMirrorFactory extends EditorFactory {
   List<String> get themes => CodeMirror.themes;
 
   @override
-  Editor createFromElement(html.Element element, {Map? options}) {
-    options ??= {
-      'continueComments': {'continueLineComment': false},
-      'autofocus': false,
-      'autoCloseTags': {
-        'whenOpening': true,
-        'whenClosing': true,
-        'indentTags':
-            [] // Android Studio/VSCode do not auto indent/add newlines for any completed tags
-        //  The default (below) would be the following tags cause indenting and blank line inserted
-        // ['applet', 'blockquote', 'body', 'button', 'div', 'dl', 'fieldset',
-        //    'form', 'frameset', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head',
-        //    'html', 'iframe', 'layer', 'legend', 'object', 'ol', 'p', 'select', \
-        //    'table', 'ul']
-      },
-      'autoCloseBrackets': true,
-      'matchBrackets': true,
-      'tabSize': 2,
-      'lineWrapping': true,
-      'indentUnit': 2,
-      'cursorHeight': 0.85,
-      // Increase the number of lines that are rendered above and before what's
-      // visible.
-      'viewportMargin': 100,
-      //'gutters': [_gutterId],
-      'extraKeys': {
-        'Esc': '...',
-        'Esc Tab': false,
-        'Esc Shift-Tab': false,
-        'Cmd-/': 'toggleComment',
-        'Ctrl-/': 'toggleComment',
-        'Shift-Tab': 'indentLess',
-        'Tab': 'indentIfMultiLineSelectionElseInsertSoftTab',
-        'Ctrl-F': 'weHandleElsewhere',
-        'Ctrl-H': 'weHandleElsewhere',
-        'Cmd-F': 'weHandleElsewhere',
-        'Cmd-H': 'weHandleElsewhere',
-        'Shift-Ctrl-G': 'weHandleElsewhere',
-        'Ctrl-G': 'weHandleElsewhere',
-        'Cmd-G': 'weHandleElsewhere',
-        'Shift-Cmd-G': 'weHandleElsewhere',
-        'F4': 'weHandleElsewhere',
-        'Shift-F4': 'weHandleElsewhere',
-        'Shift-Ctrl-F': 'weHandleElsewhere',
-        'Shift-Cmd-F': 'weHandleElsewhere',
-        'Cmd-Alt-F': false,
-        // vscode folding key combos (pc/mac)
-        'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
-        'Cmd-Alt-[': 'ourFoldWithCursorToStart',
-        'Shift-Ctrl-]': 'unfold',
-        'Cmd-Alt-]': 'unfold',
-        'Shift-Ctrl-Alt-[':
-            'foldAll', // made our own keycombo since VSCode and AndroidStudio's
-        'Shift-Cmd-Alt-[': 'foldAll', //  are taken by browser
-        'Shift-Ctrl-Alt-]': 'unfoldAll',
-        'Shift-Cmd-Alt-]': 'unfoldAll',
-      },
-      'foldGutter': true,
-      'foldOptions': {
-        'minFoldSize': 1,
-        'widget': '\u00b7\u00b7\u00b7', // like '...', but middle dots
-      },
-      'matchTags': {
-        'bothTags': true,
-      },
-      'gutters': ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-      'highlightSelectionMatches': {
-        'style': 'highlight-selection-matches',
-        'showToken': false,
-        'annotateScrollbar': true,
-      },
-      'hintOptions': {'completeSingle': false},
-      'scrollbarStyle': 'simple',
-      //'lint': true,
-      'theme': 'zenburn', // ambiance, vibrant-ink, monokai, zenburn
-    };
-
+  Editor createFromElement(html.Element element,
+      {Map options = codeMirrorOptions}) {
     final editor = CodeMirror.fromElement(element, options: options);
     CodeMirror.addCommand('goLineLeft', _handleGoLineLeft);
     CodeMirror.addCommand('indentIfMultiLineSelectionElseInsertSoftTab',
@@ -130,7 +56,7 @@ class CodeMirrorFactory extends EditorFactory {
   }
 
   /// used to set the search update callback that will be called when
-  /// the editors update their search annonations
+  /// the editors update their search annotations
   @override
   void registerSearchUpdateCallback(SearchUpdateCallback sac) {
     _searchUpdateCallback = sac;
@@ -420,6 +346,9 @@ class _CodeMirrorEditor extends Editor {
 
   @override
   Stream<html.MouseEvent> get onMouseDown => cm.onMouseDown;
+
+  @override
+  Stream get onVimModeChange => cm.onEvent('vim-mode-change');
 
   @override
   Point getCursorCoords({ed.Position? position}) {

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -16,7 +16,6 @@ import 'context.dart';
 import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
-import 'editing/codemirror_options.dart';
 import 'editing/editor_codemirror.dart';
 import 'elements/analysis_results_controller.dart';
 import 'elements/button.dart';

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -257,13 +257,12 @@ class Embed extends EditorUi {
     hintBox = FlashBox(querySelector('#hint-box') as DivElement);
     final editorTheme = isDarkMode ? 'darkpad' : 'dartpad';
 
-    editor = editorFactory.createFromElement(
-        querySelector('#user-code-editor')!,
-        options: codeMirrorOptions)
-      ..theme = editorTheme
-      ..mode = 'dart'
-      ..keyMap = window.localStorage['codemirror_keymap'] ?? 'default'
-      ..showLineNumbers = true;
+    editor =
+        editorFactory.createFromElement(querySelector('#user-code-editor')!)
+          ..theme = editorTheme
+          ..mode = 'dart'
+          ..keyMap = window.localStorage['codemirror_keymap'] ?? 'default'
+          ..showLineNumbers = true;
 
     if (!showInstallButton) {
       querySelector('#install-button')!.setAttribute('hidden', '');

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -20,7 +20,6 @@ import 'core/keys.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
 import 'documentation.dart';
-import 'editing/codemirror_options.dart';
 import 'editing/editor_codemirror.dart';
 import 'elements/analysis_results_controller.dart';
 import 'elements/bind.dart';

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -534,8 +534,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     deps[GistLoader] = GistLoader.defaultFilters();
 
     // Set up CodeMirror
-    editor = (editorFactory as CodeMirrorFactory)
-        .createFromElement(_editorHost, options: codeMirrorOptions)
+    editor = (editorFactory as CodeMirrorFactory).createFromElement(_editorHost)
       ..theme = 'darkpad'
       ..mode = 'dart'
       ..keyMap = window.localStorage['codemirror_keymap'] ?? 'default'

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 
 import '../context.dart';
 import '../dart_pad.dart';
+import '../editing/codemirror_options.dart';
 import '../editing/editor.dart';
 import '../elements/analysis_results_controller.dart';
 import '../elements/button.dart';
@@ -55,6 +56,20 @@ abstract class EditorUi {
     keys.bind(['shift-ctrl-/', 'shift-macctrl-/'], () {
       showKeyboardDialog();
     }, 'Keyboard Shortcuts');
+
+    _initEscapeTabSwitching();
+  }
+
+  // When switching to vim-insert mode, disable esc tab and esc shift-tab
+  // as the esc key is required to exit the mode
+  void _initEscapeTabSwitching() {
+    editor.onVimModeChange.listen((e) {
+      if (editor.keyMap == 'vim-insert') {
+        editor.setOption('extraKeys', extraKeysWithoutEscapeTab);
+      } else {
+        editor.setOption('extraKeys', extraKeysWithEscapeTab);
+      }
+    });
   }
 
   Future<void> showKeyboardDialog() async {
@@ -360,6 +375,7 @@ class KeyboardDialog {
       } else {
         if (currentKeyMap != 'default') editor.keyMap = 'default';
         window.localStorage['codemirror_keymap'] = 'default';
+        editor.setOption('extraKeys', extraKeysWithEscapeTab);
       }
       completer.complete(vimSet ? DialogResult.yes : DialogResult.ok);
     });

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -16,7 +16,6 @@ import 'core/dependencies.dart';
 import 'core/modules.dart';
 import 'dart_pad.dart';
 import 'documentation.dart';
-import 'editing/codemirror_options.dart';
 import 'editing/editor_codemirror.dart';
 import 'elements/analysis_results_controller.dart';
 import 'elements/button.dart';

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -133,8 +133,7 @@ class WorkshopUi extends EditorUi {
 
   void _initEditor() {
     // Set up CodeMirror
-    editor = (editorFactory as CodeMirrorFactory)
-        .createFromElement(_editorHost, options: codeMirrorOptions)
+    editor = (editorFactory as CodeMirrorFactory).createFromElement(_editorHost)
       ..theme = 'darkpad'
       ..mode = 'dart'
       ..keyMap = window.localStorage['codemirror_keymap'] ?? 'default'


### PR DESCRIPTION
The solution to enable tabbing in and out of the editor introduced in https://github.com/dart-lang/dart-pad/commit/c53fd078b1baa34ef792feb08ac06c8692d20688 caused conflicts with vim-insert mode, so this change simply disables the extra key bindings when in vim-insert mode and reenables them when leaving.

It also deduplicates the `codeMirrorOptions`.

I **recommend** staging this locally making sure you don't get stuck while in Vim mode. I tested a little but am not too familiar with Vim or its key bindings.

Fixes #2412