### PR TITLE
Fix leak of listener in keyboard dialog

### DIFF
--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -350,7 +350,7 @@ class KeyboardDialog {
 
     final completer = Completer<DialogResult>();
 
-    _okButton.onClick.listen((_) {
+    final okButtonSub = _okButton.onClick.listen((_) {
       final bool vimSet = _vimSwitch.checked!;
 
       // change keyMap if needed and *remember* their choice for next startup
@@ -364,9 +364,17 @@ class KeyboardDialog {
       completer.complete(vimSet ? DialogResult.yes : DialogResult.ok);
     });
 
+    void handleClosing(Event _) {
+      completer.complete(DialogResult.cancel);
+    }
+
+    _mdcDialog.listen('MDCDialog:closing', handleClosing);
+
     _mdcDialog.open();
 
     return completer.future.then((v) {
+      okButtonSub.cancel();
+      _mdcDialog.unlisten('MDCDialog:closing', handleClosing);
       _mdcDialog.close();
       return v;
     });


### PR DESCRIPTION
The listener was never properly cancelled and closing by clicking outside was not handled, causing the listeners to be duplicated each time.

Fixes following error:
<img width="507" alt="Example of resulting error" src="https://user-images.githubusercontent.com/18372958/202103972-f2b8bc45-89c7-4b11-89b4-cae6a77ab8ca.png">
