### PR TITLE
Update riverpod example

### DIFF
--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -245,7 +245,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
       Sample(
           '493c8b3ef8931cbac3fbbe5c04b9c4cf', 'Google Fonts', Layout.flutter),
       Sample('a133148221a8cbacbcef8bc77a6c82ec', 'Provider', Layout.flutter),
-      Sample('ef06ab3ce0b822e6cc5db0575248e6e2', 'Riverpod', Layout.flutter),
+      Sample('83e1497d3c9c6a42f4e96f9512b50ac6', 'Riverpod', Layout.flutter),
       Sample(
           'fdd369962f4ff6700a83c8a540fd6c4c', 'Flutter Bloc', Layout.flutter),
       Sample('4a546fc44db8aca351bfe791e251acc2', 'GoRouter', Layout.flutter),


### PR DESCRIPTION
The old example was using the old syntax that causes warnings.