### PR TITLE
Initialize editor before key bindings in workshop

### DIFF
--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -102,8 +102,8 @@ class WorkshopUi extends EditorUi {
     _updateInstructions();
     await _initModules();
     _initWorkshopUi();
-    initKeyBindings();
     _initEditor();
+    initKeyBindings();
     _initSplitters();
     _initStepButtons();
     _initStepListener();


### PR DESCRIPTION
This is needed since https://github.com/dart-lang/dart-pad/commit/c9ee3ba4e824d29a78592973a3ed85d37475bdd2 required access to the editor to set of some key binding switch behavior.

Fixes #2435