### PR TITLE
Replace deprecated strong mode option with newer strict mode

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,8 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
   exclude:
     - "build/**"
     - "doc/api/**"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -177,7 +177,7 @@ deploy() async {
 
   final app = yaml.loadYaml(File('web/app.yaml').readAsStringSync()) as Map;
 
-  final handlers = app['handlers'];
+  final handlers = app['handlers'] as List;
   var isSecure = false;
 
   for (final m in handlers) {


### PR DESCRIPTION
The old strong-mode options are deprecated (https://github.com/dart-lang/sdk/commit/166c54b4d94b4fe12849339bfc11e5694d4fe892) in favor of new strict modes (https://github.com/dart-lang/sdk/issues/33749).