### PR TITLE
Fix typos

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -78,7 +78,7 @@
         </button>
     </div>
     <div id="header-name-holder"><div class="header-gist-name"></div>
-        <span id="unsaved-local-edit" title="Login to GitHub to save as gist" hidden>local edits</span>
+        <span id="unsaved-local-edit" title="Log In to GitHub to save as gist" hidden>local edits</span>
         <span id="gist_star_button" title="Star this gist" hidden><i id="gist_star_inner_icon" class="material-icons mdc-button__icon" aria-hidden="true">star_outline</i></span></div>
     <div>
         <button type="button" id="samples-dropdown-button" class="mdc-button">
@@ -117,7 +117,7 @@
                     <span class="mdc-list-item__graphic">
                         <i class="material-icons mdc-select__icon" tabindex="-1" role="button">login</i>
                     </span>
-                    <span class="mdc-list-item__text">Login to Github</span>
+                    <span class="mdc-list-item__text">Log In to Github</span>
                 </li>
                 <li id="github-createpublic-item" class="mdc-list-item" role="menuitem" title="Existing Gists must be forked or made private.">
                     <span class="mdc-list-item__graphic">
@@ -159,7 +159,7 @@
                     <span class="mdc-list-item__graphic">
                         <i class="material-icons mdc-select__icon" tabindex="-1" role="button">logout</i>
                     </span>
-                    <span class="mdc-list-item__text">Logout</span>
+                    <span class="mdc-list-item__text">Log Out</span>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
Namely misspellings of “log in” and “log out.”