### PR TITLE
Temporarily disable beta workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - sdk: stable
-            experimental: false
           - sdk: beta
-            # Allowing skipping until we support Dart 3:
+            # Allow skipping until we support Dart 3:
             # https://github.com/dart-lang/dart-pad/issues/2467
             experimental: true
+          - sdk: stable
+            experimental: false
 
     continue-on-error: ${{ matrix.experimental }}
     steps:
@@ -52,4 +52,4 @@ jobs:
         run: |
           export PATH=$PATH:$HOME/.pub-cache/bin
           dart pub global activate protoc_plugin
-          dart tool/grind.dart buildbot
+          dart run tool/grind.dart buildbot

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -17,8 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable]
+        include:
+          - sdk: stable
+            experimental: false
+          - sdk: beta
+            # Allowing skipping until we support Dart 3:
+            # https://github.com/dart-lang/dart-pad/issues/2467
+            experimental: true
 
+    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, beta]
+        sdk: [stable]
 
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -25,7 +25,6 @@ jobs:
           - sdk: stable
             experimental: false
 
-    continue-on-error: ${{ matrix.experimental }}
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
@@ -53,3 +52,4 @@ jobs:
           export PATH=$PATH:$HOME/.pub-cache/bin
           dart pub global activate protoc_plugin
           dart run tool/grind.dart buildbot
+        continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
Tracking reenabling this and the migration necessary in https://github.com/dart-lang/dart-pad/issues/2467.