### PR TITLE
Escape double quotes in tester results

### DIFF
--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -8,12 +8,11 @@ import 'dart:async';
 import 'dart:html';
 
 import 'execution.dart';
+import 'execution_result_util.dart' show frameTestResultDecoration, testKey;
 
 export 'execution.dart';
 
 class ExecutionServiceIFrame implements ExecutionService {
-  static const testKey = '__TESTRESULT__ ';
-
   final StreamController<String> _stdoutController =
       StreamController<String>.broadcast();
   final StreamController<String> _stderrController =
@@ -80,21 +79,7 @@ class ExecutionServiceIFrame implements ExecutionService {
   }
 
   @override
-  String get testResultDecoration => '''
-void _result(bool success, [List<String> messages = const []]) {
-  // Join messages into a comma-separated list for inclusion in the JSON array.
-  final joinedMessages = 
-      messages.map((m) => '"\${m.replaceAll('"', '\\\\"')}"').join(',');
-  print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
-}
-
-// Ensure we have at least one use of `_result`.
-var resultFunction = _result;
-
-// Placeholder for unimplemented methods in dart-pad exercises.
-// ignore: non_constant_identifier_names
-Never TODO([String message = '']) => throw UnimplementedError(message);
-''';
+  String get testResultDecoration => frameTestResultDecoration;
 
   String _decorateJavaScript(
     String javaScript, {

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -79,12 +79,12 @@ class ExecutionServiceIFrame implements ExecutionService {
     _frameSrc = src;
   }
 
-  /// TODO(redbrogdon): Format message so internal double quotes are escaped.
   @override
   String get testResultDecoration => '''
 void _result(bool success, [List<String> messages = const []]) {
   // Join messages into a comma-separated list for inclusion in the JSON array.
-  final joinedMessages = messages.map((m) => '"\$m"').join(',');
+  final joinedMessages = 
+      messages.map((m) => '"\${m.replaceAll('"', '\\\\"')}"').join(',');
   print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
 }
 
@@ -92,7 +92,7 @@ void _result(bool success, [List<String> messages = const []]) {
 var resultFunction = _result;
 
 // Placeholder for unimplemented methods in dart-pad exercises.
-// ignore: non_constant_identifier_names, sdk_version_never
+// ignore: non_constant_identifier_names
 Never TODO([String message = '']) => throw UnimplementedError(message);
 ''';
 

--- a/lib/services/execution_result_util.dart
+++ b/lib/services/execution_result_util.dart
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+const testKey = '__TESTRESULT__ ';
+
+const frameTestResultDecoration = '''
+void _result(bool success, [List<String> messages = const []]) {
+  // Join messages into a comma-separated list for inclusion in the JSON array.
+  final joinedMessages = 
+      messages.map((m) => '"\${m.replaceAll('"', '\\\\"')}"').join(',');
+  print('$testKey{"success": \$success, "messages": [\$joinedMessages]}');
+}
+
+// Ensure we have at least one use of `_result`.
+var resultFunction = _result;
+
+// Placeholder for unimplemented methods in dart-pad exercises.
+// ignore: non_constant_identifier_names
+Never TODO([String message = '']) => throw UnimplementedError(message);
+''';

--- a/test/all.dart
+++ b/test/all.dart
@@ -7,6 +7,7 @@ library dart_pad.all_test;
 import 'core/dependencies_test.dart' as dependencies_test;
 import 'elements/bind_test.dart' as bind_test;
 import 'services/common_test.dart' as common_test;
+import 'services/execution_util_test.dart' as execution_util_test;
 
 void main() => defineTests();
 
@@ -14,4 +15,5 @@ void defineTests() {
   dependencies_test.defineTests();
   bind_test.defineTests();
   common_test.defineTests();
+  execution_util_test.defineTests();
 }

--- a/test/services/execution_util_test.dart
+++ b/test/services/execution_util_test.dart
@@ -33,7 +33,7 @@ Never TODO([String message = '']) => throw UnimplementedError(message);
     });
 
     test('frameTestResultDecoration functions as expected', () {
-      final uri = Uri.dataFromString(
+      final codeWithResultInserted = Uri.dataFromString(
         '''
 import 'dart:async';
 import 'dart:isolate';
@@ -59,7 +59,8 @@ void main(List<String> args, SendPort sendPort) {
 
       expect(() async {
         final receivePort = ReceivePort();
-        await Isolate.spawnUri(uri, [], receivePort.sendPort);
+        await Isolate.spawnUri(
+            codeWithResultInserted, [], receivePort.sendPort);
         print(await receivePort.first);
         receivePort.close();
       },

--- a/test/services/execution_util_test.dart
+++ b/test/services/execution_util_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:isolate';
+
+import 'package:dart_pad/services/execution_result_util.dart' as util;
+import 'package:test/test.dart';
+
+void main() => defineTests();
+
+void defineTests() {
+  group('Execution service result utils', () {
+    test('frameTestResultDecoration defined correctly', () {
+      expect(
+        util.frameTestResultDecoration,
+        r'''
+void _result(bool success, [List<String> messages = const []]) {
+  // Join messages into a comma-separated list for inclusion in the JSON array.
+  final joinedMessages = 
+      messages.map((m) => '"${m.replaceAll('"', '\\"')}"').join(',');
+  print('__TESTRESULT__ {"success": $success, "messages": [$joinedMessages]}');
+}
+
+// Ensure we have at least one use of `_result`.
+var resultFunction = _result;
+
+// Placeholder for unimplemented methods in dart-pad exercises.
+// ignore: non_constant_identifier_names
+Never TODO([String message = '']) => throw UnimplementedError(message);
+''',
+      );
+    });
+
+    test('frameTestResultDecoration functions as expected', () {
+      final uri = Uri.dataFromString(
+        '''
+import 'dart:async';
+import 'dart:isolate';
+        
+${util.frameTestResultDecoration}      
+      
+void main(List<String> args, SendPort sendPort) {
+  runZonedGuarded(
+    () {
+      _result(false, ['The Text widget for the name should use the "headlineSmall" textStyle.']);
+    },
+    (error, stack) {
+      sendPort.send(error);
+    },
+    zoneSpecification: ZoneSpecification(
+      print: (_, __, ___, string) => sendPort.send(string),
+    ),
+  );
+}
+''',
+        mimeType: 'application/dart',
+      );
+
+      expect(() async {
+        final receivePort = ReceivePort();
+        await Isolate.spawnUri(uri, [], receivePort.sendPort);
+        print(await receivePort.first);
+        receivePort.close();
+      },
+          prints(
+              '__TESTRESULT__ {"success": false, "messages": ["The Text widget for the name should use the \\"headlineSmall\\" textStyle."]}\n'));
+    });
+  });
+}

--- a/test/services/execution_util_test.dart
+++ b/test/services/execution_util_test.dart
@@ -32,7 +32,7 @@ Never TODO([String message = '']) => throw UnimplementedError(message);
       );
     });
 
-    test('frameTestResultDecoration functions as expected', () {
+    test('frameTestResultDecoration functions as expected', () async {
       final codeWithResultInserted = Uri.dataFromString(
         '''
 import 'dart:async';
@@ -57,15 +57,17 @@ void main(List<String> args, SendPort sendPort) {
         mimeType: 'application/dart',
       );
 
-      expect(() async {
-        final receivePort = ReceivePort();
-        await Isolate.spawnUri(
-            codeWithResultInserted, [], receivePort.sendPort);
-        print(await receivePort.first);
-        receivePort.close();
-      },
-          prints(
-              '__TESTRESULT__ {"success": false, "messages": ["The Text widget for the name should use the \\"headlineSmall\\" textStyle."]}\n'));
+      final receivePort = ReceivePort();
+      await Isolate.spawnUri(codeWithResultInserted, [], receivePort.sendPort);
+      final result = await receivePort.first;
+      receivePort.close();
+
+      expect(
+        result,
+        equals(
+          '__TESTRESULT__ {"success": false, "messages": ["The Text widget for the name should use the \\"headlineSmall\\" textStyle."]}',
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
This was causing the tests in the [Basic Flutter layout concepts](https://docs.flutter.dev/codelabs/layout-basics) codelab to error when the user failed the tests, since they include double quotes.

Let me know if you think I should do this in a different way. With the current test setup, it is not the greatest to import `dart:convert` for `JsonEncoder` since everything is combined into one file.  I know it doesn't cover all necessary escapes, but this is the most common case.