### PR TITLE
Improved UX around "Show solution" button in workshops & "Run" button in editor

### DIFF
--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -111,6 +111,10 @@ class DButton extends DElement {
   set disabled(bool value) {
     buttonElement.disabled = value;
   }
+
+  set textColor(String color) {
+    buttonElement.style.color = 'white';
+  }
 }
 
 class DSplash extends DElement {

--- a/lib/elements/elements.dart
+++ b/lib/elements/elements.dart
@@ -113,7 +113,7 @@ class DButton extends DElement {
   }
 
   set textColor(String color) {
-    buttonElement.style.color = 'white';
+    buttonElement.style.color = color;
   }
 }
 

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -197,7 +197,7 @@ abstract class EditorUi {
   Future<bool> handleRun() async {
     ga.sendEvent('main', 'run');
     runButton.disabled = true;
-
+    runButton.textColor = 'white';
     final compilationTimer = Stopwatch()..start();
     final compileRequest = CompileRequest()..source = fullDartSource;
 
@@ -250,6 +250,7 @@ abstract class EditorUi {
       return false;
     } finally {
       runButton.disabled = false;
+      runButton.textColor = 'blue';
     }
   }
 

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -592,6 +592,7 @@ class WorkshopUi extends EditorUi {
       solutionShownThisStep = true;
       editor.document.updateValue(solution);
       showSolutionButton.disabled = true;
+      showSolutionButton.textColor = 'white';
     }
   }
 

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -180,6 +180,7 @@ class WorkshopUi extends EditorUi {
       if (solutionShownThisStep) {
         // Enable the show solution button
         showSolutionButton.disabled = false;
+        showSolutionButton.textColor = 'blue';
       }
 
       // The redo button shows the user's edits again if they have previously
@@ -204,6 +205,7 @@ class WorkshopUi extends EditorUi {
         revertButton.setAttr('hidden', 'true');
         if (solutionShownThisStep) {
           showSolutionButton.disabled = false;
+          showSolutionButton.textColor = 'blue';
         }
       }
       redoButton.setAttr('hidden', 'true');
@@ -439,6 +441,7 @@ class WorkshopUi extends EditorUi {
       showSolutionButton.element.style.visibility = null;
     }
     showSolutionButton.disabled = false;
+    showSolutionButton.textColor = 'blue';
     solutionShownThisStep = false;
   }
 


### PR DESCRIPTION
I have tried to improve the user experience by changing the color of text to white whenever the run and show solution button is disabled. 

There was an enhancement request for the show solution button. I saw the Run button also behaves similarly so I decided to add the same effect there as well. 

Would love to get feedback from you on my decision and code and if there aren't any issues then please merge the pull request.