### PR TITLE
Use new CanvasKit URL

### DIFF
--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -35,6 +35,7 @@ abstract class ExecutionService {
     bool addRequireJs = false,
     bool addFirebaseJs = false,
     bool destroyFrame = false,
+    String canvasKitBaseUrl,
   });
 
   void replaceHtml(String html);

--- a/lib/services/execution.dart
+++ b/lib/services/execution.dart
@@ -35,6 +35,7 @@ abstract class ExecutionService {
     bool addRequireJs = false,
     bool addFirebaseJs = false,
     bool destroyFrame = false,
+    bool useLegacyCanvasKit,
     String canvasKitBaseUrl,
   });
 

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -45,6 +45,7 @@ class ExecutionServiceIFrame implements ExecutionService {
     bool addRequireJs = false,
     bool addFirebaseJs = false,
     bool destroyFrame = false,
+    String? canvasKitBaseUrl,
   }) async {
     if (destroyFrame) {
       await _reset();
@@ -57,6 +58,7 @@ class ExecutionServiceIFrame implements ExecutionService {
       'addRequireJs': addRequireJs,
       'addFirebaseJs': addFirebaseJs,
       'destroyFrame': destroyFrame,
+      'canvasKitBaseUrl': canvasKitBaseUrl,
     });
   }
 
@@ -205,7 +207,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
   @override
   Stream<TestResult> get testResults => _testResultsController.stream;
 
-  Future<void> _send(String command, Map<String, Object> params) {
+  Future<void> _send(String command, Map<String, Object?> params) {
     final message = {
       'command': command,
       ...params,

--- a/lib/services/execution_iframe.dart
+++ b/lib/services/execution_iframe.dart
@@ -45,6 +45,7 @@ class ExecutionServiceIFrame implements ExecutionService {
     bool addRequireJs = false,
     bool addFirebaseJs = false,
     bool destroyFrame = false,
+    bool useLegacyCanvasKit = false,
     String? canvasKitBaseUrl,
   }) async {
     if (destroyFrame) {
@@ -58,6 +59,7 @@ class ExecutionServiceIFrame implements ExecutionService {
       'addRequireJs': addRequireJs,
       'addFirebaseJs': addFirebaseJs,
       'destroyFrame': destroyFrame,
+      'useLegacyCanvasKit': useLegacyCanvasKit,
       'canvasKitBaseUrl': canvasKitBaseUrl,
     });
   }

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -5,6 +5,7 @@ import 'package:logging/logging.dart';
 import 'package:mdc_web/mdc_web.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart' as semver;
 
 import '../context.dart';
 import '../dart_pad.dart';
@@ -225,6 +226,7 @@ abstract class EditorUi {
             // TODO(ryjohn) Determine how to preserve the iframe
             // https://github.com/dart-lang/dart-pad/issues/2269
             destroyFrame: true,
+            useLegacyCanvasKit: _shouldUseLegacyCanvasKit(version.flutterSdkVersion),
             canvasKitBaseUrl: _createCanvasKitBaseUrl(version.engineVersion));
       } else {
         final response = await dartServices
@@ -303,6 +305,13 @@ abstract class EditorUi {
   static String _createCanvasKitBaseUrl(String engineSha) {
     const baseUrl = 'https://www.gstatic.com/flutter-canvaskit/';
     return path.join(baseUrl, '$engineSha/');
+  }
+
+  // A new URL for CanvasKit was introduced in 3.10, use the legacy
+  // version if the Flutter version is older than that.
+  static bool _shouldUseLegacyCanvasKit(String flutterVersion) {
+    final version = semver.Version.parse(flutterVersion);
+    return version.major == 3 && version.minor < 10;
   }
 }
 

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -262,8 +262,8 @@ abstract class EditorUi {
       final response = await dartServices.version();
 
       // Update the version information for this editor.
-      version = Version(response.flutterDartVersion,
-          response.flutterVersion, response.flutterEngineSha);
+      version = Version(response.flutterDartVersion, response.flutterVersion,
+          response.flutterEngineSha);
 
       // "Based on Flutter 1.19.0-4.1.pre Dart SDK 2.8.4"
       final versionText = 'Based on Flutter ${response.flutterVersion}'

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -226,7 +226,8 @@ abstract class EditorUi {
             // TODO(ryjohn) Determine how to preserve the iframe
             // https://github.com/dart-lang/dart-pad/issues/2269
             destroyFrame: true,
-            useLegacyCanvasKit: _shouldUseLegacyCanvasKit(version.flutterSdkVersion),
+            useLegacyCanvasKit:
+                _shouldUseLegacyCanvasKit(version.flutterSdkVersion),
             canvasKitBaseUrl: _createCanvasKitBaseUrl(version.engineVersion));
       } else {
         final response = await dartServices

--- a/lib/src/protos/dart_services.pb.dart
+++ b/lib/src/protos/dart_services.pb.dart
@@ -3,7 +3,7 @@
 //  source: protos/dart_services.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 
@@ -1996,7 +1996,7 @@ class LinkedEditGroup extends $pb.GeneratedMessage {
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
             ? ''
             : 'positions',
-        $pb.PbFieldType.P3)
+        $pb.PbFieldType.K3)
     ..a<$core.int>(
         2,
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
@@ -2444,6 +2444,12 @@ class VersionResponse extends $pb.GeneratedMessage {
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
             ? ''
             : 'experiment')
+    ..aOS(
+        12,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'flutterEngineSha',
+        protoName: 'flutterEngineSha')
     ..aOM<ErrorMessage>(
         99,
         const $core.bool.fromEnvironment('protobuf.omit_field_names')
@@ -2465,6 +2471,7 @@ class VersionResponse extends $pb.GeneratedMessage {
     $core.Map<$core.String, $core.String>? packageVersions,
     $core.Iterable<PackageInfo>? packageInfo,
     $core.Iterable<$core.String>? experiment,
+    $core.String? flutterEngineSha,
     ErrorMessage? error,
   }) {
     final _result = create();
@@ -2500,6 +2507,9 @@ class VersionResponse extends $pb.GeneratedMessage {
     }
     if (experiment != null) {
       _result.experiment.addAll(experiment);
+    }
+    if (flutterEngineSha != null) {
+      _result.flutterEngineSha = flutterEngineSha;
     }
     if (error != null) {
       _result.error = error;
@@ -2638,19 +2648,31 @@ class VersionResponse extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.List<$core.String> get experiment => $_getList(10);
 
+  @$pb.TagNumber(12)
+  $core.String get flutterEngineSha => $_getSZ(11);
+  @$pb.TagNumber(12)
+  set flutterEngineSha($core.String v) {
+    $_setString(11, v);
+  }
+
+  @$pb.TagNumber(12)
+  $core.bool hasFlutterEngineSha() => $_has(11);
+  @$pb.TagNumber(12)
+  void clearFlutterEngineSha() => clearField(12);
+
   @$pb.TagNumber(99)
-  ErrorMessage get error => $_getN(11);
+  ErrorMessage get error => $_getN(12);
   @$pb.TagNumber(99)
   set error(ErrorMessage v) {
     setField(99, v);
   }
 
   @$pb.TagNumber(99)
-  $core.bool hasError() => $_has(11);
+  $core.bool hasError() => $_has(12);
   @$pb.TagNumber(99)
   void clearError() => clearField(99);
   @$pb.TagNumber(99)
-  ErrorMessage ensureError() => $_ensure(11);
+  ErrorMessage ensureError() => $_ensure(12);
 }
 
 class PackageInfo extends $pb.GeneratedMessage {

--- a/lib/src/protos/dart_services.pbenum.dart
+++ b/lib/src/protos/dart_services.pbenum.dart
@@ -3,4 +3,4 @@
 //  source: protos/dart_services.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name

--- a/lib/src/protos/dart_services.pbjson.dart
+++ b/lib/src/protos/dart_services.pbjson.dart
@@ -3,7 +3,7 @@
 //  source: protos/dart_services.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
@@ -637,6 +637,13 @@ const VersionResponse$json = const {
     },
     const {'1': 'experiment', '3': 11, '4': 3, '5': 9, '10': 'experiment'},
     const {
+      '1': 'flutterEngineSha',
+      '3': 12,
+      '4': 1,
+      '5': 9,
+      '10': 'flutterEngineSha'
+    },
+    const {
       '1': 'error',
       '3': 99,
       '4': 1,
@@ -660,7 +667,7 @@ const VersionResponse_PackageVersionsEntry$json = const {
 
 /// Descriptor for `VersionResponse`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List versionResponseDescriptor = $convert.base64Decode(
-    'Cg9WZXJzaW9uUmVzcG9uc2USHgoKc2RrVmVyc2lvbhgBIAEoCVIKc2RrVmVyc2lvbhImCg5zZGtWZXJzaW9uRnVsbBgCIAEoCVIOc2RrVmVyc2lvbkZ1bGwSJgoOcnVudGltZVZlcnNpb24YAyABKAlSDnJ1bnRpbWVWZXJzaW9uEioKEGFwcEVuZ2luZVZlcnNpb24YBCABKAlSEGFwcEVuZ2luZVZlcnNpb24SKAoPc2VydmljZXNWZXJzaW9uGAUgASgJUg9zZXJ2aWNlc1ZlcnNpb24SJgoOZmx1dHRlclZlcnNpb24YBiABKAlSDmZsdXR0ZXJWZXJzaW9uEi4KEmZsdXR0ZXJEYXJ0VmVyc2lvbhgHIAEoCVISZmx1dHRlckRhcnRWZXJzaW9uEjYKFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwYCCABKAlSFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwSYQoPcGFja2FnZVZlcnNpb25zGAkgAygLMjcuZGFydF9zZXJ2aWNlcy5hcGkuVmVyc2lvblJlc3BvbnNlLlBhY2thZ2VWZXJzaW9uc0VudHJ5Ug9wYWNrYWdlVmVyc2lvbnMSQAoLcGFja2FnZUluZm8YCiADKAsyHi5kYXJ0X3NlcnZpY2VzLmFwaS5QYWNrYWdlSW5mb1ILcGFja2FnZUluZm8SHgoKZXhwZXJpbWVudBgLIAMoCVIKZXhwZXJpbWVudBI1CgVlcnJvchhjIAEoCzIfLmRhcnRfc2VydmljZXMuYXBpLkVycm9yTWVzc2FnZVIFZXJyb3IaQgoUUGFja2FnZVZlcnNpb25zRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSFAoFdmFsdWUYAiABKAlSBXZhbHVlOgI4AQ==');
+    'Cg9WZXJzaW9uUmVzcG9uc2USHgoKc2RrVmVyc2lvbhgBIAEoCVIKc2RrVmVyc2lvbhImCg5zZGtWZXJzaW9uRnVsbBgCIAEoCVIOc2RrVmVyc2lvbkZ1bGwSJgoOcnVudGltZVZlcnNpb24YAyABKAlSDnJ1bnRpbWVWZXJzaW9uEioKEGFwcEVuZ2luZVZlcnNpb24YBCABKAlSEGFwcEVuZ2luZVZlcnNpb24SKAoPc2VydmljZXNWZXJzaW9uGAUgASgJUg9zZXJ2aWNlc1ZlcnNpb24SJgoOZmx1dHRlclZlcnNpb24YBiABKAlSDmZsdXR0ZXJWZXJzaW9uEi4KEmZsdXR0ZXJEYXJ0VmVyc2lvbhgHIAEoCVISZmx1dHRlckRhcnRWZXJzaW9uEjYKFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwYCCABKAlSFmZsdXR0ZXJEYXJ0VmVyc2lvbkZ1bGwSYQoPcGFja2FnZVZlcnNpb25zGAkgAygLMjcuZGFydF9zZXJ2aWNlcy5hcGkuVmVyc2lvblJlc3BvbnNlLlBhY2thZ2VWZXJzaW9uc0VudHJ5Ug9wYWNrYWdlVmVyc2lvbnMSQAoLcGFja2FnZUluZm8YCiADKAsyHi5kYXJ0X3NlcnZpY2VzLmFwaS5QYWNrYWdlSW5mb1ILcGFja2FnZUluZm8SHgoKZXhwZXJpbWVudBgLIAMoCVIKZXhwZXJpbWVudBIqChBmbHV0dGVyRW5naW5lU2hhGAwgASgJUhBmbHV0dGVyRW5naW5lU2hhEjUKBWVycm9yGGMgASgLMh8uZGFydF9zZXJ2aWNlcy5hcGkuRXJyb3JNZXNzYWdlUgVlcnJvchpCChRQYWNrYWdlVmVyc2lvbnNFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoCVIFdmFsdWU6AjgB');
 @$core.Deprecated('Use packageInfoDescriptor instead')
 const PackageInfo$json = const {
   '1': 'PackageInfo',

--- a/lib/src/protos/dart_services.pbserver.dart
+++ b/lib/src/protos/dart_services.pbserver.dart
@@ -3,6 +3,6 @@
 //  source: protos/dart_services.proto
 //
 // @dart = 2.12
-// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+// ignore_for_file: annotate_overrides,camel_case_types,constant_identifier_names,deprecated_member_use_from_same_package,directives_ordering,library_prefixes,non_constant_identifier_names,prefer_final_fields,return_of_invalid_type,unnecessary_const,unnecessary_import,unnecessary_this,unused_import,unused_shown_name
 
 export 'dart_services.pb.dart';

--- a/protos/dart_services.proto
+++ b/protos/dart_services.proto
@@ -237,6 +237,9 @@ message VersionResponse {
   // Experiments that this server is running
   repeated string experiment = 11;
 
+  // The Flutter engine SHA, located in bin/internal/engine.version.
+  string flutterEngineSha = 12;
+
   // Make this response compatible with BadRequest
   ErrorMessage error = 99;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,18 +85,18 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "3.1.1"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      sha256: "017226b2fd3eef4e5f31839c930efad33110cdfe71b6255c7dca298b38dba61c"
+      sha256: d02a5b40720692c8c4c385741afb1cc50b53f192a33fa5da1f2bdaec3ec6db3e
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "4.0.7"
   build_resolvers:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "7b25ba738bc74c94187cebeb9cc29d38a32e8279ce950eabd821d3b454a5f03d"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
@@ -133,10 +133,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      sha256: e614f5e1317fe9b2574429e3e651951a1c38943416c047e02815a7d6ade264c9
+      sha256: ee45348ba9c2dfd2e165c0adf69311970fa620c6669c345ab533e16d0d119e3d
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "3.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -777,4 +777,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.0.0-134.0.dev <3.2.0"
+  dart: ">=2.19.0 <3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -514,7 +514,7 @@ packages:
     source: hosted
     version: "2.1.0"
   pub_semver:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pub_semver
       sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,548 +5,626 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
+      url: "https://pub.dev"
     source: hosted
     version: "58.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
+      url: "https://pub.dev"
     source: hosted
     version: "5.10.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.6"
+    version: "3.3.7"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   asn1lib:
     dependency: transitive
     description:
       name: asn1lib
-      url: "https://pub.dartlang.org"
+      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   async:
     dependency: "direct main"
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      url: "https://pub.dartlang.org"
+      sha256: "500584fdb80bcb70a2990a5838338a757cc24bbf27d88bf791cbe9461c57cd5a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      url: "https://pub.dartlang.org"
+      sha256: "017226b2fd3eef4e5f31839c930efad33110cdfe71b6255c7dca298b38dba61c"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "5.0.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: "7b25ba738bc74c94187cebeb9cc29d38a32e8279ce950eabd821d3b454a5f03d"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.7"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
-      url: "https://pub.dartlang.org"
+      sha256: "927ef98b58c5603ec58923c0bb943a74743e58149732665885bb1eb92983befe"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      url: "https://pub.dartlang.org"
+      sha256: e614f5e1317fe9b2574429e3e651951a1c38943416c047e02815a7d6ade264c9
+      url: "https://pub.dev"
     source: hosted
-    version: "3.2.7"
+    version: "4.0.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "31b7c748fd4b9adf8d25d72a4c4a59ef119f12876cf414f94f8af5131d5fa2b0"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.4"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   checked_yaml:
     dependency: "direct main"
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   cli_repl:
     dependency: transitive
     description:
       name: cli_repl
-      url: "https://pub.dartlang.org"
+      sha256: a2ee06d98f211cb960c777519cb3d14e882acd90fe5e078668e3ab4baab0ddd4
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.3"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.5"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   codemirror:
     dependency: "direct main"
     description:
       name: codemirror
-      url: "https://pub.dartlang.org"
+      sha256: a841d17a7e398bf1f28c29753d9274d63b6ac4b0db732942f5aa734e36e9b893
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.9+5.65.12"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
     version: "0.17.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "6d691edde054969f0e0f26abb1b30834b5138b963793e56f69d3a9a4435e6352"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   encrypt:
     dependency: "direct main"
     description:
       name: encrypt
-      url: "https://pub.dartlang.org"
+      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   fluttering_phrases:
     dependency: "direct main"
     description:
       name: fluttering_phrases
-      url: "https://pub.dartlang.org"
+      sha256: "1ea499ee70441d9d56b01d233563f2d131effd80a29d41be28bb8835a0638b39"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   git:
     dependency: "direct dev"
     description:
       name: git
-      url: "https://pub.dartlang.org"
+      sha256: "840c57646dd22c63b3305a8ef962215f0e9e9a9ba2876e6632083026b8c65f43"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   grinder:
     dependency: "direct dev"
     description:
       name: grinder
-      url: "https://pub.dartlang.org"
+      sha256: "1dabcd70f0d3975f9143d0cebf48a09cf56d4f5e0922f1d1931781e1047c8d00"
+      url: "https://pub.dev"
     source: hosted
     version: "0.9.3"
   html:
     dependency: transitive
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: "79d498e6d6761925a34ee5ea8fa6dfef38607781d2fa91e37523474282af55cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.15.2"
   html_unescape:
     dependency: "direct main"
     description:
       name: html_unescape
-      url: "https://pub.dartlang.org"
+      sha256: "15362d7a18f19d7b742ef8dcb811f5fd2a2df98db9f80ea393c075189e0b61e3"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: "direct main"
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      url: "https://pub.dartlang.org"
+      sha256: dadc08bd61f72559f938dd08ec20dbfec6c709bba83515085ea943d2078d187a
+      url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: "direct main"
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   markdown:
     dependency: "direct main"
     description:
       name: markdown
-      url: "https://pub.dartlang.org"
+      sha256: d95a9d12954aafc97f984ca29baaa7690ed4d9ec4140a23ad40580bcdb6c87f5
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.15"
   mdc_web:
     dependency: "direct main"
     description:
       name: mdc_web
-      url: "https://pub.dartlang.org"
+      sha256: c0da8278636bab76f6240a0c6542c94873d96f2b53fabe711f60f276b264b632
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
-      url: "https://pub.dartlang.org"
+      sha256: "3af2420c728173806f4378cf89c53ba9f27f7f67792b898561bff9d390deb98e"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.7.2"
+    version: "3.7.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
     dependency: "direct main"
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
   sass:
     dependency: "direct overridden"
     description:
       name: sass
-      url: "https://pub.dartlang.org"
+      sha256: "4b1777bdc5466f3dae1874bd0523e761d38e80c21ca68b3c70a7310d9419b14b"
+      url: "https://pub.dev"
     source: hosted
     version: "1.32.10"
   sass_builder:
     dependency: "direct main"
     description:
       name: sass_builder
-      url: "https://pub.dartlang.org"
+      sha256: "3304e9eaa9e10ad8c9302d46ba72e71209dcf09bfd81124d7a837fbcf5f75654"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   scratch_space:
     dependency: transitive
     description:
       name: scratch_space
-      url: "https://pub.dartlang.org"
+      sha256: a469a9642a4d7ee406d6224a85446eb8baa9dd6d81e2f0b76770deae7bd32aab
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   shelf:
     dependency: "direct main"
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: "direct main"
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.7"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      url: "https://pub.dartlang.org"
+      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "708b3f6b97248e5781f493b765c3337db11c5d2c81c3094f10904bfa8004c703"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.12"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   split:
     dependency: "direct main"
     description:
@@ -558,127 +636,145 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   stream_transform:
     dependency: "direct main"
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
-      url: "https://pub.dartlang.org"
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: "4f92f103ef63b1bbac6f4bd1930624fca81b2574464482512c4f0896319be575"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.24.1"
+    version: "1.24.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: daadc9baabec998b062c9091525aa95786508b1c48e9c30f1f891b8bf6ff2e64
+      url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "3642b184882f79e76ca57a9230fb971e494c3c1fd09c21ae3083ce891bcc0aa1"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   tuple:
     dependency: transitive
     description:
       name: tuple
-      url: "https://pub.dartlang.org"
+      sha256: "0ea99cd2f9352b2586583ab2ce6489d1f95a5f6de6fb9492faaf97ae2060f0aa"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
+      url: "https://pub.dev"
     source: hosted
     version: "11.3.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   webdriver:
     dependency: "direct dev"
     description:
       name: webdriver
-      url: "https://pub.dartlang.org"
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: "direct main"
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=3.0.0-134.0.dev <3.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -482,7 +482,7 @@ packages:
     source: hosted
     version: "2.1.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   build_test: ^2.0.0
-  build_web_compilers: ^4.0.0
+  build_web_compilers: ^3.0.0
   git: ^2.0.0
   grinder: ^0.9.1
   json_serializable: ^6.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   meta: ^1.8.0
   path: ^1.8.0
   protobuf: ^2.1.0
+  pub_semver: ^2.1.0
   # ^2.1.5 is no longer compatible with our overridden sass version
   # https://github.com/dart-lang/dart-pad/issues/2388
   sass_builder: 2.1.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   markdown: ^7.0.1
   mdc_web: ^0.6.0
   meta: ^1.8.0
+  path: ^1.8.0
   protobuf: ^2.1.0
   # ^2.1.5 is no longer compatible with our overridden sass version
   # https://github.com/dart-lang/dart-pad/issues/2388

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   markdown: ^7.0.1
   mdc_web: ^0.6.0
   meta: ^1.8.0
-  protobuf: ^2.0.0
+  protobuf: ^2.1.0
   # ^2.1.5 is no longer compatible with our overridden sass version
   # https://github.com/dart-lang/dart-pad/issues/2388
   sass_builder: 2.1.4
@@ -34,7 +34,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.1.11
   build_test: ^2.0.0
-  build_web_compilers: ^3.2.3
+  build_web_compilers: ^4.0.0
   git: ^2.0.0
   grinder: ^0.9.1
   json_serializable: ^6.0.1

--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -74,6 +74,21 @@ messageHandler = function (e) {
         // Replace HTML, CSS, possible Firebase JS, RequireJS, and app.
         body.innerHTML = obj.html;
         document.getElementById('styleId').innerHTML = obj.css;
+
+        // Flutter 3.10 doesn't use `unpkg.com` to load CanvasKit anymore, so
+        // this sets the base URL to load CanvasKit from.
+        //
+        // The web engine appends "chromium/canvaskit.js" to this string to
+        // load CanvasKit.
+        //
+        // See also:
+        // https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/configuration.dart
+        if (obj.canvasKitBaseUrl) {
+            window.flutterConfiguration = {
+                canvasKitBaseUrl: obj.canvasKitBaseUrl
+            };
+        }
+
         if (obj.addRequireJs) {
             executeWithRequireJs(obj.js);
         } else {

--- a/web/scripts/frame.js
+++ b/web/scripts/frame.js
@@ -83,9 +83,14 @@ messageHandler = function (e) {
         //
         // See also:
         // https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/configuration.dart
-        if (obj.canvasKitBaseUrl) {
+        if (obj.canvasKitBaseUrl && !obj.useLegacyCanvasKit) {
             window.flutterConfiguration = {
                 canvasKitBaseUrl: obj.canvasKitBaseUrl
+            };
+        } else {
+            // Use legacy CanvasKit URL
+            window.flutterConfiguration = {
+                canvasKitBaseUrl: "https://unpkg.com/canvaskit-wasm@0.37.1/bin/"
             };
         }
 


### PR DESCRIPTION
Flutter 3.10 doesn't use `unpkg.com` to load CanvasKit anymore, so this sets the base URL to load CanvasKit from.

See also:
https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/configuration.dart

fixes #2487

This should be deployed at the same time as https://github.com/dart-lang/dart-services/pull/1057

cc: @kevmoo @hterkelsen