### PR TITLE
Ignore unknown fields in response

### DIFF
--- a/lib/services/dartservices.dart
+++ b/lib/services/dartservices.dart
@@ -79,7 +79,7 @@ class DartservicesApi {
     );
     final jsonBody = json.decode(response.body);
     result
-      ..mergeFromProto3Json(jsonBody)
+      ..mergeFromProto3Json(jsonBody, ignoreUnknownFields: true)
       ..freeze();
 
     // 99 is the tag number for error message.


### PR DESCRIPTION
`mergeFromProto3Json` throws on unknown fields by default. Ask it to be more permissive for better backward compatibility.

This appears to be the root cause for #2491: it seems like the backend added an additional `flutterEngineSha` field to the response, which DartPad can't parse.

Fixes #2491.