### PR TITLE
Fix Flutter embeds due to `version` not being initialized

### DIFF
--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -483,6 +483,8 @@ class Embed extends EditorUi {
       dartServices.rootUrl = Channel.urlMapping[channel]!;
     }
 
+    updateVersions();
+
     context = EmbedContext(editor, !_editableTestSolution);
 
     editorFactory.registerCompleter(

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -269,9 +269,9 @@ abstract class EditorUi {
           response.flutterEngineSha);
 
       // "Based on Flutter 1.19.0-4.1.pre Dart SDK 2.8.4"
-      final versionText = 'Based on Flutter ${response.flutterVersion}'
+      querySelector('#dartpad-version')?.text =
+          'Based on Flutter ${response.flutterVersion}'
           ' Dart SDK ${response.sdkVersionFull}';
-      querySelector('#dartpad-version')!.text = versionText;
       if (response.packageVersions.isNotEmpty) {
         _packageInfo.clear();
         _packageInfo.addAll(response.packageInfo);


### PR DESCRIPTION
`updateVersions` where the new `version` initialization logic was added wasn't called before from the embed, but `version` needs to be initialized since it is used in the shared `handleRun`.

There are other potential solutions, but this seemed the most straightforward. I'm to changes.

Fixes https://github.com/dart-lang/dart-pad/issues/2494
Fixes https://github.com/flutter/website/issues/8612
Fixes https://github.com/flutter/website/issues/8611
Fixes https://github.com/flutter/website/issues/8613
Fixes https://github.com/flutter/flutter/issues/125377