### PR TITLE
Update json related package constraints to resolve warning

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -732,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6deed8ed625c52864792459709183da231ebf66ff0cf09e69b573227c377efe
+      sha256: "518254c0d3ee20667a1feef39eefe037df87439851e4b3cb277e5b3f37afa2f0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.3.0"
+    version: "11.4.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   html_unescape: ^2.0.0
   http: ^0.13.0
   js: ^0.6.4
-  json_annotation: ^4.5.0
+  json_annotation: ^4.8.0
   logging: ^1.0.0
   markdown: ^7.0.1
   mdc_web: ^0.6.0
@@ -39,7 +39,7 @@ dev_dependencies:
   build_web_compilers: ^3.0.0
   git: ^2.0.0
   grinder: ^0.9.1
-  json_serializable: ^6.0.1
+  json_serializable: ^6.6.1
   lints: ^2.0.0
   test: ^1.21.1
   webdriver: ^3.0.2


### PR DESCRIPTION
Fixes this warning when building:

```
json_serializable on lib/workshops/src/meta.dart: The version constraint "^4.5.0" on json_annotation allows versions before 4.8.0 which is not allowed.
```