### PR TITLE
Update to `codemirror` 0.7.10+5.65.13

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: codemirror
-      sha256: a841d17a7e398bf1f28c29753d9274d63b6ac4b0db732942f5aa734e36e9b893
+      sha256: da73abb03f23c3ce2345db71a0bc8072a6580c6fc63e1329b47f879a3fc5b37f
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9+5.65.12"
+    version: "0.7.10+5.65.13"
   collection:
     dependency: "direct main"
     description:
@@ -777,4 +777,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.19.0 <3.0.0"
+  dart: ">=2.19.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   async: ^2.9.0
   checked_yaml: ^2.0.0
-  codemirror: ^0.7.6+5.65.5
+  codemirror: ^0.7.10+5.65.13
   collection: ^1.16.0
   encrypt: ^5.0.1
   fluttering_phrases: ^0.4.0


### PR DESCRIPTION
This change enables keywords required for Dart 3