### PR TITLE
adjust the service call timeouts

### DIFF
--- a/lib/documentation.dart
+++ b/lib/documentation.dart
@@ -67,7 +67,7 @@ class DocHandler {
 
     dartServices
         .document(request)
-        .timeout(serviceCallTimeout)
+        .timeout(documentServiceTimeout)
         .then((DocumentResponse result) {
       final hash = result.hashCode;
       // If nothing has changed, don't need to parse Markdown and

--- a/lib/embed.dart
+++ b/lib/embed.dart
@@ -872,7 +872,7 @@ class Embed extends EditorUi {
     try {
       formatButton.disabled = true;
       final result =
-          await dartServices.format(input).timeout(serviceCallTimeout);
+          await dartServices.format(input).timeout(formatServiceTimeout);
 
       busyLight.reset();
       formatButton.disabled = false;

--- a/lib/parameter_popup.dart
+++ b/lib/parameter_popup.dart
@@ -89,7 +89,7 @@ class ParameterPopup {
 
     dartServices
         .document(input)
-        .timeout(serviceCallTimeout)
+        .timeout(documentServiceTimeout)
         .then((DocumentResponse result) {
       if (!result.info.containsKey('parameters')) {
         remove();

--- a/lib/playground.dart
+++ b/lib/playground.dart
@@ -811,7 +811,7 @@ class Playground extends EditorUi implements GistContainer, GistController {
     final input = SourceRequest()..source = originalSource;
     _formatButton.disabled = true;
 
-    final request = dartServices.format(input).timeout(serviceCallTimeout);
+    final request = dartServices.format(input).timeout(formatServiceTimeout);
     return request.then((FormatResponse result) {
       busyLight.reset();
       _formatButton.disabled = false;

--- a/lib/services/common.dart
+++ b/lib/services/common.dart
@@ -51,8 +51,13 @@ const masterServerUrlEnvironmentVar = 'MASTER_SERVER_URL';
 /// The URL of the "Flutter master" back-end server.
 const masterServerUrl = String.fromEnvironment(masterServerUrlEnvironmentVar);
 
-const Duration serviceCallTimeout = Duration(seconds: 10);
-const Duration longServiceCallTimeout = Duration(seconds: 60);
+// Shorter service call timeouts.
+const Duration documentServiceTimeout = Duration(seconds: 10);
+const Duration formatServiceTimeout = Duration(seconds: 10);
+const Duration analyzeServiceTimeout = Duration(seconds: 10);
+
+// Longer service call timeouts.
+const Duration compileServiceTimeout = Duration(seconds: 60);
 
 class Lines {
   final _starts = <int>[];

--- a/lib/sharing/editor_ui.dart
+++ b/lib/sharing/editor_ui.dart
@@ -146,7 +146,7 @@ abstract class EditorUi {
 
     final lines = Lines(input.source);
 
-    final request = dartServices.analyze(input).timeout(serviceCallTimeout);
+    final request = dartServices.analyze(input).timeout(analyzeServiceTimeout);
     analysisRequest = request;
 
     try {
@@ -210,7 +210,7 @@ abstract class EditorUi {
       if (shouldCompileDDC) {
         final response = await dartServices
             .compileDDC(compileRequest)
-            .timeout(longServiceCallTimeout);
+            .timeout(compileServiceTimeout);
 
         _sendCompilationTiming(compilationTimer.elapsedMilliseconds);
         clearOutput();
@@ -231,7 +231,7 @@ abstract class EditorUi {
       } else {
         final response = await dartServices
             .compile(compileRequest)
-            .timeout(longServiceCallTimeout);
+            .timeout(compileServiceTimeout);
 
         _sendCompilationTiming(compilationTimer.elapsedMilliseconds);
         clearOutput();

--- a/lib/workshops.dart
+++ b/lib/workshops.dart
@@ -518,7 +518,7 @@ class WorkshopUi extends EditorUi {
     final input = SourceRequest()..source = originalSource;
     formatButton.disabled = true;
 
-    final request = dartServices.format(input).timeout(serviceCallTimeout);
+    final request = dartServices.format(input).timeout(formatServiceTimeout);
     return request.then((FormatResponse result) {
       busyLight.reset();
       formatButton.disabled = false;


### PR DESCRIPTION
- make the service call timeouts more semantic - have them be named after the types of calls they're associated with

I'd been in an intermittent connection situation - connected through a hotspot - and saw some 10s timeouts in the devtools console. I was worried that these were associated w/ compilation requests (which would be too short a timeout). After digging through the source it was clear that these were likely compilation / analysis requests, but I thought it would still be valuable to more closely match up the timeout length w/ the type of operation they were intended for.