### PR TITLE
update branch name references

### DIFF
--- a/.github/ISSUE_TEMPLATE/everything-else.md
+++ b/.github/ISSUE_TEMPLATE/everything-else.md
@@ -6,5 +6,3 @@ labels: ''
 assignees: ''
 
 ---
-
-

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,11 +1,11 @@
 name: Dart
 
 on:
-  # Run CI on pushes to the master branch, and on PRs against master.
+  # Run CI on pushes to the main branch, and on PRs against main.
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # Every day at midnight

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Contributions made by corporations are covered by a different agreement than the
 1) Update the samples first in the dartpad_examples repository: https://github.com/dart-lang/dartpad_examples
 
 2) If you are updating an existing sample, create your own gist based on the existing samples.
-   Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54).
+   Gist IDs can be found in the [index file](https://github.com/dart-lang/dart-pad/blob/main/web/index.html#L54).
    Fork the gist, if necessary, then update the contents with the new version from dartpad_examples.
  
    Otherwise, use the same gist layout as the samples to make sure that DartPad recognizes it:
@@ -35,7 +35,7 @@ Contributions made by corporations are covered by a different agreement than the
    You can test your gist after updating or creating it by appending the gist ID to the URL for
    dartpad.
  
-3) Add or change sample Gist IDs to the [index file](https://github.com/dart-lang/dart-pad/blob/master/web/index.html#L54),
+3) Add or change sample Gist IDs to the [index file](https://github.com/dart-lang/dart-pad/blob/main/web/index.html#L54),
    and submit a PR for review.
 
 ## How to run DartPad locally

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ post](https://medium.com/dartlang/a-brand-new-dartpad-dev-with-flutter-support-1
 Interested in embedding DartPad in your websites? Check out this [embedding
 guide](https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide).
 
-![DartPad](https://raw.githubusercontent.com/dart-lang/dart-pad/master/doc/images/Sunflower.png)
+![DartPad](https://raw.githubusercontent.com/dart-lang/dart-pad/main/doc/images/Sunflower.png)
 
 ## **Related projects**
 
@@ -74,6 +74,6 @@ Some examples of likely triage priorities:
 ## **License and Contributing**
 
 Contributions welcome! Please read this short
-[guide](https://github.com/dart-lang/dart-pad/blob/master/CONTRIBUTING.md)
+[guide](https://github.com/dart-lang/dart-pad/blob/main/CONTRIBUTING.md)
 first. You can view our license
-[here](https://github.com/dart-lang/dart-pad/blob/master/LICENSE).
+[here](https://github.com/dart-lang/dart-pad/blob/main/LICENSE).

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -16,7 +16,7 @@ the developers that know how to run the unit tests or that remember to.
 
 CI systems typically write the build status back into a pull request.
 You can see in the PR whether the tests passed, and if that PR is safe to merge
-into master.
+into main.
 
 ### Getting it set up with Dart projects
 
@@ -26,5 +26,5 @@ GitHub Action.
 
 ### See also
 
-- The GitHub action workflow for [dart-pad](https://github.com/dart-lang/dart-pad/blob/master/.github/workflows/dart.yml).
+- The GitHub action workflow for [dart-pad](https://github.com/dart-lang/dart-pad/blob/main/.github/workflows/dart.yml).
 - Some sample [build output](https://github.com/dart-lang/dart-pad/actions/runs/1168537794).

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -2,6 +2,6 @@
 
 Some of the services we used to build DartPad:
 
-- [continuous integration](https://github.com/dart-lang/dart-pad/blob/master/doc/ci.md)
-- [code coverage](https://github.com/dart-lang/dart-pad/blob/master/doc/coverage.md)
-- [WebDriver](https://github.com/dart-lang/dart-pad/blob/master/doc/webdriver.md)
+- [continuous integration](https://github.com/dart-lang/dart-pad/blob/main/doc/ci.md)
+- [code coverage](https://github.com/dart-lang/dart-pad/blob/main/doc/coverage.md)
+- [WebDriver](https://github.com/dart-lang/dart-pad/blob/main/doc/webdriver.md)


### PR DESCRIPTION
- finish the rename of the `master` branch to `main`
- closes https://github.com/dart-lang/dart-pad/issues/2515