### PR TITLE
Use python 3.8, compatible with Flask 2.3.2.

### DIFF
--- a/web/app.yaml
+++ b/web/app.yaml
@@ -1,4 +1,4 @@
-runtime: python37
+runtime: python38
 default_expiration: "0d 0h 10m"
 
 handlers:


### PR DESCRIPTION
Fixes #2538