### PR TITLE
Update instructions for running with local backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ grind serve &
 cd ../dart-pad
 # Begin serving the front-end locally on port 8000, with the given backend
 export DARTPAD_BACKEND=http://localhost:8082
-grind serve-custom-backend
+grind serve-local-backend
 ```
 
 You can adjust the DARTPAD_BACKEND variable to match different versions of the dart-pad backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ dart pub get
 # Change the SDK version dart-services serves to the one you currently have installed
 grind update-docker-version
 # Begin serving the backend locally on port 8082.
-grind serve &
+FLUTTER_CHANNEL="stable" grind serve &
 
 cd ../dart-pad
 # Begin serving the front-end locally on port 8000, with the given backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,7 @@ grind update-docker-version
 FLUTTER_CHANNEL="stable" grind serve &
 
 cd ../dart-pad
-# Begin serving the front-end locally on port 8000, with the given backend
-export DARTPAD_BACKEND=http://localhost:8082
+# Begin serving the front-end locally on port 8000, with the given backend on the default port 8082 this is defined in tools/grind.dart
 grind serve-local-backend
 ```
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -50,7 +50,7 @@ Future<void> serveLocalAppEngine() async {
   ConstTaskArgs('build', flags: {
     _debugFlag: true,
   }, options: {
-    _serverUrlOption: 'http://127.0.0.1:8084/',
+    _serverUrlOption: 'http://127.0.0.1:8082/',
   }),
 ))
 Future<void> serveLocalBackend() async {


### PR DESCRIPTION
the grind command for serving a local backend was changed, from serve-custom-backend to serve-local-backend - this updates the docs accordingly. 

Also the Flutter channel has to be specified when running the dart-services backend, this was added accordingly

These issues might benefit from the backlink:
https://github.com/dart-lang/dart-pad/issues/883
https://github.com/dart-lang/dart-pad/issues/1591
https://github.com/dart-lang/dart-pad/issues/1069

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

#### Contribution guidelines:

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

(note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback)
