### PR TITLE
prefer package:http Client

### DIFF
--- a/lib/services/dartservices.dart
+++ b/lib/services/dartservices.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
-import 'package:http/browser_client.dart';
+import 'package:http/http.dart';
 import 'package:protobuf/protobuf.dart';
+
 import '../src/protos/dart_services.pb.dart';
+
 export '../src/protos/dart_services.pb.dart';
 
 const _apiPath = 'api/dartservices/v2';
@@ -10,7 +12,7 @@ const _apiPath = 'api/dartservices/v2';
 class DartservicesApi {
   DartservicesApi(this._client, {required this.rootUrl});
 
-  final BrowserClient _client;
+  final Client _client;
   String rootUrl;
 
   Future<AnalysisResults> analyze(SourceRequest request) => _request(


### PR DESCRIPTION
- prefer the package:http Client interface to the web specific BrowserClient impl class

This makes it possible to use the services class from a flutter desktop app.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
