### PR TITLE
use the samples in pkgs/samples in sketchpad

### DIFF
--- a/pkgs/samples/README.md
+++ b/pkgs/samples/README.md
@@ -5,11 +5,12 @@ Sample code snippets for DartPad.
 ## Samples
 
 <!-- samples -->
-| Category | Name | ID | Source |
+| Category | Name | Sample | ID |
 | --- | --- | --- | --- |
-| Dart | Hello world | `hello-world` | [lib/hello_world.dart](lib/hello_world.dart) |
-| Dart | Fibonacci | `fibonacci` | [lib/fibonacci.dart](lib/fibonacci.dart) |
-| Flutter | Counter example | `counter-example` | [lib/main.dart](lib/main.dart) |
+| Dart | Fibonacci | [fibonacci.dart](lib/fibonacci.dart) | `fibonacci` |
+| Dart | Hello world | [hello_world.dart](lib/hello_world.dart) | `hello-world` |
+| Flutter | Counter | [main.dart](lib/main.dart) | `counter` |
+| Flutter | Sunflower | [sunflower.dart](lib/sunflower.dart) | `sunflower` |
 <!-- samples -->
 
 ## Contributing

--- a/pkgs/samples/lib/samples.json
+++ b/pkgs/samples/lib/samples.json
@@ -11,7 +11,12 @@
     },
     {
         "category": "Flutter",
-        "name": "Counter example",
+        "name": "Counter",
         "path": "lib/main.dart"
+    },
+    {
+        "category": "Flutter",
+        "name": "Sunflower",
+        "path": "lib/sunflower.dart"
     }
 ]

--- a/pkgs/samples/lib/sunflower.dart
+++ b/pkgs/samples/lib/sunflower.dart
@@ -1,0 +1,150 @@
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+const Color primaryColor = Colors.orange;
+const TargetPlatform platform = TargetPlatform.android;
+
+void main() {
+  runApp(const Sunflower());
+}
+
+class SunflowerPainter extends CustomPainter {
+  static const seedRadius = 2.0;
+  static const scaleFactor = 4;
+  static const tau = math.pi * 2;
+
+  static final phi = (math.sqrt(5) + 1) / 2;
+
+  final int seeds;
+
+  SunflowerPainter(this.seeds);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.width / 2;
+
+    for (var i = 0; i < seeds; i++) {
+      final theta = i * tau / phi;
+      final r = math.sqrt(i) * scaleFactor;
+      final x = center + r * math.cos(theta);
+      final y = center - r * math.sin(theta);
+      final offset = Offset(x, y);
+      if (!size.contains(offset)) {
+        continue;
+      }
+      drawSeed(canvas, x, y);
+    }
+  }
+
+  @override
+  bool shouldRepaint(SunflowerPainter oldDelegate) {
+    return oldDelegate.seeds != seeds;
+  }
+
+  // Draw a small circle representing a seed centered at (x,y).
+  void drawSeed(Canvas canvas, double x, double y) {
+    final paint = Paint()
+      ..strokeWidth = 2
+      ..style = PaintingStyle.fill
+      ..color = primaryColor;
+    canvas.drawCircle(Offset(x, y), seedRadius, paint);
+  }
+}
+
+class Sunflower extends StatefulWidget {
+  const Sunflower({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _SunflowerState();
+  }
+}
+
+class _SunflowerState extends State<Sunflower> {
+  double seeds = 100.0;
+
+  int get seedCount => seeds.floor();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData().copyWith(
+        platform: platform,
+        brightness: Brightness.dark,
+        sliderTheme: SliderThemeData.fromPrimaryColors(
+          primaryColor: primaryColor,
+          primaryColorLight: primaryColor,
+          primaryColorDark: primaryColor,
+          valueIndicatorTextStyle: const DefaultTextStyle.fallback().style,
+        ),
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Sunflower'),
+        ),
+        drawer: Drawer(
+          child: ListView(
+            children: const [
+              DrawerHeader(
+                child: Center(
+                  child: Text(
+                    'Sunflower 🌻',
+                    style: TextStyle(fontSize: 32),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        body: Container(
+          constraints: const BoxConstraints.expand(),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.transparent,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.transparent,
+                  ),
+                ),
+                child: SizedBox(
+                  width: 400,
+                  height: 400,
+                  child: CustomPaint(
+                    painter: SunflowerPainter(seedCount),
+                  ),
+                ),
+              ),
+              Text('Showing $seedCount seeds'),
+              ConstrainedBox(
+                constraints: const BoxConstraints.tightFor(width: 300),
+                child: Slider.adaptive(
+                  min: 20,
+                  max: 2000,
+                  value: seeds,
+                  onChanged: (newValue) {
+                    setState(() {
+                      seeds = newValue;
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -14,6 +14,7 @@ import 'editor/editor.dart';
 import 'execution/execution.dart';
 import 'model.dart';
 import 'problems.dart';
+import 'samples.dart';
 import 'services/dartservices.dart';
 import 'theme.dart';
 import 'utils.dart';
@@ -173,79 +174,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
           const SizedBox(width: denseSpacing),
         ],
       ),
-      drawer: Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: <Widget>[
-            const DrawerHeader(
-              decoration: BoxDecoration(
-                color: Colors.blue,
-              ),
-              child: Text(
-                'Drawer Header',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 24,
-                ),
-              ),
-            ),
-            ListTile(
-              leading: Image.asset(
-                'assets/dart_logo_128.png',
-                width: defaultIconSize,
-              ),
-              title: const Text('Hello World'),
-              onTap: () {
-                Navigator.pop(context);
-                context.push(Uri(path: '/', queryParameters: {
-                  'id': 'c0f7c578204d61e08ec0fbc4d63456cd',
-                }).toString());
-              },
-            ),
-            ListTile(
-              leading: Image.asset(
-                'assets/dart_logo_128.png',
-                width: defaultIconSize,
-              ),
-              title: const Text('Fibonacci'),
-              onTap: () {
-                Navigator.pop(context);
-                context.push(Uri(path: '/', queryParameters: {
-                  'id': 'd3bd83918d21b6d5f778bdc69c3d36d6',
-                }).toString());
-              },
-            ),
-            ListTile(
-              leading: Image.asset(
-                'assets/flutter_logo_192.png',
-                width: defaultIconSize,
-              ),
-              title: const Text('Counter'),
-              onTap: () {
-                Navigator.pop(context);
-                context.push(Uri(path: '/', queryParameters: {
-                  'id': 'e75b493dae1287757c5e1d77a0dc73f1',
-                }).toString());
-              },
-            ),
-            ListTile(
-              leading: Image.asset(
-                'assets/flutter_logo_192.png',
-                width: defaultIconSize,
-              ),
-              title: const Text('Sunflower'),
-              onTap: () {
-                Navigator.pop(context);
-                context.push(Uri(path: '/', queryParameters: {
-                  'id': '5c0e154dd50af4a9ac856908061291bc',
-                }).toString());
-              },
-            ),
-            const Divider(),
-            const AboutListTile(icon: Icon(Icons.info)),
-          ],
-        ),
-      ),
+      drawer: const SamplesDrawer(),
       body: Column(
         children: [
           Expanded(
@@ -267,9 +196,6 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                           Expanded(
                             child: SectionWidget(
                               title: 'Code',
-                              status: ProgressWidget(
-                                status: appModel.editingProgressController,
-                              ),
                               actions: [
                                 ValueListenableBuilder<bool>(
                                   valueListenable: appModel.formattingBusy,
@@ -299,7 +225,18 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                                   },
                                 ),
                               ],
-                              child: EditorWidget(appModel: appModel),
+                              child: Stack(
+                                children: [
+                                  EditorWidget(appModel: appModel),
+                                  Container(
+                                    padding: const EdgeInsets.all(denseSpacing),
+                                    alignment: Alignment.topRight,
+                                    child: ProgressWidget(
+                                      status: appModel.statusController,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
                           ValueListenableBuilder<List<AnalysisIssue>>(
@@ -324,9 +261,6 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                         children: [
                           SectionWidget(
                             title: 'App',
-                            status: ProgressWidget(
-                              status: appModel.executionProgressController,
-                            ),
                             actions: [
                               ValueListenableBuilder<TextEditingValue>(
                                 valueListenable:
@@ -341,16 +275,22 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                                   );
                                 },
                               ),
-                              const SizedBox(width: denseSpacing),
-                              const SizedBox(
-                                  height: smallIconSize + 8,
-                                  child: VerticalDivider()),
-                              const SizedBox(width: denseSpacing),
-                              CompilingStatusWidget(
-                                  status: appModel.compilingBusy),
                             ],
-                            child: ExecutionWidget(
-                              appServices: appServices,
+                            child: Stack(
+                              children: [
+                                ExecutionWidget(
+                                  appServices: appServices,
+                                ),
+                                Container(
+                                  alignment: Alignment.topRight,
+                                  child: SizedBox(
+                                    width: 32,
+                                    child: CompilingStatusWidget(
+                                      status: appModel.compilingBusy,
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
                           SectionWidget(
@@ -389,30 +329,30 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
 
     if (result.hasError()) {
       // TODO: in practice we don't get errors back, just no formatting changes
-      appModel.editingProgressController.showToast('Error formatting code');
+      appModel.statusController.showToast('Error formatting code');
       appModel.appendLineToConsole('Formatting issue: ${result.error.message}');
     } else if (result.newString == value) {
-      appModel.editingProgressController.showToast('No formatting changes');
+      appModel.statusController.showToast('No formatting changes');
     } else {
-      appModel.editingProgressController.showToast('Format successful');
+      appModel.statusController.showToast('Format successful');
       appModel.sourceCodeController.text = result.newString;
     }
   }
 
   Future<void> _handleCompiling() async {
     final value = appModel.sourceCodeController.text;
-    final progress = appModel.executionProgressController
-        .showMessage(initialText: 'Compiling…');
+    final progress =
+        appModel.statusController.showMessage(initialText: 'Compiling…');
     _clearConsole();
 
     try {
       final response = await appServices.compile(CompileRequest(source: value));
 
-      appModel.executionProgressController
+      appModel.statusController
           .showToast('Running…', duration: const Duration(seconds: 1));
       appServices.executeJavaScript(response.result);
     } catch (error) {
-      appModel.executionProgressController.showToast('Compilation failed');
+      appModel.statusController.showToast('Compilation failed');
 
       var message = error is ApiRequestError ? error.message : '$error';
       appModel.appendLineToConsole(message);
@@ -515,13 +455,11 @@ class SectionWidget extends StatelessWidget {
   static const insets = 6.0;
 
   final String title;
-  final Widget? status;
   final List<Widget> actions;
   final Widget child;
 
   const SectionWidget({
     required this.title,
-    this.status,
     this.actions = const [],
     required this.child,
     super.key,
@@ -551,8 +489,6 @@ class SectionWidget extends StatelessWidget {
                     title,
                     style: theme.textTheme.titleSmall,
                   ),
-                  const SizedBox(width: defaultSpacing),
-                  if (status != null) status!,
                   const Expanded(child: SizedBox(width: defaultSpacing)),
                   ...actions
                 ],

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -61,6 +61,7 @@ class _DartPadAppState extends State<DartPadApp> {
             path: '/',
             builder: (BuildContext context, GoRouterState state) {
               final idParam = state.queryParameters['id'];
+              final sampleParam = state.queryParameters['sample'];
               final themeParam = state.queryParameters['theme'] ?? 'dark';
               final bool darkMode = themeParam == 'dark';
 
@@ -72,6 +73,7 @@ class _DartPadAppState extends State<DartPadApp> {
                 ),
                 child: DartPadMainPage(
                   title: appName,
+                  sampleId: sampleParam,
                   gistId: idParam,
                 ),
               );
@@ -86,10 +88,12 @@ class _DartPadAppState extends State<DartPadApp> {
 
 class DartPadMainPage extends StatefulWidget {
   final String title;
+  final String? sampleId;
   final String? gistId;
 
   const DartPadMainPage({
     required this.title,
+    this.sampleId,
     this.gistId,
     super.key,
   });
@@ -120,6 +124,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
     appServices.populateVersions();
 
     appServices.performInitialLoad(
+      sampleId: widget.sampleId,
       gistId: widget.gistId,
       fallbackSnippet: defaultSnippetSource,
     );
@@ -137,10 +142,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
       appBar: AppBar(
         title: Row(
           children: [
-            Image.asset(
-              'assets/dart_logo_128.png',
-              width: 32,
-            ),
+            dartLogo(width: 32),
             const SizedBox(width: denseSpacing),
             const Text(appName),
             const SizedBox(width: defaultSpacing),

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'gists.dart';
+import 'samples.g.dart';
 import 'services/dartservices.dart';
 import 'utils.dart';
 
@@ -77,9 +78,21 @@ class AppServices {
   }
 
   Future<void> performInitialLoad({
+    String? sampleId,
     String? gistId,
     required String fallbackSnippet,
   }) async {
+    // Delay a bit for codemirror to initialize.
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+
+    var sample = Samples.getById(sampleId);
+    if (sample != null) {
+      appModel.title.value = sample.name;
+      appModel.sourceCodeController.text = sample.source;
+      appModel.appReady.value = true;
+      return;
+    }
+
     if (gistId == null) {
       appModel.sourceCodeController.text = fallbackSnippet;
       appModel.appReady.value = true;

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -31,8 +31,7 @@ class AppModel {
   final ValueNotifier<bool> formattingBusy = ValueNotifier(false);
   final ValueNotifier<bool> compilingBusy = ValueNotifier(false);
 
-  final ProgressController editingProgressController = ProgressController();
-  final ProgressController executionProgressController = ProgressController();
+  final ProgressController statusController = ProgressController();
 
   final ValueNotifier<VersionResponse> runtimeVersions =
       ValueNotifier(VersionResponse());
@@ -89,7 +88,7 @@ class AppServices {
 
     final gistLoader = GistLoader();
     final progress =
-        appModel.editingProgressController.showMessage(initialText: 'Loading…');
+        appModel.statusController.showMessage(initialText: 'Loading…');
     try {
       final gist = await gistLoader.load(gistId);
       progress.close();
@@ -100,7 +99,7 @@ class AppServices {
 
       final source = gist.mainDartSource;
       if (source == null) {
-        appModel.editingProgressController.showToast('main.dart not found');
+        appModel.statusController.showToast('main.dart not found');
         appModel.sourceCodeController.text = fallbackSnippet;
       } else {
         appModel.sourceCodeController.text = source;
@@ -108,7 +107,7 @@ class AppServices {
 
       appModel.appReady.value = true;
     } catch (e) {
-      appModel.editingProgressController.showToast('Error loading gist');
+      appModel.statusController.showToast('Error loading gist');
       progress.close();
 
       appModel.appendLineToConsole('Error loading gist: $e');
@@ -175,8 +174,7 @@ class AppServices {
 
   void _updateEditorProblemsStatus() {
     final issues = appModel.analysisIssues.value;
-    final progress =
-        appModel.editingProgressController.getNamedMessage('problems');
+    final progress = appModel.statusController.getNamedMessage('problems');
 
     if (issues.isEmpty) {
       if (progress != null) {
@@ -185,7 +183,7 @@ class AppServices {
     } else {
       final message = '${issues.length} ${pluralize('issue', issues.length)}';
       if (progress == null) {
-        appModel.editingProgressController
+        appModel.statusController
             .showMessage(initialText: message, name: 'problems');
       } else {
         progress.updateText(message);

--- a/pkgs/sketch_pad/lib/samples.dart
+++ b/pkgs/sketch_pad/lib/samples.dart
@@ -1,0 +1,93 @@
+// Copyright 2023 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart' as url;
+
+import 'main.dart';
+import 'samples.g.dart';
+import 'utils.dart';
+
+class SamplesDrawer extends StatelessWidget {
+  const SamplesDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    var categories = Samples.categories.keys;
+
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          ListTile(
+            title: const Text(appName),
+            titleTextStyle: theme.textTheme.titleLarge,
+          ),
+          for (var category in categories) ...[
+            const Divider(),
+            ListTile(title: Text('$category samples')),
+            ...Samples.categories[category]!.map((sample) {
+              return SampleListTile(
+                image: sample.isDart ? dartLogo() : flutterLogo(),
+                name: sample.name,
+                id: sample.id,
+              );
+            })
+          ],
+          const Divider(),
+          ListTile(
+            leading: const Icon(Icons.info),
+            title: const Text('Privacy notice'),
+            trailing: const Icon(Icons.link),
+            onTap: () {
+              Navigator.pop(context);
+              url.launchUrl(
+                  Uri.parse('https://dart.dev/tools/dartpad/privacy'));
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.feedback),
+            title: const Text('Feedback'),
+            trailing: const Icon(Icons.link),
+            onTap: () {
+              Navigator.pop(context);
+              url.launchUrl(
+                  Uri.parse('https://github.com/dart-lang/dart-pad/issues'));
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class SampleListTile extends StatelessWidget {
+  final Image image;
+  final String name;
+  final String id;
+
+  const SampleListTile({
+    required this.image,
+    required this.name,
+    required this.id,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final uri = Uri(path: '/', queryParameters: {'sample': id});
+
+    return ListTile(
+      leading: image,
+      title: Text(name),
+      onTap: () {
+        Navigator.pop(context);
+        context.push(uri.toString());
+      },
+    );
+  }
+}

--- a/pkgs/sketch_pad/lib/samples.g.dart
+++ b/pkgs/sketch_pad/lib/samples.g.dart
@@ -1,0 +1,324 @@
+// Copyright 2023 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+
+class Sample {
+  final String category;
+  final String name;
+  final String id;
+  final String source;
+
+  Sample({
+    required this.category,
+    required this.name,
+    required this.id,
+    required this.source,
+  });
+
+  bool get isDart => category == 'Dart';
+
+  @override
+  String toString() => '[$category] $name ($id)';
+}
+
+class Samples {
+  static final List<Sample> all = [
+    _fibonacci,
+    _helloWorld,
+    _counter,
+    _sunflower,
+  ];
+
+  static final Map<String, List<Sample>> categories = {
+    'Dart': [
+      _fibonacci,
+      _helloWorld,
+    ],
+    'Flutter': [
+      _counter,
+      _sunflower,
+    ],
+  };
+
+  static Sample? getById(String? id) => all.firstWhereOrNull((s) => s.id == id);
+}
+
+final _fibonacci = Sample(
+  category: 'Dart',
+  name: 'Fibonacci',
+  id: 'fibonacci',
+  source: r'''
+// Copyright 2015 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+void main() {
+  var i = 20;
+
+  print('fibonacci($i) = ${fibonacci(i)}');
+}
+
+/// Computes the nth Fibonacci number.
+int fibonacci(int n) {
+  return n < 2 ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+''',
+);
+
+final _helloWorld = Sample(
+  category: 'Dart',
+  name: 'Hello world',
+  id: 'hello-world',
+  source: r'''
+// Copyright 2015 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+void main() {
+  for (var i = 0; i < 4; i++) {
+    print('hello $i');
+  }
+}
+''',
+);
+
+final _counter = Sample(
+  category: 'Flutter',
+  name: 'Counter',
+  id: 'counter',
+  source: r'''
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    );
+  }
+}
+
+class MyHomePage extends StatefulWidget {
+  final String title;
+
+  const MyHomePage({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  @override
+  State<MyHomePage> createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<MyHomePage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.title),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text(
+              'You have pushed the button this many times:',
+            ),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _incrementCounter,
+        tooltip: 'Increment',
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+''',
+);
+
+final _sunflower = Sample(
+  category: 'Flutter',
+  name: 'Sunflower',
+  id: 'sunflower',
+  source: r'''
+// Copyright 2019 the Dart project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+const Color primaryColor = Colors.orange;
+const TargetPlatform platform = TargetPlatform.android;
+
+void main() {
+  runApp(const Sunflower());
+}
+
+class SunflowerPainter extends CustomPainter {
+  static const seedRadius = 2.0;
+  static const scaleFactor = 4;
+  static const tau = math.pi * 2;
+
+  static final phi = (math.sqrt(5) + 1) / 2;
+
+  final int seeds;
+
+  SunflowerPainter(this.seeds);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.width / 2;
+
+    for (var i = 0; i < seeds; i++) {
+      final theta = i * tau / phi;
+      final r = math.sqrt(i) * scaleFactor;
+      final x = center + r * math.cos(theta);
+      final y = center - r * math.sin(theta);
+      final offset = Offset(x, y);
+      if (!size.contains(offset)) {
+        continue;
+      }
+      drawSeed(canvas, x, y);
+    }
+  }
+
+  @override
+  bool shouldRepaint(SunflowerPainter oldDelegate) {
+    return oldDelegate.seeds != seeds;
+  }
+
+  // Draw a small circle representing a seed centered at (x,y).
+  void drawSeed(Canvas canvas, double x, double y) {
+    final paint = Paint()
+      ..strokeWidth = 2
+      ..style = PaintingStyle.fill
+      ..color = primaryColor;
+    canvas.drawCircle(Offset(x, y), seedRadius, paint);
+  }
+}
+
+class Sunflower extends StatefulWidget {
+  const Sunflower({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _SunflowerState();
+  }
+}
+
+class _SunflowerState extends State<Sunflower> {
+  double seeds = 100.0;
+
+  int get seedCount => seeds.floor();
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData().copyWith(
+        platform: platform,
+        brightness: Brightness.dark,
+        sliderTheme: SliderThemeData.fromPrimaryColors(
+          primaryColor: primaryColor,
+          primaryColorLight: primaryColor,
+          primaryColorDark: primaryColor,
+          valueIndicatorTextStyle: const DefaultTextStyle.fallback().style,
+        ),
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Sunflower'),
+        ),
+        drawer: Drawer(
+          child: ListView(
+            children: const [
+              DrawerHeader(
+                child: Center(
+                  child: Text(
+                    'Sunflower 🌻',
+                    style: TextStyle(fontSize: 32),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        body: Container(
+          constraints: const BoxConstraints.expand(),
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.transparent,
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.transparent,
+                  ),
+                ),
+                child: SizedBox(
+                  width: 400,
+                  height: 400,
+                  child: CustomPaint(
+                    painter: SunflowerPainter(seedCount),
+                  ),
+                ),
+              ),
+              Text('Showing $seedCount seeds'),
+              ConstrainedBox(
+                constraints: const BoxConstraints.tightFor(width: 300),
+                child: Slider.adaptive(
+                  min: 20,
+                  max: 2000,
+                  value: seeds,
+                  onChanged: (newValue) {
+                    setState(() {
+                      seeds = newValue;
+                    });
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+''',
+);

--- a/pkgs/sketch_pad/lib/utils.dart
+++ b/pkgs/sketch_pad/lib/utils.dart
@@ -32,6 +32,16 @@ void unimplemented(BuildContext context, String message) {
 
 String generateSnippetName() => fluttering_phrases.generate();
 
+Image dartLogo({double? width}) {
+  return Image.asset('assets/dart_logo_128.png',
+      width: width ?? defaultIconSize);
+}
+
+Image flutterLogo({double? width}) {
+  return Image.asset('assets/flutter_logo_192.png',
+      width: width ?? defaultIconSize);
+}
+
 /// Support a stack of progress and status messages.
 ///
 /// Fires a notification when the top-most status changes.

--- a/pkgs/sketch_pad/lib/widgets.dart
+++ b/pkgs/sketch_pad/lib/widgets.dart
@@ -86,6 +86,10 @@ class MiniIconButton extends StatelessWidget {
   }
 }
 
+// todo: have a background
+// todo: use rounded corners
+// todo: use an elevation
+
 class ProgressWidget extends StatelessWidget {
   final ProgressController status;
 
@@ -162,7 +166,7 @@ class _CompilingStatusWidgetState extends State<CompilingStatusWidget>
       valueListenable: widget.status,
       builder: (context, bool value, _) {
         return AnimatedOpacity(
-          opacity: value ? 0.8 : 0.2,
+          opacity: value ? 0.6 : 0.0,
           duration: animationDelay,
           child: AnimatedBuilder(
             animation: controller,


### PR DESCRIPTION
- generate samples into sketchpad directly (from the content in `pkgs/samples`)
- add generated samples into the drawer
- add a sunflower sample
- (also, reduce the number of places we show progress information)

<img width="449" alt="Screenshot 2023-06-27 at 6 18 55 PM" src="https://github.com/dart-lang/dart-pad/assets/1269969/46322e96-01bf-4745-a9bd-ff092f455559">

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
