### PR TITLE
Remove timeout from flutter build step

### DIFF
--- a/.cloud_build/flutter/cloudbuild.yaml
+++ b/.cloud_build/flutter/cloudbuild.yaml
@@ -34,8 +34,6 @@ steps:
     args: ['--help']
     dir: .cloud_build/flutter
 
-timeout: '1200s'
-
 images: [
   'gcr.io/$PROJECT_ID/flutter:main',
   'gcr.io/$PROJECT_ID/flutter:beta',


### PR DESCRIPTION
This removes the Cloud Build timeout when building Flutter Docker images