### PR TITLE
update output areas

### DIFF
--- a/pkgs/sketch_pad/lib/console.dart
+++ b/pkgs/sketch_pad/lib/console.dart
@@ -42,25 +42,16 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('Output', style: subtleText),
-        const Divider(),
-        Expanded(
-          child: TextField(
-            controller: widget.consoleOutputController,
-            scrollController: scrollController,
-            maxLines: null,
-            keyboardType: TextInputType.multiline,
-            textInputAction: TextInputAction.newline,
-            expands: true,
-            decoration: null,
-            style: theme.textTheme.bodyMedium,
-            readOnly: true,
-          ),
-        ),
-      ],
+    return TextField(
+      controller: widget.consoleOutputController,
+      scrollController: scrollController,
+      maxLines: null,
+      keyboardType: TextInputType.multiline,
+      textInputAction: TextInputAction.newline,
+      expands: true,
+      decoration: null,
+      style: theme.textTheme.bodyMedium,
+      readOnly: true,
     );
   }
 

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -305,7 +305,6 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                             ValueListenableBuilder<bool>(
                               valueListenable: appModel.compilingBusy,
                               builder: (BuildContext context, bool value, _) {
-                                // todo:
                                 final isFlutter = appModel.appIsFlutter.value;
 
                                 return AnimatedContainer(

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'gists.dart';
@@ -40,22 +39,16 @@ class AppModel {
   final ValueNotifier<bool> compilingBusy = ValueNotifier(false);
 
   final StatusController editorStatus = StatusController();
-  final StatusController executionStatus = StatusController();
 
   final ValueNotifier<VersionResponse> runtimeVersions =
       ValueNotifier(VersionResponse());
 
-  final ValueNotifier<bool> _consoleShowing = ValueNotifier(true);
-  ValueListenable<bool> get consoleShowing => _consoleShowing;
-
-  final ValueNotifier<bool> _appAreaShowing = ValueNotifier(true);
-  ValueListenable<bool> get appAreaShowing => _appAreaShowing;
-
-  bool _executableIsFlutter = true;
+  final ValueNotifier<bool?> appIsFlutter = ValueNotifier(null);
+  final ValueNotifier<bool> consoleHasOutput = ValueNotifier(false);
 
   AppModel() {
     consoleOutputController.addListener(() {
-      _updateExecutionAreasVisibility();
+      consoleHasOutput.value = consoleOutputController.text.isNotEmpty;
     });
   }
 
@@ -64,17 +57,6 @@ class AppModel {
   }
 
   void clearConsole() => consoleOutputController.clear();
-
-  set executableIsFlutter(bool value) {
-    _executableIsFlutter = value;
-    _updateExecutionAreasVisibility();
-  }
-
-  void _updateExecutionAreasVisibility() {
-    _appAreaShowing.value = _executableIsFlutter;
-    _consoleShowing.value =
-        !_executableIsFlutter || consoleOutputController.text.isNotEmpty;
-  }
 }
 
 class AppServices {
@@ -223,6 +205,9 @@ class AppServices {
   }
 
   void executeJavaScript(String javaScript) {
+    final usesFlutter = hasFlutterWebMarker(javaScript);
+    appModel.appIsFlutter.value = usesFlutter;
+
     _executionService?.execute(javaScript);
   }
 

--- a/pkgs/sketch_pad/lib/utils.dart
+++ b/pkgs/sketch_pad/lib/utils.dart
@@ -51,6 +51,12 @@ RelativeRect calculatePopupMenuPosition(BuildContext context) {
   );
 }
 
+bool hasFlutterWebMarker(String javaScript) {
+  const marker = 'window.flutterConfiguration';
+
+  return javaScript.contains(marker);
+}
+
 extension ColorExtension on Color {
   Color get lighter {
     final hsl = HSLColor.fromColor(this);

--- a/pkgs/sketch_pad/lib/widgets.dart
+++ b/pkgs/sketch_pad/lib/widgets.dart
@@ -140,9 +140,11 @@ class ProgressWidget extends StatelessWidget {
 }
 
 class CompilingStatusWidget extends StatefulWidget {
+  final double size;
   final ValueListenable<bool> status;
 
   const CompilingStatusWidget({
+    required this.size,
     required this.status,
     super.key,
   });
@@ -185,23 +187,26 @@ class _CompilingStatusWidgetState extends State<CompilingStatusWidget>
     final gearIcon =
         Image.asset('assets/gear-96-${darkMode ? 'light' : 'dark'}.png');
 
-    return ValueListenableBuilder<bool>(
-      valueListenable: widget.status,
-      builder: (context, bool value, _) {
-        return AnimatedOpacity(
-          opacity: value ? 0.6 : 0.0,
-          duration: animationDelay,
-          child: AnimatedBuilder(
-            animation: controller,
-            builder: (BuildContext context, Widget? child) {
-              return Transform.rotate(
-                angle: controller.value * 2 * math.pi,
-                child: gearIcon,
-              );
-            },
-          ),
-        );
-      },
+    return SizedBox.square(
+      dimension: widget.size,
+      child: ValueListenableBuilder<bool>(
+        valueListenable: widget.status,
+        builder: (context, bool value, _) {
+          return AnimatedOpacity(
+            opacity: value ? 0.6 : 0.0,
+            duration: animationDelay,
+            child: AnimatedBuilder(
+              animation: controller,
+              builder: (BuildContext context, Widget? child) {
+                return Transform.rotate(
+                  angle: controller.value * 2 * math.pi,
+                  child: gearIcon,
+                );
+              },
+            ),
+          );
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
Update output areas:

- give the two output areas - the iframe and the console output - names in the UI (`'App'` and `'Console output'`)
- move most of the progress output into the editor area
- add back in a 'clear output' button for the console
- move the compilation spinner into the 'app' area's header
- add an opacity animation over the app area when compiling

This PR is to replace https://github.com/dart-lang/dart-pad/pull/2592.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
