### PR TITLE
use concurrency=1 for the beta channel

### DIFF
--- a/.cloud_build/README.md
+++ b/.cloud_build/README.md
@@ -2,19 +2,19 @@
 
 Cloud Build configuration files for dart-pad and dart-services.
 
-
 # Contents
 
 - `dart-services/` - Deploys the dart_services server to Cloud Run - `flutter/`
 - `dart_pad.yaml` - Deploys `dart_pad` to Firebase Hosting
 - `sketch_pad.yaml` - Deploys `sketch_pad` to Firebase Hosting
 
-This folder also has configuration files from [cloud-builders-community][], which are
-needed to build and deploy `dart_pad` and `sketch_pad` to Firebase Hosting:
+This folder also has configuration files from [cloud-builders-community][],
+which are needed to build and deploy `dart_pad` and `sketch_pad` to Firebase
+Hosting:
+
 - Uploads an image that contains the Flutter SDK to Container Registry -
   `firebase/`
-- Uploads an image that contains the Firebase SDK to Container
-  Registry
+- Uploads an image that contains the Firebase SDK to Container Registry
 
 # Deploying
 
@@ -44,6 +44,5 @@ Update the Firebase SDK images:
 ```bash
 gcloud builds submit . --config=.cloud_build/firebase/cloudbuild.yaml
 ```
-
 
 [cloud-builders-community]: https://github.com/GoogleCloudPlatform/cloud-builders-community/blob/master/flutter/Dockerfile

--- a/.cloud_build/dart-services/README.md
+++ b/.cloud_build/dart-services/README.md
@@ -1,7 +1,7 @@
 # Dart-services Cloud Build configuration
 
-Cloud Build configuration for dart-services. This runs automatically
-using a Cloud Build trigger.
+Cloud Build configuration for dart-services. This runs automatically using a
+Cloud Build trigger.
 
 To deploy a new version manually, run:
 
@@ -14,5 +14,5 @@ gcloud builds submit \
     COMMIT_SHA=$COMMIT_SHA
 ```
 
-Where `$FLUTTER_CHANNEL` is `stable`, `beta`, `dev`, `main`, or `old`. The REPO_NAME and COMMIT_SHA are for adding tags to the Docker image.
-
+Where `$FLUTTER_CHANNEL` is `stable`, `beta`, `dev`, `main`, or `old`. The
+REPO_NAME and COMMIT_SHA are for adding tags to the Docker image.

--- a/.cloud_build/dart-services/beta.yaml
+++ b/.cloud_build/dart-services/beta.yaml
@@ -17,6 +17,7 @@ steps:
     id: Push
     dir: pkgs/dart_services
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    entrypoint: gcloud
     args:
       - run
       - services
@@ -24,18 +25,19 @@ steps:
       - $_SERVICE_NAME
       - '--platform=managed'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
-      - >-
-        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS'
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
+      - '--min-instances=1'
+      - '--cpu=2'
+      - '--memory=4Gi'
+      - '--concurrency=1'
     id: Deploy
-    entrypoint: gcloud
     dir: pkgs/dart_services
 timeout: 1200s
 images:
   - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
 options:
-  machineType: N1_HIGHCPU_8
   substitutionOption: ALLOW_LOOSE
 substitutions:
   _LABELS: gcb-trigger-id=a38ddc5d-884e-4db1-a491-a5e9ff22c262

--- a/.cloud_build/dart-services/dev.yaml
+++ b/.cloud_build/dart-services/dev.yaml
@@ -35,7 +35,6 @@ timeout: 1200s
 images:
   - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
 options:
-  machineType: N1_HIGHCPU_8
   substitutionOption: ALLOW_LOOSE
 substitutions:
   _SERVICE_NAME: flutter-dev-channel

--- a/.cloud_build/dart-services/main.yaml
+++ b/.cloud_build/dart-services/main.yaml
@@ -35,7 +35,6 @@ timeout: 1200s
 images:
   - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
 options:
-  machineType: E2_HIGHCPU_8
   substitutionOption: ALLOW_LOOSE
 substitutions:
   _DEPLOY_REGION: us-central1

--- a/.cloud_build/dart-services/old.yaml
+++ b/.cloud_build/dart-services/old.yaml
@@ -35,7 +35,6 @@ timeout: 1200s
 images:
   - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
 options:
-  machineType: N1_HIGHCPU_8
   substitutionOption: ALLOW_LOOSE
 substitutions:
   _GCR_HOSTNAME: us.gcr.io

--- a/.cloud_build/dart-services/stable.yaml
+++ b/.cloud_build/dart-services/stable.yaml
@@ -35,7 +35,6 @@ timeout: 1200s
 images:
   - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
 options:
-  # machineType: N1_HIGHCPU_8
   substitutionOption: ALLOW_LOOSE
 substitutions:
   _TRIGGER_ID: 6104a3eb-7116-4b2f-a864-2418bd8173bf


### PR DESCRIPTION
- use concurrency=1 for the beta channel
- standardize on some other settings (2 cores, 4G ram, 1 min instance); again just for the beta channel, but we should probably normalize for the others later

This PR also normalizes the machine type we use to build the images with (normalizes to the default, which is one CPU). If we think we need more cpus to build the images (to reduce the build time?) we should just use the same value for all the configs. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
