### PR TITLE
normalize deployment configs and set concurrency==1

### DIFF
--- a/.cloud_build/dart-services/dev.yaml
+++ b/.cloud_build/dart-services/dev.yaml
@@ -17,6 +17,7 @@ steps:
     id: Push
     dir: pkgs/dart_services
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    entrypoint: gcloud
     args:
       - run
       - services
@@ -24,12 +25,14 @@ steps:
       - $_SERVICE_NAME
       - '--platform=managed'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
-      - >-
-        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS'
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
+      - '--min-instances=1'
+      - '--cpu=2'
+      - '--memory=4Gi'
+      - '--concurrency=1'
     id: Deploy
-    entrypoint: gcloud
     dir: pkgs/dart_services
 timeout: 1200s
 images:

--- a/.cloud_build/dart-services/main.yaml
+++ b/.cloud_build/dart-services/main.yaml
@@ -17,6 +17,7 @@ steps:
     id: Push
     dir: pkgs/dart_services
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    entrypoint: gcloud
     args:
       - run
       - services
@@ -24,12 +25,14 @@ steps:
       - $_SERVICE_NAME
       - '--platform=managed'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
-      - >-
-        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS'
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
+      - '--min-instances=1'
+      - '--cpu=2'
+      - '--memory=4Gi'
+      - '--concurrency=1'
     id: Deploy
-    entrypoint: gcloud
     dir: pkgs/dart_services
 timeout: 1200s
 images:

--- a/.cloud_build/dart-services/old.yaml
+++ b/.cloud_build/dart-services/old.yaml
@@ -17,6 +17,7 @@ steps:
     id: Push
     dir: pkgs/dart_services
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    entrypoint: gcloud
     args:
       - run
       - services
@@ -24,12 +25,14 @@ steps:
       - $_SERVICE_NAME
       - '--platform=managed'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME/$_SERVICE_NAME:$COMMIT_SHA'
-      - >-
-        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS'
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
+      - '--min-instances=1'
+      - '--cpu=2'
+      - '--memory=4Gi'
+      - '--concurrency=1'
     id: Deploy
-    entrypoint: gcloud
     dir: pkgs/dart_services
 timeout: 1200s
 images:

--- a/.cloud_build/dart-services/stable.yaml
+++ b/.cloud_build/dart-services/stable.yaml
@@ -17,6 +17,7 @@ steps:
     id: Push
     dir: pkgs/dart_services
   - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
     args:
       - run
       - services
@@ -24,12 +25,15 @@ steps:
       - $_SERVICE_NAME
       - '--platform=managed'
       - '--image=$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-      - >-
-        --labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS
+      - '--labels=managed-by=gcp-cloud-build-deploy-cloud-run,commit-sha=$COMMIT_SHA,gcb-build-id=$BUILD_ID,gcb-trigger-id=$_TRIGGER_ID,$_LABELS'
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
+      - '--min-instances=5'
+      - '--cpu=2'
+      - '--memory=4Gi'
+      - '--concurrency=1'
+      - '--max-instances=1000'
     id: Deploy
-    entrypoint: gcloud
     dir: pkgs/dart_services
 timeout: 1200s
 images:

--- a/.cloud_build/dart-services/stable.yaml
+++ b/.cloud_build/dart-services/stable.yaml
@@ -29,10 +29,10 @@ steps:
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
       - '--min-instances=5'
+      - '--max-instances=1000'
       - '--cpu=2'
       - '--memory=4Gi'
       - '--concurrency=1'
-      - '--max-instances=1000'
     id: Deploy
     dir: pkgs/dart_services
 timeout: 1200s


### PR DESCRIPTION
- normalize deployment configs to 2 cpu, 4GB, min instance count=1 (substantially the same as how they're currently configured)
- switch the configs to request concurrency=1
- for the stable channel config only, set min instance count to 5, max instance count to 1000 (no change from the current config but now encoded in the deployment file)

We'll want to watch the stable channel metrics after this deploys in order to verify that the auto-scaler works well with this change.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
