### PR TITLE
Remove some remnants of null safety transition

### DIFF
--- a/pkgs/dart_pad/lib/sharing/editor_ui.dart
+++ b/pkgs/dart_pad/lib/sharing/editor_ui.dart
@@ -282,8 +282,7 @@ abstract class EditorUi {
 
   /// A list of each package's information.
   ///
-  /// This list is set on page load, and each time the Null Safety switch is
-  /// toggled.
+  /// This list is set on page load and each time the SDK channel is updated.
   final List<PackageInfo> _packageInfo = [];
 
   void _sendCompilationTiming(int milliseconds) {

--- a/pkgs/dart_pad/test/embed/embed_test.html
+++ b/pkgs/dart_pad/test/embed/embed_test.html
@@ -120,12 +120,6 @@ BSD-style license that can be found in the LICENSE file. -->
                       </span>
                         <span class="mdc-list-item__text">Editable test/solution</span>
                     </li>
-                    <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                      <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                    </span>
-                        <span class="mdc-list-item__text">Null Safety</span>
-                    </li>
                 </ul>
             </div>
         </div>

--- a/pkgs/dart_pad/web/embed-flutter_showcase.html
+++ b/pkgs/dart_pad/web/embed-flutter_showcase.html
@@ -104,12 +104,6 @@ BSD-style license that can be found in the LICENSE file. -->
                       </span>
                             <span class="mdc-list-item__text">Editable test/solution</span>
                         </li>
-                        <li id="toggle-null-safety-menu-item" class="mdc-list-item" role="menuitem">
-                    <span id="toggle-null-safety-checkmark" class="mdc-list-item__graphic hide">
-                      <i class="material-icons mdc-select__icon" tabindex="-1" role="button">check</i>
-                    </span>
-                            <span class="mdc-list-item__text">Null Safety</span>
-                        </li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
I'm planning some minor work on a few of the embeds and noticed these still in the overflow menu. Removing since they don't do anything anymore.