### PR TITLE
Fix Flutter web SDK path on old channel

### DIFF
--- a/pkgs/dart_services/lib/src/sdk.dart
+++ b/pkgs/dart_services/lib/src/sdk.dart
@@ -92,14 +92,6 @@ class Sdk {
   String get flutterToolPath => path.join(_flutterBinPath, 'flutter');
 
   String get flutterWebSdkPath {
-    // The Flutter web SDK path changed. The SDK version test here will go
-    // through the master, beta, stable, then old waterfall. Well, the last step
-    // is the removal of this test, but you get the idea.
-    if (oldChannel) {
-      return path.join(_flutterBinPath, 'cache', 'flutter_web_sdk',
-          'flutter_web_sdk', 'kernel');
-    }
-
     return path.join(_flutterBinPath, 'cache', 'flutter_web_sdk', 'kernel');
   }
 


### PR DESCRIPTION
Now that the old channel has moved to 3.10, it should use the newer location.