### PR TITLE
Fix test and analysis failures after SDK updates

### DIFF
--- a/.github/workflows/dart_services.yml
+++ b/.github/workflows/dart_services.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [stable, beta, dev, old, master]
+        sdk: [stable, beta, dev, old, main]
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f

--- a/pkgs/dart_services/test/common_server_api_protobuf_test.dart
+++ b/pkgs/dart_services/test/common_server_api_protobuf_test.dart
@@ -376,10 +376,10 @@ main() {
       final data = json.decode(await response.transform(utf8.decoder).join());
       final reply = proto.AssistsResponse()..mergeFromProto3Json(data);
       final assists = reply.assists;
-      if (sdk.masterChannel || sdk.betaChannel) {
-        expect(assists, hasLength(3));
-      } else {
+      if (sdk.oldChannel) {
         expect(assists, hasLength(2));
+      } else {
+        expect(assists, hasLength(3));
       }
       expect(assists.first.edits, isNotNull);
       expect(assists.first.edits, hasLength(1));
@@ -733,10 +733,10 @@ main() {
       final data = json.decode(await response.transform(utf8.decoder).join());
       final reply = proto.AssistsResponse()..mergeFromProto3Json(data);
       final assists = reply.assists;
-      if (sdk.masterChannel || sdk.betaChannel) {
-        expect(assists, hasLength(3));
-      } else {
+      if (sdk.oldChannel) {
         expect(assists, hasLength(2));
+      } else {
+        expect(assists, hasLength(3));
       }
       expect(assists.first.edits, isNotNull);
       expect(assists.first.edits, hasLength(1));

--- a/pkgs/dart_services/test/common_server_api_test.dart
+++ b/pkgs/dart_services/test/common_server_api_test.dart
@@ -505,10 +505,10 @@ main() {
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
         final assists = data['assists'] as List<dynamic>;
-        if (sdk.masterChannel || sdk.betaChannel) {
-          expect(assists, hasLength(3));
-        } else {
+        if (sdk.oldChannel) {
           expect(assists, hasLength(2));
+        } else {
+          expect(assists, hasLength(3));
         }
         final firstEdit = assists.first as Map<String, dynamic>;
         expect(firstEdit['edits'], isNotNull);
@@ -1216,10 +1216,10 @@ main() {
         final encoded = await response.transform(utf8.decoder).join();
         final data = json.decode(encoded) as Map<String, dynamic>;
         final assists = data['assists'] as List<dynamic>;
-        if (sdk.masterChannel || sdk.betaChannel) {
-          expect(assists, hasLength(3));
-        } else {
+        if (sdk.oldChannel) {
           expect(assists, hasLength(2));
+        } else {
+          expect(assists, hasLength(3));
         }
         final firstEdit = assists.first as Map<String, dynamic>;
         expect(firstEdit['edits'], isNotNull);


### PR DESCRIPTION
Old is failing because it still needs to be updated.