### PR TITLE
Use a singleton GoRouter configuration

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -35,8 +35,44 @@ import 'widgets.dart';
 
 const appName = 'DartPad';
 
+final router = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (BuildContext context, GoRouterState state) {
+        final idParam = state.uri.queryParameters['id'];
+        final sampleParam = state.uri.queryParameters['sample'];
+        final themeParam = state.uri.queryParameters['theme'] ?? 'dark';
+        final bool darkMode = themeParam == 'dark';
+        final colorScheme = ColorScheme.fromSwatch(
+          brightness: darkMode ? Brightness.dark : Brightness.light,
+        );
+
+        return Theme(
+          data: ThemeData(
+            colorScheme: colorScheme,
+            // TODO: We should switch to using material 3.
+            useMaterial3: false,
+            textButtonTheme: TextButtonThemeData(
+              style: TextButton.styleFrom(
+                foregroundColor: colorScheme.onPrimary,
+              ),
+            ),
+          ),
+          child: DartPadMainPage(
+            title: appName,
+            sampleId: sampleParam,
+            gistId: idParam,
+          ),
+        );
+      },
+    ),
+  ],
+);
+
 void main() async {
-  setPathUrlStrategy();
+  // setPathUrlStrategy();
 
   runApp(const DartPadApp());
 }
@@ -55,41 +91,7 @@ class _DartPadAppState extends State<DartPadApp> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       title: appName,
-      routerConfig: GoRouter(
-        initialLocation: '/',
-        routes: [
-          GoRoute(
-            path: '/',
-            builder: (BuildContext context, GoRouterState state) {
-              final idParam = state.uri.queryParameters['id'];
-              final sampleParam = state.uri.queryParameters['sample'];
-              final themeParam = state.uri.queryParameters['theme'] ?? 'dark';
-              final bool darkMode = themeParam == 'dark';
-              final colorScheme = ColorScheme.fromSwatch(
-                brightness: darkMode ? Brightness.dark : Brightness.light,
-              );
-
-              return Theme(
-                data: ThemeData(
-                  colorScheme: colorScheme,
-                  // TODO: We should switch to using material 3.
-                  useMaterial3: false,
-                  textButtonTheme: TextButtonThemeData(
-                    style: TextButton.styleFrom(
-                      foregroundColor: colorScheme.onPrimary,
-                    ),
-                  ),
-                ),
-                child: DartPadMainPage(
-                  title: appName,
-                  sampleId: sampleParam,
-                  gistId: idParam,
-                ),
-              );
-            },
-          ),
-        ],
-      ),
+      routerConfig: router,
       debugShowCheckedModeBanner: false,
     );
   }
@@ -100,12 +102,11 @@ class DartPadMainPage extends StatefulWidget {
   final String? sampleId;
   final String? gistId;
 
-  const DartPadMainPage({
+  DartPadMainPage({
     required this.title,
     this.sampleId,
     this.gistId,
-    super.key,
-  });
+  }) : super(key: ValueKey('sample:$sampleId gist:$gistId'));
 
   @override
   State<DartPadMainPage> createState() => _DartPadMainPageState();
@@ -668,7 +669,7 @@ class ListSamplesWidget extends StatelessWidget {
 
   void _handleSelection(BuildContext context, String sampleId) {
     final uri = Uri(path: '/', queryParameters: {'sample': sampleId});
-    context.push(uri.toString());
+    context.go(uri.toString());
   }
 }
 

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -72,7 +72,7 @@ final router = GoRouter(
 );
 
 void main() async {
-  // setPathUrlStrategy();
+  setPathUrlStrategy();
 
   runApp(const DartPadApp());
 }

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -63,41 +63,43 @@ class _DartPadAppState extends State<DartPadApp> {
   }
 }
 
-GoRouter _createRouter() => GoRouter(
-  initialLocation: '/',
-  routes: [
-    GoRoute(
-      path: '/',
-      builder: (BuildContext context, GoRouterState state) {
-        final idParam = state.uri.queryParameters['id'];
-        final sampleParam = state.uri.queryParameters['sample'];
-        final themeParam = state.uri.queryParameters['theme'] ?? 'dark';
-        final bool darkMode = themeParam == 'dark';
-        final colorScheme = ColorScheme.fromSwatch(
-          brightness: darkMode ? Brightness.dark : Brightness.light,
-        );
+GoRouter _createRouter() {
+  return GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (BuildContext context, GoRouterState state) {
+          final idParam = state.uri.queryParameters['id'];
+          final sampleParam = state.uri.queryParameters['sample'];
+          final themeParam = state.uri.queryParameters['theme'] ?? 'dark';
+          final bool darkMode = themeParam == 'dark';
+          final colorScheme = ColorScheme.fromSwatch(
+            brightness: darkMode ? Brightness.dark : Brightness.light,
+          );
 
-        return Theme(
-          data: ThemeData(
-            colorScheme: colorScheme,
-            // TODO: We should switch to using material 3.
-            useMaterial3: false,
-            textButtonTheme: TextButtonThemeData(
-              style: TextButton.styleFrom(
-                foregroundColor: colorScheme.onPrimary,
+          return Theme(
+            data: ThemeData(
+              colorScheme: colorScheme,
+              // TODO: We should switch to using material 3.
+              useMaterial3: false,
+              textButtonTheme: TextButtonThemeData(
+                style: TextButton.styleFrom(
+                  foregroundColor: colorScheme.onPrimary,
+                ),
               ),
             ),
-          ),
-          child: DartPadMainPage(
-            title: appName,
-            sampleId: sampleParam,
-            gistId: idParam,
-          ),
-        );
-      },
-    ),
-  ],
-);
+            child: DartPadMainPage(
+              title: appName,
+              sampleId: sampleParam,
+              gistId: idParam,
+            ),
+          );
+        },
+      ),
+    ],
+  );
+}
 
 class DartPadMainPage extends StatefulWidget {
   final String title;

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -35,7 +35,35 @@ import 'widgets.dart';
 
 const appName = 'DartPad';
 
-final router = GoRouter(
+final router = _createRouter();
+
+void main() async {
+  setPathUrlStrategy();
+
+  runApp(const DartPadApp());
+}
+
+class DartPadApp extends StatefulWidget {
+  const DartPadApp({
+    super.key,
+  });
+
+  @override
+  State<DartPadApp> createState() => _DartPadAppState();
+}
+
+class _DartPadAppState extends State<DartPadApp> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: appName,
+      routerConfig: router,
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+
+GoRouter _createRouter() => GoRouter(
   initialLocation: '/',
   routes: [
     GoRoute(
@@ -70,32 +98,6 @@ final router = GoRouter(
     ),
   ],
 );
-
-void main() async {
-  setPathUrlStrategy();
-
-  runApp(const DartPadApp());
-}
-
-class DartPadApp extends StatefulWidget {
-  const DartPadApp({
-    super.key,
-  });
-
-  @override
-  State<DartPadApp> createState() => _DartPadAppState();
-}
-
-class _DartPadAppState extends State<DartPadApp> {
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: appName,
-      routerConfig: router,
-      debugShowCheckedModeBanner: false,
-    );
-  }
-}
 
 class DartPadMainPage extends StatefulWidget {
   final String title;


### PR DESCRIPTION
A new GoRouter configuration was being created on every build phase, which caused the app to change from "/?id=<id>" to "/".

This also fixes an issue where selecting a sample pushed a new page onto the Navigator stack (`context.push()` instead of `go()`), causing the in-app back button to be displayed. This isn't necessary for DartPad's UX since the user can use the browser back and forward button to switch between gists and samples. 

fixes #2632