### PR TITLE
add back in a request queue; switch to concurrency=2

### DIFF
--- a/.cloud_build/dart-services/beta.yaml
+++ b/.cloud_build/dart-services/beta.yaml
@@ -31,7 +31,7 @@ steps:
       - '--min-instances=1'
       - '--cpu=2'
       - '--memory=4Gi'
-      - '--concurrency=1'
+      - '--concurrency=2'
       - '--cpu-boost'
     id: Deploy
     dir: pkgs/dart_services
@@ -41,12 +41,12 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:
-  _LABELS: gcb-trigger-id=a38ddc5d-884e-4db1-a491-a5e9ff22c262
-  _TRIGGER_ID: a38ddc5d-884e-4db1-a491-a5e9ff22c262
-  _SERVICE_NAME: flutter-beta-channel
   _DEPLOY_REGION: us-central1
   _GCR_HOSTNAME: us.gcr.io
+  _LABELS: gcb-trigger-id=a38ddc5d-884e-4db1-a491-a5e9ff22c262
   _PLATFORM: managed
+  _SERVICE_NAME: flutter-beta-channel
+  _TRIGGER_ID: a38ddc5d-884e-4db1-a491-a5e9ff22c262
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - gcp-cloud-build-deploy-cloud-run-managed

--- a/.cloud_build/dart-services/dev.yaml
+++ b/.cloud_build/dart-services/dev.yaml
@@ -31,7 +31,7 @@ steps:
       - '--min-instances=1'
       - '--cpu=2'
       - '--memory=4Gi'
-      - '--concurrency=1'
+      - '--concurrency=2'
       - '--cpu-boost'
     id: Deploy
     dir: pkgs/dart_services
@@ -41,11 +41,11 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:
-  _SERVICE_NAME: flutter-dev-channel
   _DEPLOY_REGION: us-central1
   _GCR_HOSTNAME: us.gcr.io
-  _PLATFORM: managed
   _LABELS: gcb-trigger-id=34c44e1d-d415-413a-9af6-005b575e1800
+  _PLATFORM: managed
+  _SERVICE_NAME: flutter-dev-channel
   _TRIGGER_ID: 34c44e1d-d415-413a-9af6-005b575e1800
 tags:
   - gcp-cloud-build-deploy-cloud-run

--- a/.cloud_build/dart-services/main.yaml
+++ b/.cloud_build/dart-services/main.yaml
@@ -31,7 +31,7 @@ steps:
       - '--min-instances=1'
       - '--cpu=2'
       - '--memory=4Gi'
-      - '--concurrency=1'
+      - '--concurrency=2'
       - '--cpu-boost'
     id: Deploy
     dir: pkgs/dart_services
@@ -43,10 +43,10 @@ options:
 substitutions:
   _DEPLOY_REGION: us-central1
   _GCR_HOSTNAME: us.gcr.io
-  _PLATFORM: managed
   _LABELS: gcb-trigger-id=1ce24c6a-c6b4-4368-bbd7-2ea13a839f48
-  _TRIGGER_ID: 1ce24c6a-c6b4-4368-bbd7-2ea13a839f48
+  _PLATFORM: managed
   _SERVICE_NAME: flutter-master-channel
+  _TRIGGER_ID: 1ce24c6a-c6b4-4368-bbd7-2ea13a839f48
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - gcp-cloud-build-deploy-cloud-run-managed

--- a/.cloud_build/dart-services/old.yaml
+++ b/.cloud_build/dart-services/old.yaml
@@ -31,7 +31,7 @@ steps:
       - '--min-instances=1'
       - '--cpu=2'
       - '--memory=4Gi'
-      - '--concurrency=1'
+      - '--concurrency=2'
       - '--cpu-boost'
     id: Deploy
     dir: pkgs/dart_services
@@ -41,12 +41,12 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:
-  _GCR_HOSTNAME: us.gcr.io
-  _PLATFORM: managed
-  _LABELS: gcb-trigger-id=e6472250-2fe8-44de-985f-7822fa767bc7
-  _TRIGGER_ID: e6472250-2fe8-44de-985f-7822fa767bc7
-  _SERVICE_NAME: flutter-old-channel
   _DEPLOY_REGION: us-central1
+  _GCR_HOSTNAME: us.gcr.io
+  _LABELS: gcb-trigger-id=e6472250-2fe8-44de-985f-7822fa767bc7
+  _PLATFORM: managed
+  _SERVICE_NAME: flutter-old-channel
+  _TRIGGER_ID: e6472250-2fe8-44de-985f-7822fa767bc7
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - gcp-cloud-build-deploy-cloud-run-managed

--- a/.cloud_build/dart-services/stable.yaml
+++ b/.cloud_build/dart-services/stable.yaml
@@ -16,7 +16,7 @@ steps:
       - '$_GCR_HOSTNAME/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
     id: Push
     dir: pkgs/dart_services
-  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: gcloud
     args:
       - run
@@ -29,11 +29,11 @@ steps:
       - '--region=$_DEPLOY_REGION'
       - '--quiet'
       - '--min-instances=5'
-      - '--max-instances=1000'
       - '--cpu=2'
       - '--memory=4Gi'
-      - '--concurrency=1'
+      - '--concurrency=2'
       - '--cpu-boost'
+      - '--max-instances=1000'
     id: Deploy
     dir: pkgs/dart_services
 timeout: 1200s
@@ -42,12 +42,12 @@ images:
 options:
   substitutionOption: ALLOW_LOOSE
 substitutions:
-  _TRIGGER_ID: 6104a3eb-7116-4b2f-a864-2418bd8173bf
   _DEPLOY_REGION: us-central1
   _GCR_HOSTNAME: us.gcr.io
+  _LABELS: gcb-trigger-id=6104a3eb-7116-4b2f-a864-2418bd8173bf
   _PLATFORM: managed
   _SERVICE_NAME: dart-service-cloud-run
-  _LABELS: gcb-trigger-id=6104a3eb-7116-4b2f-a864-2418bd8173bf
+  _TRIGGER_ID: 6104a3eb-7116-4b2f-a864-2418bd8173bf
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - gcp-cloud-build-deploy-cloud-run-managed

--- a/pkgs/dart_services/lib/src/common_server_api.dart
+++ b/pkgs/dart_services/lib/src/common_server_api.dart
@@ -13,6 +13,7 @@ import 'package:shelf_router/shelf_router.dart';
 
 import 'common_server_impl.dart' show BadRequest, CommonServerImpl;
 import 'protos/dart_services.pb.dart' as proto;
+import 'scheduler.dart';
 import 'shelf_cors.dart' as shelf_cors;
 
 export 'common_server_impl.dart' show log;
@@ -26,155 +27,209 @@ const protoApiUrlPrefix = '/api/dartservices/<apiVersion>';
 
 class CommonServerApi {
   final CommonServerImpl _impl;
+  final TaskScheduler scheduler = TaskScheduler();
 
   CommonServerApi(this._impl);
 
   @Route.post('$protoApiUrlPrefix/analyze')
-  Future<Response> analyze(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.analyze);
+  Future<Response> analyze(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.analyze,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/compile')
-  Future<Response> compile(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.CompileRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.CompileRequest.fromBuffer,
-          transform: _impl.compile);
+  Future<Response> compile(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.CompileRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.CompileRequest.fromBuffer,
+      transform: _impl.compile,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/compileDDC')
-  Future<Response> compileDDC(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.CompileDDCRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.CompileDDCRequest.fromBuffer,
-          transform: _impl.compileDDC);
+  Future<Response> compileDDC(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.CompileDDCRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.CompileDDCRequest.fromBuffer,
+      transform: _impl.compileDDC,
+    );
+  }
 
   @experimental
   @Route.post('$protoApiUrlPrefix/_flutterBuild')
-  Future<Response> flutterBuild(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.FlutterBuildRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.FlutterBuildRequest.fromBuffer,
-          transform: _impl.flutterBuild);
+  Future<Response> flutterBuild(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.FlutterBuildRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.FlutterBuildRequest.fromBuffer,
+      transform: _impl.flutterBuild,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/complete')
-  Future<Response> complete(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.complete);
+  Future<Response> complete(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.complete,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/fixes')
-  Future<Response> fixes(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.fixes);
+  Future<Response> fixes(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.fixes,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/assists')
-  Future<Response> assists(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.assists);
+  Future<Response> assists(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.assists,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/format')
-  Future<Response> format(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.format);
+  Future<Response> format(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.format,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/document')
-  Future<Response> document(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceRequest.fromBuffer,
-          transform: _impl.document);
+  Future<Response> document(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceRequest.fromBuffer,
+      transform: _impl.document,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/version')
-  Future<Response> versionPost(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.VersionRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.VersionRequest.fromBuffer,
-          transform: _impl.version);
+  Future<Response> versionPost(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.VersionRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.VersionRequest.fromBuffer,
+      transform: _impl.version,
+    );
+  }
 
   @Route.get('$protoApiUrlPrefix/version')
-  Future<Response> versionGet(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.VersionRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.VersionRequest.fromBuffer,
-          transform: _impl.version);
+  Future<Response> versionGet(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.VersionRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.VersionRequest.fromBuffer,
+      transform: _impl.version,
+    );
+  }
 
   // Beginning of multi file map end points:
   @Route.post('$protoApiUrlPrefix/analyzeFiles')
-  Future<Response> analyzeFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceFilesRequest.fromBuffer,
-          transform: _impl.analyzeFiles);
+  Future<Response> analyzeFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceFilesRequest.fromBuffer,
+      transform: _impl.analyzeFiles,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/compileFiles')
-  Future<Response> compileFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.CompileFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.CompileFilesRequest.fromBuffer,
-          transform: _impl.compileFiles);
+  Future<Response> compileFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.CompileFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.CompileFilesRequest.fromBuffer,
+      transform: _impl.compileFiles,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/compileFilesDDC')
-  Future<Response> compileFilesDDC(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.CompileFilesDDCRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.CompileFilesDDCRequest.fromBuffer,
-          transform: _impl.compileFilesDDC);
+  Future<Response> compileFilesDDC(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.CompileFilesDDCRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.CompileFilesDDCRequest.fromBuffer,
+      transform: _impl.compileFilesDDC,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/completeFiles')
-  Future<Response> completeFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceFilesRequest.fromBuffer,
-          transform: _impl.completeFiles);
+  Future<Response> completeFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceFilesRequest.fromBuffer,
+      transform: _impl.completeFiles,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/fixesFiles')
-  Future<Response> fixesFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceFilesRequest.fromBuffer,
-          transform: _impl.fixesFiles);
+  Future<Response> fixesFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceFilesRequest.fromBuffer,
+      transform: _impl.fixesFiles,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/assistsFiles')
-  Future<Response> assistsFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceFilesRequest.fromBuffer,
-          transform: _impl.assistsFiles);
+  Future<Response> assistsFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceFilesRequest.fromBuffer,
+      transform: _impl.assistsFiles,
+    );
+  }
 
   @Route.post('$protoApiUrlPrefix/documentFiles')
-  Future<Response> documentFiles(Request request, String apiVersion) =>
-      _processRequest(request,
-          decodeFromJSON: (json) =>
-              proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
-          decodeFromProto: proto.SourceFilesRequest.fromBuffer,
-          transform: _impl.documentFiles);
-  // End of Multi file files={} file map end points.
+  Future<Response> documentFiles(Request request, String apiVersion) {
+    return _processRequest(
+      request,
+      decodeFromJSON: (json) =>
+          proto.SourceFilesRequest.create()..mergeFromProto3Json(json),
+      decodeFromProto: proto.SourceFilesRequest.fromBuffer,
+      transform: _impl.documentFiles,
+    );
+  }
 
   /// The (lazily-constructed) router.
   late final Router router = _$CommonServerApiRouter(this);
@@ -190,6 +245,45 @@ class CommonServerApi {
     required I Function(Object json) decodeFromJSON,
     required Future<O> Function(I input) transform,
   }) async {
+    return scheduler.schedule(_ServerTask(
+      request,
+      decodeFromProto: decodeFromProto,
+      decodeFromJSON: decodeFromJSON,
+      transform: transform,
+    ));
+  }
+}
+
+final JsonEncoder _jsonEncoder = const JsonEncoder.withIndent(' ');
+
+const _jsonHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Content-Type': jsonContentType,
+};
+
+const _protobufHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Content-Type': protobufContentType,
+};
+
+class _ServerTask<I, O extends GeneratedMessage> extends Task<Response> {
+  final Request request;
+  final I Function(List<int> bytes) decodeFromProto;
+  final I Function(Object json) decodeFromJSON;
+  final Future<O> Function(I input) transform;
+
+  _ServerTask(
+    this.request, {
+    required this.decodeFromProto,
+    required this.decodeFromJSON,
+    required this.transform,
+  });
+
+  @override
+  Duration get timeoutDuration => const Duration(minutes: 5);
+
+  @override
+  Future<Response> perform() async {
     if (request.mimeType == protobufContentType) {
       // Dealing with binary Protobufs
       final body = <int>[];
@@ -230,18 +324,6 @@ class CommonServerApi {
       }
     }
   }
-
-  final JsonEncoder _jsonEncoder = const JsonEncoder.withIndent(' ');
-
-  static const _jsonHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Content-Type': jsonContentType
-  };
-
-  static const _protobufHeaders = {
-    'Access-Control-Allow-Origin': '*',
-    'Content-Type': protobufContentType
-  };
 }
 
 Middleware createCustomCorsHeadersMiddleware() {

--- a/pkgs/dart_services/lib/src/common_server_impl.dart
+++ b/pkgs/dart_services/lib/src/common_server_impl.dart
@@ -34,10 +34,6 @@ class CommonServerImpl {
   late Compiler _compiler;
   late AnalyzerWrapper _analysisServer;
 
-  // Restarting and health status of the two Analysis Servers
-  bool get isRestarting => _analysisServer.isRestarting;
-  bool get isHealthy => _analysisServer.isHealthy;
-
   CommonServerImpl(this._cache, this._sdk);
 
   Future<void> init() async {

--- a/pkgs/dart_services/lib/src/scheduler.dart
+++ b/pkgs/dart_services/lib/src/scheduler.dart
@@ -20,6 +20,7 @@ class TaskScheduler {
       _isActive = true;
       return _performTask(task).whenComplete(_next);
     }
+
     final taskResult = Completer<T>();
     _taskQueue.add(_Task<T>(task, taskResult));
     return taskResult.future;
@@ -31,6 +32,7 @@ class TaskScheduler {
       _isActive = false;
       return;
     }
+
     final first = _taskQueue.removeFirst();
     first.taskResult.complete(_performTask(first.task).whenComplete(_next));
   }
@@ -40,13 +42,14 @@ class TaskScheduler {
 class _Task<T> {
   final Task<T> task;
   final Completer<T> taskResult;
+
   _Task(this.task, this.taskResult);
 }
 
 // Public working data structure.
 abstract class Task<T> {
-  Future<T> perform();
   late Duration timeoutDuration;
+  Future<T> perform();
 }
 
 class ClosureTask<T> extends Task<T> {


### PR DESCRIPTION
- add back in a request queue (move the logic into one centralized place - `common_server_api.dart`
- switch our cloud run concurrency to `2`; this should address some dropped request issues we're seeing (the auto-scaler needs our images to start under 10s in order to function well)
- some minor normalization of the cloud build config files

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
