### PR TITLE
remove the dev channel from the dart_pad UI

### DIFF
--- a/pkgs/dart_pad/build.yaml
+++ b/pkgs/dart_pad/build.yaml
@@ -20,7 +20,6 @@ targets:
           - -DSERVER_URL=https://stable.api.dartpad.dev/
           - -DSTABLE_SERVER_URL=https://stable.api.dartpad.dev/
           - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
-          - -DDEV_SERVER_URL=https://dev.api.dartpad.dev/
           - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
           - -DMASTER_SERVER_URL=https://master.api.dartpad.dev/
 
@@ -42,6 +41,5 @@ global_options:
         SERVER_URL: https://stable.api.dartpad.dev/
         STABLE_SERVER_URL: https://stable.api.dartpad.dev/
         BETA_SERVER_URL: https://beta.api.dartpad.dev/
-        DEV_SERVER_URL: https://dev.api.dartpad.dev/
         OLD_SERVER_URL: https://old.api.dartpad.dev/
         MASTER_SERVER_URL: https://master.api.dartpad.dev/

--- a/pkgs/dart_pad/lib/playground.dart
+++ b/pkgs/dart_pad/lib/playground.dart
@@ -335,36 +335,34 @@ class Playground extends EditorUi implements GistContainer, GistController {
         checkmark.classes.toggle('hide');
       }
 
-      final menuElement = _mdcListItem(children: [
-        DivElement()
-          ..classes.add('channel-item-group')
-          ..children = [
-            checkmark,
-            SpanElement()
-              ..classes.add('channel-menu-right')
-              ..children = [
-                ParagraphElement()
-                  ..classes.add('mdc-list-item__title')
-                  ..text = '${channel.name} channel',
-                ParagraphElement()
-                  ..classes.add('mdc-list-item__details')
-                  ..text =
-                      'Use Flutter version ${channel.flutterVersion} and Dart '
-                          'version ${channel.dartVersion}',
-                if (channel.experiments.isNotEmpty)
+      final menuElement = _mdcListItem(
+        children: [
+          DivElement()
+            ..classes.add('channel-item-group')
+            ..children = [
+              checkmark,
+              SpanElement()
+                ..classes.add('channel-menu-right')
+                ..children = [
+                  ParagraphElement()
+                    ..classes.add('mdc-list-item__title')
+                    ..text = '${channel.name} channel',
                   ParagraphElement()
                     ..classes.add('mdc-list-item__details')
-                    ..text = '+ Dart experiments: '
-                        "--enable-experiment=${channel.experiments.reduce((value, element) => '$value,$element')}",
-              ],
-          ],
-      ])
-        ..classes.add('channel-item');
+                    ..text =
+                        'Use Flutter version ${channel.flutterVersion} and Dart '
+                            'version ${channel.dartVersion}',
+                  if (channel.experiments.isNotEmpty)
+                    ParagraphElement()
+                      ..classes.add('mdc-list-item__details')
+                      ..text = '+ Dart experiments: '
+                          "--enable-experiment=${channel.experiments.reduce((value, element) => '$value,$element')}",
+                ],
+            ],
+        ],
+      )..classes.add('channel-item');
 
-      // The dev channel is hidden unless it's selected via a query parameter.
-      if (!channel.hidden || currentChannel == channel.name) {
-        listElement.children.add(menuElement);
-      }
+      listElement.children.add(menuElement);
     }
 
     return element;
@@ -376,7 +374,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
       Channel.fromVersion('beta'),
       Channel.fromVersion('old'),
       Channel.fromVersion('master'),
-      Channel.fromVersion('dev', hidden: true),
     ]);
 
     final element = _buildChannelsMenu(channels);

--- a/pkgs/dart_pad/lib/services/common.dart
+++ b/pkgs/dart_pad/lib/services/common.dart
@@ -31,13 +31,6 @@ const betaServerUrlEnvironmentVar = 'BETA_SERVER_URL';
 const betaServerUrl = String.fromEnvironment(betaServerUrlEnvironmentVar);
 
 /// The environment variable name which specifies the URL of the back-end
-/// server serving "Flutter dev".
-const devServerUrlEnvironmentVar = 'DEV_SERVER_URL';
-
-/// The URL of the "Flutter dev" back-end server.
-const devServerUrl = String.fromEnvironment(devServerUrlEnvironmentVar);
-
-/// The environment variable name which specifies the URL of the back-end
 /// server serving "Flutter old" (stable -1).
 const oldServerUrlEnvironmentVar = 'OLD_SERVER_URL';
 

--- a/pkgs/dart_pad/lib/sharing/editor_ui.dart
+++ b/pkgs/dart_pad/lib/sharing/editor_ui.dart
@@ -322,12 +322,11 @@ class Channel {
   final String dartVersion;
   final String flutterVersion;
   final String engineVersion;
-  final bool hidden;
 
   /// SDK experiment flags enabled for this channel.
   final List<String> experiments;
 
-  static Future<Channel> fromVersion(String name, {bool hidden = false}) async {
+  static Future<Channel> fromVersion(String name) async {
     var rootUrl = urlMapping[name];
     // If the user provided bad URL query parameter (`?channel=nonsense`),
     // default to the stable channel.
@@ -339,7 +338,6 @@ class Channel {
       name: name,
       dartVersion: versionResponse.sdkVersionFull,
       flutterVersion: versionResponse.flutterVersion,
-      hidden: hidden,
       experiments: versionResponse.experiment,
       engineVersion: versionResponse.flutterEngineSha,
     );
@@ -350,7 +348,6 @@ class Channel {
     'beta': betaServerUrl,
     'old': oldServerUrl,
     'master': masterServerUrl,
-    'dev': devServerUrl,
   };
 
   Channel._({
@@ -358,7 +355,6 @@ class Channel {
     required this.dartVersion,
     required this.flutterVersion,
     required this.engineVersion,
-    required this.hidden,
     required this.experiments,
   });
 }

--- a/pkgs/dart_pad/lib/util/query_params.dart
+++ b/pkgs/dart_pad/lib/util/query_params.dart
@@ -117,7 +117,6 @@ class _QueryParams {
     'stable',
     'beta',
     'old',
-    'dev',
     'master',
   ];
 


### PR DESCRIPTION
- remove the dev channel from the dart_pad UI

This is a precursor to removing the dev channel support from the backend.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
