### PR TITLE
Fix 'main' channel missing extension types experiment

### DIFF
--- a/pkgs/dart_services/lib/src/sdk.dart
+++ b/pkgs/dart_services/lib/src/sdk.dart
@@ -36,24 +36,24 @@ class Sdk {
   /// Is this SDK being used in development mode. True if channel is `dev`.
   bool get devMode => _channel == 'dev';
 
-  /// Is this the old channel
+  /// If this is the old channel.
   bool get oldChannel => _channel == 'old';
 
-  /// Is this the stable channel
+  /// If this is the stable channel.
   bool get stableChannel => _channel == 'stable';
 
-  /// Is this the beta channel
+  /// If this is the beta channel.
   bool get betaChannel => _channel == 'beta';
 
-  /// Is this the master channel
-  bool get masterChannel => _channel == 'master';
+  /// If this is the main channel.
+  bool get mainChannel => _channel == 'main';
 
   // Which channel is this SDK?
   final String _channel;
 
   /// Experiments that this SDK is configured with
   List<String> get experiments {
-    if (masterChannel) return const ['inline-class'];
+    if (mainChannel) return const ['inline-class'];
     return const [];
   }
 


### PR DESCRIPTION
Since the channel was renamed to `main` in https://github.com/dart-lang/dart-pad/commit/fcf8566ba5f645df2fac2fdd1ad9ba80548e4eba, this caused the check to add the `inline-class` experiment to not work: https://github.com/dart-lang/dart-pad/blob/90309774b1c860fcb7d995b8f55294d8d066cd32/pkgs/dart_services/lib/src/sdk.dart#L56