### PR TITLE
remove the 'old' channel from the UI

### DIFF
--- a/pkgs/dart_pad/build.yaml
+++ b/pkgs/dart_pad/build.yaml
@@ -20,7 +20,6 @@ targets:
           - -DSERVER_URL=https://stable.api.dartpad.dev/
           - -DSTABLE_SERVER_URL=https://stable.api.dartpad.dev/
           - -DBETA_SERVER_URL=https://beta.api.dartpad.dev/
-          - -DOLD_SERVER_URL=https://old.api.dartpad.dev/
           - -DMASTER_SERVER_URL=https://master.api.dartpad.dev/
 
       json_serializable:
@@ -41,5 +40,4 @@ global_options:
         SERVER_URL: https://stable.api.dartpad.dev/
         STABLE_SERVER_URL: https://stable.api.dartpad.dev/
         BETA_SERVER_URL: https://beta.api.dartpad.dev/
-        OLD_SERVER_URL: https://old.api.dartpad.dev/
         MASTER_SERVER_URL: https://master.api.dartpad.dev/

--- a/pkgs/dart_pad/lib/playground.dart
+++ b/pkgs/dart_pad/lib/playground.dart
@@ -372,7 +372,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
     channels = await Future.wait([
       Channel.fromVersion('stable'),
       Channel.fromVersion('beta'),
-      Channel.fromVersion('old'),
       Channel.fromVersion('master'),
     ]);
 

--- a/pkgs/dart_pad/lib/services/common.dart
+++ b/pkgs/dart_pad/lib/services/common.dart
@@ -31,13 +31,6 @@ const betaServerUrlEnvironmentVar = 'BETA_SERVER_URL';
 const betaServerUrl = String.fromEnvironment(betaServerUrlEnvironmentVar);
 
 /// The environment variable name which specifies the URL of the back-end
-/// server serving "Flutter old" (stable -1).
-const oldServerUrlEnvironmentVar = 'OLD_SERVER_URL';
-
-/// The URL of the "Flutter old" back-end server.
-const oldServerUrl = String.fromEnvironment(oldServerUrlEnvironmentVar);
-
-/// The environment variable name which specifies the URL of the back-end
 /// server serving "Flutter master".
 const masterServerUrlEnvironmentVar = 'MASTER_SERVER_URL';
 

--- a/pkgs/dart_pad/lib/sharing/editor_ui.dart
+++ b/pkgs/dart_pad/lib/sharing/editor_ui.dart
@@ -346,7 +346,6 @@ class Channel {
   static const urlMapping = {
     'stable': stableServerUrl,
     'beta': betaServerUrl,
-    'old': oldServerUrl,
     'master': masterServerUrl,
   };
 


### PR DESCRIPTION
- remove the `old` channel from the UI

This will drain uses of the old channel, letting us remove support for it from the backend w/o disruption.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
