### PR TITLE
add a helper class to efficiently perform 'pub get' operations

### DIFF
--- a/pkgs/dart_services/lib/src/project_creator.dart
+++ b/pkgs/dart_services/lib/src/project_creator.dart
@@ -40,6 +40,7 @@ class ProjectCreator {
     final projectPath = path.join(_templatesPath, 'dart_project');
     final projectDirectory = Directory(projectPath);
     await projectDirectory.create(recursive: true);
+
     final dependencies = _dependencyVersions(supportedBasicDartPackages());
     File(path.join(projectPath, 'pubspec.yaml'))
         .writeAsStringSync(createPubspec(
@@ -210,7 +211,7 @@ Map<String, String> parsePubDependenciesFile({required File dependenciesFile}) {
   return packageVersions.cast<String, String>();
 }
 
-/// Build a return a `pubspec.yaml` file.
+/// Build and return a `pubspec.yaml` file.
 String createPubspec({
   required bool includeFlutterWeb,
   required String dartLanguageVersion,

--- a/pkgs/dart_services/lib/src/pub.dart
+++ b/pkgs/dart_services/lib/src/pub.dart
@@ -2,14 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:json_annotation/json_annotation.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 import 'project.dart' as project;
+import 'sdk.dart';
+import 'server_cache.dart';
+
+part 'pub.g.dart';
 
 /// Extract all imports from [dartSource] source code.
 List<ImportDirective> getAllImportsFor(String? dartSource) {
@@ -85,5 +91,283 @@ extension ImportIterableExtensions on Iterable<ImportDirective> {
         .map((import) => Uri.parse(import.uri.stringValue!))
         .where((uri) => uri.scheme == 'package' && uri.pathSegments.isNotEmpty)
         .map((uri) => uri.pathSegments.first);
+  }
+}
+
+// TODO: for dart, handle package:lints
+
+// TODO: for flutter, handle package:flutter_lints
+
+/// Provide resolution and caching for package information.
+class PackageResolver {
+  final ServerCache serverCache;
+  final Sdk sdk;
+
+  late final Directory pubCache;
+
+  PackageResolver({
+    required this.serverCache,
+    required this.sdk,
+  }) {
+    pubCache = Directory.systemTemp.createTempSync('pub-cache');
+  }
+
+  /// Run the equivalent of 'pub get' in the given directory.
+  ///
+  /// The pubspec dependencies are inferred from the import statements in
+  /// [dartSource]. The resolution information is cached; subsequent similar
+  /// resolutions will be faster.
+  Future<PackageConfig> pubGet(Directory dir, String dartSource) async {
+    // parse the packages
+    final packages = parsePackages(dartSource);
+
+    // write the pubspec
+    final pubspec = File(path.join(dir.path, 'pubspec.yaml'));
+    pubspec.writeAsStringSync('''
+name: dartpad_sample
+
+environment:
+  sdk: ^${sdk.version}
+
+dependencies:
+${packages.map((package) {
+      // auto-promote flutter packages to sdk dependencies
+      return isFlutterSdkPackage(package)
+          ? '  $package:\n    sdk: flutter'
+          : '  $package: any';
+    }).join('\n')}
+
+dev_dependencies:
+  lints: any
+''');
+
+    // remove any existing pubspec.lock
+    final pubspecLock = File(path.join(dir.path, 'pubspec.lock'));
+    if (pubspecLock.existsSync()) {
+      pubspecLock.deleteSync();
+    }
+
+    PackageConfig? packageConfig;
+    final packageConfigFile =
+        File(path.join(dir.path, '.dart_tool', 'package_config.json'));
+
+    final cacheKey = '${sdk.version}:${packages.join(':')}';
+    final resolutionData = await serverCache.get(cacheKey);
+
+    if (resolutionData != null) {
+      packageConfig = PackageConfig.fromJson(
+          jsonDecode(resolutionData) as Map<String, dynamic>);
+      packageConfig = PackageConfig(
+        configVersion: packageConfig.configVersion,
+        packages: packageConfig.packages,
+        fromCached: true,
+      );
+    }
+
+    if (packageConfig != null &&
+        packageConfig.allPackagesExist(sdk, pubCache)) {
+      // create our own package config file
+      packageConfig.writeToFile(packageConfigFile,
+          sdk: sdk, pubCache: pubCache);
+      return packageConfig;
+    } else {
+      final resolutionNotCached = packageConfig == null;
+
+      // run dart pub get
+      await _runDartPubGet(dir);
+
+      packageConfig = PackageConfig.readFromFile(sdk, packageConfigFile);
+
+      // If there had been no cache entry, cache the resolution results.
+      if (resolutionNotCached) {
+        await serverCache.set(
+          cacheKey,
+          jsonEncode(packageConfig.toJson()),
+          expiration: const Duration(hours: 1),
+        );
+      }
+
+      return packageConfig;
+    }
+  }
+
+  Future<void> _runDartPubGet(Directory dir) async {
+    final result = Process.runSync(
+      sdk.flutterToolPath,
+      ['pub', 'get'],
+      workingDirectory: dir.path,
+      environment: {'PUB_CACHE': pubCache.path},
+    );
+
+    if (result.exitCode != 0) {
+      throw Exception(result.stderr as String);
+    }
+  }
+
+  List<String> parsePackages(String dartSource) {
+    final imports = getAllImportsFor(dartSource);
+
+    return imports
+        .where((import) {
+          final uriString = import.uri.stringValue;
+          if (uriString == null || uriString.isEmpty) {
+            return false;
+          }
+
+          final uri = Uri.tryParse(uriString);
+          return uri != null && uri.scheme == 'package';
+        })
+        .map((import) {
+          final uri = Uri.parse(import.uri.stringValue!);
+          final segments = uri.pathSegments;
+
+          return segments.isEmpty ? null : segments.first;
+        })
+        .whereType<String>()
+        .toSet()
+        .toList()
+      ..sort();
+  }
+
+  void dispose() {
+    pubCache.deleteSync(recursive: true);
+  }
+
+  static bool isFlutterSdkPackage(String name) {
+    const flutterSdkPackages = {
+      'flutter',
+      'flutter_driver',
+      'flutter_goldens',
+      'flutter_localizations',
+      'flutter_test',
+      'flutter_web_plugins',
+      'integration_test',
+    };
+
+    return flutterSdkPackages.contains(name);
+  }
+}
+
+@JsonSerializable()
+class PackageConfig {
+  final int configVersion;
+  final List<PackageInfo> packages;
+  final bool fromCached;
+
+  PackageConfig({
+    required this.configVersion,
+    required this.packages,
+    required this.fromCached,
+  });
+
+  factory PackageConfig.fromJson(Map<String, dynamic> json) =>
+      _$PackageConfigFromJson(json);
+
+  bool allPackagesExist(Sdk sdk, Directory pubCache) {
+    return packages.every((package) {
+      return package.exists(sdk, pubCache);
+    });
+  }
+
+  Map<String, dynamic> toJson() => _$PackageConfigToJson(this);
+
+  void writeToFile(
+    File packageConfigFile, {
+    required Sdk sdk,
+    required Directory pubCache,
+  }) {
+    const encoder = JsonEncoder.withIndent('  ');
+
+    final json = {
+      'configVersion': configVersion,
+      'packages': packages.map((package) {
+        final dir = package.directoryForCache(sdk, pubCache).absolute;
+
+        return {
+          'name': package.name,
+          'rootUri': dir.uri.toString(),
+          'packageUri': 'lib/',
+          'languageVersion': package.languageVersion,
+        };
+      }).toList(),
+      'generator': 'dartpad',
+    };
+
+    packageConfigFile.writeAsStringSync(encoder.convert(json));
+  }
+
+  static PackageConfig readFromFile(Sdk sdk, File packageConfigFile) {
+    final json = jsonDecode(packageConfigFile.readAsStringSync())
+        as Map<String, dynamic>;
+
+    final packages = (json['packages'] as List).cast<Map<String, dynamic>>();
+
+    return PackageConfig(
+      configVersion: json['configVersion'] as int,
+      packages: packages
+          .map((data) {
+            // file:///Users/devoncarew/.pub-cache/hosted/pub.dev/path-1.8.3
+            final rootUri = data['rootUri'] as String;
+            if (rootUri == '../') return null;
+
+            final filePath = Uri.parse(rootUri).toFilePath();
+            final flutterPackage = path.isWithin(sdk.sdkPath, filePath);
+
+            if (flutterPackage) {
+              return PackageInfo(
+                name: data['name'] as String,
+                languageVersion: data['languageVersion'] as String,
+                flutterSdkPath: path.relative(filePath, from: sdk.sdkPath),
+              );
+            } else {
+              // .../web-0.1.4-beta
+              final uri = Uri.parse(rootUri);
+              final name = uri.pathSegments.last;
+              final index = name.contains('-') ? name.indexOf('-') + 1 : 0;
+
+              return PackageInfo(
+                name: data['name'] as String,
+                languageVersion: data['languageVersion'] as String,
+                version: name.substring(index),
+              );
+            }
+          })
+          .whereType<PackageInfo>()
+          .toList(),
+      fromCached: false,
+    );
+  }
+}
+
+@JsonSerializable()
+class PackageInfo {
+  final String name;
+  final String languageVersion;
+  final String? version;
+  final String? flutterSdkPath;
+
+  PackageInfo({
+    required this.name,
+    required this.languageVersion,
+    this.version,
+    this.flutterSdkPath,
+  });
+
+  factory PackageInfo.fromJson(Map<String, dynamic> json) =>
+      _$PackageInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PackageInfoToJson(this);
+
+  bool exists(Sdk sdk, Directory pubCache) {
+    return directoryForCache(sdk, pubCache).existsSync();
+  }
+
+  Directory directoryForCache(Sdk sdk, Directory pubCache) {
+    if (flutterSdkPath != null) {
+      return Directory(path.join(sdk.sdkPath, flutterSdkPath));
+    } else {
+      return Directory(
+          path.join(pubCache.path, 'hosted', 'pub.dev', '$name-$version'));
+    }
   }
 }

--- a/pkgs/dart_services/lib/src/pub.dart
+++ b/pkgs/dart_services/lib/src/pub.dart
@@ -127,7 +127,7 @@ class PackageResolver {
 name: dartpad_sample
 
 environment:
-  sdk: ^${sdk.version}
+  sdk: ^${sdk.versionFull}
 
 dependencies:
 ${packages.map((package) {

--- a/pkgs/dart_services/lib/src/pub.g.dart
+++ b/pkgs/dart_services/lib/src/pub.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pub.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PackageConfig _$PackageConfigFromJson(Map<String, dynamic> json) =>
+    PackageConfig(
+      configVersion: json['configVersion'] as int,
+      packages: (json['packages'] as List<dynamic>)
+          .map((e) => PackageInfo.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      fromCached: json['fromCached'] as bool,
+    );
+
+Map<String, dynamic> _$PackageConfigToJson(PackageConfig instance) =>
+    <String, dynamic>{
+      'configVersion': instance.configVersion,
+      'packages': instance.packages,
+      'fromCached': instance.fromCached,
+    };
+
+PackageInfo _$PackageInfoFromJson(Map<String, dynamic> json) => PackageInfo(
+      name: json['name'] as String,
+      languageVersion: json['languageVersion'] as String,
+      version: json['version'] as String?,
+      flutterSdkPath: json['flutterSdkPath'] as String?,
+    );
+
+Map<String, dynamic> _$PackageInfoToJson(PackageInfo instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'languageVersion': instance.languageVersion,
+      'version': instance.version,
+      'flutterSdkPath': instance.flutterSdkPath,
+    };

--- a/pkgs/dart_services/test/pub_test.dart
+++ b/pkgs/dart_services/test/pub_test.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:collection/collection.dart';
 import 'package:dart_services/src/pub.dart';
+import 'package:dart_services/src/sdk.dart';
+import 'package:dart_services/src/server_cache.dart';
 import 'package:test/test.dart';
 
 void main() => defineTests();
@@ -120,6 +125,123 @@ import '../foo.dart';
       expect(imports, hasLength(1));
       expect(imports.single.uri.stringValue, equals('../foo.dart'));
       expect(imports.filterSafePackages(), isEmpty);
+    });
+  });
+
+  group('PackageResolver', () {
+    late final Sdk sdk;
+
+    setUpAll(() {
+      final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
+      sdk = Sdk.create(channel);
+    });
+
+    late ServerCache serverCache;
+    late PackageResolver resolver;
+    late Directory tempDir;
+
+    setUp(() {
+      serverCache = InMemoryCache();
+      resolver = PackageResolver(serverCache: serverCache, sdk: sdk);
+      tempDir = Directory.systemTemp.createTempSync();
+    });
+
+    tearDown(() {
+      resolver.dispose();
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('no packages', () async {
+      final result = await resolver.pubGet(tempDir, '''
+void main() {
+  print('hello world');
+}
+''');
+      final package =
+          result.packages.firstWhereOrNull((p) => p.name == 'lints');
+      expect(package, isNotNull);
+      expect(package!.version, isNotNull);
+      expect(package.flutterSdkPath, isNull);
+    });
+
+    test('one package', () async {
+      final result = await resolver.pubGet(tempDir, '''
+import 'package:path/path.dart';
+
+void main() {
+  print('hello world');
+}
+''');
+      expect(result.packages.length, greaterThanOrEqualTo(2));
+
+      final names = result.packages.map((p) => p.name).toSet();
+      expect(names, contains('lints'));
+      expect(names, contains('path'));
+    });
+
+    test('several packages', () async {
+      final result = await resolver.pubGet(tempDir, '''
+import 'package:args/args.dart';
+import 'package:path/path.dart';
+
+void main() {
+  print('hello world');
+}
+''');
+      expect(result.packages.length, greaterThanOrEqualTo(3));
+
+      final names = result.packages.map((p) => p.name).toSet();
+      expect(names, contains('args'));
+      expect(names, contains('path'));
+    });
+
+    test('flutter', () async {
+      final result = await resolver.pubGet(tempDir, '''
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  print('hello world');
+}
+''');
+      expect(result.packages.length, greaterThanOrEqualTo(2));
+
+      final names = result.packages.map((p) => p.name).toSet();
+      expect(names, contains('collection'));
+      expect(names, contains('meta'));
+      expect(names, contains('flutter'));
+      expect(names, contains('flutter_test'));
+
+      final package =
+          result.packages.firstWhereOrNull((p) => p.name == 'flutter');
+      expect(package, isNotNull);
+      expect(package!.version, isNull);
+      expect(package.flutterSdkPath, isNotNull);
+    });
+
+    test('multiple runs', () async {
+      const source = '''
+import 'package:args/args.dart';
+import 'package:path/path.dart';
+
+void main() {
+  print('hello world');
+}
+''';
+
+      var result = await resolver.pubGet(tempDir, source);
+
+      expect(result.fromCached, false);
+      expect(result.packages.length, greaterThanOrEqualTo(2));
+
+      final names = result.packages.map((p) => p.name).toSet();
+      expect(names, contains('args'));
+      expect(names, contains('path'));
+
+      result = await resolver.pubGet(tempDir, source);
+
+      expect(result.fromCached, true);
+      expect(result.packages.length, greaterThanOrEqualTo(2));
     });
   });
 }

--- a/pkgs/dart_services/test/pub_test.dart
+++ b/pkgs/dart_services/test/pub_test.dart
@@ -132,8 +132,8 @@ import '../foo.dart';
     late final Sdk sdk;
 
     setUpAll(() {
-      final channel = Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel;
-      sdk = Sdk.create(channel);
+      sdk =
+          Sdk.create(Platform.environment['FLUTTER_CHANNEL'] ?? stableChannel);
     });
 
     late ServerCache serverCache;

--- a/pkgs/dart_services/test/pub_test.dart
+++ b/pkgs/dart_services/test/pub_test.dart
@@ -179,6 +179,19 @@ void main() {
       expect(names, contains('path'));
     });
 
+    test('resolution failure', () async {
+      final result = resolver.pubGet(tempDir, '''
+import 'package:args_12349/args.dart';
+
+void main() {
+  print('hello world');
+}
+''');
+
+      // TODO: test that the exception's message contains "which doesn't exist"
+      expect(result, throwsException);
+    });
+
     test('several packages', () async {
       final result = await resolver.pubGet(tempDir, '''
 import 'package:args/args.dart';


### PR DESCRIPTION
- add a helper class to efficiently perform 'pub get' operations

Starting as a draft for now; this functionality could be used to build support for arbitrary pub packages.

Before landing this we'd want to go through a design review.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
