### PR TITLE
add a packageImports fields to the analysis response

### DIFF
--- a/pkgs/dart_services/lib/src/common_server_api.dart
+++ b/pkgs/dart_services/lib/src/common_server_api.dart
@@ -67,6 +67,7 @@ class CommonServerApi {
             column: issue.column,
           );
         }).toList(),
+        packageImports: result.packageImports,
       ).toJson());
     } else {
       return unhandledVersion(apiVersion);

--- a/pkgs/dart_services/lib/src/shared/model.dart
+++ b/pkgs/dart_services/lib/src/shared/model.dart
@@ -25,8 +25,12 @@ class SourceRequest {
 @JsonSerializable()
 class AnalysisResponse {
   final List<AnalysisIssue> issues;
+  final List<String> packageImports;
 
-  AnalysisResponse({this.issues = const []});
+  AnalysisResponse({
+    required this.issues,
+    required this.packageImports,
+  });
 
   factory AnalysisResponse.fromJson(Map<String, dynamic> json) =>
       _$AnalysisResponseFromJson(json);
@@ -138,6 +142,11 @@ class FlutterBuildResponse {
 
 @JsonSerializable()
 class FixesResponse {
+  static final FixesResponse empty = FixesResponse(
+    fixes: [],
+    assists: [],
+  );
+
   final List<SourceChange> fixes;
   final List<SourceChange> assists;
 
@@ -222,6 +231,12 @@ class DocumentResponse {
 
 @JsonSerializable()
 class CompleteResponse {
+  static final CompleteResponse empty = CompleteResponse(
+    replacementLength: 0,
+    replacementOffset: 0,
+    suggestions: [],
+  );
+
   final int replacementOffset;
   final int replacementLength;
   final List<CompletionSuggestion> suggestions;

--- a/pkgs/dart_services/lib/src/shared/model.g.dart
+++ b/pkgs/dart_services/lib/src/shared/model.g.dart
@@ -20,15 +20,18 @@ Map<String, dynamic> _$SourceRequestToJson(SourceRequest instance) =>
 
 AnalysisResponse _$AnalysisResponseFromJson(Map<String, dynamic> json) =>
     AnalysisResponse(
-      issues: (json['issues'] as List<dynamic>?)
-              ?.map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          const [],
+      issues: (json['issues'] as List<dynamic>)
+          .map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      packageImports: (json['packageImports'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$AnalysisResponseToJson(AnalysisResponse instance) =>
     <String, dynamic>{
       'issues': instance.issues,
+      'packageImports': instance.packageImports,
     };
 
 AnalysisIssue _$AnalysisIssueFromJson(Map<String, dynamic> json) =>

--- a/pkgs/dart_services/test/server_v3_test.dart
+++ b/pkgs/dart_services/test/server_v3_test.dart
@@ -53,6 +53,7 @@ void main() {
 }
 '''));
       expect(result.issues, isEmpty);
+      expect(result.packageImports, isEmpty);
     });
 
     test('analyze flutter', () async {
@@ -79,6 +80,8 @@ class MyApp extends StatelessWidget {
 
       expect(result, isNotNull);
       expect(result.issues, isEmpty);
+      expect(result.packageImports, isNotEmpty);
+      expect(result.packageImports, contains('flutter'));
     });
 
     test('analyze errors', () async {

--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -25,8 +25,12 @@ class SourceRequest {
 @JsonSerializable()
 class AnalysisResponse {
   final List<AnalysisIssue> issues;
+  final List<String> packageImports;
 
-  AnalysisResponse({this.issues = const []});
+  AnalysisResponse({
+    required this.issues,
+    required this.packageImports,
+  });
 
   factory AnalysisResponse.fromJson(Map<String, dynamic> json) =>
       _$AnalysisResponseFromJson(json);
@@ -138,6 +142,11 @@ class FlutterBuildResponse {
 
 @JsonSerializable()
 class FixesResponse {
+  static final FixesResponse empty = FixesResponse(
+    fixes: [],
+    assists: [],
+  );
+
   final List<SourceChange> fixes;
   final List<SourceChange> assists;
 
@@ -222,6 +231,12 @@ class DocumentResponse {
 
 @JsonSerializable()
 class CompleteResponse {
+  static final CompleteResponse empty = CompleteResponse(
+    replacementLength: 0,
+    replacementOffset: 0,
+    suggestions: [],
+  );
+
   final int replacementOffset;
   final int replacementLength;
   final List<CompletionSuggestion> suggestions;

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -20,15 +20,18 @@ Map<String, dynamic> _$SourceRequestToJson(SourceRequest instance) =>
 
 AnalysisResponse _$AnalysisResponseFromJson(Map<String, dynamic> json) =>
     AnalysisResponse(
-      issues: (json['issues'] as List<dynamic>?)
-              ?.map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
-              .toList() ??
-          const [],
+      issues: (json['issues'] as List<dynamic>)
+          .map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      packageImports: (json['packageImports'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
     );
 
 Map<String, dynamic> _$AnalysisResponseToJson(AnalysisResponse instance) =>
     <String, dynamic>{
       'issues': instance.issues,
+      'packageImports': instance.packageImports,
     };
 
 AnalysisIssue _$AnalysisIssueFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
- add a `packageImports` fields to the analysis response

We can use this field to help know whether to compile with DDC or dart2js.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
