### PR TITLE
add final completion and quick fix support to the v3 protocol

### DIFF
--- a/pkgs/dart_services/lib/src/analysis_server.dart
+++ b/pkgs/dart_services/lib/src/analysis_server.dart
@@ -186,8 +186,10 @@ abstract class AnalysisServerWrapper {
           deprecated: suggestion.isDeprecated,
           selectionOffset: suggestion.selectionOffset,
           displayText: suggestion.displayText,
+          parameterNames: suggestion.parameterNames,
           returnType: suggestion.returnType,
           elementKind: suggestion.element?.kind,
+          elementParameters: suggestion.element?.parameters,
         );
       }).toList(),
     );
@@ -694,6 +696,18 @@ extension SourceChangeExtension on SourceChange {
             ),
           )
           .toList(),
+      linkedEditGroups: linkedEditGroups.map((editGroup) {
+        return api.LinkedEditGroup(
+          offsets: editGroup.positions.map((pos) => pos.offset).toList(),
+          length: editGroup.length,
+          suggestions: editGroup.suggestions.map((sug) {
+            return api.LinkedEditSuggestion(
+              value: sug.value,
+              kind: sug.kind,
+            );
+          }).toList(),
+        );
+      }).toList(),
       selectionOffset: selection?.offset,
     );
   }

--- a/pkgs/dart_services/lib/src/common_server_api.dart
+++ b/pkgs/dart_services/lib/src/common_server_api.dart
@@ -25,7 +25,9 @@ part 'common_server_api.g.dart';
 
 const protobufContentType = 'application/x-protobuf';
 const jsonContentType = 'application/json; charset=utf-8';
-const apiPrefix = '/api/dartservices/<apiVersion>';
+
+const oldApiPrefix = '/api/dartservices/<apiVersion>';
+const newApiPrefix = '/api/<apiVersion>';
 
 const api2 = 'v2';
 const api3 = 'v3';
@@ -36,7 +38,8 @@ class CommonServerApi {
 
   CommonServerApi(this._impl);
 
-  @Route.post('$apiPrefix/analyze')
+  @Route.post('$oldApiPrefix/analyze')
+  @Route.post('$newApiPrefix/analyze')
   Future<Response> analyze(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -74,7 +77,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/compile')
+  @Route.post('$oldApiPrefix/compile')
+  @Route.post('$newApiPrefix/compile')
   Future<Response> compile(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -100,7 +104,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/compileDDC')
+  @Route.post('$oldApiPrefix/compileDDC')
+  @Route.post('$newApiPrefix/compileDDC')
   Future<Response> compileDDC(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -130,7 +135,8 @@ class CommonServerApi {
   }
 
   @experimental
-  @Route.post('$apiPrefix/_flutterBuild')
+  @Route.post('$oldApiPrefix/_flutterBuild')
+  @Route.post('$newApiPrefix/_flutterBuild')
   Future<Response> flutterBuild(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -161,7 +167,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/complete')
+  @Route.post('$oldApiPrefix/complete')
+  @Route.post('$newApiPrefix/complete')
   Future<Response> complete(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -182,7 +189,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/fixes')
+  @Route.post('$oldApiPrefix/fixes')
+  @Route.post('$newApiPrefix/fixes')
   Future<Response> fixes(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -203,7 +211,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/assists')
+  @Route.post('$oldApiPrefix/assists')
+  @Route.post('$newApiPrefix/assists')
   Future<Response> assists(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -218,7 +227,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/format')
+  @Route.post('$oldApiPrefix/format')
+  @Route.post('$newApiPrefix/format')
   Future<Response> format(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -247,7 +257,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/document')
+  @Route.post('$oldApiPrefix/document')
+  @Route.post('$newApiPrefix/document')
   Future<Response> document(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -273,7 +284,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.post('$apiPrefix/version')
+  @Route.post('$oldApiPrefix/version')
+  @Route.post('$newApiPrefix/version')
   Future<Response> versionPost(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -288,7 +300,8 @@ class CommonServerApi {
     }
   }
 
-  @Route.get('$apiPrefix/version')
+  @Route.get('$oldApiPrefix/version')
+  @Route.get('$newApiPrefix/version')
   Future<Response> versionGet(Request request, String apiVersion) async {
     if (apiVersion == api2) {
       return _processRequest(
@@ -306,7 +319,8 @@ class CommonServerApi {
   }
 
   // Beginning of multi file map end points:
-  @Route.post('$apiPrefix/analyzeFiles')
+  @Route.post('$oldApiPrefix/analyzeFiles')
+  @Route.post('$newApiPrefix/analyzeFiles')
   Future<Response> analyzeFiles(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -317,7 +331,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/compileFiles')
+  @Route.post('$oldApiPrefix/compileFiles')
+  @Route.post('$newApiPrefix/compileFiles')
   Future<Response> compileFiles(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -328,7 +343,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/compileFilesDDC')
+  @Route.post('$oldApiPrefix/compileFilesDDC')
+  @Route.post('$newApiPrefix/compileFilesDDC')
   Future<Response> compileFilesDDC(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -339,7 +355,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/completeFiles')
+  @Route.post('$oldApiPrefix/completeFiles')
+  @Route.post('$newApiPrefix/completeFiles')
   Future<Response> completeFiles(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -350,7 +367,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/fixesFiles')
+  @Route.post('$oldApiPrefix/fixesFiles')
+  @Route.post('$newApiPrefix/fixesFiles')
   Future<Response> fixesFiles(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -361,7 +379,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/assistsFiles')
+  @Route.post('$oldApiPrefix/assistsFiles')
+  @Route.post('$newApiPrefix/assistsFiles')
   Future<Response> assistsFiles(Request request, String apiVersion) {
     return _processRequest(
       request,
@@ -372,7 +391,8 @@ class CommonServerApi {
     );
   }
 
-  @Route.post('$apiPrefix/documentFiles')
+  @Route.post('$oldApiPrefix/documentFiles')
+  @Route.post('$newApiPrefix/documentFiles')
   Future<Response> documentFiles(Request request, String apiVersion) {
     return _processRequest(
       request,

--- a/pkgs/dart_services/lib/src/common_server_api.g.dart
+++ b/pkgs/dart_services/lib/src/common_server_api.g.dart
@@ -15,7 +15,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/analyze',
+    service.analyze,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/compile',
+    service.compile,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/compile',
     service.compile,
   );
   router.add(
@@ -25,7 +35,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/compileDDC',
+    service.compileDDC,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/_flutterBuild',
+    service.flutterBuild,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/_flutterBuild',
     service.flutterBuild,
   );
   router.add(
@@ -35,7 +55,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/complete',
+    service.complete,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/fixes',
+    service.fixes,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/fixes',
     service.fixes,
   );
   router.add(
@@ -45,7 +75,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/assists',
+    service.assists,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/format',
+    service.format,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/format',
     service.format,
   );
   router.add(
@@ -55,12 +95,27 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/document',
+    service.document,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/version',
+    service.versionPost,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/version',
     service.versionPost,
   );
   router.add(
     'GET',
     r'/api/dartservices/<apiVersion>/version',
+    service.versionGet,
+  );
+  router.add(
+    'GET',
+    r'/api/<apiVersion>/version',
     service.versionGet,
   );
   router.add(
@@ -70,7 +125,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/analyzeFiles',
+    service.analyzeFiles,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/compileFiles',
+    service.compileFiles,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/compileFiles',
     service.compileFiles,
   );
   router.add(
@@ -80,7 +145,17 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/compileFilesDDC',
+    service.compileFilesDDC,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/completeFiles',
+    service.completeFiles,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/completeFiles',
     service.completeFiles,
   );
   router.add(
@@ -90,12 +165,27 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/fixesFiles',
+    service.fixesFiles,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/assistsFiles',
     service.assistsFiles,
   );
   router.add(
     'POST',
+    r'/api/<apiVersion>/assistsFiles',
+    service.assistsFiles,
+  );
+  router.add(
+    'POST',
     r'/api/dartservices/<apiVersion>/documentFiles',
+    service.documentFiles,
+  );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/documentFiles',
     service.documentFiles,
   );
   return router;

--- a/pkgs/dart_services/lib/src/shared/model.dart
+++ b/pkgs/dart_services/lib/src/shared/model.dart
@@ -165,13 +165,13 @@ class FixesResponse {
 class SourceChange {
   final String message;
   final List<SourceEdit> edits;
-  // TODO: Add linked edit groups once we start using them.
-  // final List<LinkedEditGroup> linkedEditGroups;
+  final List<LinkedEditGroup> linkedEditGroups;
   final int? selectionOffset;
 
   SourceChange({
     required this.message,
     required this.edits,
+    required this.linkedEditGroups,
     this.selectionOffset,
   });
 
@@ -203,6 +203,40 @@ class SourceEdit {
 
   @override
   String toString() => 'SourceEdit [$offset,$length,$replacement]';
+}
+
+@JsonSerializable()
+class LinkedEditGroup {
+  final List<int> offsets;
+  final int length;
+  final List<LinkedEditSuggestion> suggestions;
+
+  LinkedEditGroup({
+    required this.offsets,
+    required this.length,
+    required this.suggestions,
+  });
+
+  factory LinkedEditGroup.fromJson(Map<String, dynamic> json) =>
+      _$LinkedEditGroupFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LinkedEditGroupToJson(this);
+}
+
+@JsonSerializable()
+class LinkedEditSuggestion {
+  final String value;
+  final String kind;
+
+  LinkedEditSuggestion({
+    required this.value,
+    required this.kind,
+  });
+
+  factory LinkedEditSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$LinkedEditSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LinkedEditSuggestionToJson(this);
 }
 
 @JsonSerializable()
@@ -261,8 +295,10 @@ class CompletionSuggestion {
   final bool deprecated;
   final int selectionOffset;
   final String? displayText;
+  final List<String>? parameterNames;
   final String? returnType;
   final String? elementKind;
+  final String? elementParameters;
 
   CompletionSuggestion({
     required this.kind,
@@ -271,8 +307,10 @@ class CompletionSuggestion {
     required this.deprecated,
     required this.selectionOffset,
     required this.displayText,
+    required this.parameterNames,
     required this.returnType,
     required this.elementKind,
+    required this.elementParameters,
   });
 
   factory CompletionSuggestion.fromJson(Map<String, dynamic> json) =>

--- a/pkgs/dart_services/lib/src/shared/model.g.dart
+++ b/pkgs/dart_services/lib/src/shared/model.g.dart
@@ -135,6 +135,9 @@ SourceChange _$SourceChangeFromJson(Map<String, dynamic> json) => SourceChange(
       edits: (json['edits'] as List<dynamic>)
           .map((e) => SourceEdit.fromJson(e as Map<String, dynamic>))
           .toList(),
+      linkedEditGroups: (json['linkedEditGroups'] as List<dynamic>)
+          .map((e) => LinkedEditGroup.fromJson(e as Map<String, dynamic>))
+          .toList(),
       selectionOffset: json['selectionOffset'] as int?,
     );
 
@@ -142,6 +145,7 @@ Map<String, dynamic> _$SourceChangeToJson(SourceChange instance) =>
     <String, dynamic>{
       'message': instance.message,
       'edits': instance.edits,
+      'linkedEditGroups': instance.linkedEditGroups,
       'selectionOffset': instance.selectionOffset,
     };
 
@@ -156,6 +160,36 @@ Map<String, dynamic> _$SourceEditToJson(SourceEdit instance) =>
       'offset': instance.offset,
       'length': instance.length,
       'replacement': instance.replacement,
+    };
+
+LinkedEditGroup _$LinkedEditGroupFromJson(Map<String, dynamic> json) =>
+    LinkedEditGroup(
+      offsets: (json['offsets'] as List<dynamic>).map((e) => e as int).toList(),
+      length: json['length'] as int,
+      suggestions: (json['suggestions'] as List<dynamic>)
+          .map((e) => LinkedEditSuggestion.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$LinkedEditGroupToJson(LinkedEditGroup instance) =>
+    <String, dynamic>{
+      'offsets': instance.offsets,
+      'length': instance.length,
+      'suggestions': instance.suggestions,
+    };
+
+LinkedEditSuggestion _$LinkedEditSuggestionFromJson(
+        Map<String, dynamic> json) =>
+    LinkedEditSuggestion(
+      value: json['value'] as String,
+      kind: json['kind'] as String,
+    );
+
+Map<String, dynamic> _$LinkedEditSuggestionToJson(
+        LinkedEditSuggestion instance) =>
+    <String, dynamic>{
+      'value': instance.value,
+      'kind': instance.kind,
     };
 
 DocumentResponse _$DocumentResponseFromJson(Map<String, dynamic> json) =>
@@ -203,8 +237,12 @@ CompletionSuggestion _$CompletionSuggestionFromJson(
       deprecated: json['deprecated'] as bool,
       selectionOffset: json['selectionOffset'] as int,
       displayText: json['displayText'] as String?,
+      parameterNames: (json['parameterNames'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       returnType: json['returnType'] as String?,
       elementKind: json['elementKind'] as String?,
+      elementParameters: json['elementParameters'] as String?,
     );
 
 Map<String, dynamic> _$CompletionSuggestionToJson(
@@ -216,8 +254,10 @@ Map<String, dynamic> _$CompletionSuggestionToJson(
       'deprecated': instance.deprecated,
       'selectionOffset': instance.selectionOffset,
       'displayText': instance.displayText,
+      'parameterNames': instance.parameterNames,
       'returnType': instance.returnType,
       'elementKind': instance.elementKind,
+      'elementParameters': instance.elementParameters,
     };
 
 VersionResponse _$VersionResponseFromJson(Map<String, dynamic> json) =>

--- a/pkgs/dart_services/lib/src/shared/services.dart
+++ b/pkgs/dart_services/lib/src/shared/services.dart
@@ -51,8 +51,7 @@ class ServicesClient {
     String action,
     T Function(Map<String, dynamic> json) responseFactory,
   ) async {
-    final response =
-        await client.get(Uri.parse('${rootUrl}api/dartservices/v3/$action'));
+    final response = await client.get(Uri.parse('${rootUrl}api/v3/$action'));
 
     if (response.statusCode != 200) {
       throw ApiRequestError(
@@ -74,10 +73,8 @@ class ServicesClient {
     Map<String, dynamic> request,
     T Function(Map<String, dynamic> json) responseFactory,
   ) async {
-    final response = await client.post(
-        Uri.parse('${rootUrl}api/dartservices/v3/$action'),
-        encoding: utf8,
-        body: json.encode(request));
+    final response = await client.post(Uri.parse('${rootUrl}api/v3/$action'),
+        encoding: utf8, body: json.encode(request));
     if (response.statusCode != 200) {
       throw ApiRequestError(
         '$action: ${response.statusCode}: ${response.reasonPhrase}',

--- a/pkgs/dart_services/test/server_v3_test.dart
+++ b/pkgs/dart_services/test/server_v3_test.dart
@@ -80,7 +80,6 @@ class MyApp extends StatelessWidget {
 
       expect(result, isNotNull);
       expect(result.issues, isEmpty);
-      expect(result.packageImports, isNotEmpty);
       expect(result.packageImports, contains('flutter'));
     });
 
@@ -120,7 +119,9 @@ void main() {
       });
       expect(suggestion, isNotNull);
       expect(suggestion!.returnType, 'void');
+      expect(suggestion.parameterNames, isNotEmpty);
       expect(suggestion.elementKind, 'FUNCTION');
+      expect(suggestion.elementParameters, isNotEmpty);
     });
 
     test('format', () async {
@@ -289,6 +290,7 @@ void main() {
           .firstWhereOrNull((fix) => fix.message.contains('Ignore'));
       expect(fix, isNotNull);
       expect(fix!.edits, hasLength(1));
+      expect(fix.linkedEditGroups, isEmpty);
       expect(fix.edits.first.replacement,
           contains('// ignore: unused_local_variable'));
     });
@@ -322,6 +324,8 @@ void main() => print('hello world');
           (assist) => assist.message.contains('Convert to block body'));
       expect(assist, isNotNull);
       expect(assist!.edits, hasLength(1));
+      expect(assist.linkedEditGroups, isEmpty);
+      expect(assist.selectionOffset, greaterThan(0));
       expect(assist.edits.first.replacement, isNotEmpty);
     });
   });

--- a/pkgs/dart_services/tool/grind.dart
+++ b/pkgs/dart_services/tool/grind.dart
@@ -366,9 +366,6 @@ void generateProtos() async {
     arguments: ['format', '--fix', 'lib/src/protos'],
   );
 
-  // Copy to the dart_pad front-end package.
-  copy(getDir('lib/src/protos'), getDir('../dart_pad/lib/src/protos'));
-
   // TODO: We'd like to remove this copy operation; that will require work in
   // the cloud build configuration.
   copy(getDir('../dartpad_shared/lib'), getDir('lib/src/shared'));

--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -165,13 +165,13 @@ class FixesResponse {
 class SourceChange {
   final String message;
   final List<SourceEdit> edits;
-  // TODO: Add linked edit groups once we start using them.
-  // final List<LinkedEditGroup> linkedEditGroups;
+  final List<LinkedEditGroup> linkedEditGroups;
   final int? selectionOffset;
 
   SourceChange({
     required this.message,
     required this.edits,
+    required this.linkedEditGroups,
     this.selectionOffset,
   });
 
@@ -203,6 +203,40 @@ class SourceEdit {
 
   @override
   String toString() => 'SourceEdit [$offset,$length,$replacement]';
+}
+
+@JsonSerializable()
+class LinkedEditGroup {
+  final List<int> offsets;
+  final int length;
+  final List<LinkedEditSuggestion> suggestions;
+
+  LinkedEditGroup({
+    required this.offsets,
+    required this.length,
+    required this.suggestions,
+  });
+
+  factory LinkedEditGroup.fromJson(Map<String, dynamic> json) =>
+      _$LinkedEditGroupFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LinkedEditGroupToJson(this);
+}
+
+@JsonSerializable()
+class LinkedEditSuggestion {
+  final String value;
+  final String kind;
+
+  LinkedEditSuggestion({
+    required this.value,
+    required this.kind,
+  });
+
+  factory LinkedEditSuggestion.fromJson(Map<String, dynamic> json) =>
+      _$LinkedEditSuggestionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LinkedEditSuggestionToJson(this);
 }
 
 @JsonSerializable()
@@ -261,8 +295,10 @@ class CompletionSuggestion {
   final bool deprecated;
   final int selectionOffset;
   final String? displayText;
+  final List<String>? parameterNames;
   final String? returnType;
   final String? elementKind;
+  final String? elementParameters;
 
   CompletionSuggestion({
     required this.kind,
@@ -271,8 +307,10 @@ class CompletionSuggestion {
     required this.deprecated,
     required this.selectionOffset,
     required this.displayText,
+    required this.parameterNames,
     required this.returnType,
     required this.elementKind,
+    required this.elementParameters,
   });
 
   factory CompletionSuggestion.fromJson(Map<String, dynamic> json) =>

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -135,6 +135,9 @@ SourceChange _$SourceChangeFromJson(Map<String, dynamic> json) => SourceChange(
       edits: (json['edits'] as List<dynamic>)
           .map((e) => SourceEdit.fromJson(e as Map<String, dynamic>))
           .toList(),
+      linkedEditGroups: (json['linkedEditGroups'] as List<dynamic>)
+          .map((e) => LinkedEditGroup.fromJson(e as Map<String, dynamic>))
+          .toList(),
       selectionOffset: json['selectionOffset'] as int?,
     );
 
@@ -142,6 +145,7 @@ Map<String, dynamic> _$SourceChangeToJson(SourceChange instance) =>
     <String, dynamic>{
       'message': instance.message,
       'edits': instance.edits,
+      'linkedEditGroups': instance.linkedEditGroups,
       'selectionOffset': instance.selectionOffset,
     };
 
@@ -156,6 +160,36 @@ Map<String, dynamic> _$SourceEditToJson(SourceEdit instance) =>
       'offset': instance.offset,
       'length': instance.length,
       'replacement': instance.replacement,
+    };
+
+LinkedEditGroup _$LinkedEditGroupFromJson(Map<String, dynamic> json) =>
+    LinkedEditGroup(
+      offsets: (json['offsets'] as List<dynamic>).map((e) => e as int).toList(),
+      length: json['length'] as int,
+      suggestions: (json['suggestions'] as List<dynamic>)
+          .map((e) => LinkedEditSuggestion.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$LinkedEditGroupToJson(LinkedEditGroup instance) =>
+    <String, dynamic>{
+      'offsets': instance.offsets,
+      'length': instance.length,
+      'suggestions': instance.suggestions,
+    };
+
+LinkedEditSuggestion _$LinkedEditSuggestionFromJson(
+        Map<String, dynamic> json) =>
+    LinkedEditSuggestion(
+      value: json['value'] as String,
+      kind: json['kind'] as String,
+    );
+
+Map<String, dynamic> _$LinkedEditSuggestionToJson(
+        LinkedEditSuggestion instance) =>
+    <String, dynamic>{
+      'value': instance.value,
+      'kind': instance.kind,
     };
 
 DocumentResponse _$DocumentResponseFromJson(Map<String, dynamic> json) =>
@@ -203,8 +237,12 @@ CompletionSuggestion _$CompletionSuggestionFromJson(
       deprecated: json['deprecated'] as bool,
       selectionOffset: json['selectionOffset'] as int,
       displayText: json['displayText'] as String?,
+      parameterNames: (json['parameterNames'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
       returnType: json['returnType'] as String?,
       elementKind: json['elementKind'] as String?,
+      elementParameters: json['elementParameters'] as String?,
     );
 
 Map<String, dynamic> _$CompletionSuggestionToJson(
@@ -216,8 +254,10 @@ Map<String, dynamic> _$CompletionSuggestionToJson(
       'deprecated': instance.deprecated,
       'selectionOffset': instance.selectionOffset,
       'displayText': instance.displayText,
+      'parameterNames': instance.parameterNames,
       'returnType': instance.returnType,
       'elementKind': instance.elementKind,
+      'elementParameters': instance.elementParameters,
     };
 
 VersionResponse _$VersionResponseFromJson(Map<String, dynamic> json) =>

--- a/pkgs/dartpad_shared/lib/services.dart
+++ b/pkgs/dartpad_shared/lib/services.dart
@@ -51,8 +51,7 @@ class ServicesClient {
     String action,
     T Function(Map<String, dynamic> json) responseFactory,
   ) async {
-    final response =
-        await client.get(Uri.parse('${rootUrl}api/dartservices/v3/$action'));
+    final response = await client.get(Uri.parse('${rootUrl}api/v3/$action'));
 
     if (response.statusCode != 200) {
       throw ApiRequestError(
@@ -74,10 +73,8 @@ class ServicesClient {
     Map<String, dynamic> request,
     T Function(Map<String, dynamic> json) responseFactory,
   ) async {
-    final response = await client.post(
-        Uri.parse('${rootUrl}api/dartservices/v3/$action'),
-        encoding: utf8,
-        body: json.encode(request));
+    final response = await client.post(Uri.parse('${rootUrl}api/v3/$action'),
+        encoding: utf8, body: json.encode(request));
     if (response.statusCode != 200) {
       throw ApiRequestError(
         '$action: ${response.statusCode}: ${response.reasonPhrase}',


### PR DESCRIPTION
- add final completion and quick fix support to the v3 protocol
- add shorter `/api/v3/...` endpoints for the server protocol (instead of `/api/dartservices/v3/...`)

This implements enough of the v3 protocol to support the existing dart web UI.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
