### PR TITLE
Remove index.html from redirect URL

### DIFF
--- a/pkgs/dart_pad/firebase.json
+++ b/pkgs/dart_pad/firebase.json
@@ -10,7 +10,7 @@
     "redirects": [
       {
         "regex": "/([a-zA-Z0-9]+)",
-        "destination": "/index.html?id=:1",
+        "destination": "/?id=:1",
         "type": 301
       }
     ],


### PR DESCRIPTION
This removes `index.html` from the path when redirecting from a url like https://dartpad.dev/854a0c97716bb6328d7004abf2e7e3c1 

Thanks @Deleplace for the [suggestion](https://github.com/dart-lang/dart-pad/pull/2700#issuecomment-1790420915).