### PR TITLE
Set theme when app first loads

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -66,15 +66,15 @@ class _DartPadAppState extends State<DartPadApp> {
 
   @override
   void initState() {
+    super.initState();
     router.routeInformationProvider.addListener(_setTheme);
     _setTheme();
-    super.initState();
   }
 
   @override
   void dispose() {
-    super.dispose();
     router.routeInformationProvider.removeListener(_setTheme);
+    super.dispose();
   }
 
   // Changes the `themeMode` from the system default to either light or dark.

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -67,6 +67,7 @@ class _DartPadAppState extends State<DartPadApp> {
   @override
   void initState() {
     router.routeInformationProvider.addListener(_setTheme);
+    _setTheme();
     super.initState();
   }
 


### PR DESCRIPTION
This caused navigating to ?theme=dark and refreshing to load the wrong theme brightness.