### PR TITLE
Remove padracing sample from the dropdown

### DIFF
--- a/pkgs/dart_pad/lib/playground.dart
+++ b/pkgs/dart_pad/lib/playground.dart
@@ -241,7 +241,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
           Layout.flutter),
       Sample('85e77d36533b16647bf9b6eb8c03296d', 'Implicit animations',
           Layout.flutter),
-      Sample('ecabed4a17a3aad8bee7c6327e472fc8', 'Padracing', Layout.flutter),
       Sample('d57c6c898dabb8c6fb41018588b8cf73', 'Firebase Nanochat',
           Layout.flutter),
       Sample(


### PR DESCRIPTION
Rather than update this sample, I think we should consider removing it for now and having use a simpler Flame sample when we switch to the Flutter version of DartPad.

cc: @devoncarew 

Fixes #2684