### PR TITLE
use replaceQueryParam when changing channels

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -28,8 +28,6 @@ import 'widgets.dart';
 
 // TODO: explore using the monaco editor
 
-// TODO: have a theme toggle
-
 // TODO: show documentation on hover
 
 // TODO: implement find / find next
@@ -67,6 +65,7 @@ class _DartPadAppState extends State<DartPadApp> {
   @override
   void initState() {
     super.initState();
+
     router.routeInformationProvider.addListener(_setTheme);
     _setTheme();
   }
@@ -74,6 +73,7 @@ class _DartPadAppState extends State<DartPadApp> {
   @override
   void dispose() {
     router.routeInformationProvider.removeListener(_setTheme);
+
     super.dispose();
   }
 
@@ -104,7 +104,7 @@ class _DartPadAppState extends State<DartPadApp> {
           });
         case _:
           setState(() {
-            themeMode = ThemeMode.system;
+            themeMode = ThemeMode.dark;
           });
       }
     });
@@ -272,15 +272,15 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                     children: [
                       Text('Install SDK'),
                       SizedBox(width: denseSpacing),
-                      Icon(Icons.launch, size: smallIconSize),
+                      Icon(Icons.launch, size: 18),
                     ],
                   ),
                 ),
                 const SizedBox(width: denseSpacing),
-                const OverflowMenu(),
                 _BrightnessButton(
                   handleBrightnessChange: widget.handleBrightnessChanged,
                 ),
+                const OverflowMenu(),
               ],
             ),
       body: Column(
@@ -318,6 +318,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                                           child: MiniIconButton(
                                             icon: Icons.format_align_left,
                                             tooltip: 'Format',
+                                            small: true,
                                             onPressed: value
                                                 ? null
                                                 : _handleFormatting,
@@ -562,7 +563,13 @@ class StatusLineWidget extends StatelessWidget {
               const url = 'https://dart.dev/tools/dartpad/privacy';
               url_launcher.launchUrl(Uri.parse(url));
             },
-            child: const Text('Privacy notice'),
+            child: const Row(
+              children: [
+                Text('Privacy notice'),
+                SizedBox(width: denseSpacing),
+                Icon(Icons.launch, size: 16),
+              ],
+            ),
           ),
           const SizedBox(width: defaultSpacing),
           TextButton(
@@ -570,7 +577,13 @@ class StatusLineWidget extends StatelessWidget {
               const url = 'https://github.com/dart-lang/dart-pad/issues';
               url_launcher.launchUrl(Uri.parse(url));
             },
-            child: const Text('Feedback'),
+            child: const Row(
+              children: [
+                Text('Feedback'),
+                SizedBox(width: denseSpacing),
+                Icon(Icons.launch, size: 16),
+              ],
+            ),
           ),
           const Expanded(child: SizedBox(width: defaultSpacing)),
           VersionInfoWidget(appModel.runtimeVersions),
@@ -803,15 +816,17 @@ class SelectChannelWidget extends StatelessWidget {
     );
   }
 
-  void _handleSelection(BuildContext context, Channel channel) {
+  void _handleSelection(BuildContext context, Channel channel) async {
     final appServices = Provider.of<AppServices>(context, listen: false);
 
-    appServices.setChannel(channel);
-
     // update the url
-    // TODO: preserve id? sample? theme?
-    context.go(
-      Uri(path: '/', queryParameters: {'channel': channel.name}).toString(),
+    GoRouter.of(context).replaceQueryParam('channel', channel.name);
+
+    final version = await appServices.setChannel(channel);
+
+    appServices.appModel.editorStatus.showToast(
+      'Switched to Dart ${version.dartVersion} '
+      'and Flutter ${version.flutterVersion}',
     );
   }
 }

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -138,10 +138,11 @@ class AppServices {
 
   ValueListenable<Channel> get channel => _channel;
 
-  void setChannel(Channel channel) async {
+  Future<VersionResponse> setChannel(Channel channel) async {
     services = ServicesClient(_httpClient, rootUrl: channel.url);
-    await populateVersions();
+    final versionResponse = await populateVersions();
     _channel.value = channel;
+    return versionResponse;
   }
 
   void resetTo({String? type}) {
@@ -170,9 +171,10 @@ class AppServices {
     });
   }
 
-  Future<void> populateVersions() async {
+  Future<VersionResponse> populateVersions() async {
     final version = await services.version();
     appModel.runtimeVersions.value = version;
+    return version;
   }
 
   Future<void> performInitialLoad({

--- a/pkgs/sketch_pad/lib/widgets.dart
+++ b/pkgs/sketch_pad/lib/widgets.dart
@@ -68,8 +68,6 @@ class MiniIconButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const smallIconContrants = BoxConstraints(minWidth: 30, minHeight: 30);
-
     final brightness = Theme.of(context).brightness;
     final colorScheme = Theme.of(context).colorScheme;
     final backgroundColor = switch (brightness) {
@@ -86,10 +84,9 @@ class MiniIconButton extends StatelessWidget {
           backgroundColor: MaterialStateProperty.all(backgroundColor),
         ),
         icon: Icon(icon),
-        iconSize: small ? 18 : smallIconSize,
-        splashRadius: small ? 18 : smallIconSize,
+        iconSize: small ? 16 : smallIconSize,
+        splashRadius: small ? 16 : smallIconSize,
         visualDensity: VisualDensity.compact,
-        constraints: small ? smallIconContrants : null,
         onPressed: onPressed,
       ),
     );

--- a/pkgs/sketch_pad/pubspec.yaml
+++ b/pkgs/sketch_pad/pubspec.yaml
@@ -11,8 +11,8 @@ dependencies:
   dartpad_shared: any
   flutter:
     sdk: flutter
-  fluttering_phrases: any
-  go_router: ^10.0.0
+  fluttering_phrases: ^1.0.0
+  go_router: ^12.1.0
   http: any
   json_annotation: ^4.8.1
   pointer_interceptor: ^0.9.0


### PR DESCRIPTION
- use `GoRouter.replaceQueryParam` when changing channels (replaces https://github.com/dart-lang/dart-pad/pull/2704)
- move the overflow menu to the last item on the toolbar
- show 'external link' icons for the privacy notice and feedback links
- default dartpad to the dark theme (instead of the system one)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
