### PR TITLE
Fix issue with split_view and iframe

### DIFF
--- a/pkgs/sketch_pad/lib/execution/execution.dart
+++ b/pkgs/sketch_pad/lib/execution/execution.dart
@@ -68,8 +68,7 @@ class _ExecutionWidgetState extends State<ExecutionWidget> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    widget.appServices.executionService?.frame.style.pointerEvents =
-        widget.ignorePointer ? 'none' : 'auto';
+    widget.appServices.executionService?.ignorePointer = widget.ignorePointer;
 
     return Container(
       color: theme.scaffoldBackgroundColor,

--- a/pkgs/sketch_pad/lib/execution/execution.dart
+++ b/pkgs/sketch_pad/lib/execution/execution.dart
@@ -68,7 +68,8 @@ class _ExecutionWidgetState extends State<ExecutionWidget> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    widget.appServices.executionService?.frame.style.pointerEvents = widget.ignorePointer ? 'none' : 'auto';
+    widget.appServices.executionService?.frame.style.pointerEvents =
+        widget.ignorePointer ? 'none' : 'auto';
 
     return Container(
       color: theme.scaffoldBackgroundColor,

--- a/pkgs/sketch_pad/lib/execution/frame.dart
+++ b/pkgs/sketch_pad/lib/execution/frame.dart
@@ -46,7 +46,9 @@ class ExecutionServiceImpl implements ExecutionService {
   Stream<String> get onStdout => _stdoutController.stream;
 
   @override
-  html.IFrameElement get frame => _frame;
+  set ignorePointer(bool ignorePointer) {
+    _frame.style.pointerEvents = ignorePointer ? 'none' : 'auto';
+  }
 
   @override
   Future<void> reset() => _reset();

--- a/pkgs/sketch_pad/lib/execution/frame.dart
+++ b/pkgs/sketch_pad/lib/execution/frame.dart
@@ -45,6 +45,7 @@ class ExecutionServiceImpl implements ExecutionService {
   @override
   Stream<String> get onStdout => _stdoutController.stream;
 
+  @override
   html.IFrameElement get frame => _frame;
 
   @override

--- a/pkgs/sketch_pad/lib/execution/frame.dart
+++ b/pkgs/sketch_pad/lib/execution/frame.dart
@@ -45,6 +45,8 @@ class ExecutionServiceImpl implements ExecutionService {
   @override
   Stream<String> get onStdout => _stdoutController.stream;
 
+  html.IFrameElement get frame => _frame;
+
   @override
   Future<void> reset() => _reset();
 

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:html' as html;
 
 import 'package:collection/collection.dart';
 import 'package:dartpad_shared/services.dart';
@@ -23,6 +24,7 @@ abstract class ExecutionService {
     String? engineVersion,
   });
   Stream<String> get onStdout;
+  html.IFrameElement get frame;
   Future<void> reset();
   Future<void> tearDown();
 }
@@ -135,6 +137,7 @@ class AppServices {
   }
 
   EditorService? get editorService => _editorService;
+  ExecutionService? get executionService => _executionService;
 
   ValueListenable<Channel> get channel => _channel;
 

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -25,9 +25,9 @@ abstract class ExecutionService {
     String? engineVersion,
   });
   Stream<String> get onStdout;
-  html.IFrameElement get frame;
   Future<void> reset();
   Future<void> tearDown();
+  set ignorePointer(bool ignorePointer);
 }
 
 abstract class EditorService {

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+// ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html;
 
 import 'package:collection/collection.dart';

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -3,8 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
 
 import 'package:collection/collection.dart';
 import 'package:dartpad_shared/services.dart';


### PR DESCRIPTION
Right now the iframe is capturing all of the pointer events, so this sets `pointer-events` to `none` while the splitter is being dragged. When it's not being dragged, we need to set it back to `auto` so that the Flutter app can receive its pointer events.