### PR TITLE
Run build-project-templates in Dockerfile

### DIFF
--- a/pkgs/dart_services/Dockerfile
+++ b/pkgs/dart_services/Dockerfile
@@ -8,5 +8,7 @@ COPY . /app
 RUN dart pub get
 RUN dart compile exe bin/server.dart -o bin/server
 
+RUN dart pub run grinder build-project-templates
+
 EXPOSE 8080
 CMD ["/app/bin/server"]


### PR DESCRIPTION
This was previously run automatically in the Dockerfile as a dependency of `build-storage-artifacts`. 

I verified that this fixes Flutter web compilation here: https://dartpad-experiments.web.app/?channel=experiments