### PR TITLE
Fix CORS issue due to new Flutter API docs location

### DIFF
--- a/pkgs/dart_pad/lib/sharing/gists.dart
+++ b/pkgs/dart_pad/lib/sharing/gists.dart
@@ -108,8 +108,7 @@ class GistLoader {
   static const String _metadataFilename = 'dartpad_metadata.yaml';
 
   static const String _stableApiDocsUrl = 'https://api.flutter.dev/snippets';
-  static const String _mainApiDocsUrl =
-      'https://main-api.flutter.dev/snippets';
+  static const String _mainApiDocsUrl = 'https://main-api.flutter.dev/snippets';
 
   static const String gistAlreadyForked = 'GIST_ALREADY_FORK';
   static const String gistNotFound = 'GIST_NOT_FOUND';

--- a/pkgs/dart_pad/lib/sharing/gists.dart
+++ b/pkgs/dart_pad/lib/sharing/gists.dart
@@ -108,8 +108,8 @@ class GistLoader {
   static const String _metadataFilename = 'dartpad_metadata.yaml';
 
   static const String _stableApiDocsUrl = 'https://api.flutter.dev/snippets';
-  static const String _masterApiDocsUrl =
-      'https://master-api.flutter.dev/snippets';
+  static const String _mainApiDocsUrl =
+      'https://main-api.flutter.dev/snippets';
 
   static const String gistAlreadyForked = 'GIST_ALREADY_FORK';
   static const String gistNotFound = 'GIST_NOT_FOUND';
@@ -594,7 +594,7 @@ $styleRef$dartRef  </head>
     }
 
     final sampleUrl = (channel == FlutterSdkChannel.master)
-        ? '$_masterApiDocsUrl/$sampleId.dart'
+        ? '$_mainApiDocsUrl/$sampleId.dart'
         : '$_stableApiDocsUrl/$sampleId.dart';
 
     final response = await _client.get(Uri.parse(sampleUrl));

--- a/pkgs/dart_pad/test/sharing/gist_loader_test.dart
+++ b/pkgs/dart_pad/test/sharing/gist_loader_test.dart
@@ -18,7 +18,7 @@ void defineTests() {
           return Future.value(http.Response(validGist, 200));
         case 'https://api.flutter.dev/snippets/material.AppBar.1.dart':
           return Future.value(http.Response(stableAPIDocSample, 200));
-        case 'https://master-api.flutter.dev/snippets/material.AppBar.1.dart':
+        case 'https://main-api.flutter.dev/snippets/material.AppBar.1.dart':
           return Future.value(http.Response(masterAPIDocSample, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.yaml':
           return Future.value(http.Response(basicDartMetadata, 200));

--- a/pkgs/dart_pad/test/sharing/gist_loader_test.dart
+++ b/pkgs/dart_pad/test/sharing/gist_loader_test.dart
@@ -19,7 +19,7 @@ void defineTests() {
         case 'https://api.flutter.dev/snippets/material.AppBar.1.dart':
           return Future.value(http.Response(stableAPIDocSample, 200));
         case 'https://main-api.flutter.dev/snippets/material.AppBar.1.dart':
-          return Future.value(http.Response(masterAPIDocSample, 200));
+          return Future.value(http.Response(mainAPIDocSample, 200));
         case 'https://api.github.com/repos/owner/repo/contents/basic/dartpad_metadata.yaml':
           return Future.value(http.Response(basicDartMetadata, 200));
         case 'https://api.github.com/repos/owner/repo/contents/alt_branch/dartpad_metadata.yaml?ref=some_branch':
@@ -104,7 +104,7 @@ void defineTests() {
         final gist = await loader.loadGistFromAPIDocs(
             'material.AppBar.1', FlutterSdkChannel.master);
         final contents = gist.files.firstWhere((f) => f.name == 'main.dart');
-        expect(contents.content, masterAPIDocSample);
+        expect(contents.content, mainAPIDocSample);
       });
       test('Throws correct exception for nonexistent sample', () async {
         final loader = GistLoader(client: mockClient);
@@ -273,7 +273,7 @@ final validGist = '''
 
 final stableAPIDocSample =
     'This is some sample code from the stable API Doc server.';
-final masterAPIDocSample =
+final mainAPIDocSample =
     'This is some sample code from the master API Doc server.';
 
 /// Create a GitHub API-like contents response for the provided content.


### PR DESCRIPTION
`master-api.flutter.dev` was [adjusted](https://github.com/flutter/flutter/issues/133877) to redirect to `main-api.flutter.dev` today. Without the CORS configuration to allow retrieving the snippets, loading the embedded DartPads resulted in errors on the new `main` docs. 

You can find an example at https://main-api.flutter.dev/flutter/widgets/PopScope-class.html.