### PR TITLE
Update SDK constraints for Dart 3.2.0 release

### DIFF
--- a/pkgs/dart_pad/lib/elements/dialog.dart
+++ b/pkgs/dart_pad/lib/elements/dialog.dart
@@ -18,10 +18,10 @@ enum DialogResult {
 
 class Dialog {
   final MDCDialog _mdcDialog;
-  final Element? _leftButton;
-  final Element? _rightButton;
-  final Element? _title;
-  final Element? _content;
+  final Element _leftButton;
+  final Element _rightButton;
+  final Element _title;
+  final Element _content;
 
   Dialog()
       : assert(querySelector('.mdc-dialog') != null),
@@ -30,10 +30,10 @@ class Dialog {
         assert(querySelector('#my-dialog-title') != null),
         assert(querySelector('#my-dialog-content') != null),
         _mdcDialog = MDCDialog(querySelector('.mdc-dialog')!),
-        _leftButton = querySelector('#dialog-left-button'),
-        _rightButton = querySelector('#dialog-right-button'),
-        _title = querySelector('#my-dialog-title'),
-        _content = querySelector('#my-dialog-content');
+        _leftButton = querySelector('#dialog-left-button')!,
+        _rightButton = querySelector('#dialog-right-button')!,
+        _title = querySelector('#my-dialog-title')!,
+        _content = querySelector('#my-dialog-content')!;
 
   Future<DialogResult> showYesNo(String title, String htmlMessage,
       {String yesText = 'Yes', String noText = 'No'}) {
@@ -78,24 +78,24 @@ class Dialog {
       DialogResult leftButtonResult,
       DialogResult rightButtonResult,
       [bool showLeftButton = true]) {
-    _title!.text = title;
-    _content!.setInnerHtml(htmlMessage, validator: PermissiveNodeValidator());
-    _rightButton!.text = rightButtonText;
+    _title.text = title;
+    _content.setInnerHtml(htmlMessage, validator: PermissiveNodeValidator());
+    _rightButton.text = rightButtonText;
 
     final completer = Completer<DialogResult>();
     StreamSubscription<MouseEvent>? leftSub;
 
     if (showLeftButton) {
-      _leftButton!.text = leftButtonText;
-      _leftButton!.removeAttribute('hidden');
-      leftSub = _leftButton!.onClick.listen((_) {
+      _leftButton.text = leftButtonText;
+      _leftButton.removeAttribute('hidden');
+      leftSub = _leftButton.onClick.listen((_) {
         completer.complete(leftButtonResult);
       });
     } else {
-      _leftButton!.setAttribute('hidden', 'true');
+      _leftButton.setAttribute('hidden', 'true');
     }
 
-    final rightSub = _rightButton!.onClick.listen((_) {
+    final rightSub = _rightButton.onClick.listen((_) {
       completer.complete(rightButtonResult);
     });
 

--- a/pkgs/dart_pad/pubspec.lock
+++ b/pkgs/dart_pad/pubspec.lock
@@ -840,4 +840,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <3.4.0"
+  dart: ">=3.2.0 <3.4.0"

--- a/pkgs/dart_pad/pubspec.yaml
+++ b/pkgs/dart_pad/pubspec.yaml
@@ -3,7 +3,7 @@ description: The front end of DartPad.
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   checked_yaml: ^2.0.3

--- a/pkgs/dart_pad/third_party/pkg/split/pubspec.yaml
+++ b/pkgs/dart_pad/third_party/pkg/split/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/s
 version: 0.0.7
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   js: ^0.6.7

--- a/pkgs/dart_services/pubspec.lock
+++ b/pkgs/dart_services/pubspec.lock
@@ -682,4 +682,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"

--- a/pkgs/dart_services/pubspec.yaml
+++ b/pkgs/dart_services/pubspec.yaml
@@ -2,7 +2,7 @@ name: dart_services
 publish_to: none
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   analysis_server_lib: ^0.2.4

--- a/pkgs/dartpad_shared/pubspec.yaml
+++ b/pkgs/dartpad_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Shared code between the DartPad frontend and backend.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   http: ^1.1.0

--- a/pkgs/samples/pubspec.yaml
+++ b/pkgs/samples/pubspec.yaml
@@ -3,7 +3,7 @@ description: Sample code snippets for DartPad.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/pkgs/sketch_pad/pubspec.yaml
+++ b/pkgs/sketch_pad/pubspec.yaml
@@ -3,7 +3,7 @@ description: An experimental redux of the DartPad UI.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.1.0
+  sdk: ^3.2.0
 
 dependencies:
   codemirror: any


### PR DESCRIPTION
In `dialog.dart`, instead of fixing the new warning from private field promotion, I made the elements non-null earlier since we used them like that anyway.