### PR TITLE
enable language experiments on the beta channel

### DIFF
--- a/pkgs/dart_services/lib/src/experiments.dart
+++ b/pkgs/dart_services/lib/src/experiments.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/pkgs/dart_services/lib/src/experiments.dart
+++ b/pkgs/dart_services/lib/src/experiments.dart
@@ -1,0 +1,8 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The experiments to use on the main and beta channels.
+const List<String> enabledExperiments = [
+  'inline-class',
+];

--- a/pkgs/dart_services/lib/src/sdk.dart
+++ b/pkgs/dart_services/lib/src/sdk.dart
@@ -7,6 +7,8 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
+import 'experiments.dart';
+
 class Sdk {
   /// The path to the Dart SDK (vended into the Flutter SDK).
   late final String dartSdkPath;
@@ -38,11 +40,9 @@ class Sdk {
   /// If this is the main channel.
   bool get mainChannel => channel == 'main';
 
-  /// Experiments that this SDK is configured with
-  List<String> get experiments {
-    if (mainChannel) return const ['inline-class'];
-    return const [];
-  }
+  /// The experiments to use for the current channel.
+  List<String> get experiments =>
+      (mainChannel || betaChannel) ? enabledExperiments : const [];
 
   void _initPaths() {
     // Note below, 'Platform.resolvedExecutable' will not lead to a real SDK if

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -206,7 +206,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
           });
 
     final channel = widget.initialChannel != null
-        ? Channel.channelForName(widget.initialChannel!)
+        ? Channel.forName(widget.initialChannel!)
         : null;
 
     appModel = AppModel();

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -348,6 +348,7 @@ class AppServices {
 enum Channel {
   stable('Stable', 'https://stable.api.dartpad.dev/'),
   beta('Beta', 'https://beta.api.dartpad.dev/'),
+  main('Main', 'https://master.api.dartpad.dev/'),
   // This channel is only used for local development.
   localhost('Localhost', 'http://localhost:8080/');
 
@@ -362,7 +363,7 @@ enum Channel {
     return values.whereNot((channel) => channel == localhost).toList();
   }
 
-  static Channel? channelForName(String name) {
+  static Channel? forName(String name) {
     name = name.trim().toLowerCase();
 
     return Channel.values.firstWhereOrNull((c) => c.name == name);


### PR DESCRIPTION
- enable language experiments on the `beta` channel
- move the list of enabled experiments into their own file in order to make them slightly easier to find
- expose the 'main' channel in the flutter web frontend (previously we'd only exposed beta and stable)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
