### PR TITLE
allow analysis of snippets irregardless of imports

### DIFF
--- a/pkgs/dart_services/lib/src/pub.dart
+++ b/pkgs/dart_services/lib/src/pub.dart
@@ -67,13 +67,10 @@ Map<String, String> packageVersionsFromPubspecLock(String templatePath) {
   return packageVersions;
 }
 
-/// Returns the names of packages that are referenced in this collection.
-/// These package names are sanitized defensively.
-List<String> filterSafePackages(List<ImportDirective> imports) {
-  return imports
-      .where((import) => !import.uri.stringValue!.startsWith('package:../'))
-      .map((import) => Uri.parse(import.uri.stringValue!))
-      .where((uri) => uri.scheme == 'package' && uri.pathSegments.isNotEmpty)
-      .map((uri) => uri.pathSegments.first)
-      .toList();
+extension ImportDirectiveExtension on ImportDirective {
+  bool get dartImport => Uri.parse(uri.stringValue!).scheme == 'dart';
+
+  bool get packageImport => Uri.parse(uri.stringValue!).scheme == 'package';
+
+  String get packageName => Uri.parse(uri.stringValue!).pathSegments.first;
 }

--- a/pkgs/dart_services/lib/src/utils.dart
+++ b/pkgs/dart_services/lib/src/utils.dart
@@ -134,3 +134,37 @@ class ClosureTask<T> extends SchedulerTask<T> {
 /// This pattern is essentially "possibly some letters and colons, followed by a
 /// slash, followed by non-whitespace."
 final _possiblePathPattern = RegExp(r'[a-zA-Z:]*\/\S*');
+
+class Lines {
+  final _starts = <int>[];
+
+  Lines(String source) {
+    final units = source.codeUnits;
+    var nextIsEol = true;
+    for (var i = 0; i < units.length; i++) {
+      if (nextIsEol) {
+        nextIsEol = false;
+        _starts.add(i);
+      }
+      if (units[i] == 10) nextIsEol = true;
+    }
+  }
+
+  /// Return the 1-based line number.
+  int lineForOffset(int offset) {
+    if (_starts.isEmpty) return 1;
+    for (var i = 1; i < _starts.length; i++) {
+      if (offset < _starts[i]) return i;
+    }
+    return _starts.length;
+  }
+
+  /// Return the 1-based column number.
+  int columnForOffset(int offset) {
+    if (_starts.isEmpty) return 1;
+    for (var i = _starts.length - 1; i >= 0; i--) {
+      if (offset >= _starts[i]) return offset - _starts[i] + 1;
+    }
+    return 1;
+  }
+}

--- a/pkgs/dart_services/test/pub_test.dart
+++ b/pkgs/dart_services/test/pub_test.dart
@@ -70,58 +70,5 @@ void main() { }
             ]));
       });
     });
-
-    group('filterSafePackagesFromImports', () {
-      test('empty', () {
-        const source = '''import 'package:';
-void main() { }
-''';
-        expect(filterSafePackages(getAllImportsFor(source)), isEmpty);
-      });
-
-      test('simple', () {
-        const source = '''
-import 'package:foo/foo.dart';
-import 'package:bar/bar.dart';
-void main() { }
-''';
-        expect(filterSafePackages(getAllImportsFor(source)),
-            unorderedEquals(['foo', 'bar']));
-      });
-
-      test('defensive', () {
-        const source = '''
-library woot;
-import 'dart:math';
-import 'package:../foo/foo.dart';
-void main() { }
-''';
-        final imports = getAllImportsFor(source);
-        expect(imports, hasLength(2));
-        expect(imports[0].uri.stringValue, equals('dart:math'));
-        expect(imports[1].uri.stringValue, equals('package:../foo/foo.dart'));
-        expect(filterSafePackages(imports), isEmpty);
-      });
-
-      test('negative dart import', () {
-        const source = '''
-import 'dart:../bar.dart';
-''';
-        final imports = getAllImportsFor(source);
-        expect(imports, hasLength(1));
-        expect(imports.single.uri.stringValue, equals('dart:../bar.dart'));
-        expect(filterSafePackages(imports), isEmpty);
-      });
-
-      test('negative path import', () {
-        const source = '''
-import '../foo.dart';
-''';
-        final imports = getAllImportsFor(source);
-        expect(imports, hasLength(1));
-        expect(imports.single.uri.stringValue, equals('../foo.dart'));
-        expect(filterSafePackages(imports), isEmpty);
-      });
-    });
   });
 }

--- a/pkgs/dart_services/test/server_test.dart
+++ b/pkgs/dart_services/test/server_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 void main() => defineTests();
 
 void defineTests() {
-  group('server v3', () {
+  group('server', () {
     late final Sdk sdk;
     late final EndpointsServer server;
     late final Client httpClient;
@@ -96,6 +96,22 @@ void main() {
           contains(
               "A value of type 'String' can't be assigned to a variable of type 'int'"));
       expect(issue.location.line, 2);
+    });
+
+    test('analyze unsupported import', () async {
+      final result = await client.analyze(SourceRequest(source: r'''
+import 'package:foo_bar/foo_bar.dart';
+
+void main() => print('hello world');
+'''));
+
+      expect(result.issues, isNotEmpty);
+
+      final issue = result.issues.first;
+      expect(issue.kind, 'warning');
+      expect(
+          issue.message, contains("Unsupported package: 'package:foo_bar'."));
+      expect(issue.location.line, 1);
     });
 
     test('complete', () async {

--- a/pkgs/dart_services/test/utils_test.dart
+++ b/pkgs/dart_services/test/utils_test.dart
@@ -62,4 +62,42 @@ void defineTests() {
       );
     });
   });
+
+  group('Lines', () {
+    test('empty string', () {
+      final lines = Lines('');
+      expect(lines.lineForOffset(0), 1);
+      expect(lines.lineForOffset(1), 1);
+      expect(lines.columnForOffset(0), 1);
+      expect(lines.columnForOffset(1), 1);
+    });
+
+    test('lineForOffset', () {
+      final lines = Lines('one\ntwo\nthree');
+      expect(lines.lineForOffset(0), 1);
+      expect(lines.lineForOffset(1), 1);
+      expect(lines.lineForOffset(2), 1);
+      expect(lines.lineForOffset(3), 1);
+      expect(lines.lineForOffset(4), 2);
+      expect(lines.lineForOffset(5), 2);
+      expect(lines.lineForOffset(6), 2);
+      expect(lines.lineForOffset(7), 2);
+      expect(lines.lineForOffset(8), 3);
+      expect(lines.lineForOffset(9), 3);
+      expect(lines.lineForOffset(10), 3);
+      expect(lines.lineForOffset(11), 3);
+      expect(lines.lineForOffset(12), 3);
+      expect(lines.lineForOffset(13), 3);
+
+      expect(lines.lineForOffset(14), 3);
+    });
+
+    test('columnForOffset', () {
+      final lines = Lines('one\ntwo\nthree');
+      expect(lines.columnForOffset(0), 1);
+      expect(lines.columnForOffset(1), 2);
+      expect(lines.columnForOffset(2), 3);
+      expect(lines.columnForOffset(3), 4);
+    });
+  });
 }


### PR DESCRIPTION
- allow analysis of snippets irregardless of imports
- related to https://github.com/dart-lang/dart-pad/issues/2732

When analyzing a snippet, return the analysis results regardless of the imports used. Return additional warnings if packages are imported that aren't on the allow list.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
