### PR TITLE
ensure that error level css has priority

### DIFF
--- a/pkgs/dart_pad/lib/scss/shared.scss
+++ b/pkgs/dart_pad/lib/scss/shared.scss
@@ -111,18 +111,18 @@ a {
 }
 
 // Code annotations
-.squiggle-error {
-  border-bottom: 2px solid $dark-squiggle-error-color;
+
+.squiggle-info {
+  border-bottom: 2px solid $dark-squiggle-info-color;
 }
 
 .squiggle-warning {
   border-bottom: 2px solid $dark-squiggle-warning-color;
 }
 
-.squiggle-info {
-  border-bottom: 2px solid $dark-squiggle-info-color;
+.squiggle-error {
+  border-bottom: 2px solid $dark-squiggle-error-color;
 }
-
 
 .clickable {
   cursor: pointer;

--- a/pkgs/dart_pad/web/styles/embed/styles.scss
+++ b/pkgs/dart_pad/web/styles/embed/styles.scss
@@ -132,16 +132,16 @@ body {
 
 // Code annotations
 
-.squiggle-error {
-  border-bottom: 2px solid $dark-squiggle-error-color;
+.squiggle-info {
+  border-bottom: 2px solid $dark-squiggle-info-color;
 }
 
 .squiggle-warning {
   border-bottom: 2px solid $dark-squiggle-warning-color;
 }
 
-.squiggle-info {
-  border-bottom: 2px solid $dark-squiggle-info-color;
+.squiggle-error {
+  border-bottom: 2px solid $dark-squiggle-error-color;
 }
 
 // Styling specifically for CodeMirror editor

--- a/pkgs/dart_pad/web/styles/embed/styles_light.scss
+++ b/pkgs/dart_pad/web/styles/embed/styles_light.scss
@@ -129,16 +129,17 @@ a {
 }
 
 // Code annotations
-.squiggle-error {
-  border-bottom: 2px solid $dark-squiggle-error-color;
+
+.squiggle-info {
+  border-bottom: 2px solid $dark-squiggle-info-color;
 }
 
 .squiggle-warning {
   border-bottom: 2px solid $dark-squiggle-warning-color;
 }
 
-.squiggle-info {
-  border-bottom: 2px solid $dark-squiggle-info-color;
+.squiggle-error {
+  border-bottom: 2px solid $dark-squiggle-error-color;
 }
 
 // Labels and scrollbars


### PR DESCRIPTION
- ensure that the css for error level issues take priority over warning level issues (and, warnings take priority over info level issues)
- fix https://github.com/dart-lang/dart-pad/issues/2581 (and https://github.com/dart-lang/dart-pad/issues/2741)

(note that the flutter web frontend doesn't have this issue)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
