### PR TITLE
ensure the run button displays on the RHS in rtl locales

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -322,6 +322,10 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
                                 padding: const EdgeInsets.all(denseSpacing),
                                 child: Row(
                                   mainAxisAlignment: MainAxisAlignment.end,
+                                  // We use explicit directionality here in
+                                  // order to have the format and run buttons on
+                                  // the right hand side of the editing area.
+                                  textDirection: TextDirection.ltr,
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
                                     // Format action


### PR DESCRIPTION
- ensure the run button displays on the RHS in rtl locales

This should fix the issue with the run and format buttons seen in https://github.com/dart-lang/dart-pad/pull/2748.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
