### PR TITLE
Remove Nanochat from samples menu

### DIFF
--- a/pkgs/dart_pad/lib/playground.dart
+++ b/pkgs/dart_pad/lib/playground.dart
@@ -241,8 +241,6 @@ class Playground extends EditorUi implements GistContainer, GistController {
           Layout.flutter),
       Sample('85e77d36533b16647bf9b6eb8c03296d', 'Implicit animations',
           Layout.flutter),
-      Sample('d57c6c898dabb8c6fb41018588b8cf73', 'Firebase Nanochat',
-          Layout.flutter),
       Sample(
           '493c8b3ef8931cbac3fbbe5c04b9c4cf', 'Google Fonts', Layout.flutter),
       Sample('a133148221a8cbacbcef8bc77a6c82ec', 'Provider', Layout.flutter),


### PR DESCRIPTION
This is the primary indicator of Firebase support. Let's drop the sample for now to reduce expectations of any future support.