### PR TITLE
[Investigation] Update SketchPad codemirror code to use extension types

### DIFF
--- a/pkgs/sketch_pad/lib/editor/codemirror.dart
+++ b/pkgs/sketch_pad/lib/editor/codemirror.dart
@@ -2,34 +2,29 @@ import 'dart:js_interop';
 import 'package:web/web.dart';
 
 @JS()
-@staticInterop
 @anonymous
-class CodeMirrorOptions {
-  external factory CodeMirrorOptions();
-}
-
-extension CodeMirrorOptionsExtension on CodeMirrorOptions {
+extension type CodeMirrorOptions._(JSObject _) {
   external String theme;
   external String mode;
   external bool autoCloseTags;
   external bool lineNumbers;
   external bool lineWrapping;
   external JSObject extraKeys;
+
+  external factory CodeMirrorOptions();
 }
 
 @JS()
-@staticInterop
-class CodeMirror {
-  external factory CodeMirror(Element element, JSAny? codeMirrorOptions);
+extension type CodeMirror._(JSObject _) {
+  external factory CodeMirror(HTMLElement element, JSAny? codeMirrorOptions);
   external factory CodeMirror.fromTextArea(HTMLTextAreaElement textArea);
+
   external static String get version;
   external static Commands commands;
   external static Hint hint;
   external static void registerHelper(
       String type, String mode, JSFunction helper);
-}
 
-extension CodeMirrorExtension on CodeMirror {
   external void refresh();
   external void focus();
   external void setOption(String option, JSAny value);
@@ -40,7 +35,6 @@ extension CodeMirrorExtension on CodeMirror {
   external JSAny execCommand(String command, [JSAny? object]);
   external Events events;
   external void on(String event, JSFunction callback);
-  external Commands commands;
   external Position getCursor();
   external JSAny? getHelper(Position pos, String name);
   external void showHint(HintOptions? options);
@@ -59,10 +53,7 @@ extension CodeMirrorExtension on CodeMirror {
 }
 
 @JS()
-@staticInterop
-class Commands {}
-
-extension CommandsExtension on Commands {
+extension type Commands._(JSObject _) {
   external set goLineLeft(JSFunction callback);
   external set indentIfMultiLineSelectionElseInsertSoftTab(JSFunction callback);
   external set weHandleElsewhere(JSFunction callback);
@@ -70,18 +61,12 @@ extension CommandsExtension on Commands {
 }
 
 @JS()
-@staticInterop
-class Events {}
-
-extension EventsExtension on Events {
+extension type Events._(JSObject _) {
   external set change(JSFunction callback);
 }
 
 @JS()
-@staticInterop
-class Doc {}
-
-extension DocExtension on Doc {
+extension type Doc._(JSObject _) {
   external void setValue(String value);
   external String getValue();
   external String? getLine(int n);
@@ -98,70 +83,44 @@ extension DocExtension on Doc {
 }
 
 @JS()
-@staticInterop
 @anonymous
-class Position {
+extension type Position._(JSObject _) {
+  external int line;
+  external int ch;
+
   external factory Position({int line, int ch});
 }
 
-extension PositionExtension on Position {
-  external int line;
-  external int ch;
-}
-
 @JS()
-@staticInterop
-@anonymous
-class TextMarker {}
-
-extension TextMarkerExtension on TextMarker {
+extension type TextMarker._(JSObject _) {
   external void clear();
 }
 
 @JS()
-@staticInterop
 @anonymous
-class MarkTextOptions {
+extension type MarkTextOptions._(JSObject _) {
+  external String className;
+  external String title;
+
   external factory MarkTextOptions({
     String className,
     String title,
   });
 }
 
-extension MarkTextOptionsExtension on MarkTextOptions {
-  external String className;
-  external String title;
-}
-
 @JS()
-@staticInterop
 @anonymous
-class HintResults {
-  external factory HintResults({JSArray list, Position from, Position to});
-}
-
-extension HintResultsExtension on HintResults {
+extension type HintResults._(JSObject _) {
   external JSArray/*<HintResult>*/ list;
   external Position from;
   external Position to;
+
+  external factory HintResults({JSArray list, Position from, Position to});
 }
 
 @JS()
-@staticInterop
 @anonymous
-class HintResult {
-  external factory HintResult({
-    String? text,
-    String? displayText,
-    String? className,
-    Position? from,
-    Position? to,
-    JSFunction? hintRenderer,
-    JSFunction? hint,
-  });
-}
-
-extension HintResultExtension on HintResult {
+extension type HintResult._(JSObject _) {
   external String? text;
 
   external String? displayText;
@@ -173,24 +132,28 @@ extension HintResultExtension on HintResult {
   external Position? to;
   external JSFunction? hintRenderer;
   external JSFunction? hint;
+
+  external factory HintResult({
+    String? text,
+    String? displayText,
+    String? className,
+    Position? from,
+    Position? to,
+    JSFunction? hintRenderer,
+    JSFunction? hint,
+  });
 }
 
 @JS()
-@staticInterop
 @anonymous
-class HintOptions {
+extension type HintOptions._(JSObject _) {
+  external JSAny hint;
+  external HintResults results;
+
   external factory HintOptions({JSAny hint, HintResults results});
 }
 
-extension HintOptionsExtension on HintOptions {
-  external JSAny hint;
-  external HintResults results;
-}
-
 @JS()
-@staticInterop
-class Hint {}
-
-extension HintExtension on Hint {
+extension type Hint._(JSObject _) {
   external JSAny dart;
 }

--- a/pkgs/sketch_pad/pubspec.yaml
+++ b/pkgs/sketch_pad/pubspec.yaml
@@ -3,7 +3,7 @@ description: An experimental redux of the DartPad UI.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.2.0
+  sdk: ^3.3.0-0
 
 dependencies:
   collection: any


### PR DESCRIPTION
This feels painful due to the necessary primary constructors when we rarely will ever need to construct them like that. Trying to see if I'm just holding them wrong or if there's ergonomic improvements to be had.

Also there's a few analysis server issues I have to dig in to and fix or report.
