### PR TITLE
Add workaround for compiler type checks on iframe window

### DIFF
--- a/pkgs/sketch_pad/lib/execution/frame.dart
+++ b/pkgs/sketch_pad/lib/execution/frame.dart
@@ -10,6 +10,7 @@ import 'package:web/helpers.dart';
 import 'package:web/web.dart' as web;
 
 import '../model.dart';
+import 'frame_utils.dart';
 
 class ExecutionServiceImpl implements ExecutionService {
   final StreamController<String> _stdoutController =
@@ -136,7 +137,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
       ...params,
     }.jsify();
     // TODO: Use dartpad.dev instead of '*'?
-    _frame.contentWindow!.postMessage(message, '*'.toJS);
+    _frame.safelyPostMessage(message, '*');
     return Future.value();
   }
 

--- a/pkgs/sketch_pad/lib/execution/frame_utils.dart
+++ b/pkgs/sketch_pad/lib/execution/frame_utils.dart
@@ -9,6 +9,10 @@ import 'package:web/web.dart';
 
 /// Extensions to work around Dart compiler issues that result
 /// in calls that sandboxed iframes error on.
+///
+/// If the compilers are adjusted to handle this case or
+/// `package:web` provides a helper for this, switch to that.
+/// Tracked in https://github.com/dart-lang/sdk/issues/54443.
 extension HTMLIFrameElementExtension on HTMLIFrameElement {
   /// Send the specified [message] to this iframe,
   /// configured with the specified [optionsOrTargetOrigin].

--- a/pkgs/sketch_pad/lib/execution/frame_utils.dart
+++ b/pkgs/sketch_pad/lib/execution/frame_utils.dart
@@ -1,13 +1,23 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
 import 'package:web/web.dart';
 
+/// Extensions to work around Dart compiler issues that result
+/// in calls that sandboxed iframes error on.
 extension HTMLIFrameElementExtension on HTMLIFrameElement {
+  /// Send the specified [message] to this iframe,
+  /// configured with the specified [optionsOrTargetOrigin].
   void safelyPostMessage(
     JSAny? message,
     String optionsOrTargetOrigin,
   ) {
+    // Uses unsafe calls to prevent the Dart web compilers from
+    // inserting type or null checks that access restricted properties.
     (this as JSObject)
         .getProperty<JSObject>('contentWindow'.toJS)
         .callMethod('postMessage'.toJS, message, optionsOrTargetOrigin.toJS);

--- a/pkgs/sketch_pad/lib/execution/frame_utils.dart
+++ b/pkgs/sketch_pad/lib/execution/frame_utils.dart
@@ -1,0 +1,15 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:web/web.dart';
+
+extension HTMLIFrameElementExtension on HTMLIFrameElement {
+  void safelyPostMessage(
+    JSAny? message,
+    String optionsOrTargetOrigin,
+  ) {
+    (this as JSObject)
+        .getProperty<JSObject>('contentWindow'.toJS)
+        .callMethod('postMessage'.toJS, message, optionsOrTargetOrigin.toJS);
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart-pad/issues/2765
Fixes https://github.com/dart-lang/dart-pad/issues/2766

Staged: https://parlough-testing-skwasm.web.app/
_Ignore the subdomain, it's built with `flutter build web` (`dart2js`)_