### PR TITLE
Add a variety of security headers to SketchPad

### DIFF
--- a/pkgs/sketch_pad/firebase.json
+++ b/pkgs/sketch_pad/firebase.json
@@ -53,7 +53,6 @@
       {
         "source": "**",
         "headers": [
-          { "key": "Content-Security-Policy", "value":  "default-src https:"},
           { "key": "Cross-Origin-Opener-Policy", "value":  "same-origin"},
           { "key": "Cross-Origin-Embedder-Policy", "value":  "credentialless"},
           { "key": "X-Content-Type-Options", "value":  "nosniff"},

--- a/pkgs/sketch_pad/firebase.json
+++ b/pkgs/sketch_pad/firebase.json
@@ -49,6 +49,16 @@
             "value": "*"
           }
         ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          { "key": "Content-Security-Policy", "value":  "default-src https:"},
+          { "key": "Cross-Origin-Opener-Policy", "value":  "same-origin"},
+          { "key": "Cross-Origin-Embedder-Policy", "value":  "credentialless"},
+          { "key": "X-Content-Type-Options", "value":  "nosniff"},
+          { "key": "Referrer-Policy", "value":  "strict-origin-when-cross-origin"}
+        ]
       }
     ]
   }


### PR DESCRIPTION
Add these to enable `SharedArrayBuffer` access by skwasm.

Contributes to https://github.com/dart-lang/dart-pad/issues/2770