### PR TITLE
Add shelf_gzip middleware compression to dart_services

### DIFF
--- a/pkgs/dart_services/Dockerfile
+++ b/pkgs/dart_services/Dockerfile
@@ -8,7 +8,7 @@ COPY . /app
 RUN dart pub get
 RUN dart compile exe bin/server.dart -o bin/server
 
-RUN dart pub run grinder build-project-templates
+RUN dart run grinder build-project-templates
 
 EXPOSE 8080
 CMD ["/app/bin/server"]

--- a/pkgs/dart_services/README.md
+++ b/pkgs/dart_services/README.md
@@ -35,7 +35,7 @@ To run tests:
 
 `dart test`
 
-### Re-renerating source
+### Re-generating source
 
 To rebuild the shelf router, run:
 

--- a/pkgs/dart_services/lib/server.dart
+++ b/pkgs/dart_services/lib/server.dart
@@ -9,6 +9,7 @@ import 'package:args/args.dart';
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf;
+import 'package:shelf_gzip/shelf_gzip.dart';
 
 import 'src/caching.dart';
 import 'src/common_server.dart';
@@ -103,7 +104,6 @@ class EndpointsServer {
 
   late final HttpServer server;
 
-  late final Pipeline pipeline;
   late final Handler handler;
 
   late final CommonServerApi commonServer;
@@ -127,10 +127,11 @@ class EndpointsServer {
     GitHubOAuthHandler.setCache(cache);
     GitHubOAuthHandler.addRoutes(commonServer.router);
 
-    pipeline = const Pipeline()
+    final pipeline = const Pipeline()
         .addMiddleware(logRequestsToLogger(_logger))
         .addMiddleware(createCustomCorsHeadersMiddleware())
-        .addMiddleware(exceptionResponse());
+        .addMiddleware(exceptionResponse())
+        .addMiddleware(gzipMiddleware);
 
     handler = pipeline.addHandler(commonServer.router.call);
   }

--- a/pkgs/dart_services/pubspec.lock
+++ b/pkgs/dart_services/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: cli_util
-      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   clock:
     dependency: transitive
     description:
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: code_builder
-      sha256: b2151ce26a06171005b379ecff6e08d34c470180ffe16b8e14b6d52be292b55f
+      sha256: feee43a5c05e7b3199bb375a86430b8ada1b04104f2923d0e03cc01ca87b6d84
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   collection:
     dependency: "direct dev"
     description:
@@ -573,10 +573,10 @@ packages:
     dependency: "direct dev"
     description:
       name: synchronized
-      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:
@@ -661,10 +661,10 @@ packages:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "045ec2137c27bf1a32e6ffa0e734d532a6677bf9016a0d1a406c54e499ff945b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/pkgs/dart_services/pubspec.lock
+++ b/pkgs/dart_services/pubspec.lock
@@ -449,6 +449,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  shelf_gzip:
+    dependency: "direct main"
+    description:
+      name: shelf_gzip
+      sha256: "4f4b793c0f969f348aece1ab4cc05fceba9fea431c1ce76b1bc0fa369cecfc15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   shelf_packages_handler:
     dependency: transitive
     description:

--- a/pkgs/dart_services/pubspec.yaml
+++ b/pkgs/dart_services/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   path: ^1.8.3
   resp_client: ^1.2.0
   shelf: ^1.4.1
+  shelf_gzip: ^4.1.0
   shelf_router: ^1.1.4
   yaml: ^3.1.2
 


### PR DESCRIPTION
The compression results on DDC compilation output with just the default gzip 4 level is quite good, often around 15-20% (of the original size).