### PR TITLE
adjust how we select the 500 completion results to return

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -123,18 +123,14 @@ class AnalysisServerWrapper {
   Future<api.CompleteResponse> complete(String source, int offset) async {
     const maxResults = 500;
 
-    // Request 2x the max number of completion results. The analysis server
-    // doesn't return sorted results, which is super concerning when also asking
-    // it to only return the first n number of results (how are these n items
-    // selected?).
     final results = await _completeImpl(
       {kMainDart: source},
       kMainDart,
       offset,
-      maxResults: maxResults * 2,
+      maxResults: maxResults,
     );
 
-    var suggestions =
+    final suggestions =
         results.suggestions.where((CompletionSuggestion suggestion) {
       // Filter suggestions that would require adding an import.
       return suggestion.isNotImported != true;
@@ -156,17 +152,7 @@ class AnalysisServerWrapper {
       }
 
       return false;
-    }).toList();
-
-    suggestions.sort((CompletionSuggestion x, CompletionSuggestion y) {
-      if (x.relevance == y.relevance) {
-        return x.completion.compareTo(y.completion);
-      } else {
-        return y.relevance.compareTo(x.relevance);
-      }
     });
-
-    suggestions = suggestions.take(maxResults).toList();
 
     return api.CompleteResponse(
       replacementOffset: results.replacementOffset,

--- a/pkgs/dart_services/test/src/sample_code.dart
+++ b/pkgs/dart_services/test/src/sample_code.dart
@@ -4,7 +4,7 @@
 
 const sampleCode = '''
 void main() {
-  print("hello");
+  print('hello');
 }
 ''';
 
@@ -12,7 +12,7 @@ const sampleCodeWeb = """
 import 'dart:html';
 
 void main() {
-  print("hello");
+  print('hello');
   querySelector('#foo')?.text = 'bar';
 }
 """;
@@ -114,6 +114,7 @@ class _MyHomePageState extends State<MyHomePage> {
 // From https://gist.github.com/RedBrogdon/e0a2e942e85fde2cd39b2741ff0c49e5
 const sampleCodeFlutterSunflower = r'''
 import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 const Color primaryColor = Colors.orange;
@@ -254,7 +255,7 @@ const sampleCodeFlutterDraggableCard = '''
 import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 
-main() {
+void main() {
   runApp(
     MaterialApp(
       debugShowCheckedModeBanner: false,


### PR DESCRIPTION
- adjust how we select the 500 completion results to return

It doesn't look like the analysis server returns sorted completion results. This PR adjusts the results we return to the client (we ask for 1000 completion results from the analysis server, sort those results based on the `relevance` field, and then return the first 500 results).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
