### PR TITLE
populate a new 'serverRevision' field for the version response

### DIFF
--- a/pkgs/dart_services/lib/src/common_server.dart
+++ b/pkgs/dart_services/lib/src/common_server.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
@@ -241,6 +242,7 @@ class CommonServerApi {
       dartVersion: sdk.dartVersion,
       flutterVersion: sdk.flutterVersion,
       engineVersion: sdk.engineVersion,
+      serverRevision: Platform.environment['K_REVISION'],
       experiments: sdk.experiments,
       packages: packages,
     );

--- a/pkgs/dart_services/lib/src/shared/model.dart
+++ b/pkgs/dart_services/lib/src/shared/model.dart
@@ -363,6 +363,7 @@ class VersionResponse {
   final String dartVersion;
   final String flutterVersion;
   final String engineVersion;
+  final String? serverRevision;
   final List<String> experiments;
   final List<PackageInfo> packages;
 
@@ -370,6 +371,7 @@ class VersionResponse {
     required this.dartVersion,
     required this.flutterVersion,
     required this.engineVersion,
+    this.serverRevision,
     required this.experiments,
     required this.packages,
   });

--- a/pkgs/dart_services/lib/src/shared/model.g.dart
+++ b/pkgs/dart_services/lib/src/shared/model.g.dart
@@ -281,6 +281,7 @@ VersionResponse _$VersionResponseFromJson(Map<String, dynamic> json) =>
       dartVersion: json['dartVersion'] as String,
       flutterVersion: json['flutterVersion'] as String,
       engineVersion: json['engineVersion'] as String,
+      serverRevision: json['serverRevision'] as String?,
       experiments: (json['experiments'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
@@ -294,6 +295,7 @@ Map<String, dynamic> _$VersionResponseToJson(VersionResponse instance) =>
       'dartVersion': instance.dartVersion,
       'flutterVersion': instance.flutterVersion,
       'engineVersion': instance.engineVersion,
+      'serverRevision': instance.serverRevision,
       'experiments': instance.experiments,
       'packages': instance.packages,
     };

--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -363,6 +363,7 @@ class VersionResponse {
   final String dartVersion;
   final String flutterVersion;
   final String engineVersion;
+  final String? serverRevision;
   final List<String> experiments;
   final List<PackageInfo> packages;
 
@@ -370,6 +371,7 @@ class VersionResponse {
     required this.dartVersion,
     required this.flutterVersion,
     required this.engineVersion,
+    this.serverRevision,
     required this.experiments,
     required this.packages,
   });

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -281,6 +281,7 @@ VersionResponse _$VersionResponseFromJson(Map<String, dynamic> json) =>
       dartVersion: json['dartVersion'] as String,
       flutterVersion: json['flutterVersion'] as String,
       engineVersion: json['engineVersion'] as String,
+      serverRevision: json['serverRevision'] as String?,
       experiments: (json['experiments'] as List<dynamic>)
           .map((e) => e as String)
           .toList(),
@@ -294,6 +295,7 @@ Map<String, dynamic> _$VersionResponseToJson(VersionResponse instance) =>
       'dartVersion': instance.dartVersion,
       'flutterVersion': instance.flutterVersion,
       'engineVersion': instance.engineVersion,
+      'serverRevision': instance.serverRevision,
       'experiments': instance.experiments,
       'packages': instance.packages,
     };


### PR DESCRIPTION
- populate a new `serverRevision` field for the version response

This can help us know which revision a server is serving. I believe that the cloud `K_REVISION` env var - when deployed via a github trigger - is the git SHA value.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
