### PR TITLE
Define BUILD_SHA env var from arg in Dockerfile

### DIFF
--- a/pkgs/dart_services/Dockerfile
+++ b/pkgs/dart_services/Dockerfile
@@ -12,5 +12,7 @@ RUN dart compile exe bin/server.dart -o bin/server
 
 RUN dart run grinder build-project-templates
 
+ENV BUILD_SHA=$BUILD_SHA
+
 EXPOSE 8080
 CMD ["/app/bin/server"]


### PR DESCRIPTION
This is a follow up to https://github.com/dart-lang/dart-pad/pull/2776 that should fix the Docker argument not being available as an env var when the container starts.