### PR TITLE
Add back check for invalid core library imports

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -312,7 +312,7 @@ class AnalysisServerWrapper {
         if (!isSupportedCoreLibrary(libraryName)) {
           importIssues.add(api.AnalysisIssue(
             kind: 'error',
-            message: "Unsupported core library: 'dart:$libraryName'.",
+            message: "Unsupported library on the web: 'dart:$libraryName'.",
             correction: 'Try removing the import and usages of the library.',
             location: import.getLocation(source),
           ));

--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -307,8 +307,24 @@ class AnalysisServerWrapper {
     final importIssues = <api.AnalysisIssue>[];
 
     for (final import in imports) {
-      // Ignore `dart:` core library imports.
       if (import.dartImport) {
+        final libraryName = import.packageName;
+        if (!isSupportedCoreLibrary(libraryName)) {
+          importIssues.add(api.AnalysisIssue(
+            kind: 'error',
+            message: "Unsupported core library: 'dart:$libraryName'.",
+            correction: 'Try removing the import and usages of the library.',
+            location: import.getLocation(source),
+          ));
+        } else if (isDeprecatedCoreWebLibrary(libraryName)) {
+          importIssues.add(api.AnalysisIssue(
+            kind: 'info', // TODO(parlough): Expand to 'warning' in future.
+            message: "Deprecated core web library: 'dart:$libraryName'.",
+            correction: 'Try using static JS interop instead.',
+            url: 'https://dart.dev/go/next-gen-js-interop',
+            location: import.getLocation(source),
+          ));
+        }
         continue;
       }
 

--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -325,10 +325,7 @@ class AnalysisServerWrapper {
             location: import.getLocation(source),
           ));
         }
-        continue;
-      }
-
-      if (import.packageImport) {
+      } else if (import.packageImport) {
         final packageName = import.packageName;
         if (!isSupportedPackage(packageName)) {
           importIssues.add(api.AnalysisIssue(

--- a/pkgs/dart_services/lib/src/project_creator.dart
+++ b/pkgs/dart_services/lib/src/project_creator.dart
@@ -151,6 +151,7 @@ include: package:flutter_lints/flutter.yaml
 linter:
   rules:
     avoid_print: false
+    avoid_web_libraries_in_flutter: false
     use_key_in_widget_constructors: false
 ''';
     if (_sdk.experiments.isNotEmpty) {

--- a/pkgs/dart_services/test/analysis_test.dart
+++ b/pkgs/dart_services/test/analysis_test.dart
@@ -80,7 +80,7 @@ void defineTests() {
 
       expect(results.issues, hasLength(1));
       final issue = results.issues.first;
-      expect(issue.message, contains('Unsupported core library'));
+      expect(issue.message, contains('Unsupported library on the web'));
     });
 
     test('Warn on deprecated web library imports', () async {

--- a/pkgs/dart_services/test/analysis_test.dart
+++ b/pkgs/dart_services/test/analysis_test.dart
@@ -75,6 +75,22 @@ void defineTests() {
       }
     });
 
+    test('Error on VM library imports', () async {
+      final results = await analysisServer.analyze(unsupportedCoreLibrary);
+
+      expect(results.issues, hasLength(1));
+      final issue = results.issues.first;
+      expect(issue.message, contains('Unsupported core library'));
+    });
+
+    test('Warn on deprecated web library imports', () async {
+      final results = await analysisServer.analyze(deprecatedWebLibrary);
+
+      expect(results.issues, hasLength(1));
+      final issue = results.issues.first;
+      expect(issue.message, contains('Deprecated core web library'));
+    });
+
     test('import_dart_core_test', () async {
       // Ensure we can import dart: imports.
       final testCode = "import 'dart:c'; main() { int a = 0; a. }";
@@ -323,5 +339,21 @@ const lintWarningTrigger = '''
 void main() async {
   var unknown;
   print(unknown);
+}
+''';
+
+const unsupportedCoreLibrary = '''
+import 'dart:io' as io;
+
+void main() {
+  print(io.exitCode);
+}
+''';
+
+const deprecatedWebLibrary = '''
+import 'dart:js' as js;
+
+void main() {
+  print(js.context);
 }
 ''';

--- a/pkgs/dart_services/test/flutter_web_test.dart
+++ b/pkgs/dart_services/test/flutter_web_test.dart
@@ -29,43 +29,36 @@ void defineTests() {
       expect(isFlutterWebImport('package:flutter/'), isTrue);
     });
 
-    test('isUnsupportedImport allows current library import', () {
-      expect(isUnsupportedImport(''), isFalse);
+    test('isSupportedCoreLibrary allows dart:html', () {
+      expect(isSupportedCoreLibrary('html'), isTrue);
     });
 
-    test('isUnsupportedImport allows dart:html', () {
-      expect(isUnsupportedImport('dart:html'), isFalse);
+    test('isSupportedCoreLibrary allows dart:ui', () {
+      expect(isSupportedCoreLibrary('ui'), isTrue);
     });
 
-    test('isUnsupportedImport allows dart:ui', () {
-      expect(isUnsupportedImport('dart:ui'), isFalse);
+    test('isSupportedCoreLibrary does not allow VM-only imports', () {
+      expect(isSupportedCoreLibrary('io'), isFalse);
     });
 
-    test('isUnsupportedImport allows package:flutter', () {
-      expect(isUnsupportedImport('package:flutter'), isFalse);
+    test('isSupportedCoreLibrary does not allow superseded web libraries', () {
+      expect(isSupportedCoreLibrary('web_gl'), isFalse);
     });
 
-    test('isUnsupportedImport allows package:path', () {
-      expect(isUnsupportedImport('package:path'), isFalse);
+    test('isSupportedPackage allows package:flutter', () {
+      expect(isSupportedPackage('flutter'), isTrue);
     });
 
-    test('isUnsupportedImport does not allow package:unsupported', () {
-      expect(isUnsupportedImport('package:unsupported'), isTrue);
+    test('isSupportedPackage allows package:path', () {
+      expect(isSupportedPackage('path'), isTrue);
     });
 
-    test('isUnsupportedImport does not allow random local imports', () {
-      expect(isUnsupportedImport('foo.dart'), isTrue);
+    test('isSupportedPackage does not allow package:unsupported', () {
+      expect(isSupportedPackage('unsupported'), isFalse);
     });
 
-    test('isUnsupportedImport allows specified local imports', () {
-      expect(
-        isUnsupportedImport('foo.dart', sourceFiles: {'foo.dart'}),
-        isFalse,
-      );
-    });
-
-    test('isUnsupportedImport does not allow VM-only imports', () {
-      expect(isUnsupportedImport('dart:io'), isTrue);
+    test('isSupportedPackage does not allow random local imports', () {
+      expect(isSupportedPackage('foo.dart'), isFalse);
     });
   });
 


### PR DESCRIPTION
https://github.com/dart-lang/dart-pad/commit/93dc547d9d84607e0e4c35f018d4241e6a85d710 simplified import handling but no longer reported invalid Dart core library imports. Since then I've seen a few cases of people posting DartPad screenshots trying to use VM-only libraries.

To prevent any confusion, this PR reintroduces checks and reports warnings if a user tries to import a core library that won't work.

It also introduces support for indicating a core web library as deprecated. For now this only includes `dart:js`, but likely will expand to `dart:html` and `dart:js_util` in the future. It doesn't include the other web libraries like `dart:web_gl`, `dart:web_audio`, etc since they are already resulting in errors in the DartPad frontend.