### PR TITLE
Disable creating new HTML pads in UI

### DIFF
--- a/pkgs/dart_pad/lib/playground.dart
+++ b/pkgs/dart_pad/lib/playground.dart
@@ -1079,26 +1079,23 @@ class NewPadDialog {
   final MDCRipple _dartButton;
   final MDCRipple _flutterButton;
   final MDCButton _cancelButton;
-  final MDCSwitch _htmlSwitch;
 
   NewPadDialog()
       : assert(querySelector('#new-pad-dialog') != null),
         assert(querySelector('#new-pad-select-dart') != null),
         assert(querySelector('#new-pad-select-flutter') != null),
         assert(querySelector('#new-pad-cancel-button') != null),
-        assert(querySelector('#new-pad-html-switch') != null),
         _mdcDialog = MDCDialog(querySelector('#new-pad-dialog')!),
         _dartButton = MDCRipple(querySelector('#new-pad-select-dart')!),
         _flutterButton = MDCRipple(querySelector('#new-pad-select-flutter')!),
         _cancelButton =
-            MDCButton(querySelector('#new-pad-cancel-button') as ButtonElement),
-        _htmlSwitch = MDCSwitch(querySelector('#new-pad-html-switch'));
+            MDCButton(querySelector('#new-pad-cancel-button') as ButtonElement);
 
   Future<Layout?> show() {
     final completer = Completer<Layout?>();
 
     void completeDart() {
-      completer.complete(_htmlSwitch.checked! ? Layout.html : Layout.dart);
+      completer.complete(Layout.dart);
     }
 
     final dartSub = _dartButton.root.onClick.listen((_) {

--- a/pkgs/dart_pad/web/index.html
+++ b/pkgs/dart_pad/web/index.html
@@ -443,18 +443,6 @@
                         <img src="pictures/logo_dart.png" alt="Dart logo"/>
                         <span>Dart</span>
                     </div>
-                    <div id="new-pad-html-switch" class="mdc-switch">
-                        <div class="mdc-switch__track"></div>
-                        <div class="mdc-switch__thumb-underlay">
-                            <div class="mdc-switch__thumb">
-                                <input type="checkbox"
-                                        id="new-pad-html-switch-control"
-                                        class="mdc-switch__native-control"
-                                        role="switch">
-                            </div>
-                        </div>
-                    </div>
-                    <label for="new-pad-html-switch">HTML</label>
                 </div>
                 <div class="divider"></div>
                 <div id="new-pad-select-flutter" class="select-project-button mdc-ripple-surface mdc-ripple-surface--primary" role="button" tabindex="0">

--- a/pkgs/dart_pad/web/styles/styles.scss
+++ b/pkgs/dart_pad/web/styles/styles.scss
@@ -384,10 +384,6 @@ a {
   .dart-container {
     @include layout-vertical;
     @include layout-center;
-
-    #new-pad-html-switch-container {
-      margin-top: 8px;
-    }
   }
 
   .select-project-button {
@@ -408,10 +404,6 @@ a {
       max-height: 120px;
       margin-bottom: 16px;
     }
-  }
-
-  label[for=new-pad-html-switch] {
-    margin-left: 8px;
   }
 }
 


### PR DESCRIPTION
The old UI is still able to load them from existing gists, but this removes the "HTML" checkbox from the "New Pad" dialog. This helps prevent new user expectations that this workflow will be supported.