### PR TITLE
Add missing header Firefox requires for communicating with frame

### DIFF
--- a/pkgs/sketch_pad/firebase.json
+++ b/pkgs/sketch_pad/firebase.json
@@ -89,6 +89,10 @@
             "value": "credentialless"
           },
           {
+            "key": "Cross-Origin-Resource-Policy",
+            "value": "cross-origin"
+          },
+          {
             "key": "X-Content-Type-Options",
             "value": "nosniff"
           },


### PR DESCRIPTION
Without this, Firefox errors when trying to communicate with the running frame.

I don't fully follow but this `Cross-Origin-Resource-Policy` config is needed to go along with the `Cross-Origin-Embedder-Policy` to indicate the frame results can be embedded. [Relationship to cross-origin embedder policy (COEP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy#relationship_to_cross-origin_embedder_policy_coep) has some more context.