### PR TITLE
fix: use text button for keyboard shortcuts

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -568,26 +568,20 @@ class StatusLineWidget extends StatelessWidget {
           Tooltip(
             message: 'Keyboard shortcuts',
             waitDuration: tooltipDelay,
-            child: IconButton(
-              icon: const Icon(Icons.keyboard),
-              iconSize: smallIconSize,
-              splashRadius: defaultIconSize,
-              constraints: const BoxConstraints(minWidth: 20, minHeight: 20),
-              padding: const EdgeInsets.all(2),
-              visualDensity: VisualDensity.compact,
-              onPressed: () {
-                showDialog<void>(
-                  context: context,
-                  builder: (context) {
-                    return MediumDialog(
-                      title: 'Keyboard shortcuts',
-                      smaller: true,
-                      child: KeyBindingsTable(bindings: keys.keyBindings),
-                    );
-                  },
-                );
-              },
-              color: textColor,
+            child: TextButton(
+              onPressed: () => showDialog<void>(
+                context: context,
+                builder: (context) => MediumDialog(
+                  title: 'Keyboard shortcuts',
+                  smaller: true,
+                  child: KeyBindingsTable(bindings: keys.keyBindings),
+                ),
+              ),
+              child: Icon(
+                Icons.keyboard,
+                color: textColor,
+                size: 20,
+              ),
             ),
           ),
           const SizedBox(width: defaultSpacing),
@@ -621,10 +615,7 @@ class StatusLineWidget extends StatelessWidget {
           const Expanded(child: SizedBox(width: defaultSpacing)),
           VersionInfoWidget(appModel.runtimeVersions),
           const SizedBox(width: defaultSpacing),
-          const SizedBox(
-            height: 26,
-            child: SelectChannelWidget(),
-          ),
+          const SizedBox(height: 26, child: SelectChannelWidget()),
         ],
       ),
     );


### PR DESCRIPTION
Part of #2747 - Replaces the IconButton with a TextButton, to make the style of the buttons uniform. This seems like a better method than to try to make the IconButton adhere to the style of the TextButton.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>

---

https://github.com/dart-lang/dart-pad/assets/42929161/0dfd2285-111c-410a-be7e-a0bd8a46b294
