### PR TITLE
support package:web snippets from the UI

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -547,6 +547,7 @@ class _DartPadMainPageState extends State<DartPadMainPage> {
         response.result,
         modulesBaseUrl: response.modulesBaseUrl,
         engineVersion: appModel.runtimeVersions.value?.engineVersion,
+        dartSource: source,
       );
     } catch (error) {
       appModel.clearConsole();

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -37,6 +37,7 @@ abstract class EditorService {
 
 class AppModel {
   bool? _appIsFlutter;
+  bool? _usesPackageWeb;
 
   final ValueNotifier<bool> appReady = ValueNotifier(false);
 
@@ -83,8 +84,11 @@ class AppModel {
   void _recalcLayout() {
     final hasConsoleText = consoleOutputController.text.isNotEmpty;
     final isFlutter = _appIsFlutter;
+    final usesPackageWeb = _usesPackageWeb;
 
-    if (isFlutter == null) {
+    if (isFlutter == null || usesPackageWeb == null) {
+      _layoutMode.value = LayoutMode.both;
+    } else if (usesPackageWeb) {
       _layoutMode.value = LayoutMode.both;
     } else if (!isFlutter) {
       _layoutMode.value = LayoutMode.justConsole;
@@ -326,12 +330,12 @@ class AppServices {
 
   void executeJavaScript(
     String javaScript, {
+    required String dartSource,
     String? modulesBaseUrl,
     String? engineVersion,
   }) {
-    final usesFlutter = hasFlutterWebMarker(javaScript);
-
-    appModel._appIsFlutter = usesFlutter;
+    appModel._appIsFlutter = hasFlutterWebMarker(javaScript);
+    appModel._usesPackageWeb = hasPackageWebImport(dartSource);
     appModel._recalcLayout();
 
     _executionService?.execute(

--- a/pkgs/sketch_pad/lib/utils.dart
+++ b/pkgs/sketch_pad/lib/utils.dart
@@ -69,6 +69,12 @@ bool hasFlutterWebMarker(String javaScript) {
   return false;
 }
 
+bool hasPackageWebImport(String dartSource) {
+  // TODO(devoncarew): There are better ways to do this.
+  return dartSource.contains("import 'package:web/") ||
+      dartSource.contains('import "package:web/');
+}
+
 extension ColorExtension on Color {
   Color get lighter {
     final hsl = HSLColor.fromColor(this);


### PR DESCRIPTION
- support package:web snippets from the UI (follow up to https://github.com/dart-lang/dart-pad/pull/2820)

This detects the use of `package:web` in the snippet source and ensures that the DOM portion of the execution area is visible.

It may be worth re-thinking how we display the execution area. Right now we try and auto-detect the type of snippet and re-configure as necessary. We could instead always show the DOM and console output areas and have a user-moveable splitter between them (and perhaps have it start out favoring the DOM area? 70% DOM 30% console?).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
