### PR TITLE
Enable links to sites in new tabs without forcing sandbox

### DIFF
--- a/pkgs/sketch_pad/lib/execution/execution.dart
+++ b/pkgs/sketch_pad/lib/execution/execution.dart
@@ -32,6 +32,7 @@ web.Element _iFrameFactory(int viewId) {
   final frame = web_helpers.createIFrameElement()
     ..sandbox.add('allow-scripts')
     ..sandbox.add('allow-popups')
+    ..sandbox.add('allow-popups-to-escape-sandbox')
     ..src = 'frame.html'
     ..style.border = 'none'
     ..style.width = '100%'


### PR DESCRIPTION
@johnpryan  I think should enable your sample to work if you specify `target: LinkTarget.blank` (new tab) to your `Link` widget.

https://googlechrome.github.io/samples/allow-popups-to-escape-sandbox/ has some more details.