### PR TITLE
Use consistent scrollbar style

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -392,6 +392,7 @@ const codeMirrorOptions = {
   },
   'tabSize': 2,
   'viewportMargin': 100,
+  'scrollbarStyle': 'simple',
 };
 
 enum CompletionType {

--- a/pkgs/sketch_pad/web/index.html
+++ b/pkgs/sketch_pad/web/index.html
@@ -45,6 +45,40 @@
     .squiggle-error {
       border-bottom: 2px solid #EF5350;
     }
+
+    .CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div {
+      position: absolute;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      border-radius: 4px;
+    }
+
+    .CodeMirror-simplescroll-horizontal, .CodeMirror-simplescroll-vertical {
+      position: absolute;
+      z-index: 6;
+    }
+
+    .CodeMirror-simplescroll-horizontal {
+      bottom: 0;
+      left: 0;
+      height: 9px;
+    }
+
+    .CodeMirror-simplescroll-horizontal div {
+      bottom: 0;
+      height: 100%;
+    }
+
+    .CodeMirror-simplescroll-vertical {
+      right: 0;
+      top: 0;
+      width: 9px;
+    }
+
+    .CodeMirror-simplescroll-vertical div {
+      right: 0;
+      width: 100%;
+    }
   </style>
 
   <!-- This script adds the flutter initialization JS code -->


### PR DESCRIPTION
This was a regression in the new editor, we are using the Codemirror simplescroll add-on to show a consistent scrollbar style on all platforms.

This doesn't fix the issue where scroll events aren't being handled, but at consistently provides a scrollbar that the user can click and drag.