### PR TITLE
Deploy sketch_pad to dartpad.dev

### DIFF
--- a/.cloud_build/dart_pad.yaml
+++ b/.cloud_build/dart_pad.yaml
@@ -1,12 +1,7 @@
 steps:
   - name: gcr.io/$PROJECT_ID/flutter:stable
-    entrypoint: 'dart'
-    args: ['pub', 'get']
-    dir: pkgs/dart_pad
-  - name: gcr.io/$PROJECT_ID/flutter:stable
-    entrypoint: 'dart'
-    args: ['run', 'tool/grind.dart', 'build']
-    dir: pkgs/dart_pad
+    args: ['build', 'web']
+    dir: pkgs/sketch_pad
   - name: gcr.io/$PROJECT_ID/firebase
-    args: ['deploy', '--project=$PROJECT_ID', '--only=hosting']
-    dir: pkgs/dart_pad
+    args: ['deploy', '--project=$PROJECT_ID', '--only=dartpad']
+    dir: pkgs/sketch_pad

--- a/.cloud_build/dart_pad.yaml
+++ b/.cloud_build/dart_pad.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: gcr.io/$PROJECT_ID/flutter:stable
+  - name: gcr.io/$PROJECT_ID/flutter:main
     args: ['build', 'web']
     dir: pkgs/sketch_pad
   - name: gcr.io/$PROJECT_ID/firebase

--- a/.cloud_build/sketch_pad.yaml
+++ b/.cloud_build/sketch_pad.yaml
@@ -3,5 +3,5 @@ steps:
     args: ['build', 'web']
     dir: pkgs/sketch_pad
   - name: gcr.io/$PROJECT_ID/firebase
-    args: ['deploy', '--project=$PROJECT_ID', '--only=hosting']
+    args: ['deploy', '--project=$PROJECT_ID', '--only=preview']
     dir: pkgs/sketch_pad

--- a/pkgs/dart_pad/.firebaserc
+++ b/pkgs/dart_pad/.firebaserc
@@ -6,7 +6,7 @@
     "dart-pad": {
       "hosting": {
         "dartpad": [
-          "dart-pad-a3c64"
+          "old-dartpad-3ce3f"
         ]
       }
     }

--- a/pkgs/dart_pad/lib/inject/inject_embed.dart
+++ b/pkgs/dart_pad/lib/inject/inject_embed.dart
@@ -14,7 +14,7 @@ final Logger _logger = Logger('dartpad-embed');
 
 // Use this prefix for local development:
 //var iframePrefix = '../';
-String iframePrefix = 'https://dartpad.dev/';
+String iframePrefix = 'https://old-dartpad-3ce3f.web.app/';
 
 final HtmlUnescape _htmlUnescape = HtmlUnescape();
 

--- a/pkgs/sketch_pad/.firebaserc
+++ b/pkgs/sketch_pad/.firebaserc
@@ -5,7 +5,10 @@
   "targets": {
     "dart-pad": {
       "hosting": {
-        "sketchpad": [
+        "dartpad": [
+          "dartpad-a3c64"
+        ],
+        "preview": [
           "sketch-pad-1cebb"
         ]
       }


### PR DESCRIPTION
Rather than changing DNS settings, it's easier to configure the sketch_pad project to deploy to multiple sites.