### PR TITLE
Preserves wheel events over the CodeMirror editor.

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -57,9 +57,12 @@ web.Element _codeMirrorFactory(int viewId) {
   // wheel events over CodeMirror's HtmlElementView.
   //
   // This is needed so users can scroll code with their mouse wheel.
-  div.addEventListener('wheel', ((web.WheelEvent e) {
-    e.stopPropagation();
-  }).toJS);
+  div.addEventListener(
+    'wheel',
+    (web.WheelEvent e) {
+      e.stopPropagation();
+    }.toJS,
+  );
 
   return div;
 }

--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -53,6 +53,14 @@ web.Element _codeMirrorFactory(int viewId) {
   CodeMirror.commands.weHandleElsewhere =
       ((JSObject? _) => _weHandleElsewhere(codeMirrorInstance!)).toJS;
 
+  // Prevent the flutter web engine from handling (and preventing default on)
+  // wheel events over CodeMirror's HtmlElementView.
+  //
+  // This is needed so users can scroll code with their mouse wheel.
+  div.addEventListener('wheel', ((web.WheelEvent e) {
+    e.stopPropagation();
+  }).toJS);
+
   return div;
 }
 


### PR DESCRIPTION
This change prevents `'wheel'` events from bubbling out of the CodeMirror editor (and being handled by the Flutter web engine, which [prevents their default behavior](https://github.com/flutter/engine/blob/main/lib/web_ui/lib/src/engine/pointer_binding.dart#L724-L735) which is... scrolling).

After this change, users should be able to scroll the CodeMirror source with the scroll wheel of their mice as expected.

(Discussed offline with @johnpryan)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
