### PR TITLE
write json with a closing eol

### DIFF
--- a/pkgs/dart_services/tool/grind.dart
+++ b/pkgs/dart_services/tool/grind.dart
@@ -297,9 +297,8 @@ Future<void> _updateDependenciesFile({
   await runFlutterPubGet(sdk, tempDir.path, log: log);
   final packageVersions = packageVersionsFromPubspecLock(tempDir.path);
 
-  _pubDependenciesFile(channel: channel).writeAsStringSync(
-    const JsonEncoder.withIndent('  ').convert(packageVersions),
-  );
+  final deps = const JsonEncoder.withIndent('  ').convert(packageVersions);
+  _pubDependenciesFile(channel: channel).writeAsStringSync('$deps\n');
 }
 
 /// Returns the File containing the pub dependencies and their version numbers.


### PR DESCRIPTION
- write json with a closing eol

This addresses a very minor nit I see in code reviews.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
