### PR TITLE
Force CodeMirror refresh once in view port

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -173,6 +173,21 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         (CodeMirror editor, [HintOptions? options]) {
           return options!.results;
         }.toJS);
+
+    // Listen for document body to be visible, then force a code mirror refresh.
+    final observer = web.IntersectionObserver(
+      (JSArray entries, web.IntersectionObserver observer) {
+        for (final entry in entries.toDart) {
+          if ((entry as web.IntersectionObserverEntry).isIntersecting) {
+            observer.unobserve(web.document.body!);
+            Timer.run(() => codeMirror!.refresh());
+            return;
+          }
+        }
+      }.toJS,
+    );
+
+    observer.observe(web.document.body!);
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart-pad/issues/2854

I tested this by deploying and then using the updated version instead of dartpad.dev for the DartPad at the bottom of dart.dev.

I have never used any of these APIs though, so there might be something I'm misusing or a better way to do this?