### PR TITLE
Update flame sample and add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 *.pyc
 
 .idea/
+
+# IDE settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ build/
 # Python generated files
 *.pyc
 
+# IDE configuration
 .idea/
-
-# IDE settings
 .vscode/

--- a/pkgs/samples/lib/brick_breaker.dart
+++ b/pkgs/samples/lib/brick_breaker.dart
@@ -138,7 +138,7 @@ class BrickBreaker extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(
-    RawKeyEvent event, // ignore: deprecated_member_use
+    KeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     super.onKeyEvent(event, keysPressed);

--- a/pkgs/samples/pubspec.yaml
+++ b/pkgs/samples/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.3.0
 
 dependencies:
-  flame: ^1.15.0
+  flame: ^1.16.0
   flutter:
     sdk: flutter
   flutter_markdown: ^0.6.19

--- a/pkgs/sketch_pad/lib/samples.g.dart
+++ b/pkgs/sketch_pad/lib/samples.g.dart
@@ -277,7 +277,7 @@ class BrickBreaker extends FlameGame
 
   @override
   KeyEventResult onKeyEvent(
-    RawKeyEvent event, // ignore: deprecated_member_use
+    KeyEvent event,
     Set<LogicalKeyboardKey> keysPressed,
   ) {
     super.onKeyEvent(event, keysPressed);


### PR DESCRIPTION
Flame sample became outdated after flutter 3.19.0

I've also added `.vscode` to `.gitignore` while I was at it 

fixes #2862

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
