### PR TITLE
Update Sunflower sample

### DIFF
--- a/pkgs/samples/lib/sunflower.dart
+++ b/pkgs/samples/lib/sunflower.dart
@@ -27,12 +27,14 @@ class _SunflowerState extends State<Sunflower> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(brightness: Brightness.dark),
+      theme: ThemeData(
+        brightness: Brightness.dark,
+        appBarTheme: const AppBarTheme(elevation: 2),
+      ),
       debugShowCheckedModeBanner: false,
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Sunflower'),
-          elevation: 2,
         ),
         body: Center(
           child: Column(

--- a/pkgs/samples/lib/sunflower.dart
+++ b/pkgs/samples/lib/sunflower.dart
@@ -6,7 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-const int maxSeeds = 500;
+const int maxSeeds = 250;
 
 void main() {
   runApp(const Sunflower());
@@ -28,7 +28,12 @@ class _SunflowerState extends State<Sunflower> {
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(brightness: Brightness.dark),
+      debugShowCheckedModeBanner: false,
       home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Sunflower'),
+          elevation: 2,
+        ),
         body: Center(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.center,
@@ -60,8 +65,8 @@ class _SunflowerState extends State<Sunflower> {
 
 class SunflowerWidget extends StatelessWidget {
   static const tau = math.pi * 2;
-  static const scaleFactor = 1 / 64;
-  static const size = 800.0;
+  static const scaleFactor = 1 / 40;
+  static const size = 600.0;
   static final phi = (math.sqrt(5) + 1) / 2;
   static final rng = math.Random();
 
@@ -87,9 +92,9 @@ class SunflowerWidget extends StatelessWidget {
     }
 
     for (var j = seeds; j < maxSeeds; j++) {
-      final index = maxSeeds - j - 1;
-      final x = (index % 80) * 0.025 - 1;
-      final y = 1 - ((index / 80).floor() * 0.025);
+      final x = math.cos(tau * j / (maxSeeds - 1)) * 0.9;
+      final y = math.sin(tau * j / (maxSeeds - 1)) * 0.9;
+
       seedWidgets.add(AnimatedAlign(
         key: ValueKey(j),
         duration: Duration(milliseconds: rng.nextInt(500) + 250),

--- a/pkgs/samples/lib/sunflower.dart
+++ b/pkgs/samples/lib/sunflower.dart
@@ -6,7 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-const double maxSeeds = 1000;
+const int maxSeeds = 500;
 
 void main() {
   runApp(const Sunflower());
@@ -22,92 +22,113 @@ class Sunflower extends StatefulWidget {
 }
 
 class _SunflowerState extends State<Sunflower> {
-  double seeds = maxSeeds / 2;
+  int seeds = maxSeeds ~/ 2;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        brightness: Brightness.dark,
-        appBarTheme: const AppBarTheme(elevation: 2),
-      ),
+      theme: ThemeData(brightness: Brightness.dark),
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Sunflower'),
-          elevation: 2,
-        ),
-        body: Column(
-          children: [
-            Expanded(
-              child: LayoutBuilder(builder: (context, constraints) {
-                return SizedBox(
-                  width: constraints.maxWidth,
-                  height: constraints.maxHeight,
-                  child: CustomPaint(
-                    painter: SunflowerPainter(seeds.round()),
-                  ),
-                );
-              }),
-            ),
-            Text('Showing ${seeds.round()} seeds'),
-            Container(
-              constraints: const BoxConstraints.tightFor(width: 300),
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Slider(
-                min: 1,
-                max: maxSeeds,
-                value: seeds,
-                onChanged: (newValue) {
-                  setState(() => seeds = newValue);
-                },
+        body: Center(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: SunflowerWidget(seeds),
               ),
-            ),
-          ],
+              const SizedBox(height: 20),
+              Text('Showing ${seeds.round()} seeds'),
+              SizedBox(
+                width: 300,
+                child: Slider(
+                  min: 1,
+                  max: maxSeeds.toDouble(),
+                  value: seeds.toDouble(),
+                  onChanged: (val) {
+                    setState(() => seeds = val.round());
+                  },
+                ),
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class SunflowerPainter extends CustomPainter {
-  static const Color primaryColor = Colors.orange;
-  static const double seedRadius = 2;
-  static const double tau = math.pi * 2;
-  static final double phi = (math.sqrt(5) + 1) / 2;
+class SunflowerWidget extends StatelessWidget {
+  static const tau = math.pi * 2;
+  static const scaleFactor = 1 / 64;
+  static const size = 800.0;
+  static final phi = (math.sqrt(5) + 1) / 2;
+  static final rng = math.Random();
 
   final int seeds;
 
-  SunflowerPainter(this.seeds);
+  const SunflowerWidget(this.seeds, {super.key});
 
   @override
-  void paint(Canvas canvas, Size size) {
-    final scaleFactor = 5 * size.shortestSide / 375;
-    final center = size.center(Offset.zero);
+  Widget build(BuildContext context) {
+    final seedWidgets = <Widget>[];
 
     for (var i = 0; i < seeds; i++) {
       final theta = i * tau / phi;
       final r = math.sqrt(i) * scaleFactor;
 
-      drawSeed(
-        canvas,
-        center.dx + r * math.cos(theta),
-        center.dy - r * math.sin(theta),
-      );
+      seedWidgets.add(AnimatedAlign(
+        key: ValueKey(i),
+        duration: Duration(milliseconds: rng.nextInt(500) + 250),
+        curve: Curves.easeInOut,
+        alignment: Alignment(r * math.cos(theta), -1 * r * math.sin(theta)),
+        child: const Dot(true),
+      ));
     }
+
+    for (var j = seeds; j < maxSeeds; j++) {
+      final index = maxSeeds - j - 1;
+      final x = (index % 80) * 0.025 - 1;
+      final y = 1 - ((index / 80).floor() * 0.025);
+      seedWidgets.add(AnimatedAlign(
+        key: ValueKey(j),
+        duration: Duration(milliseconds: rng.nextInt(500) + 250),
+        curve: Curves.easeInOut,
+        alignment: Alignment(x, y),
+        child: const Dot(false),
+      ));
+    }
+
+    return FittedBox(
+      fit: BoxFit.contain,
+      child: SizedBox(
+        height: size,
+        width: size,
+        child: Stack(children: seedWidgets),
+      ),
+    );
   }
+}
+
+class Dot extends StatelessWidget {
+  static const size = 5.0;
+  static const radius = 3.0;
+
+  final bool lit;
+
+  const Dot(this.lit, {super.key});
 
   @override
-  bool shouldRepaint(SunflowerPainter oldDelegate) {
-    return oldDelegate.seeds != seeds;
-  }
-
-  void drawSeed(Canvas canvas, double x, double y) {
-    // Draw a small circle representing a seed centered at (x,y).
-    final paint = Paint()
-      ..strokeWidth = 2
-      ..style = PaintingStyle.fill
-      ..color = primaryColor;
-    canvas.drawCircle(Offset(x, y), seedRadius, paint);
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: lit ? Colors.orange : Colors.grey.shade700,
+        borderRadius: BorderRadius.circular(radius),
+      ),
+      child: const SizedBox(
+        height: size,
+        width: size,
+      ),
+    );
   }
 }

--- a/pkgs/sketch_pad/lib/samples.g.dart
+++ b/pkgs/sketch_pad/lib/samples.g.dart
@@ -912,7 +912,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-const double maxSeeds = 1000;
+const int maxSeeds = 250;
 
 void main() {
   runApp(const Sunflower());
@@ -928,93 +928,121 @@ class Sunflower extends StatefulWidget {
 }
 
 class _SunflowerState extends State<Sunflower> {
-  double seeds = maxSeeds / 2;
+  int seeds = maxSeeds ~/ 2;
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         brightness: Brightness.dark,
         appBarTheme: const AppBarTheme(elevation: 2),
       ),
+      debugShowCheckedModeBanner: false,
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Sunflower'),
-          elevation: 2,
         ),
-        body: Column(
-          children: [
-            Expanded(
-              child: LayoutBuilder(builder: (context, constraints) {
-                return SizedBox(
-                  width: constraints.maxWidth,
-                  height: constraints.maxHeight,
-                  child: CustomPaint(
-                    painter: SunflowerPainter(seeds.round()),
-                  ),
-                );
-              }),
-            ),
-            Text('Showing ${seeds.round()} seeds'),
-            Container(
-              constraints: const BoxConstraints.tightFor(width: 300),
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Slider(
-                min: 1,
-                max: maxSeeds,
-                value: seeds,
-                onChanged: (newValue) {
-                  setState(() => seeds = newValue);
-                },
+        body: Center(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: SunflowerWidget(seeds),
               ),
-            ),
-          ],
+              const SizedBox(height: 20),
+              Text('Showing ${seeds.round()} seeds'),
+              SizedBox(
+                width: 300,
+                child: Slider(
+                  min: 1,
+                  max: maxSeeds.toDouble(),
+                  value: seeds.toDouble(),
+                  onChanged: (val) {
+                    setState(() => seeds = val.round());
+                  },
+                ),
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class SunflowerPainter extends CustomPainter {
-  static const Color primaryColor = Colors.orange;
-  static const double seedRadius = 2;
-  static const double tau = math.pi * 2;
-  static final double phi = (math.sqrt(5) + 1) / 2;
+class SunflowerWidget extends StatelessWidget {
+  static const tau = math.pi * 2;
+  static const scaleFactor = 1 / 40;
+  static const size = 600.0;
+  static final phi = (math.sqrt(5) + 1) / 2;
+  static final rng = math.Random();
 
   final int seeds;
 
-  SunflowerPainter(this.seeds);
+  const SunflowerWidget(this.seeds, {super.key});
 
   @override
-  void paint(Canvas canvas, Size size) {
-    final scaleFactor = 5 * size.shortestSide / 375;
-    final center = size.center(Offset.zero);
+  Widget build(BuildContext context) {
+    final seedWidgets = <Widget>[];
 
     for (var i = 0; i < seeds; i++) {
       final theta = i * tau / phi;
       final r = math.sqrt(i) * scaleFactor;
 
-      drawSeed(
-        canvas,
-        center.dx + r * math.cos(theta),
-        center.dy - r * math.sin(theta),
-      );
+      seedWidgets.add(AnimatedAlign(
+        key: ValueKey(i),
+        duration: Duration(milliseconds: rng.nextInt(500) + 250),
+        curve: Curves.easeInOut,
+        alignment: Alignment(r * math.cos(theta), -1 * r * math.sin(theta)),
+        child: const Dot(true),
+      ));
     }
+
+    for (var j = seeds; j < maxSeeds; j++) {
+      final x = math.cos(tau * j / (maxSeeds - 1)) * 0.9;
+      final y = math.sin(tau * j / (maxSeeds - 1)) * 0.9;
+
+      seedWidgets.add(AnimatedAlign(
+        key: ValueKey(j),
+        duration: Duration(milliseconds: rng.nextInt(500) + 250),
+        curve: Curves.easeInOut,
+        alignment: Alignment(x, y),
+        child: const Dot(false),
+      ));
+    }
+
+    return FittedBox(
+      fit: BoxFit.contain,
+      child: SizedBox(
+        height: size,
+        width: size,
+        child: Stack(children: seedWidgets),
+      ),
+    );
   }
+}
+
+class Dot extends StatelessWidget {
+  static const size = 5.0;
+  static const radius = 3.0;
+
+  final bool lit;
+
+  const Dot(this.lit, {super.key});
 
   @override
-  bool shouldRepaint(SunflowerPainter oldDelegate) {
-    return oldDelegate.seeds != seeds;
-  }
-
-  void drawSeed(Canvas canvas, double x, double y) {
-    // Draw a small circle representing a seed centered at (x,y).
-    final paint = Paint()
-      ..strokeWidth = 2
-      ..style = PaintingStyle.fill
-      ..color = primaryColor;
-    canvas.drawCircle(Offset(x, y), seedRadius, paint);
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: lit ? Colors.orange : Colors.grey.shade700,
+        borderRadius: BorderRadius.circular(radius),
+      ),
+      child: const SizedBox(
+        height: size,
+        width: size,
+      ),
+    );
   }
 }
 ''',


### PR DESCRIPTION
Updates the sunflower example in the following ways:

* Removes use of CustomPainter, replacing it with more basic widgets like DecoratedBox and Stack.
* Adds an animation effect when changing the number of seeds. "Unused" seeds are now show in grey in a circle around the sunflower.
* Reduces the maximum number of seeds from 1000 to 250 in order to improve performance of the animation.
* Updates the code in general to remove anything that looked like an out of date pattern or idiom.

I did this after seeing a comment from @parlough suggesting that someone try jazzing up the sunflower example, but it was mostly done as a fun, weekend coding exercise. Feel free to suggest significant changes or to turn down the PR entirely.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.