### PR TITLE
fix the samples regeneration validation

### DIFF
--- a/pkgs/samples/tool/samples.dart
+++ b/pkgs/samples/tool/samples.dart
@@ -111,8 +111,16 @@ class Samples {
     print('Verifying sample file generation...');
 
     final readme = File('README.md');
-    if (readme.readAsStringSync() != _generateReadmeContent()) {
+    final readmeUpToDate =
+        readme.readAsStringSync() == _generateReadmeContent();
+
+    final codeFile = File('../sketch_pad/lib/samples.g.dart');
+    final codeFileUpToDate =
+        codeFile.readAsStringSync() == _generateSourceContent();
+
+    if (!readmeUpToDate || !codeFileUpToDate) {
       stderr.writeln('Generated sample files not up-to-date.');
+      stderr.writeln('');
       stderr.writeln('Re-generate by running:');
       stderr.writeln('');
       stderr.writeln('  dart run tool/samples.dart');
@@ -121,7 +129,7 @@ class Samples {
     }
 
     // print success message
-    print('Generated files up-to-date');
+    print('Generated files up-to-date.');
   }
 
   String _generateReadmeContent() {


### PR DESCRIPTION
- fix the samples regeneration validation

Related to https://github.com/dart-lang/dart-pad/pull/2874 - I saw that the CI wasn't failing when it should have been.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
