### PR TITLE
support older gist formats

### DIFF
--- a/pkgs/sketch_pad/lib/editor/codemirror.dart
+++ b/pkgs/sketch_pad/lib/editor/codemirror.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'dart:js_interop';
+
 import 'package:web/web.dart';
 
 extension type CodeMirrorOptions._(JSObject _) implements JSObject {

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -262,6 +262,14 @@ class AppServices {
           appModel.sourceCodeController.text = fallbackSnippet;
         } else {
           appModel.sourceCodeController.text = source;
+
+          if (gist.validationIssues.isNotEmpty) {
+            final message = gist.validationIssues.join('\n');
+            appModel.editorStatus.showToast(
+              message,
+              duration: const Duration(seconds: 10),
+            );
+          }
         }
 
         appModel.appReady.value = true;

--- a/pkgs/sketch_pad/test/gists_test.dart
+++ b/pkgs/sketch_pad/test/gists_test.dart
@@ -32,6 +32,20 @@ void main() {
 
       expect(gist.mainDartSource, isNull);
     });
+
+    test('validates main.dart missing', () {
+      final gist =
+          Gist.fromJson(jsonDecode(jsonSampleNoMain) as Map<String, dynamic>);
+
+      expect(gist.validationIssues, isNotEmpty);
+    });
+
+    test('validates unexpected dart content file', () {
+      final gist = Gist.fromJson(
+          jsonDecode(jsonSampleAlternativeFile) as Map<String, dynamic>);
+
+      expect(gist.validationIssues, isNotEmpty);
+    });
   });
 }
 
@@ -76,8 +90,35 @@ const String jsonSampleNoMain = '''
   "user": null,
   "truncated": false,
   "files": {
-    "main.dart": {
+    "main.html": {
       "filename": "main.html",
+      "type": "application/vnd.dart",
+      "language": "Dart",
+      "raw_url": "https://gist.githubusercontent.com/flutterdevrelgists/d3bd83918d21b6d5f778bdc69c3d36d6/raw/5eaecf3519fe453298d077068194720c9729be62/main.dart",
+      "size": 369,
+      "truncated": false,
+      "content": "..."
+    }
+  }
+}
+''';
+
+const String jsonSampleAlternativeFile = '''
+{
+  "id": "d3bd83918d21b6d5f778bdc69c3d36d6",
+  "description": "Fibonacci",
+  "owner": {
+    "login": "flutterdevrelgists"
+  },
+  "public": false,
+  "created_at": "2021-08-23T23:27:20Z",
+  "updated_at": "2023-05-30T10:59:27Z",
+  "comments": 0,
+  "user": null,
+  "truncated": false,
+  "files": {
+    "sample_1.dart": {
+      "filename": "sample_1.dart",
       "type": "application/vnd.dart",
       "language": "Dart",
       "raw_url": "https://gist.githubusercontent.com/flutterdevrelgists/d3bd83918d21b6d5f778bdc69c3d36d6/raw/5eaecf3519fe453298d077068194720c9729be62/main.dart",


### PR DESCRIPTION
- support older gist formats (related to https://github.com/dart-lang/dart-pad/issues/2873 and others)

This restores support for older (mostly unintentional) gists formats; loading from a gist with a single dart file in the gist with any name. We do now nag about the gist - that authors should prefer naming the gist file `main.dart`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
