### PR TITLE
support multiple keybindings for some actions

### DIFF
--- a/pkgs/sketch_pad/lib/keys.dart
+++ b/pkgs/sketch_pad/lib/keys.dart
@@ -13,11 +13,17 @@ bool get _nonMac => defaultTargetPlatform != TargetPlatform.macOS;
 
 // key activators
 
-final ShortcutActivator reloadKeyActivator = SingleActivator(
-  LogicalKeyboardKey.keyS,
+final ShortcutActivator reloadKeyActivator1 = SingleActivator(
+  LogicalKeyboardKey.keyR,
   meta: _mac,
   control: _nonMac,
 );
+final ShortcutActivator reloadKeyActivator2 = SingleActivator(
+  LogicalKeyboardKey.enter,
+  meta: _mac,
+  control: _nonMac,
+);
+
 final ShortcutActivator findKeyActivator = SingleActivator(
   LogicalKeyboardKey.keyF,
   meta: _mac,
@@ -28,30 +34,45 @@ final ShortcutActivator findNextKeyActivator = SingleActivator(
   meta: _mac,
   control: _nonMac,
 );
+
+final ShortcutActivator formatKeyActivator1 = SingleActivator(
+  LogicalKeyboardKey.keyS,
+  meta: _mac,
+  control: _nonMac,
+);
+const ShortcutActivator formatKeyActivator2 = SingleActivator(
+  LogicalKeyboardKey.keyF,
+  shift: true,
+  alt: true,
+);
+
 const ShortcutActivator codeCompletionKeyActivator = SingleActivator(
   LogicalKeyboardKey.space,
   control: true,
 );
-final ShortcutActivator quickFixKeyActivator = SingleActivator(
+
+final ShortcutActivator quickFixKeyActivator1 = SingleActivator(
   LogicalKeyboardKey.period,
   meta: _mac,
   control: _nonMac,
 );
+const ShortcutActivator quickFixKeyActivator2 = SingleActivator(
+  LogicalKeyboardKey.enter,
+  alt: true,
+);
 
 // map of key activator names
 
-final List<(String, ShortcutActivator)> keyBindings = [
-  ('Code completion', codeCompletionKeyActivator),
-  ('Find', findKeyActivator),
-  ('Find next', findNextKeyActivator),
-  ('Quick fixes', quickFixKeyActivator),
-  ('Reload', reloadKeyActivator),
+final List<(String, List<ShortcutActivator>)> keyBindings = [
+  ('Code completion', [codeCompletionKeyActivator]),
+  ('Find', [findKeyActivator]),
+  ('Find next', [findNextKeyActivator]),
+  ('Format', [formatKeyActivator1, formatKeyActivator2]),
+  ('Quick fixes', [quickFixKeyActivator1, quickFixKeyActivator2]),
+  ('Run', [reloadKeyActivator1, reloadKeyActivator2]),
 ];
 
 extension SingleActivatorExtension on SingleActivator {
-  // Note that this only works in debug mode.
-  String get describe => debugDescribeKeys();
-
   Widget renderToWidget(BuildContext context) {
     var text = trigger.keyLabel;
     if (trigger == LogicalKeyboardKey.space) {
@@ -60,10 +81,11 @@ extension SingleActivatorExtension on SingleActivator {
 
     return Container(
       decoration: BoxDecoration(
-          border: Border.fromBorderSide(
-            Divider.createBorderSide(context, width: 1.0, color: subtleColor),
-          ),
-          borderRadius: const BorderRadius.all(Radius.circular(4))),
+        border: Border.fromBorderSide(
+          Divider.createBorderSide(context, width: 1.0, color: subtleColor),
+        ),
+        borderRadius: const BorderRadius.all(Radius.circular(4)),
+      ),
       padding: const EdgeInsets.symmetric(
         vertical: 2,
         horizontal: 6,
@@ -71,6 +93,18 @@ extension SingleActivatorExtension on SingleActivator {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (shift)
+            const Icon(
+              Icons.arrow_upward,
+              size: 16,
+              color: subtleColor,
+            ),
+          if (alt)
+            Icon(
+              _mac ? Icons.keyboard_option_key : Icons.keyboard_alt,
+              size: 16,
+              color: subtleColor,
+            ),
           if (control)
             const Icon(
               Icons.keyboard_control_key,

--- a/pkgs/sketch_pad/lib/keys.dart
+++ b/pkgs/sketch_pad/lib/keys.dart
@@ -11,14 +11,14 @@ import 'theme.dart';
 bool get _mac => defaultTargetPlatform == TargetPlatform.macOS;
 bool get _nonMac => defaultTargetPlatform != TargetPlatform.macOS;
 
-// key activators
+// ## Key activators
 
-final ShortcutActivator reloadKeyActivator1 = SingleActivator(
+final ShortcutActivator runKeyActivator1 = SingleActivator(
   LogicalKeyboardKey.keyR,
   meta: _mac,
   control: _nonMac,
 );
-final ShortcutActivator reloadKeyActivator2 = SingleActivator(
+final ShortcutActivator runKeyActivator2 = SingleActivator(
   LogicalKeyboardKey.enter,
   meta: _mac,
   control: _nonMac,
@@ -61,7 +61,7 @@ const ShortcutActivator quickFixKeyActivator2 = SingleActivator(
   alt: true,
 );
 
-// map of key activator names
+// ## Map of key activator names
 
 final List<(String, List<ShortcutActivator>)> keyBindings = [
   ('Code completion', [codeCompletionKeyActivator]),
@@ -69,7 +69,7 @@ final List<(String, List<ShortcutActivator>)> keyBindings = [
   ('Find next', [findNextKeyActivator]),
   ('Format', [formatKeyActivator1, formatKeyActivator2]),
   ('Quick fixes', [quickFixKeyActivator1, quickFixKeyActivator2]),
-  ('Run', [reloadKeyActivator1, reloadKeyActivator2]),
+  ('Run', [runKeyActivator1, runKeyActivator2]),
 ];
 
 extension SingleActivatorExtension on SingleActivator {

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -435,10 +435,10 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         value: appModel,
         child: CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
-            keys.reloadKeyActivator1: () {
+            keys.runKeyActivator1: () {
               if (!appModel.compilingBusy.value) _performCompileAndRun();
             },
-            keys.reloadKeyActivator2: () {
+            keys.runKeyActivator2: () {
               if (!appModel.compilingBusy.value) _performCompileAndRun();
             },
             keys.findKeyActivator: () {

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -28,10 +28,6 @@ import 'utils.dart';
 import 'versions.dart';
 import 'widgets.dart';
 
-// TODO: show documentation on hover
-
-// TODO: implement find / find next
-
 const appName = 'DartPad';
 const smallScreenWidth = 720;
 
@@ -439,10 +435,11 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         value: appModel,
         child: CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
-            keys.reloadKeyActivator: () {
-              if (!appModel.compilingBusy.value) {
-                _performCompileAndRun();
-              }
+            keys.reloadKeyActivator1: () {
+              if (!appModel.compilingBusy.value) _performCompileAndRun();
+            },
+            keys.reloadKeyActivator2: () {
+              if (!appModel.compilingBusy.value) _performCompileAndRun();
             },
             keys.findKeyActivator: () {
               // TODO:
@@ -452,10 +449,19 @@ class _DartPadMainPageState extends State<DartPadMainPage>
               // TODO:
               unimplemented(context, 'find next');
             },
+            keys.formatKeyActivator1: () {
+              if (!appModel.formattingBusy.value) _handleFormatting();
+            },
+            keys.formatKeyActivator2: () {
+              if (!appModel.formattingBusy.value) _handleFormatting();
+            },
             keys.codeCompletionKeyActivator: () {
               appServices.editorService?.showCompletions();
             },
-            keys.quickFixKeyActivator: () {
+            keys.quickFixKeyActivator1: () {
+              appServices.editorService?.showQuickFixes();
+            },
+            keys.quickFixKeyActivator2: () {
               appServices.editorService?.showQuickFixes();
             },
           },
@@ -1056,7 +1062,7 @@ class OverflowMenu extends StatelessWidget {
 }
 
 class KeyBindingsTable extends StatelessWidget {
-  final List<(String, ShortcutActivator)> bindings;
+  final List<(String, List<ShortcutActivator>)> bindings;
 
   const KeyBindingsTable({
     required this.bindings,
@@ -1070,7 +1076,7 @@ class KeyBindingsTable extends StatelessWidget {
       children: [
         const Divider(),
         Expanded(
-          child: VTable<(String, ShortcutActivator)>(
+          child: VTable<(String, List<ShortcutActivator>)>(
             showToolbar: false,
             showHeaders: false,
             startsSorted: true,
@@ -1087,12 +1093,24 @@ class KeyBindingsTable extends StatelessWidget {
                 width: 100,
                 grow: 0.5,
                 alignment: Alignment.centerRight,
-                transformFunction: (binding) =>
-                    (binding.$2 as SingleActivator).describe,
                 styleFunction: (binding) => subtleText,
                 renderFunction: (context, binding, _) {
-                  return (binding.$2 as SingleActivator)
-                      .renderToWidget(context);
+                  final children = <Widget>[];
+                  var first = true;
+                  for (final shortcut in binding.$2) {
+                    if (!first) {
+                      children.add(
+                        const Padding(
+                          padding: EdgeInsets.only(left: 4, right: 8),
+                          child: Text(','),
+                        ),
+                      );
+                    }
+                    first = false;
+                    children.add(
+                        (shortcut as SingleActivator).renderToWidget(context));
+                  }
+                  return Row(children: children);
                 },
               ),
             ],


### PR DESCRIPTION
- support multiple keybindings for some actions
- run is now cmd-r (as well as the older dartpad binding, cmd-enter); fix https://github.com/dart-lang/dart-pad/issues/2818
- format is now cmd-s (as well as the vs code binding, shift-option-f); fix https://github.com/dart-lang/dart-pad/issues/2848
- added support for the older dartpad binding for quick fixes - option-enter; address part of https://github.com/dart-lang/dart-pad/issues/2868

Note that the behavior of cmd-s changes with this PR; before, it runs the snippet, after, it formats it. cmd-r is probably better as a run keybinding (and will probably prevent people from unintentionally reloading the dartpad page), and cmd-s should be familiar to vs code users as many have format-on-save active.

<img width="456" alt="Screenshot 2024-02-29 at 8 06 40 AM" src="https://github.com/dart-lang/dart-pad/assets/1269969/45a59050-95dc-4db1-a267-e80f6e7abb0f">

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
