### PR TITLE
restore cursor pos after formatting

### DIFF
--- a/pkgs/sketch_pad/lib/editor/codemirror.dart
+++ b/pkgs/sketch_pad/lib/editor/codemirror.dart
@@ -43,11 +43,14 @@ extension type CodeMirror._(JSObject _) implements JSObject {
   external void refresh();
   external void focus();
   external void showHint(HintOptions? options);
-  external JSAny execCommand(String command, [JSAny? object]);
+  external JSAny? execCommand(String command);
   external void on(String event, JSFunction callback);
 
   String getTheme() => (getOption('theme') as JSString).toDart;
   void setTheme(String theme) => setOption('theme', theme.toJS);
+
+  external void scrollTo(num? x, num? y);
+  external ScrollInfo getScrollInfo();
 
   void setReadOnly(bool value, [bool noCursor = false]) {
     if (value) {
@@ -78,7 +81,7 @@ extension type Doc._(JSObject _) implements JSObject {
   external String getValue();
   external String? getLine(int n);
   external bool somethingSelected();
-  external String? getSelection(String s);
+  external String? getSelection(String? s);
   external void setSelection(Position position, [Position head]);
   external JSArray<TextMarker> getAllMarks();
   external TextMarker markText(
@@ -87,6 +90,16 @@ extension type Doc._(JSObject _) implements JSObject {
   external void replaceRange(String replacement, Position from,
       [Position? to, String? origin]);
   external Position posFromIndex(int index);
+}
+
+@anonymous
+extension type ScrollInfo._(JSObject _) implements JSObject {
+  external int top;
+  external int left;
+  external int width;
+  external int height;
+  external int clientWidth;
+  external int clientHeight;
 }
 
 @anonymous

--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -22,8 +22,6 @@ import 'codemirror.dart';
 
 // TODO: hover - show links to hosted dartdoc? (flutter, dart api, packages)
 
-// TODO: preserve scroll pos and cursor postion on format
-
 const String _viewType = 'dartpad-editor';
 
 bool _viewFactoryInitialized = false;

--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -14,6 +14,16 @@ import 'package:web/web.dart' as web;
 import '../model.dart';
 import 'codemirror.dart';
 
+// TODO: show documentation on hover
+
+// TODO: implement find / find next
+
+// TODO: improve the code completion UI
+
+// TODO: hover - show links to hosted dartdoc? (flutter, dart api, packages)
+
+// TODO: preserve scroll pos and cursor postion on format
+
 const String _viewType = 'dartpad-editor';
 
 bool _viewFactoryInitialized = false;
@@ -116,6 +126,19 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
       codeMirror?.getDoc().setSelection(Position(line: 0, ch: 0));
     }
 
+    codeMirror?.focus();
+  }
+
+  @override
+  int get cursorOffset {
+    final pos = codeMirror?.getCursor();
+    if (pos == null) return 0;
+
+    return codeMirror?.getDoc().indexFromPos(pos) ?? 0;
+  }
+
+  @override
+  void focus() {
     codeMirror?.focus();
   }
 
@@ -227,8 +250,19 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
   }
 
   void _updateCodemirrorFromModel() {
-    final value = widget.appModel.sourceCodeController.text;
-    codeMirror?.getDoc().setValue(value);
+    final value = widget.appModel.sourceCodeController.value;
+    final cursorOffset = value.selection.baseOffset;
+    final cm = codeMirror!;
+    final doc = cm.getDoc();
+
+    if (cursorOffset == -1) {
+      doc.setValue(value.text);
+    } else {
+      final scrollInfo = cm.getScrollInfo();
+      doc.setValue(value.text);
+      doc.setSelection(doc.posFromIndex(cursorOffset));
+      cm.scrollTo(scrollInfo.left, scrollInfo.top);
+    }
   }
 
   void _updateEditableStatus() {
@@ -320,10 +354,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
 // codemirror commands
 
 JSAny? _handleGoLineLeft(CodeMirror editor) {
-  // Change the cmd-left behavior to move the cursor to the leftmost non-ws
-  // char.
-  editor.execCommand('goLineLeftSmart');
-  return JSObject();
+  // Change the cmd-left behavior to move the cursor to leftmost non-ws char.
+  return editor.execCommand('goLineLeftSmart');
 }
 
 void _indentIfMultiLineSelectionElseInsertSoftTab(CodeMirror editor) {

--- a/pkgs/sketch_pad/lib/execution/frame_utils.dart
+++ b/pkgs/sketch_pad/lib/execution/frame_utils.dart
@@ -7,15 +7,16 @@ import 'dart:js_interop_unsafe';
 
 import 'package:web/web.dart';
 
-/// Extensions to work around Dart compiler issues that result
-/// in calls that sandboxed iframes error on.
+/// Extensions to work around Dart compiler issues that result in calls that
+/// sandboxed iframes error on.
 ///
-/// If the compilers are adjusted to handle this case or
-/// `package:web` provides a helper for this, switch to that.
+/// If the compilers are adjusted to handle this case or `package:web` provides
+/// a helper for this, switch to that.
+///
 /// Tracked in https://github.com/dart-lang/sdk/issues/54443.
 extension HTMLIFrameElementExtension on HTMLIFrameElement {
-  /// Send the specified [message] to this iframe,
-  /// configured with the specified [optionsOrTargetOrigin].
+  /// Send the specified [message] to this iframe, configured with the specified
+  /// [optionsOrTargetOrigin].
   void safelyPostMessage(
     JSAny? message,
     String optionsOrTargetOrigin,

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -470,15 +470,23 @@ class _DartPadMainPageState extends State<DartPadMainPage>
 
   Future<void> _handleFormatting() async {
     try {
-      final value = appModel.sourceCodeController.text;
-      final result = await appServices.format(SourceRequest(source: value));
+      final source = appModel.sourceCodeController.text;
+      final offset = appServices.editorService?.cursorOffset;
+      final result = await appServices.format(
+        SourceRequest(source: source, offset: offset),
+      );
 
-      if (result.source == value) {
+      if (result.source == source) {
         appModel.editorStatus.showToast('No formatting changes');
       } else {
         appModel.editorStatus.showToast('Format successful');
-        appModel.sourceCodeController.text = result.source;
+        appModel.sourceCodeController.value = TextEditingValue(
+          text: result.source,
+          selection: TextSelection.collapsed(offset: result.offset ?? 0),
+        );
       }
+
+      appServices.editorService!.focus();
     } catch (error) {
       appModel.editorStatus.showToast('Error formatting code');
       appModel.appendLineToConsole('Formatting issue: $error');

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -33,6 +33,8 @@ abstract class EditorService {
   void showCompletions();
   void showQuickFixes();
   void jumpTo(AnalysisIssue issue);
+  int get cursorOffset;
+  void focus();
 }
 
 class AppModel {


### PR DESCRIPTION
- restore cursor pos after formatting
- fix a JS interop issue with the `goLineLeft` command (we'd throw an NPE from interop code when trying to return a null result)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
