### PR TITLE
remove the code folding UI from the editor

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -382,27 +382,27 @@ const codeMirrorOptions = {
     'Shift-Ctrl-F': 'weHandleElsewhere',
     'Shift-Cmd-F': 'weHandleElsewhere',
     'Cmd-Alt-F': false,
-    // vscode folding key combos (pc/mac)
-    'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
-    'Cmd-Alt-[': 'ourFoldWithCursorToStart',
-    'Shift-Ctrl-]': 'unfold',
-    'Cmd-Alt-]': 'unfold',
-    // made our own keycombo since VSCode and AndroidStudio's
-    'Shift-Ctrl-Alt-[': 'foldAll',
-    // are taken by browser
-    'Shift-Cmd-Alt-[': 'foldAll',
-    'Shift-Ctrl-Alt-]': 'unfoldAll',
-    'Shift-Cmd-Alt-]': 'unfoldAll',
+    // // vscode folding key combos (pc/mac)
+    // 'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
+    // 'Cmd-Alt-[': 'ourFoldWithCursorToStart',
+    // 'Shift-Ctrl-]': 'unfold',
+    // 'Cmd-Alt-]': 'unfold',
+    // // made our own keycombo since VSCode and AndroidStudio's
+    // 'Shift-Ctrl-Alt-[': 'foldAll',
+    // // are taken by browser
+    // 'Shift-Cmd-Alt-[': 'foldAll',
+    // 'Shift-Ctrl-Alt-]': 'unfoldAll',
+    // 'Shift-Cmd-Alt-]': 'unfoldAll',
   },
-  'foldGutter': true,
-  'foldOptions': {
-    'minFoldSize': 1,
-    // like '...', but middle dots
-    'widget': '\u00b7\u00b7\u00b7',
-  },
+  // 'foldGutter': true,
+  // 'foldOptions': {
+  //   'minFoldSize': 1,
+  //   // like '...', but middle dots
+  //   'widget': '\u00b7\u00b7\u00b7',
+  // },
   'gutters': [
     'CodeMirror-linenumbers',
-    'CodeMirror-foldgutter',
+    // 'CodeMirror-foldgutter',
   ],
   'highlightSelectionMatches': {
     'style': 'highlight-selection-matches',

--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -382,27 +382,9 @@ const codeMirrorOptions = {
     'Shift-Ctrl-F': 'weHandleElsewhere',
     'Shift-Cmd-F': 'weHandleElsewhere',
     'Cmd-Alt-F': false,
-    // // vscode folding key combos (pc/mac)
-    // 'Shift-Ctrl-[': 'ourFoldWithCursorToStart',
-    // 'Cmd-Alt-[': 'ourFoldWithCursorToStart',
-    // 'Shift-Ctrl-]': 'unfold',
-    // 'Cmd-Alt-]': 'unfold',
-    // // made our own keycombo since VSCode and AndroidStudio's
-    // 'Shift-Ctrl-Alt-[': 'foldAll',
-    // // are taken by browser
-    // 'Shift-Cmd-Alt-[': 'foldAll',
-    // 'Shift-Ctrl-Alt-]': 'unfoldAll',
-    // 'Shift-Cmd-Alt-]': 'unfoldAll',
   },
-  // 'foldGutter': true,
-  // 'foldOptions': {
-  //   'minFoldSize': 1,
-  //   // like '...', but middle dots
-  //   'widget': '\u00b7\u00b7\u00b7',
-  // },
   'gutters': [
     'CodeMirror-linenumbers',
-    // 'CodeMirror-foldgutter',
   ],
   'highlightSelectionMatches': {
     'style': 'highlight-selection-matches',


### PR DESCRIPTION
- remove the code folding UI from the editor

This is just in the interest of simplifying the look of the UI a bit.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
