### PR TITLE
refactor the mobile UI

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -336,6 +336,8 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         Tab(text: 'Code'),
         Tab(text: 'Output'),
       ],
+      // Remove the divider line at the bottom of the tab bar.
+      dividerHeight: 0,
       key: _tabBarKey,
     );
 
@@ -573,7 +575,6 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
     return LayoutBuilder(builder: (context, constraints) {
       return AppBar(
         backgroundColor: theme.colorScheme.surface,
-        bottom: bottom,
         title: SizedBox(
           height: toolbarItemHeight,
           child: Row(
@@ -611,6 +612,7 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
             ],
           ),
         ),
+        bottom: bottom,
         actions: [
           // Hide the Install SDK button when the screen width is too small.
           if (constraints.maxWidth > smallScreenWidth)

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -224,28 +224,44 @@ class DartPadMainPage extends StatefulWidget {
 
 class _DartPadMainPageState extends State<DartPadMainPage>
     with SingleTickerProviderStateMixin {
+  late final AppModel appModel;
+  late final AppServices appServices;
   late final SplitViewController mainSplitter;
-
-  late AppModel appModel;
-  late AppServices appServices;
   late final TabController tabController;
+
   final ValueKey<String> _executionWidgetKey =
       const ValueKey('execution-widget');
   final ValueKey<String> _loadingOverlayKey =
       const ValueKey('loading-overlay-widget');
   final ValueKey<String> _editorKey = const ValueKey('editor');
   final ValueKey<String> _consoleKey = const ValueKey('console');
+  final ValueKey<String> _tabBarKey = const ValueKey('tab-bar');
+  final ValueKey<String> _executionStackKey = const ValueKey('execution-stack');
+  final ValueKey<String> _scaffoldKey = const ValueKey('scaffold');
+
+  late final VoidCallback runStartedListener;
 
   @override
   void initState() {
     super.initState();
 
-    tabController = TabController(length: 3, vsync: this)
-      ..addListener(() {
-        // Rebuild when the user changes tabs so that the IndexedStack updates
-        // its active child view.
-        setState(() {});
+    tabController = TabController(length: 2, vsync: this)
+      ..addListener(
+        () {
+          // Rebuild when the user changes tabs so that the IndexedStack updates
+          // its active child view.
+          setState(() {});
+        },
+      );
+    runStartedListener = () {
+      setState(() {
+        // Switch to the application output tab.]
+        if (appModel.compilingBusy.value) {
+          tabController.animateTo(1);
+        }
       });
+    };
+
     final leftPanelSize = widget.embedMode ? 0.62 : 0.50;
     mainSplitter =
         SplitViewController(weights: [leftPanelSize, 1.0 - leftPanelSize])
@@ -277,10 +293,14 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         _performCompileAndRun();
       }
     });
+
+    appModel.compilingBusy.addListener(runStartedListener);
   }
 
   @override
   void dispose() {
+    appModel.compilingBusy.removeListener(runStartedListener);
+
     appServices.dispose();
     appModel.dispose();
 
@@ -290,15 +310,18 @@ class _DartPadMainPageState extends State<DartPadMainPage>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
     final executionWidget = ExecutionWidget(
       appServices: appServices,
       appModel: appModel,
       key: _executionWidgetKey,
     );
+
     final loadingOverlay = LoadingOverlay(
       appModel: appModel,
       key: _loadingOverlayKey,
     );
+
     final editor = EditorWithButtons(
       appModel: appModel,
       appServices: appServices,
@@ -307,81 +330,93 @@ class _DartPadMainPageState extends State<DartPadMainPage>
       key: _editorKey,
     );
 
-    consoleWidget({bool showDivider = false}) => ConsoleWidget(
-          textController: appModel.consoleOutputController,
-          showDivider: showDivider,
-          key: _consoleKey,
-        );
-    final scaffold =
-        LayoutBuilder(builder: (context, BoxConstraints constraints) {
-      // Use the mobile UI layout for small screen widths.
-      if (constraints.maxWidth <= smallScreenWidth) {
-        return Scaffold(
-          appBar: widget.embedMode
-              ? TabBar(
-                  controller: tabController,
-                  tabs: [
-                    Tab(
-                      icon: const Icon(Icons.code),
-                      child: Semantics(
-                        label: 'Dart Code',
-                        child: const Text('Code'),
-                      ),
-                    ),
-                    Tab(
-                      icon: const Icon(Icons.phone_android),
-                      child: Semantics(
-                        label: 'UI Output',
-                        child: const Text('UI Output'),
-                      ),
-                    ),
-                    Tab(
-                      icon: const Icon(Icons.terminal),
-                      child: Semantics(
-                        label: 'Console Output',
-                        child: const Text('Console Output'),
+    final tabBar = TabBar(
+      controller: tabController,
+      tabs: const [
+        Tab(text: 'Code'),
+        Tab(text: 'Output'),
+      ],
+      key: _tabBarKey,
+    );
+
+    final executionStack = Stack(
+      key: _executionStackKey,
+      children: [
+        ValueListenableBuilder(
+          valueListenable: appModel.layoutMode,
+          builder: (context, LayoutMode mode, _) {
+            return LayoutBuilder(
+              builder: (BuildContext context, BoxConstraints constraints) {
+                final domHeight = mode.calcDomHeight(constraints.maxHeight);
+                final consoleHeight =
+                    mode.calcConsoleHeight(constraints.maxHeight);
+
+                return Column(
+                  children: [
+                    SizedBox(height: domHeight, child: executionWidget),
+                    SizedBox(
+                      height: consoleHeight,
+                      child: ConsoleWidget(
+                        textController: appModel.consoleOutputController,
+                        showDivider: mode == LayoutMode.both,
+                        key: _consoleKey,
                       ),
                     ),
                   ],
-                )
+                );
+              },
+            );
+          },
+        ),
+        loadingOverlay,
+      ],
+    );
+
+    final scaffold = LayoutBuilder(builder: (context, constraints) {
+      // Use the mobile UI layout for small screen widths.
+      if (constraints.maxWidth <= smallScreenWidth) {
+        return Scaffold(
+          key: _scaffoldKey,
+          appBar: widget.embedMode
+              ? tabBar
               : DartPadAppBar(
                   theme: theme,
                   appServices: appServices,
                   appModel: appModel,
                   widget: widget,
-                  bottom: TabBar(
-                    controller: tabController,
-                    tabs: const [
-                      Tab(icon: Icon(Icons.code)),
-                      Tab(icon: Icon(Icons.phone_android)),
-                      Tab(icon: Icon(Icons.terminal)),
-                    ],
-                  ),
+                  bottom: tabBar,
                 ),
-          body: IndexedStack(
-            index: tabController.index,
+          body: Column(
             children: [
-              editor,
-              executionWidget,
-              consoleWidget(),
+              Expanded(
+                child: IndexedStack(
+                  index: tabController.index,
+                  children: [
+                    editor,
+                    executionStack,
+                  ],
+                ),
+              ),
+              if (!widget.embedMode)
+                const StatusLineWidget(mobileVersion: true),
             ],
           ),
         );
-      }
-
-      return Scaffold(
-        appBar: widget.embedMode
-            ? null
-            : DartPadAppBar(
-                theme: theme,
-                appServices: appServices,
-                appModel: appModel,
-                widget: widget,
-              ),
-        body: Column(
-          children: [
-            Expanded(
-              child: Center(
+      } else {
+        // Return the desktop UI.
+        return Scaffold(
+          key: _scaffoldKey,
+          appBar: widget.embedMode
+              ? null
+              : DartPadAppBar(
+                  theme: theme,
+                  appServices: appServices,
+                  appModel: appModel,
+                  widget: widget,
+                ),
+          body: Column(
+            children: [
+              Expanded(
                 child: SplitView(
                   viewMode: SplitViewMode.Horizontal,
                   gripColor: theme.colorScheme.surface,
@@ -390,47 +425,15 @@ class _DartPadMainPageState extends State<DartPadMainPage>
                   controller: mainSplitter,
                   children: [
                     editor,
-                    Stack(
-                      children: [
-                        ValueListenableBuilder(
-                          valueListenable: appModel.layoutMode,
-                          builder: (context, LayoutMode mode, _) {
-                            return LayoutBuilder(
-                              builder: (BuildContext context,
-                                  BoxConstraints constraints) {
-                                final domHeight =
-                                    mode.calcDomHeight(constraints.maxHeight);
-                                final consoleHeight = mode
-                                    .calcConsoleHeight(constraints.maxHeight);
-
-                                return Column(
-                                  children: [
-                                    SizedBox(
-                                      height: domHeight,
-                                      child: executionWidget,
-                                    ),
-                                    SizedBox(
-                                      height: consoleHeight,
-                                      child: consoleWidget(
-                                          showDivider: mode == LayoutMode.both),
-                                    ),
-                                  ],
-                                );
-                              },
-                            );
-                          },
-                        ),
-                        loadingOverlay,
-                      ],
-                    ),
+                    executionStack,
                   ],
                 ),
               ),
-            ),
-            if (!widget.embedMode) const StatusLineWidget(),
-          ],
-        ),
-      );
+              if (!widget.embedMode) const StatusLineWidget(),
+            ],
+          ),
+        );
+      }
     });
 
     return Provider<AppServices>.value(
@@ -669,7 +672,10 @@ class EditorWithButtons extends StatelessWidget {
                   appServices: appServices,
                 ),
                 Padding(
-                  padding: const EdgeInsets.all(denseSpacing),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: denseSpacing,
+                    horizontal: defaultSpacing,
+                  ),
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     // We use explicit directionality here in order to have the
@@ -730,7 +736,12 @@ class EditorWithButtons extends StatelessWidget {
 }
 
 class StatusLineWidget extends StatelessWidget {
-  const StatusLineWidget({super.key});
+  final bool mobileVersion;
+
+  const StatusLineWidget({
+    this.mobileVersion = false,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -768,33 +779,35 @@ class StatusLineWidget extends StatelessWidget {
             ),
           ),
           const SizedBox(width: defaultSpacing),
-          TextButton(
-            onPressed: () {
-              const url = 'https://dart.dev/tools/dartpad/privacy';
-              url_launcher.launchUrl(Uri.parse(url));
-            },
-            child: const Row(
-              children: [
-                Text('Privacy notice'),
-                SizedBox(width: denseSpacing),
-                Icon(Icons.launch, size: 16),
-              ],
+          if (!mobileVersion)
+            TextButton(
+              onPressed: () {
+                const url = 'https://dart.dev/tools/dartpad/privacy';
+                url_launcher.launchUrl(Uri.parse(url));
+              },
+              child: const Row(
+                children: [
+                  Text('Privacy notice'),
+                  SizedBox(width: denseSpacing),
+                  Icon(Icons.launch, size: 16),
+                ],
+              ),
             ),
-          ),
           const SizedBox(width: defaultSpacing),
-          TextButton(
-            onPressed: () {
-              const url = 'https://github.com/dart-lang/dart-pad/issues';
-              url_launcher.launchUrl(Uri.parse(url));
-            },
-            child: const Row(
-              children: [
-                Text('Feedback'),
-                SizedBox(width: denseSpacing),
-                Icon(Icons.launch, size: 16),
-              ],
+          if (!mobileVersion)
+            TextButton(
+              onPressed: () {
+                const url = 'https://github.com/dart-lang/dart-pad/issues';
+                url_launcher.launchUrl(Uri.parse(url));
+              },
+              child: const Row(
+                children: [
+                  Text('Feedback'),
+                  SizedBox(width: denseSpacing),
+                  Icon(Icons.launch, size: 16),
+                ],
+              ),
             ),
-          ),
           const Expanded(child: SizedBox(width: defaultSpacing)),
           VersionInfoWidget(appModel.runtimeVersions),
           const SizedBox(width: defaultSpacing),

--- a/pkgs/sketch_pad/lib/widgets.dart
+++ b/pkgs/sketch_pad/lib/widgets.dart
@@ -94,6 +94,7 @@ class MiniIconButton extends StatelessWidget {
 
 class RunButton extends StatelessWidget {
   final VoidCallback? onPressed;
+
   const RunButton({this.onPressed, super.key});
 
   @override
@@ -121,11 +122,9 @@ class RunButton extends StatelessWidget {
             Icon(
               Icons.play_arrow,
               color: Colors.black,
-              size: 20.0,
+              size: 20,
             ),
-            SizedBox(
-              width: 16.0,
-            ),
+            SizedBox(width: 8),
             Text(
               'Run',
               style: TextStyle(color: Colors.black),


### PR DESCRIPTION
Refactor the mobile UI:
- move from using three tabs (code, ui, console) to two (code and app output)
- when starting to run an app, auto-switch to the app output tab
- fix https://github.com/dart-lang/dart-pad/issues/2859

This should address an issue where the execution iframe wasn'y inited when we tried to run something. It also combines the app + console tabs into one (as we do on the regular desktop UI).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>

<img width="612" alt="Screenshot 2024-03-01 at 1 08 23 PM" src="https://github.com/dart-lang/dart-pad/assets/1269969/0de30e44-8894-4722-a27b-e030dfd002e3">

<img width="612" alt="Screenshot 2024-03-01 at 1 08 34 PM" src="https://github.com/dart-lang/dart-pad/assets/1269969/97ec123b-109f-4d94-bfe7-29de89333fe7">
