### PR TITLE
Fix menu contrast issue after color scheme changes

### DIFF
--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -139,13 +139,11 @@ class _DartPadAppState extends State<DartPadApp> {
       themeMode: themeMode,
       theme: ThemeData(
         useMaterial3: true,
-        colorScheme:
-            ColorScheme.fromSeed(seedColor: lightPrimaryColor).copyWith(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: lightPrimaryColor,
           surface: lightSurfaceColor,
           onSurface: Colors.black,
-          // TODO: Migrate to expanded Material 3 color palette.
-          // ignore: deprecated_member_use
-          surfaceVariant: lightSurfaceVariantColor,
+          surfaceContainerHighest: lightSurfaceVariantColor,
           onPrimary: lightLinkButtonColor,
         ),
         brightness: Brightness.light,
@@ -162,13 +160,12 @@ class _DartPadAppState extends State<DartPadApp> {
       ),
       darkTheme: ThemeData(
         useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(seedColor: darkPrimaryColor).copyWith(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: darkPrimaryColor,
           brightness: Brightness.dark,
           surface: darkSurfaceColor,
           onSurface: Colors.white,
-          // TODO: Migrate to expanded Material 3 color palette.
-          // ignore: deprecated_member_use
-          surfaceVariant: darkSurfaceVariantColor,
+          surfaceContainerHighest: darkSurfaceVariantColor,
           onSurfaceVariant: Colors.white,
           onPrimary: darkLinkButtonColor,
         ),

--- a/pkgs/sketch_pad/lib/problems.dart
+++ b/pkgs/sketch_pad/lib/problems.dart
@@ -43,9 +43,7 @@ class ProblemsTableWidget extends StatelessWidget {
       curve: animationCurve,
       child: Container(
         decoration: BoxDecoration(
-          // TODO: Migrate to expanded Material 3 color palette.
-          // ignore: deprecated_member_use
-          color: colorScheme.surfaceVariant,
+          color: colorScheme.surfaceContainerHighest,
         ),
         padding: const EdgeInsets.all(denseSpacing),
         child: ListView.builder(


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart-pad/issues/2895

Before fix:
<img width="220" alt="Menu with poor text contrast" src="https://github.com/dart-lang/dart-pad/assets/18372958/80f6f4b6-6f0c-4ef5-85cc-31c27e01d0f5">

After fix:
<img width="237" alt="Screenshot of menu with improved contrast" src="https://github.com/dart-lang/dart-pad/assets/18372958/bbacd8bc-6057-4bc6-b889-180f5f1ff184">
