### PR TITLE
make the sdk version text selectable

### DIFF
--- a/pkgs/sketch_pad/lib/versions.dart
+++ b/pkgs/sketch_pad/lib/versions.dart
@@ -31,7 +31,7 @@ class VersionTable extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         const Divider(),
-        Text(versionText),
+        SelectableText(versionText),
         const Divider(),
         const SizedBox(height: denseSpacing),
         Expanded(


### PR DESCRIPTION
- make the sdk version text selectable

We aren't able to easily make the version text at the bottom of the page selectable as we use that mouse click to open the versions dialog.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
