### PR TITLE
Send embed ready message later

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -163,9 +163,6 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     final contents = appModel.sourceCodeController.text;
     codeMirror!.getDoc().setValue(contents);
 
-    // Start listening for inject code messages.
-    handleEmbedMessage(appModel);
-
     // darkmode
     _updateCodemirrorMode(darkMode);
 
@@ -198,6 +195,9 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         (CodeMirror editor, [HintOptions? options]) {
           return options!.results;
         }.toJS);
+
+    // Start listening for inject code messages.
+    handleEmbedMessage(appModel);
 
     // Listen for document body to be visible, then force a code mirror refresh.
     final observer = web.IntersectionObserver(

--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -11,7 +11,6 @@ import 'package:dartpad_shared/services.dart' as services;
 import 'package:flutter/material.dart';
 import 'package:web/web.dart' as web;
 
-import '../embed.dart';
 import '../model.dart';
 import 'codemirror.dart';
 
@@ -195,9 +194,6 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         (CodeMirror editor, [HintOptions? options]) {
           return options!.results;
         }.toJS);
-
-    // Start listening for inject code messages.
-    handleEmbedMessage(appModel);
 
     // Listen for document body to be visible, then force a code mirror refresh.
     final observer = web.IntersectionObserver(

--- a/pkgs/sketch_pad/lib/embed.dart
+++ b/pkgs/sketch_pad/lib/embed.dart
@@ -12,19 +12,10 @@ void handleEmbedMessage(AppModel model) {
 
   web.window.addEventListener(
     'message',
-    (web.Event event) {
-      if (event is web.MessageEvent) {
-        final data = event.data.dartify() as Map<Object?, Object?>?;
-        if (data == null || data['sender'] == 'frame') {
-          return;
-        }
-
-        if ((data['type'] as String?) != 'sourceCode') {
-          return;
-        }
-
-        final sourceCode = data['sourceCode'];
-        if (sourceCode is String && sourceCode.isNotEmpty) {
+    (web.MessageEvent event) {
+      if (event.data case _SourceCodeMessage(:final type?, :final sourceCode?)
+          when type == 'sourceCode') {
+        if (sourceCode.isNotEmpty) {
           model.sourceCodeController.text = sourceCode;
         }
       }
@@ -35,4 +26,9 @@ void handleEmbedMessage(AppModel model) {
     ({'sender': web.window.name, 'type': 'ready'}).jsify(),
     '*'.toJS,
   );
+}
+
+extension type _SourceCodeMessage._(JSObject _) {
+  external String? get sourceCode;
+  external String? get type;
 }

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:vtable/vtable.dart';
 
 import 'console.dart';
 import 'editor/editor.dart';
+import 'embed.dart';
 import 'execution/execution.dart';
 import 'extensions.dart';
 import 'keys.dart' as keys;
@@ -282,6 +283,8 @@ class _DartPadMainPageState extends State<DartPadMainPage>
             channel: widget.initialChannel,
             fallbackSnippet: Samples.getDefault(type: 'dart'))
         .then((value) {
+      // Start listening for inject code messages.
+      handleEmbedMessage(appModel);
       if (widget.runOnLoad) {
         _performCompileAndRun();
       }


### PR DESCRIPTION
In https://github.com/dart-lang/dart-pad/commit/b29b8fe8906cbe93880885d6ad8f879dcab77b08 I had the embed send the ready message too early, before the connection between the editor and the controller were set up. This waits to indicate the frame is ready until after that and the other initial loading is complete.

Fixes https://github.com/dart-lang/dart-pad/issues/2893

**Staged:** https://parlough-dart-dev.web.app/