### PR TITLE
focus the editor at app startup; restrict focus traversal

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -218,6 +218,10 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
 
     _updateCodemirrorMode(darkMode);
 
+    // Ensure that the editor gets focus (from the POV of the Flutter focus
+    // system) at app startup.
+    FocusScope.of(context).requestFocus();
+
     return HtmlElementView(
       key: _elementViewKey,
       viewType: _viewType,

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -683,9 +683,21 @@ class EditorWithButtons extends StatelessWidget {
           child: SectionWidget(
             child: Stack(
               children: [
-                EditorWidget(
-                  appModel: appModel,
-                  appServices: appServices,
+                // Define a FocusScope in order to capture tab key events from
+                // the codemirror editor (these should manipulate the editor's
+                // contents; they should not cause a focus traversal).
+                FocusScope(
+                  onFocusChange: (focused) {
+                    // If the editor receives a Flutter focus event, tell the
+                    // codemirror editor.
+                    if (focused) {
+                      appServices.editorService?.focus();
+                    }
+                  },
+                  child: EditorWidget(
+                    appModel: appModel,
+                    appServices: appServices,
+                  ),
                 ),
                 Padding(
                   padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
- focus the editor at app startup
- restrict focus traversal out of the editing area

Wrapping the editing area in a new `FocusScope` will restrict focus traversal out of the widget. In particular, hitting tab will not move the flutter focus to another widget (the tab key - and shift-tab - will still be interpreted by codemirror). This should address https://github.com/dart-lang/dart-pad/issues/2852 and related.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
