### PR TITLE
When a period is typed, auto-invoke code completion

### DIFF
--- a/pkgs/sketch_pad/lib/editor/editor.dart
+++ b/pkgs/sketch_pad/lib/editor/editor.dart
@@ -98,6 +98,15 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
   CompletionType completionType = CompletionType.auto;
 
   final FocusNode _focusNode = FocusNode(onKeyEvent: (node, event) {
+    // // todo:
+    // if (event is KeyDownEvent) {
+    //   if (event.logicalKey == LogicalKeyboardKey.period) {
+    //     // Introduce a delay here to allow codemirror to process the key
+    //     // event.
+    //     Timer.run(() => showCompletions(autoInvoked: true));
+    //   }
+    // }
+
     // If focused, allow CodeMirror to handle tab.
     if (node.hasFocus && event.logicalKey == LogicalKeyboardKey.tab) {
       return KeyEventResult.skipRemainingHandlers;
@@ -107,8 +116,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
   });
 
   @override
-  void showCompletions() {
-    completionType = CompletionType.manual;
+  void showCompletions({required bool autoInvoked}) {
+    completionType = autoInvoked ? CompletionType.auto : CompletionType.manual;
 
     codeMirror?.execCommand('autocomplete');
   }
@@ -377,8 +386,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
           .map((suggestion) => suggestion.toHintResult())
           .toList();
 
-      // Remove hints where both the replacement text and the display text are the
-      // same.
+      // Remove hints where both the replacement text and the display text are
+      // the same.
       final memos = <String>{};
       hints.retainWhere((hint) {
         return memos.add('${hint.text}:${hint.displayText}');

--- a/pkgs/sketch_pad/lib/main.dart
+++ b/pkgs/sketch_pad/lib/main.dart
@@ -461,7 +461,7 @@ class _DartPadMainPageState extends State<DartPadMainPage>
               if (!appModel.formattingBusy.value) _handleFormatting();
             },
             keys.codeCompletionKeyActivator: () {
-              appServices.editorService?.showCompletions();
+              appServices.editorService?.showCompletions(autoInvoked: false);
             },
             keys.quickFixKeyActivator1: () {
               appServices.editorService?.showQuickFixes();

--- a/pkgs/sketch_pad/lib/model.dart
+++ b/pkgs/sketch_pad/lib/model.dart
@@ -30,7 +30,7 @@ abstract class ExecutionService {
 }
 
 abstract class EditorService {
-  void showCompletions();
+  void showCompletions({required bool autoInvoked});
   void showQuickFixes();
   void jumpTo(AnalysisIssue issue);
   int get cursorOffset;


### PR DESCRIPTION
- when a period is typed, auto-invoke code completion

Note that this implementation is a little bit racy as we directly query the `HardwareKeyboard` key modifiers.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
