### PR TITLE
fix syntax issue in .cloud_build/dart_services.yaml

### DIFF
--- a/.cloud_build/dart_services.yaml
+++ b/.cloud_build/dart_services.yaml
@@ -15,7 +15,7 @@ steps:
 
   # Run pub get
   - name: gcr.io/$PROJECT_ID/flutter:${_FLUTTER_CHANNEL}
-    id: Build storage artifacts
+    id: Run pub get
     entrypoint: dart
     args:
       - pub


### PR DESCRIPTION
- fix syntax issue in .cloud_build/dart_services.yaml ("invalid .steps field: build step #2 - "Build storage artifacts": the ID is not unique")

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
