### PR TITLE
Use gstatic URL for canvaskit, to avoid CORS errors

### DIFF
--- a/pkgs/dartpad_ui/firebase.json
+++ b/pkgs/dartpad_ui/firebase.json
@@ -84,15 +84,6 @@
           ]
         },
         {
-          "source": "/canvaskit/chromium/canvaskit.wasm",
-          "headers": [
-            {
-              "key": "Access-Control-Allow-Origin",
-              "value": "*"
-            }
-          ]
-        },
-        {
           "source": "**",
           "headers": [
             {

--- a/pkgs/dartpad_ui/web/frame.js
+++ b/pkgs/dartpad_ui/web/frame.js
@@ -22,17 +22,19 @@ function messageHandler(e) {
   var obj = e.data;
 
   if (obj.command === 'execute') {
-    runFlutterApp(obj.js);
+    runFlutterApp(obj.js, obj.canvasKitBaseUrl);
   }
 };
 
-function runFlutterApp(compiledScript) {
+function runFlutterApp(compiledScript, canvasKitBaseUrl) {
   var blob = new Blob([compiledScript], {type: 'text/javascript'});
   var url = URL.createObjectURL(blob);
   _flutter.loader.loadEntrypoint({
     entrypointUrl: url,
     onEntrypointLoaded: async function(engineInitializer) {
-      let appRunner = await engineInitializer.initializeEngine();
+      let appRunner = await engineInitializer.initializeEngine(
+          {canvasKitBaseUrl: canvasKitBaseUrl}
+      );
       appRunner.runApp();
     }
   });


### PR DESCRIPTION
Follow up for https://github.com/dart-lang/dart-pad/pull/2960

This ensures that we are loading from the gstatic CDN. The flutter.js bootstrapping engine seems to use the local web server (probably because we are using DDC to compile) but we should be using the CDN.

This also will likely fix CORS errors happening in Safari and Firefox (https://github.com/dart-lang/dart-pad/issues/2963)