### PR TITLE
Corrects a lint error in the Gemini sample

### DIFF
--- a/pkgs/dartpad_ui/lib/samples.g.dart
+++ b/pkgs/dartpad_ui/lib/samples.g.dart
@@ -776,7 +776,7 @@ class MessageWidget extends StatelessWidget {
             decoration: BoxDecoration(
               color: isFromUser
                   ? Theme.of(context).colorScheme.primaryContainer
-                  : Theme.of(context).colorScheme.surfaceVariant,
+                  : Theme.of(context).colorScheme.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(18),
             ),
             padding: const EdgeInsets.symmetric(

--- a/pkgs/samples/lib/google_ai.dart
+++ b/pkgs/samples/lib/google_ai.dart
@@ -300,7 +300,7 @@ class MessageWidget extends StatelessWidget {
             decoration: BoxDecoration(
               color: isFromUser
                   ? Theme.of(context).colorScheme.primaryContainer
-                  : Theme.of(context).colorScheme.surfaceVariant,
+                  : Theme.of(context).colorScheme.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(18),
             ),
             padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
Swaps one instance of `surfaceVariant` for the new `surfaceContainerHighest`, since the former is deprecated in 3.22. Tested the new code in DartPad, ad it's analyzing and running fine.

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.