### PR TITLE
add an experimental gemini call to the backend

### DIFF
--- a/pkgs/dart_services/Dockerfile
+++ b/pkgs/dart_services/Dockerfile
@@ -1,6 +1,7 @@
 ARG PROJECT_ID
 ARG FLUTTER_CHANNEL
 ARG BUILD_SHA
+ARG GOOGLE_API_KEY
 
 FROM gcr.io/$PROJECT_ID/flutter:$FLUTTER_CHANNEL
 
@@ -16,6 +17,7 @@ RUN dart compile exe bin/server.dart -o bin/server
 RUN dart run grinder build-project-templates
 
 ENV BUILD_SHA=$BUILD_SHA
+ENV GOOGLE_API_KEY=$GOOGLE_API_KEY
 
 EXPOSE 8080
 CMD ["/app/bin/server"]

--- a/pkgs/dart_services/README.md
+++ b/pkgs/dart_services/README.md
@@ -43,12 +43,6 @@ To rebuild the shelf router, run:
 dart run build_runner build --delete-conflicting-outputs
 ```
 
-And to update the shared code from dartpad_shared, run:
-
-```
-dart tool/grind.dart copy-shared-source
-```
-
 ### Modifying supported packages
 
 Package dependencies are pinned using the `pub_dependencies_<CHANNEL>.yaml`

--- a/pkgs/dart_services/analysis_options.yaml
+++ b/pkgs/dart_services/analysis_options.yaml
@@ -17,3 +17,4 @@ linter:
   rules:
     - prefer_final_in_for_each
     - prefer_final_locals
+    - sort_pub_dependencies

--- a/pkgs/dart_services/lib/src/common_server.dart
+++ b/pkgs/dart_services/lib/src/common_server.dart
@@ -202,7 +202,7 @@ class CommonServerApi {
     return ok(version().toJson());
   }
 
-  static String? googleApiKey = Platform.environment['GOOGLE_API_KEY'];
+  static final String? googleApiKey = Platform.environment['GOOGLE_API_KEY'];
   http.Client? geminiHttpClient;
 
   @Route.post('$apiPrefix/_gemini')

--- a/pkgs/dart_services/lib/src/common_server.dart
+++ b/pkgs/dart_services/lib/src/common_server.dart
@@ -7,11 +7,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dartpad_shared/model.dart' as api;
+import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
+import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
-import 'package:google_generative_ai/google_generative_ai.dart' as google_ai;
-import 'package:http/http.dart' as http;
 
 import 'analysis.dart';
 import 'caching.dart';

--- a/pkgs/dart_services/lib/src/common_server.dart
+++ b/pkgs/dart_services/lib/src/common_server.dart
@@ -209,13 +209,6 @@ class CommonServerApi {
   Future<Response> gemini(Request request, String apiVersion) async {
     if (apiVersion != api3) return unhandledVersion(apiVersion);
 
-    // Read the api key from env variables (populated on the server).
-    final apiKey = googleApiKey;
-    if (apiKey == null) {
-      return Response.internalServerError(
-          body: 'gemini key not configured on server');
-    }
-
     // Only allow the call from known clients / endpoints.
     const firebaseHostAddress = '199.36.158.100';
     const localHostAddress = '127.0.0.1';
@@ -225,6 +218,13 @@ class CommonServerApi {
         clientAddress != localHostAddress) {
       return Response.badRequest(
           body: 'gemini calls only allowed from the DartPad frontend');
+    }
+
+    // Read the api key from env variables (populated on the server).
+    final apiKey = googleApiKey;
+    if (apiKey == null) {
+      return Response.internalServerError(
+          body: 'gemini key not configured on server');
     }
 
     final sourceRequest =

--- a/pkgs/dart_services/lib/src/common_server.g.dart
+++ b/pkgs/dart_services/lib/src/common_server.g.dart
@@ -48,5 +48,10 @@ Router _$CommonServerApiRouter(CommonServerApi service) {
     r'/api/<apiVersion>/version',
     service.versionGet,
   );
+  router.add(
+    'POST',
+    r'/api/<apiVersion>/_gemini',
+    service.gemini,
+  );
   return router;
 }

--- a/pkgs/dart_services/pubspec.yaml
+++ b/pkgs/dart_services/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   bazel_worker: ^1.1.1
   dartpad_shared: any
   encrypt: ^5.0.3
+  google_generative_ai: ^0.4.0  
   http: ^1.2.1
   json_annotation: any
   logging: ^1.2.0

--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -376,6 +376,23 @@ class VersionResponse {
 }
 
 @JsonSerializable()
+class GeminiResponse {
+  final String response;
+
+  GeminiResponse({
+    required this.response,
+  });
+
+  factory GeminiResponse.fromJson(Map<String, dynamic> json) =>
+      _$GeminiResponseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$GeminiResponseToJson(this);
+
+  @override
+  String toString() => 'GeminiResponse[response=$response]';
+}
+
+@JsonSerializable()
 class PackageInfo {
   final String name;
   final String version;

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -296,6 +296,16 @@ Map<String, dynamic> _$VersionResponseToJson(VersionResponse instance) =>
       'packages': instance.packages,
     };
 
+GeminiResponse _$GeminiResponseFromJson(Map<String, dynamic> json) =>
+    GeminiResponse(
+      response: json['response'] as String,
+    );
+
+Map<String, dynamic> _$GeminiResponseToJson(GeminiResponse instance) =>
+    <String, dynamic>{
+      'response': instance.response,
+    };
+
 PackageInfo _$PackageInfoFromJson(Map<String, dynamic> json) => PackageInfo(
       name: json['name'] as String,
       version: json['version'] as String,

--- a/pkgs/dartpad_shared/lib/services.dart
+++ b/pkgs/dartpad_shared/lib/services.dart
@@ -102,4 +102,4 @@ class _Experimental {
   const _Experimental();
 }
 
-const _Experimental experimental = _Experimental();
+const Object experimental = _Experimental();

--- a/pkgs/dartpad_shared/lib/services.dart
+++ b/pkgs/dartpad_shared/lib/services.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart';
+import 'package:meta/meta.dart';
 
 import 'model.dart';
 
@@ -97,9 +98,3 @@ class ApiRequestError implements Exception {
   @override
   String toString() => '$message: $body';
 }
-
-class _Experimental {
-  const _Experimental();
-}
-
-const Object experimental = _Experimental();

--- a/pkgs/dartpad_shared/lib/services.dart
+++ b/pkgs/dartpad_shared/lib/services.dart
@@ -40,6 +40,11 @@ class ServicesClient {
   Future<CompileDDCResponse> compileDDC(CompileRequest request) =>
       _requestPost('compileDDC', request.toJson(), CompileDDCResponse.fromJson);
 
+  /// Note: this API is experimental and could change or be removed at any time.
+  @experimental
+  Future<GeminiResponse> gemini(SourceRequest request) =>
+      _requestPost('_gemini', request.toJson(), GeminiResponse.fromJson);
+
   void dispose() => client.close();
 
   Future<T> _requestGet<T>(
@@ -92,3 +97,9 @@ class ApiRequestError implements Exception {
   @override
   String toString() => '$message: $body';
 }
+
+class _Experimental {
+  const _Experimental();
+}
+
+const _Experimental experimental = _Experimental();

--- a/pkgs/dartpad_shared/pubspec.yaml
+++ b/pkgs/dartpad_shared/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 dependencies:
   http: ^1.1.0
   json_annotation: ^4.9.0
+  meta: ^1.14.0
 
 dev_dependencies:
   build_runner: ^2.4.5

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -317,6 +317,10 @@ class AppServices {
     return await services.document(request);
   }
 
+  Future<GeminiResponse> gemini(SourceRequest request) async {
+    return await services.gemini(request);
+  }
+
   Future<CompileResponse> compile(CompileRequest request) async {
     try {
       appModel.compilingBusy.value = true;


### PR DESCRIPTION
Add an experimental gemini call to the backend:

- add an experimental gemini call to the backend
- a `GOOGLE_API_KEY` will need to be configured in the cloud serving infra
- the api call uses the `gemini-1.5-flash-latest` model
- calls are currently restricted to firebase hosted apps (and local development)
- no UI is hooked up as yet

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
