### PR TITLE
Only allow DartPad injection from window.parent

### DIFF
--- a/pkgs/dartpad_ui/lib/embed.dart
+++ b/pkgs/dartpad_ui/lib/embed.dart
@@ -13,7 +13,7 @@ void handleEmbedMessage(AppModel model) {
   web.window.addEventListener(
     'message',
     (web.MessageEvent event) {
-      if (event.source !== web.window.parent) return;
+      if (event.source != web.window.parent) return;
       if (event.data case _SourceCodeMessage(:final type?, :final sourceCode?)
           when type == 'sourceCode') {
         if (sourceCode.isNotEmpty) {

--- a/pkgs/dartpad_ui/lib/embed.dart
+++ b/pkgs/dartpad_ui/lib/embed.dart
@@ -13,6 +13,7 @@ void handleEmbedMessage(AppModel model) {
   web.window.addEventListener(
     'message',
     (web.MessageEvent event) {
+      if (event.source !== web.window.parent) return;
       if (event.data case _SourceCodeMessage(:final type?, :final sourceCode?)
           when type == 'sourceCode') {
         if (sourceCode.isNotEmpty) {

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source == null || event.source != _frame.contentWindow) {
+            if (data['sender'] != 'frame' || _frame.contentWindow == null || event.source != _frame.contentWindow) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,10 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source == null || _frame.contentWindow != event.source) {
+            if (data['sender'] != 'frame') {
+              return;
+            }
+            if (event.source == null || _frame.contentWindow != event.source) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source.parent! != web.window) {
+            if (data['sender'] != 'frame' || web.event.source.parent != web.window) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || web.event.source.parent != web.window) {
+            if (data['sender'] != 'frame' || _frame.contentWindow != event.source) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source != _frame.contentWindow) {
+            if (data['sender'] != 'frame' || event.source.top != _frame.contentWindow.top) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source?.parent? != web.window) {
+            if (data['sender'] != 'frame' || _frame.contentWindow &&  event.source != _frame.contentWindow) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source.parent != web.window) {
+            if (data['sender'] != 'frame' || event.source?.parent? != web.window) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || !_frame || event.source != _frame) {
+            if (data['sender'] != 'frame' || event.source.top != web.window.top) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source.top != _frame.contentWindow.top) {
+            if (data['sender'] != 'frame' || event.source.parent! != web.window) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || event.source.top != web.window.top) {
+            if (data['sender'] != 'frame' || event.source.parent != web.window) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || _frame.contentWindow &&  event.source != _frame.contentWindow) {
+            if (data['sender'] != 'frame' || event.source == null || event.source != _frame.contentWindow) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || _frame.contentWindow != event.source) {
+            if (data['sender'] != 'frame' || event.source == null || _frame.contentWindow != event.source) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame') {
+            if (data['sender'] != 'frame' || !_frame || event.source != _frame) {
               return;
             }
             final type = data['type'] as String?;

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -165,7 +165,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         (web.Event event) {
           if (event is web.MessageEvent) {
             final data = event.data.dartify() as Map<Object?, Object?>;
-            if (data['sender'] != 'frame' || _frame.contentWindow == null || event.source != _frame.contentWindow) {
+            if (data['sender'] != 'frame' || event.source != _frame.contentWindow) {
               return;
             }
             final type = data['type'] as String?;


### PR DESCRIPTION
```js
w = open('https://docs.flutter.dev/cookbook/effects/staggered-menu-animation#interactive-example');
setTimeout(() => {
 w[0].postMessage({sourceCode: ':)', type: 'sourceCode'}, '*')
}, 1000)
```

This PR forces code injection to be from the parent so I cant modify docs.flutter.dev :)
Improvement on #2943 but still don't know what I'm doing.