### PR TITLE
Install bash in Firebase Dockerfile

### DIFF
--- a/.cloud_build/firebase/Dockerfile
+++ b/.cloud_build/firebase/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:lts-alpine3.14 AS app-env
 
+RUN apk add --no-cache bash
 RUN npm install -g firebase-tools
 
 ADD firebase.bash /usr/bin


### PR DESCRIPTION
This was accidentally removed in https://github.com/dart-lang/dart-pad/pull/2991

```
Step #1: exec /usr/bin/firebase.bash: no such file or directory
```