### PR TITLE
Remove unused title generation

### DIFF
--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -182,7 +182,7 @@ class AppServices {
     appModel.sourceCodeController.text = source;
 
     // Reset the title.
-    appModel.title.value = generateSnippetName();
+    appModel.title.value = '';
 
     // Reset the console.
     appModel.clearConsole();

--- a/pkgs/dartpad_ui/lib/utils.dart
+++ b/pkgs/dartpad_ui/lib/utils.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:fluttering_phrases/fluttering_phrases.dart'
-    as fluttering_phrases;
 
 import 'theme.dart';
 
@@ -19,8 +17,6 @@ String pluralize(String word, int count) {
 String titleCase(String phrase) {
   return phrase.substring(0, 1).toUpperCase() + phrase.substring(1);
 }
-
-String generateSnippetName() => fluttering_phrases.generate();
 
 RelativeRect calculatePopupMenuPosition(
   BuildContext context, {

--- a/pkgs/dartpad_ui/pubspec.yaml
+++ b/pkgs/dartpad_ui/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   flutter_markdown: ^0.7.2
   flutter_web_plugins:
     sdk: flutter
-  fluttering_phrases: ^1.0.0
   go_router: ^14.1.4
   google_fonts: ^6.2.1
   http: ^1.2.1


### PR DESCRIPTION
Since we dropped sharing from within the DartPad UI, no need to generate a title that may cause users to wonder why it's there. Still surface titles from gists and samples.

Closes https://github.com/dart-lang/dart-pad/issues/925