### PR TITLE
Enable clipboard write access in DartPad frame

### DIFF
--- a/pkgs/dartpad_ui/lib/execution/execution.dart
+++ b/pkgs/dartpad_ui/lib/execution/execution.dart
@@ -32,6 +32,7 @@ web.Element _iFrameFactory(int viewId) {
     ..sandbox.add('allow-scripts')
     ..sandbox.add('allow-popups')
     ..sandbox.add('allow-popups-to-escape-sandbox')
+    ..allow += 'clipboard-write; '
     ..src = 'frame.html'
     ..style.border = 'none'
     ..style.width = '100%'


### PR DESCRIPTION
Does not add read access for security reasons.

Fixes https://github.com/dart-lang/dart-pad/issues/1620