### PR TITLE
Migrate DartPad UI (not frame) to new bootstrap mechanism

### DIFF
--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -20,11 +20,6 @@
   <title>DartPad</title>
   <link rel="manifest" href="manifest.json">
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    const serviceWorkerVersion = null;
-  </script>
-
   <link href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap" rel="stylesheet">
   <link href="codemirror/codemirror.css" rel="stylesheet">
   <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
@@ -80,26 +75,11 @@
       width: 100%;
     }
   </style>
-
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 
 <body>
   <script>
-    window.addEventListener('load', function (ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function (engineInitializer) {
-          engineInitializer.initializeEngine().then(function (appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
+    {{flutter_bootstrap_js}}
   </script>
 </body>
 

--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -82,9 +82,7 @@
 </head>
 
 <body>
-  <script>
-    {{flutter_bootstrap_js}}
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart-pad/issues/3020

Uses the new bootstrapping mechanism documented at https://docs.flutter.dev/platform-integration/web/bootstrapping.