### PR TITLE
Stop scrolling to end of console on selection

### DIFF
--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -10,11 +10,11 @@ import 'widgets.dart';
 
 class ConsoleWidget extends StatefulWidget {
   final bool showDivider;
-  final TextEditingController textController;
+  final ValueNotifier<String> output;
 
   const ConsoleWidget({
     this.showDivider = true,
-    required this.textController,
+    required this.output,
     super.key,
   });
 
@@ -30,12 +30,12 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
     super.initState();
 
     scrollController = ScrollController();
-    widget.textController.addListener(_scrollToEnd);
+    widget.output.addListener(_scrollToEnd);
   }
 
   @override
   void dispose() {
-    widget.textController.removeListener(_scrollToEnd);
+    widget.output.removeListener(_scrollToEnd);
     scrollController?.dispose();
     scrollController = null;
 
@@ -59,47 +59,44 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
             : null,
       ),
       padding: const EdgeInsets.all(denseSpacing),
-      child: Stack(
-        children: [
-          TextField(
-            controller: widget.textController,
-            scrollController: scrollController,
-            maxLines: null,
-            keyboardType: TextInputType.multiline,
-            textInputAction: TextInputAction.newline,
-            expands: true,
-            decoration: null,
-            style: GoogleFonts.robotoMono(
-              fontSize: theme.textTheme.bodyMedium?.fontSize,
-            ),
-            readOnly: true,
-          ),
-          Padding(
-            padding: const EdgeInsets.all(denseSpacing),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ValueListenableBuilder(
-                  valueListenable: widget.textController,
-                  builder: (context, value, _) {
-                    return MiniIconButton(
-                      icon: Icons.playlist_remove,
-                      tooltip: 'Clear console',
-                      onPressed: value.text.isEmpty ? null : _clearConsole,
-                    );
-                  },
+      child: ValueListenableBuilder(
+        valueListenable: widget.output,
+        builder: (context, value, _) => Stack(
+          children: [
+            SizedBox.expand(
+              child: SingleChildScrollView(
+                controller: scrollController,
+                child: SelectableText(
+                  value,
+                  maxLines: null,
+                  style: GoogleFonts.robotoMono(
+                    fontSize: theme.textTheme.bodyMedium?.fontSize,
+                  ),
                 ),
-              ],
+              ),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.all(denseSpacing),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  MiniIconButton(
+                    icon: Icons.playlist_remove,
+                    tooltip: 'Clear console',
+                    onPressed: value.isEmpty ? null : _clearConsole,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
   void _clearConsole() {
-    widget.textController.clear();
+    widget.output.value = '';
   }
 
   void _scrollToEnd() {

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -379,7 +379,7 @@ class _DartPadMainPageState extends State<DartPadMainPage>
                     SizedBox(
                       height: consoleHeight,
                       child: ConsoleWidget(
-                        textController: appModel.consoleOutputController,
+                        output: appModel.consoleOutput,
                         showDivider: mode == LayoutMode.both,
                         key: _consoleKey,
                       ),

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -48,7 +48,7 @@ class AppModel {
   final ValueNotifier<String> title = ValueNotifier('');
 
   final TextEditingController sourceCodeController = TextEditingController();
-  final TextEditingController consoleOutputController = TextEditingController();
+  final ValueNotifier<String> consoleOutput = ValueNotifier('');
 
   final ValueNotifier<bool> formattingBusy = ValueNotifier(false);
   final ValueNotifier<bool> compilingBusy = ValueNotifier(false);
@@ -76,7 +76,7 @@ class AppModel {
   late final StreamSubscription<SplitDragState> _splitSubscription;
 
   AppModel() {
-    consoleOutputController.addListener(_recalcLayout);
+    consoleOutput.addListener(_recalcLayout);
 
     _splitSubscription =
         splitDragStateManager.onSplitDragUpdated.listen((SplitDragState value) {
@@ -85,18 +85,18 @@ class AppModel {
   }
 
   void appendLineToConsole(String str) {
-    consoleOutputController.text += '$str\n';
+    consoleOutput.value += '$str\n';
   }
 
-  void clearConsole() => consoleOutputController.clear();
+  void clearConsole() => consoleOutput.value = '';
 
   void dispose() {
-    consoleOutputController.removeListener(_recalcLayout);
+    consoleOutput.removeListener(_recalcLayout);
     _splitSubscription.cancel();
   }
 
   void _recalcLayout() {
-    final hasConsoleText = consoleOutputController.text.isNotEmpty;
+    final hasConsoleText = consoleOutput.value.isNotEmpty;
     final isFlutter = _appIsFlutter;
     final usesPackageWeb = _usesPackageWeb;
 


### PR DESCRIPTION
I believe this fixes it as the text editing controller was triggering the listener when selections were made. We don't use the text field/editing functionality anyway.

Fixes https://github.com/dart-lang/dart-pad/issues/2931