### PR TITLE
Add custom styling for deprecated diagnostic hint

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -353,12 +353,15 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     for (final issue in issues) {
       final line = math.max(issue.location.line - 1, 0);
       final column = math.max(issue.location.column - 1, 0);
+      final isDeprecation =
+          issue.code?.contains('deprecated_member_use') ?? false;
+      final kind = isDeprecation ? 'deprecation' : issue.kind;
 
       doc.markText(
         Position(line: line, ch: column),
         Position(line: line, ch: column + issue.location.charLength),
         MarkTextOptions(
-          className: 'squiggle-${issue.kind}',
+          className: 'squiggle-$kind',
           title: issue.message,
         ),
       );

--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -45,6 +45,10 @@
     .squiggle-error {
       border-bottom: 2px solid #EF5350;
     }
+    .squiggle-deprecation {
+      text-decoration: line-through;
+      text-decoration-thickness: 10%;
+    }
 
     .CodeMirror-simplescroll-horizontal div, .CodeMirror-simplescroll-vertical div {
       position: absolute;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/dart-pad/issues/1444

<img width="374" alt="Specialize the styling for the deprecation diagnostics" src="https://github.com/dart-lang/dart-pad/assets/18372958/35b3f4ba-3a00-4709-8c0a-b03ab1849ff8">
