### PR TITLE
Add a checklist to PR template to catch potential downstream breakages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.
+
+---
+
+<details>
+  <summary>Downstream effects:</summary><br>
+Review the following checklist to determine if your change could affect
+downstream users or embedders of DartPad.
+If your change matches any of the following situations, please
+note why it won't affect downstream users or include a migration plan.
+
+- [ ] Changes the behavior or default value of a query parameter.
+- [ ] Removes a query parameter.
+- [ ] Changes the mobile/narrow layout of DartPad.
+- [ ] Touches the event handling and messaging with the parent window when embedded.
+- [ ] Touches the loading of API doc samples or gists.
+- [ ] Removes support for a package maintained by the Dart or Flutter team.
+</details>
+
+---
+
+- [ ] I've reviewed the contributor guide and applied the relevant portions to this PR.
+
+<details>
+  <summary>Contribution guidelines:</summary><br>
+
+- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
+- Large or significant changes should be discussed in an issue before creating a PR.
+- Contributions to DartPad should follow the [Dart style guide](https://dart.dev/effective-dart) and use `dart format`.
+- Potential breakages and accessibility should be considered with every change.
+
+Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
+</details>


### PR DESCRIPTION
Sort of resolves https://github.com/dart-lang/dart-pad/issues/2879 by requiring contributors to be more conscious about changes that could affect DartPad embedders.

The rest of the template is mostly taken from the `dart-lang` shared one.