### PR TITLE
Use onNodeCreated to set crossorigin: anonymous on requirejs scripts

### DIFF
--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -92,7 +92,8 @@ window.onerror = function(message, url, line, column, error) {
       script.writeln('''
 require.config({
   "baseUrl": "$modulesBaseUrl",
-  "waitSeconds": 60
+  "waitSeconds": 60,
+  "onNodeCreated": function(node, config, id, url) { node.setAttribute('crossorigin', 'anonymous'); }
 });
 ''');
     }

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -88,6 +88,8 @@ window.onerror = function(message, url, line, column, error) {
 };
 ''');
 
+    // Set the crossorigin: anonymous attribute on require.js scripts.
+    // For example, dart_sdk.js or flutter_web.js.
     if (modulesBaseUrl != null) {
       script.writeln('''
 require.config({


### PR DESCRIPTION
This sets the crossorigin: anonymous attribute for any require.js scripts that are loaded into the execution iframe.

You can test Wasm locally using:

```
flutter build web --wasm
dhttpd '--headers=Cross-Origin-Embedder-Policy=require-corp;Cross-Origin-Opener-Policy=same-origin;Cross-Origin-Resource-Policy=cross-origin' --path=build/web
```

To use `flutter run -d -chrome --wasm`, you need to make this change to `flutter_tool`:
https://github.com/flutter/flutter/pull/152048

[Staged version](https://dart-pad-a3c64--wasm-ilsdfobw.web.app/)

cc @eyebrowsoffire

closes #3030