### PR TITLE
disable opening the docs panel

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -545,8 +545,12 @@ class _DartPadMainPageState extends State<DartPadMainPage>
   static final RegExp identifierChar = RegExp(r'[\w\d_<=>]');
 
   void _handleDocClicked() async {
-    // TODO: Support having the escape key close the doc panel.
+    // TODO(devoncarew): Disable opening the documentation panel; this is too
+    // disruptive when people are editing code. We should switch to using a
+    // tooltip (https://github.com/dart-lang/dart-pad/issues/3032).
+    return;
 
+    // ignore: dead_code
     try {
       final source = appModel.sourceCodeController.text;
       final offset = appModel.lastEditorClickOffset.value;


### PR DESCRIPTION
- Disable opening the documentation panel; this is too disruptive when people are editing code. We should switch to using a tooltip (https://github.com/dart-lang/dart-pad/issues/3032).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
