### PR TITLE
use a larger machine type to build the flutter images

### DIFF
--- a/.cloud_build/flutter/cloudbuild.yaml
+++ b/.cloud_build/flutter/cloudbuild.yaml
@@ -38,6 +38,8 @@ steps:
     args: ['--help']
     dir: .cloud_build/flutter
 
+options:
+  machineType: 'E2_HIGHCPU_8'
 images: [
   'gcr.io/$PROJECT_ID/flutter:main',
   'gcr.io/$PROJECT_ID/flutter:beta',


### PR DESCRIPTION
- use a larger machine type to build the flutter images

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
