### PR TITLE
Enable --wasm flag for production builds

### DIFF
--- a/.cloud_build/dart_pad.yaml
+++ b/.cloud_build/dart_pad.yaml
@@ -1,6 +1,6 @@
 steps:
   - name: gcr.io/$PROJECT_ID/flutter:main
-    args: ['build', 'web']
+    args: ['build', 'web', '--wasm']
     dir: pkgs/dartpad_ui
   - name: gcr.io/$PROJECT_ID/firebase
     args: ['deploy', '--project=$PROJECT_ID', '--only', 'hosting:dartpad']

--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -199,7 +199,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     // darkmode
     _updateCodemirrorMode(darkMode);
 
-    Timer.run(() => codeMirror!.refresh());
+    Future.delayed(
+        const Duration(milliseconds: 80), () => codeMirror!.refresh());
 
     codeMirror!.on(
       'change',

--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -199,6 +199,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     // darkmode
     _updateCodemirrorMode(darkMode);
 
+    // Use a longer delay so that the platform view is displayed
+    // correctly when compiled to Wasm
     Future.delayed(
         const Duration(milliseconds: 80), () => codeMirror!.refresh());
 
@@ -259,7 +261,10 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         for (final entry in entries.toDart) {
           if (entry.isIntersecting) {
             observer.unobserve(web.document.body!);
-            Timer.run(() => codeMirror!.refresh());
+            // Use a longer delay so that the platform view is displayed
+            // correctly when compiled to Wasm
+            Future.delayed(
+                const Duration(milliseconds: 80), () => codeMirror!.refresh());
             return;
           }
         }


### PR DESCRIPTION
The UI is working nicely when built with the latest version Flutter engine, so it would be great to start using Wasm for the production version of DartPad. (The remaining issues with platform views have been fixed on the main channel of the SDK.)

Here's a staged version built with the `--wasm` flag, using the latest Flutter SDK (main channel): https://dart-pad-a3c64--wasm-cdjiko6q.web.app/

I made sure to update the Flutter SDK images to the latest version of the `main` channel of the SDK in GCP, so once this is merged it should use those images.