### PR TITLE
Add support for vim keymap and emulation

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/codemirror.dart
+++ b/pkgs/dartpad_ui/lib/editor/codemirror.dart
@@ -50,6 +50,9 @@ extension type CodeMirror._(JSObject _) implements JSObject {
   String getTheme() => (getOption('theme') as JSString).toDart;
   void setTheme(String theme) => setOption('theme', theme.toJS);
 
+  String getKeymap() => (getOption('keyMap') as JSString).toDart;
+  void setKeymap(String keyMap) => setOption('keyMap', keyMap.toJS);
+
   external void scrollTo(num? x, num? y);
   external ScrollInfo getScrollInfo();
 

--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -236,6 +236,7 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     appModel.sourceCodeController.addListener(_updateCodemirrorFromModel);
     appModel.analysisIssues
         .addListener(() => _updateIssues(appModel.analysisIssues.value));
+    appModel.vimKeymapsEnabled.addListener(_updateCodemirrorKeymap);
 
     widget.appServices.registerEditorService(this);
 
@@ -317,6 +318,7 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     widget.appModel.sourceCodeController
         .removeListener(_updateCodemirrorFromModel);
     widget.appModel.appReady.removeListener(_updateEditableStatus);
+    widget.appModel.vimKeymapsEnabled.removeListener(_updateCodemirrorKeymap);
 
     super.dispose();
   }
@@ -430,6 +432,17 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         from: doc.posFromIndex(offset),
         to: doc.posFromIndex(offset + length),
       );
+    }
+  }
+
+  void _updateCodemirrorKeymap() {
+    final enabled = widget.appModel.vimKeymapsEnabled.value;
+    final cm = codeMirror!;
+
+    if (enabled) {
+      cm.setKeymap('vim');
+    } else {
+      cm.setKeymap('default');
     }
   }
 }

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -830,7 +830,10 @@ class StatusLineWidget extends StatelessWidget {
                 builder: (context) => MediumDialog(
                   title: 'Keyboard shortcuts',
                   smaller: true,
-                  child: KeyBindingsTable(bindings: keys.keyBindings),
+                  child: KeyBindingsTable(
+                    bindings: keys.keyBindings,
+                    appModel: appModel,
+                  ),
                 ),
               ),
               child: Icon(
@@ -1156,9 +1159,11 @@ class ContinueInMenu extends StatelessWidget {
 
 class KeyBindingsTable extends StatelessWidget {
   final List<(String, List<ShortcutActivator>)> bindings;
+  final AppModel appModel;
 
   const KeyBindingsTable({
     required this.bindings,
+    required this.appModel,
     super.key,
   });
 
@@ -1208,6 +1213,10 @@ class KeyBindingsTable extends StatelessWidget {
               ),
             ],
           ),
+        ),
+        const Divider(),
+        _VimModeSwitch(
+          appModel: appModel,
         ),
       ],
     );
@@ -1279,6 +1288,32 @@ class _BrightnessButton extends StatelessWidget {
         },
       ),
     );
+  }
+}
+
+class _VimModeSwitch extends StatelessWidget {
+  final AppModel appModel;
+
+  const _VimModeSwitch({
+    required this.appModel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: appModel.vimKeymapsEnabled,
+      builder: (BuildContext context, bool value, Widget? child) {
+        return SwitchListTile(
+          value: value,
+          title: const Text('Use Vim Key Bindings'),
+          onChanged: _handleToggle,
+        );
+      },
+    );
+  }
+
+  void _handleToggle(bool value) {
+    appModel.vimKeymapsEnabled.value = value;
   }
 }
 

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -75,6 +75,8 @@ class AppModel {
   final SplitDragStateManager splitDragStateManager = SplitDragStateManager();
   late final StreamSubscription<SplitDragState> _splitSubscription;
 
+  final ValueNotifier<bool> vimKeymapsEnabled = ValueNotifier(false);
+
   AppModel() {
     consoleOutput.addListener(_recalcLayout);
 


### PR DESCRIPTION
Addresses #2902 by adding back support for vim-mode, which was removed from the new version.

![Screenshot 2024-08-18 at 7 09 51 PM](https://github.com/user-attachments/assets/f81e46a7-32d6-4f5b-9c0a-7c41e185b1dd)

![Screenshot 2024-08-18 at 7 10 07 PM](https://github.com/user-attachments/assets/56dd91f1-9eaf-455e-9459-ecc2d6cf7575)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
