### PR TITLE
show dartdoc documentation in a model dialog

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -225,14 +225,6 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
       }.toJS,
     );
 
-    codeMirror!.on(
-      'mousedown',
-      ([JSAny? _, JSAny? __]) {
-        // Delay slightly to allow codemirror to update the cursor position.
-        Timer.run(() => appModel.lastEditorClickOffset.value = cursorOffset);
-      }.toJS,
-    );
-
     appModel.sourceCodeController.addListener(_updateCodemirrorFromModel);
     appModel.analysisIssues
         .addListener(() => _updateIssues(appModel.analysisIssues.value));

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -52,6 +52,7 @@ class AppModel {
 
   final ValueNotifier<bool> formattingBusy = ValueNotifier(false);
   final ValueNotifier<bool> compilingBusy = ValueNotifier(false);
+  final ValueNotifier<bool> docHelpBusy = ValueNotifier(false);
 
   final StatusController editorStatus = StatusController();
 
@@ -59,15 +60,6 @@ class AppModel {
 
   final ValueNotifier<LayoutMode> _layoutMode = ValueNotifier(LayoutMode.both);
   ValueListenable<LayoutMode> get layoutMode => _layoutMode;
-
-  /// Whether the docs panel is showing or should show.
-  final ValueNotifier<bool> docsShowing = ValueNotifier(false);
-
-  /// The last document request received.
-  final ValueNotifier<DocumentResponse?> currentDocs = ValueNotifier(null);
-
-  /// Used to pass information about mouse clicks in the editor.
-  final ValueNotifier<int> lastEditorClickOffset = ValueNotifier(0);
 
   final ValueNotifier<SplitDragState> splitViewDragState =
       ValueNotifier(SplitDragState.inactive);

--- a/pkgs/dartpad_ui/lib/widgets.dart
+++ b/pkgs/dartpad_ui/lib/widgets.dart
@@ -205,7 +205,7 @@ class MediumDialog extends StatelessWidget {
       return PointerInterceptor(
         child: AlertDialog(
           backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-          title: Text(title),
+          title: Text(title, maxLines: 1),
           contentTextStyle: Theme.of(context).textTheme.bodyMedium,
           contentPadding: const EdgeInsets.fromLTRB(24, defaultSpacing, 24, 8),
           content: Column(


### PR DESCRIPTION
- move our dartdoc display from a in-line panel to a modal dialog; the docs dialog is opened by a new FAB, next to the format button

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>

<img width="258" alt="Screenshot 2024-08-27 at 11 43 20 AM" src="https://github.com/user-attachments/assets/d1157401-cad7-4cc6-8715-e78ccb913d28">

<img width="872" alt="Screenshot 2024-08-27 at 11 43 32 AM" src="https://github.com/user-attachments/assets/b0990316-8e5b-4f53-bad8-f8dd497f1c73">

