### PR TITLE
convert dartpad over to use styled_widget

### DIFF
--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:styled_widget/styled_widget.dart';
 
 import 'theme.dart';
 import 'widgets.dart';
@@ -75,20 +76,17 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
                 ),
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.all(denseSpacing),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  MiniIconButton(
-                    icon: Icons.playlist_remove,
-                    tooltip: 'Clear console',
-                    onPressed: value.isEmpty ? null : _clearConsole,
-                  ),
-                ],
-              ),
-            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                MiniIconButton(
+                  icon: Icons.playlist_remove,
+                  tooltip: 'Clear console',
+                  onPressed: value.isEmpty ? null : _clearConsole,
+                ),
+              ],
+            ).padding(all: denseSpacing),
           ],
         ),
       ),

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:provider/provider.dart';
 import 'package:split_view/split_view.dart';
+import 'package:styled_widget/styled_widget.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:vtable/vtable.dart';
 
@@ -599,12 +600,10 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
               // Hide the snippet title when the screen width is too small.
               if (constraints.maxWidth > smallScreenWidth)
                 Expanded(
-                  child: Center(
-                    child: ValueListenableBuilder<String>(
-                      valueListenable: appModel.title,
-                      builder: (_, String value, __) => Text(value),
-                    ),
-                  ),
+                  child: ValueListenableBuilder<String>(
+                    valueListenable: appModel.title,
+                    builder: (_, String value, __) => Text(value),
+                  ).center(),
                 ),
               const SizedBox(width: defaultSpacing),
             ],
@@ -667,64 +666,57 @@ class EditorWithButtons extends StatelessWidget {
                   appModel: appModel,
                   appServices: appServices,
                 ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    vertical: denseSpacing,
-                    horizontal: defaultSpacing,
-                  ),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    // We use explicit directionality here in order to have the
-                    // format and run buttons on the right hand side of the
-                    // editing area.
-                    textDirection: TextDirection.ltr,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      // Dartdoc help button
-                      ValueListenableBuilder<bool>(
-                        valueListenable: appModel.docHelpBusy,
-                        builder: (_, bool value, __) {
-                          return PointerInterceptor(
-                            child: MiniIconButton(
-                              icon: Icons.help_outline,
-                              tooltip: 'Show docs',
-                              // small: true,
-                              onPressed:
-                                  value ? null : () => _showDocs(context),
-                            ),
-                          );
-                        },
-                      ),
-                      const SizedBox(width: denseSpacing),
-                      // Format action
-                      ValueListenableBuilder<bool>(
-                        valueListenable: appModel.formattingBusy,
-                        builder: (_, bool value, __) {
-                          return PointerInterceptor(
-                            child: MiniIconButton(
-                              icon: Icons.format_align_left,
-                              tooltip: 'Format',
-                              small: true,
-                              onPressed: value ? null : onFormat,
-                            ),
-                          );
-                        },
-                      ),
-                      const SizedBox(width: defaultSpacing),
-                      // Run action
-                      ValueListenableBuilder<bool>(
-                        valueListenable: appModel.compilingBusy,
-                        builder: (_, bool value, __) {
-                          return PointerInterceptor(
-                            child: RunButton(
-                              onPressed: value ? null : onCompileAndRun,
-                            ),
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  // We use explicit directionality here in order to have the
+                  // format and run buttons on the right hand side of the
+                  // editing area.
+                  textDirection: TextDirection.ltr,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Dartdoc help button
+                    ValueListenableBuilder<bool>(
+                      valueListenable: appModel.docHelpBusy,
+                      builder: (_, bool value, __) {
+                        return PointerInterceptor(
+                          child: MiniIconButton(
+                            icon: Icons.help_outline,
+                            tooltip: 'Show docs',
+                            // small: true,
+                            onPressed: value ? null : () => _showDocs(context),
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(width: denseSpacing),
+                    // Format action
+                    ValueListenableBuilder<bool>(
+                      valueListenable: appModel.formattingBusy,
+                      builder: (_, bool value, __) {
+                        return PointerInterceptor(
+                          child: MiniIconButton(
+                            icon: Icons.format_align_left,
+                            tooltip: 'Format',
+                            small: true,
+                            onPressed: value ? null : onFormat,
+                          ),
+                        );
+                      },
+                    ),
+                    const SizedBox(width: defaultSpacing),
+                    // Run action
+                    ValueListenableBuilder<bool>(
+                      valueListenable: appModel.compilingBusy,
+                      builder: (_, bool value, __) {
+                        return PointerInterceptor(
+                          child: RunButton(
+                            onPressed: value ? null : onCompileAndRun,
+                          ),
+                        );
+                      },
+                    ),
+                  ],
+                ).padding(vertical: denseSpacing, horizontal: defaultSpacing),
                 Container(
                   alignment: Alignment.bottomRight,
                   padding: const EdgeInsets.all(denseSpacing),
@@ -919,10 +911,7 @@ class SectionWidget extends StatelessWidget {
       );
     }
 
-    return Padding(
-      padding: const EdgeInsets.all(denseSpacing),
-      child: c,
-    );
+    return c.padding(all: denseSpacing);
   }
 }
 
@@ -970,10 +959,7 @@ class NewSnippetWidget extends StatelessWidget {
           PointerInterceptor(
             child: MenuItemButton(
               leadingIcon: item.icon,
-              child: Padding(
-                padding: const EdgeInsets.only(right: 32),
-                child: Text(item.label),
-              ),
+              child: Text(item.label).padding(right: 32),
               onPressed: () => appServices.resetTo(type: item.kind),
             ),
           )
@@ -1022,10 +1008,7 @@ class ListSamplesWidget extends StatelessWidget {
             leadingIcon: Logo(type: sample.icon),
             onPressed: () =>
                 GoRouter.of(context).replaceQueryParam('sample', sample.id),
-            child: Padding(
-              padding: const EdgeInsets.only(right: 32),
-              child: Text(sample.name),
-            ),
+            child: Text(sample.name).padding(right: 32),
           ),
       ]
     ];
@@ -1059,10 +1042,8 @@ class SelectChannelWidget extends StatelessWidget {
             PointerInterceptor(
               child: MenuItemButton(
                 onPressed: () => _onTap(context, channel),
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(0, 0, 32, 0),
-                  child: Text('${channel.displayName} channel'),
-                ),
+                child:
+                    Text('${channel.displayName} channel').padding(right: 32),
               ),
             ),
         ],
@@ -1114,10 +1095,7 @@ class OverflowMenu extends StatelessWidget {
             child: MenuItemButton(
               trailingIcon: const Icon(Icons.launch),
               onPressed: () => _onSelected(context, item.uri),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(0, 0, 32, 0),
-                child: Text(item.label),
-              ),
+              child: Text(item.label).padding(right: 32),
             ),
           )
       ],
@@ -1151,10 +1129,7 @@ class ContinueInMenu extends StatelessWidget {
             onPressed: () {
               openInIdx();
             },
-            child: const Padding(
-              padding: EdgeInsets.fromLTRB(0, 0, 32, 0),
-              child: Text('IDX'),
-            ),
+            child: const Text('IDX').padding(right: 32),
           ),
         ].map((widget) => PointerInterceptor(child: widget))
       ],
@@ -1201,10 +1176,7 @@ class KeyBindingsTable extends StatelessWidget {
                   for (final shortcut in binding.$2) {
                     if (!first) {
                       children.add(
-                        const Padding(
-                          padding: EdgeInsets.only(left: 4, right: 8),
-                          child: Text(','),
-                        ),
+                        const Text(',').padding(left: 4, right: 8),
                       );
                     }
                     first = false;

--- a/pkgs/dartpad_ui/lib/problems.dart
+++ b/pkgs/dartpad_ui/lib/problems.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import 'package:styled_widget/styled_widget.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 import 'model.dart';
@@ -75,53 +76,50 @@ class ProblemWidget extends StatelessWidget {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
 
-    final widget = Padding(
-      padding: const EdgeInsets.only(bottom: _rowPadding),
-      child: Column(
-        children: [
+    final widget = Column(
+      children: [
+        Row(
+          children: [
+            Icon(
+              issue.errorIcon,
+              size: smallIconSize,
+              color: issue.colorFor(
+                  darkMode: colorScheme.brightness == Brightness.dark),
+            ),
+            const SizedBox(width: denseSpacing),
+            Expanded(
+              child: Text(
+                issue.message,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            Text(
+              ' line ${issue.location.line}, col ${issue.location.column}',
+              maxLines: 1,
+              overflow: TextOverflow.clip,
+              textAlign: TextAlign.end,
+              style: subtleText,
+            )
+          ],
+        ),
+        if (issue.correction != null) const SizedBox(height: _rowPadding),
+        if (issue.correction != null)
           Row(
             children: [
-              Icon(
-                issue.errorIcon,
-                size: smallIconSize,
-                color: issue.colorFor(
-                    darkMode: colorScheme.brightness == Brightness.dark),
-              ),
+              const SizedBox.square(dimension: smallIconSize),
               const SizedBox(width: denseSpacing),
               Expanded(
                 child: Text(
-                  issue.message,
+                  issue.correction!,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              Text(
-                ' line ${issue.location.line}, col ${issue.location.column}',
-                maxLines: 1,
-                overflow: TextOverflow.clip,
-                textAlign: TextAlign.end,
-                style: subtleText,
-              )
             ],
           ),
-          if (issue.correction != null) const SizedBox(height: _rowPadding),
-          if (issue.correction != null)
-            Row(
-              children: [
-                const SizedBox.square(dimension: smallIconSize),
-                const SizedBox(width: denseSpacing),
-                Expanded(
-                  child: Text(
-                    issue.correction!,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-              ],
-            ),
-        ],
-      ),
-    );
+      ],
+    ).padding(bottom: _rowPadding);
 
     final appServices = Provider.of<AppServices>(context);
     final diagnosticDocUrl = issue.url;

--- a/pkgs/dartpad_ui/lib/widgets.dart
+++ b/pkgs/dartpad_ui/lib/widgets.dart
@@ -232,7 +232,7 @@ class MediumDialog extends StatelessWidget {
 }
 
 class GoldenRatioCenter extends StatelessWidget {
-  final Widget? child;
+  final Widget child;
 
   const GoldenRatioCenter({
     required this.child,

--- a/pkgs/dartpad_ui/pubspec.yaml
+++ b/pkgs/dartpad_ui/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  collection: any
+  collection: ^1.19.0
   dartpad_shared: any
   flutter:
     sdk: flutter
@@ -20,6 +20,7 @@ dependencies:
   pointer_interceptor: ^0.10.1
   provider: ^6.1.2
   split_view: ^3.2.1
+  styled_widget: ^0.4.0
   url_launcher: ^6.3.0
   vtable: ^0.4.0
   web: ^0.5.1


### PR DESCRIPTION
- convert dartpad over to use styled_widget

This converts uses of `Padding` and `Center` to use extension method from `package:styled_widget`. It may be interesting convert more code over to use the styled_widget extension methods, to better gauge changes to the readability of the code, ...

Note that it looks like some parts of the github diff get confused by the changes - the delta looks bigger than it is.

I generally like the changes; it reduces the level of nesting, making it easier to work within 80 cols. And suspect that I'd like having the modifier methods trail after the main widgets, esp. if we used more of the extension methods (so, `Foo(...).padding(...).center().background(...)`).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
