### PR TITLE
[dartpad_ui] Specify that Dart 3.6 or later is required

### DIFF
--- a/pkgs/dartpad_ui/pubspec.yaml
+++ b/pkgs/dartpad_ui/pubspec.yaml
@@ -3,7 +3,7 @@ description: The front-end UI of DartPad.
 publish_to: none
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.6.0-0
 
 dependencies:
   collection: ^1.19.0


### PR DESCRIPTION
Due to some Flutter API changes and our web/Wasm build requirements, we currently require Dart 3.6 beta (Flutter 3.26 beta) or newer to properly run DartPad. This makes it more clear by requiring that with the package's SDK constraint.

Resolves https://github.com/dart-lang/dart-pad/issues/3061