### PR TITLE
Implement /flutter for flutter.new as firebase redirect

### DIFF
--- a/pkgs/dartpad_ui/firebase.json
+++ b/pkgs/dartpad_ui/firebase.json
@@ -10,6 +10,21 @@
       ],
       "redirects": [
         {
+          "source": "/dart",
+          "destination": "/?sample=dart",
+          "type": 301
+        },
+        {
+          "source": "/flutter",
+          "destination": "/?sample=flutter",
+          "type": 301
+        },
+        {
+          "source": "/dart",
+          "destination": "/?sample=dart",
+          "type": 301
+        },
+        {
           "source": "/embed-dart?(.html)",
           "destination": "/?embed=true",
           "type": 301

--- a/pkgs/dartpad_ui/firebase.json
+++ b/pkgs/dartpad_ui/firebase.json
@@ -20,11 +20,6 @@
           "type": 301
         },
         {
-          "source": "/dart",
-          "destination": "/?sample=dart",
-          "type": 301
-        },
-        {
           "source": "/embed-dart?(.html)",
           "destination": "/?embed=true",
           "type": 301

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -59,10 +59,6 @@ class _DartPadAppState extends State<DartPadApp> {
         path: '/',
         builder: _homePageBuilder,
       ),
-      GoRoute(
-        path: '/flutter',
-        builder: _homePageBuilder,
-      ),
     ],
   );
 
@@ -117,7 +113,6 @@ class _DartPadAppState extends State<DartPadApp> {
   }
 
   Widget _homePageBuilder(BuildContext context, GoRouterState state) {
-    final path = state.path;
     final gistId = state.uri.queryParameters['id'];
     final builtinSampleId = state.uri.queryParameters['sample'];
     final flutterSampleId = state.uri.queryParameters['sample_id'];
@@ -126,7 +121,6 @@ class _DartPadAppState extends State<DartPadApp> {
     final runOnLoad = state.uri.queryParameters['run'] == 'true';
 
     return DartPadMainPage(
-      path: path,
       initialChannel: channelParam,
       embedMode: embedMode,
       runOnLoad: runOnLoad,
@@ -205,7 +199,6 @@ class DartPadMainPage extends StatefulWidget {
   final String? gistId;
   final String? builtinSampleId;
   final String? flutterSampleId;
-  final String? path;
 
   DartPadMainPage({
     required this.initialChannel,
@@ -215,7 +208,6 @@ class DartPadMainPage extends StatefulWidget {
     this.gistId,
     this.builtinSampleId,
     this.flutterSampleId,
-    this.path,
   }) : super(
           key: ValueKey(
             'sample:$builtinSampleId gist:$gistId flutter:$flutterSampleId',
@@ -274,14 +266,13 @@ class _DartPadMainPageState extends State<DartPadMainPage>
     );
 
     appServices.populateVersions();
-    final fallBackSnippetType = widget.path == '/flutter' ? 'flutter' : 'dart';
     appServices
         .performInitialLoad(
             gistId: widget.gistId,
             sampleId: widget.builtinSampleId,
             flutterSampleId: widget.flutterSampleId,
             channel: widget.initialChannel,
-            fallbackSnippet: Samples.getDefault(type: fallBackSnippetType))
+            fallbackSnippet: Samples.defaultSnippet())
         .then((value) {
       // Start listening for inject code messages.
       handleEmbedMessage(appServices, runOnInject: widget.runOnLoad);

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -168,7 +168,8 @@ class AppServices {
 
   void resetTo({String? type}) {
     type ??= 'dart';
-    final source = Samples.getDefault(type: type);
+    final source =
+        Samples.defaultSnippet(forFlutter: type.toLowerCase() == 'flutter');
 
     // Reset the source.
     appModel.sourceCodeController.text = source;

--- a/pkgs/dartpad_ui/lib/samples.g.dart
+++ b/pkgs/dartpad_ui/lib/samples.g.dart
@@ -1,6 +1,6 @@
-// Copyright 2023 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // This file has been automatically generated - please do not edit it manually.
 
@@ -68,10 +68,6 @@ const _fibonacci = Sample(
   name: 'Fibonacci',
   id: 'fibonacci',
   source: r'''
-// Copyright 2015 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 void main() {
   const i = 20;
 
@@ -91,10 +87,6 @@ const _helloWorld = Sample(
   name: 'Hello world',
   id: 'hello-world',
   source: r'''
-// Copyright 2015 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 void main() {
   for (var i = 0; i < 10; i++) {
     print('hello ${i + 1}');
@@ -153,10 +145,6 @@ const _flameGame = Sample(
   name: 'Flame game',
   id: 'flame-game',
   source: r'''
-// Copyright 2024 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 /// A simplified brick-breaker game,
 /// built using the Flame game engine for Flutter.
 ///
@@ -490,10 +478,6 @@ const _googleSdk = Sample(
   name: 'Google AI SDK',
   id: 'google-ai-sdk',
   source: r'''
-// Copyright 2024 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:google_generative_ai/google_generative_ai.dart';
@@ -838,10 +822,6 @@ const _counter = Sample(
   name: 'Counter',
   id: 'counter',
   source: r'''
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'package:flutter/material.dart';
 
 void main() => runApp(const MyApp());
@@ -920,10 +900,6 @@ const _sunflower = Sample(
   name: 'Sunflower',
   id: 'sunflower',
   source: r'''
-// Copyright 2019 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/pkgs/dartpad_ui/lib/samples.g.dart
+++ b/pkgs/dartpad_ui/lib/samples.g.dart
@@ -23,6 +23,8 @@ class Sample {
 
   bool get isDart => category == 'Dart';
 
+  bool get shouldList => category != 'Defaults';
+
   @override
   String toString() => '[$category] $name ($id)';
 }
@@ -31,6 +33,8 @@ abstract final class Samples {
   static const List<Sample> all = [
     _fibonacci,
     _helloWorld,
+    _dart,
+    _flutter,
     _flameGame,
     _googleSdk,
     _counter,
@@ -54,41 +58,9 @@ abstract final class Samples {
 
   static Sample? getById(String? id) => all.firstWhereOrNull((s) => s.id == id);
 
-  static String getDefault({required String type}) => _defaults[type]!;
+  static String defaultSnippet({bool forFlutter = false}) =>
+      getById(forFlutter ? 'flutter' : 'dart')!.source;
 }
-
-const Map<String, String> _defaults = {
-  'dart': r'''
-void main() {
-  for (int i = 0; i < 10; i++) {
-    print('hello ${i + 1}');
-  }
-}
-''',
-  'flutter': r'''
-import 'package:flutter/material.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: Scaffold(
-        body: Center(
-          child: Text('Hello, World!'),
-        ),
-      ),
-    );
-  }
-}
-''',
-};
 
 const _fibonacci = Sample(
   category: 'Dart',
@@ -126,6 +98,50 @@ const _helloWorld = Sample(
 void main() {
   for (var i = 0; i < 10; i++) {
     print('hello ${i + 1}');
+  }
+}
+''',
+);
+
+const _dart = Sample(
+  category: 'Defaults',
+  icon: 'dart',
+  name: 'Dart snippet',
+  id: 'dart',
+  source: r'''
+void main() {
+  for (var i = 0; i < 10; i++) {
+    print('hello ${i + 1}');
+  }
+}
+''',
+);
+
+const _flutter = Sample(
+  category: 'Defaults',
+  icon: 'flutter',
+  name: 'Flutter snippet',
+  id: 'flutter',
+  source: r'''
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        body: Center(
+          child: Text('Hello, World!'),
+        ),
+      ),
+    );
   }
 }
 ''',

--- a/pkgs/dartpad_ui/test/samples_test.dart
+++ b/pkgs/dartpad_ui/test/samples_test.dart
@@ -7,13 +7,13 @@ import 'package:test/test.dart';
 
 void main() {
   group('samples', () {
-    test('has dart default', () {
-      final sample = Samples.getDefault(type: 'dart');
+    test('has default dart sample', () {
+      final sample = Samples.getById('dart');
       expect(sample, isNotNull);
     });
 
-    test('has flutter default', () {
-      final sample = Samples.getDefault(type: 'flutter');
+    test('has default flutter sample', () {
+      final sample = Samples.getById('flutter');
       expect(sample, isNotNull);
     });
   });

--- a/pkgs/samples/README.md
+++ b/pkgs/samples/README.md
@@ -9,6 +9,8 @@ Sample code snippets for DartPad.
 | --- | --- | --- | --- |
 | Dart | Fibonacci | [fibonacci.dart](lib/fibonacci.dart) | `fibonacci` |
 | Dart | Hello world | [hello_world.dart](lib/hello_world.dart) | `hello-world` |
+| Defaults | Dart snippet | [default_dart.dart](lib/default_dart.dart) | `dart` |
+| Defaults | Flutter snippet | [default_flutter.dart](lib/default_flutter.dart) | `flutter` |
 | Ecosystem | Flame game | [brick_breaker.dart](lib/brick_breaker.dart) | `flame-game` |
 | Ecosystem | Google AI SDK | [google_ai.dart](lib/google_ai.dart) | `google-ai-sdk` |
 | Flutter | Counter | [main.dart](lib/main.dart) | `counter` |

--- a/pkgs/samples/lib/default_dart.dart
+++ b/pkgs/samples/lib/default_dart.dart
@@ -1,5 +1,5 @@
 void main() {
-  for (int i = 0; i < 10; i++) {
+  for (var i = 0; i < 10; i++) {
     print('hello ${i + 1}');
   }
 }

--- a/pkgs/samples/lib/default_dart.dart
+++ b/pkgs/samples/lib/default_dart.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 void main() {
   for (var i = 0; i < 10; i++) {
     print('hello ${i + 1}');

--- a/pkgs/samples/lib/default_flutter.dart
+++ b/pkgs/samples/lib/default_flutter.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 void main() {

--- a/pkgs/samples/lib/samples.json
+++ b/pkgs/samples/lib/samples.json
@@ -1,44 +1,52 @@
-{
-    "defaults": {
-        "dart": "lib/default_dart.dart",
-        "flutter": "lib/default_flutter.dart"
-    },
-    "samples": [
-        {
-            "category": "Dart",
-            "icon": "dart",
-            "name": "Hello world",
-            "path": "lib/hello_world.dart"
-        },
-        {
-            "category": "Dart",
-            "icon": "dart",
-            "name": "Fibonacci",
-            "path": "lib/fibonacci.dart"
-        },
-        {
-            "category": "Flutter",
-            "icon": "flutter",
-            "name": "Counter",
-            "path": "lib/main.dart"
-        },
-        {
-            "category": "Flutter",
-            "icon": "flutter",
-            "name": "Sunflower",
-            "path": "lib/sunflower.dart"
-        },
-        {
-            "category": "Ecosystem",
-            "icon": "gemini",
-            "name": "Google AI SDK",
-            "path": "lib/google_ai.dart"
-        },
-        {
-            "category": "Ecosystem",
-            "icon": "flame",
-            "name": "Flame game",
-            "path": "lib/brick_breaker.dart"
-        }
-    ]
-}
+[
+  {
+    "category": "Defaults",
+    "icon": "dart",
+    "id": "dart",
+    "name": "Dart snippet",
+    "path": "lib/default_dart.dart"
+  },
+  {
+    "category": "Defaults",
+    "icon": "flutter",
+    "id": "flutter",
+    "name": "Flutter snippet",
+    "path": "lib/default_flutter.dart"
+  },
+  {
+    "category": "Dart",
+    "icon": "dart",
+    "name": "Hello world",
+    "path": "lib/hello_world.dart"
+  },
+  {
+    "category": "Dart",
+    "icon": "dart",
+    "name": "Fibonacci",
+    "path": "lib/fibonacci.dart"
+  },
+  {
+    "category": "Flutter",
+    "icon": "flutter",
+    "name": "Counter",
+    "path": "lib/main.dart"
+  },
+  {
+    "category": "Flutter",
+    "icon": "flutter",
+    "name": "Sunflower",
+    "path": "lib/sunflower.dart"
+  },
+  {
+    "category": "Ecosystem",
+    "icon": "gemini",
+    "name": "Google AI SDK",
+    "path": "lib/google_ai.dart"
+  },
+  {
+    "category": "Ecosystem",
+    "icon": "flame",
+    "name": "Flame game",
+    "path": "lib/brick_breaker.dart"
+  }
+]

--- a/pkgs/samples/tool/samples.dart
+++ b/pkgs/samples/tool/samples.dart
@@ -1,6 +1,6 @@
-// Copyright 2023 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
 import 'dart:io';
@@ -146,9 +146,9 @@ ${samples.map((s) => s.toTableRow()).join('\n')}
 
   String _generateSourceContent() {
     final buf = StringBuffer('''
-// Copyright 2023 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
 
 // This file has been automatically generated - please do not edit it manually.
 
@@ -243,7 +243,10 @@ class Sample implements Comparable<Sample> {
     return '_$gen';
   }
 
-  String get source => File(path).readAsStringSync();
+  String get _rawSource => File(path).readAsStringSync();
+
+  String get source =>
+      _rawSource.replaceFirst(_copyrightCommentPattern, '').trim();
 
   String get sourceDef {
     return '''
@@ -253,7 +256,7 @@ const $sourceId = Sample(
   name: '$name',
   id: '$id',
   source: r\'\'\'
-${source.trimRight()}
+$source
 \'\'\',
 );
 ''';
@@ -276,4 +279,7 @@ ${source.trimRight()}
 
   static String _idFromName(String name) =>
       name.trim().toLowerCase().replaceAll(' ', '-');
+
+  static final RegExp _copyrightCommentPattern =
+      RegExp(r'^\/\/ Copyright.*LICENSE file.', multiLine: true, dotAll: true);
 }


### PR DESCRIPTION
This removes the concept of a "default snippet" from the samples generation tool, instead opting for a simple `dart` and `flutter` sample that can be redirected to.