### PR TITLE
fix(editor): switch to normal mode on pressing Esc in vim keybindings

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/codemirror.dart
+++ b/pkgs/dartpad_ui/lib/editor/codemirror.dart
@@ -22,6 +22,8 @@ extension type CodeMirror._(JSObject _) implements JSObject {
   external static Commands commands;
   external static String get version;
   external static Hint hint;
+  @JS('Vim')
+  external static Vim vim;
 
   external static void registerHelper(
     String type,
@@ -173,4 +175,13 @@ extension type HintOptions._(JSObject _) implements JSObject {
 
 extension type Hint._(JSObject _) implements JSObject {
   external JSAny dart;
+}
+
+extension type Vim._(JSObject _) implements JSObject {
+  external void exitInsertMode(CodeMirror cm);
+
+  void handleEsc(CodeMirror cm) => switch (cm.getKeymap()) {
+        'vim-insert' => exitInsertMode(cm),
+        _ => _,
+      };
 }

--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:math' as math;
 import 'dart:ui_web' as ui_web;
 
@@ -124,6 +125,14 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
           Timer.run(() => showCompletions(autoInvoked: true));
 
           return KeyEventResult.skipRemainingHandlers;
+        }
+
+        if (event.logicalKey == LogicalKeyboardKey.escape) {
+          if (codeMirror == null) {
+            return KeyEventResult.ignored;
+          }
+
+          CodeMirror.vim.handleEsc(codeMirror!);
         }
 
         return KeyEventResult.ignored;

--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
 import 'dart:math' as math;
 import 'dart:ui_web' as ui_web;
 


### PR DESCRIPTION
This PR aims to fix a bug introduced in #3044 and closes #3122.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
