### PR TITLE
feat(editor): persist keybinding preference between sessions

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -442,8 +442,10 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
 
     if (enabled) {
       cm.setKeymap('vim');
+      LocalStorage.instance.saveUserKeybinding('vim');
     } else {
       cm.setKeymap('default');
+      LocalStorage.instance.saveUserKeybinding('default');
     }
   }
 }

--- a/pkgs/dartpad_ui/lib/local_storage.dart
+++ b/pkgs/dartpad_ui/lib/local_storage.dart
@@ -10,4 +10,7 @@ abstract class LocalStorage {
 
   void saveUserCode(String code);
   String? getUserCode();
+
+  void saveUserKeybinding(String keybinding);
+  String? getUserKeybinding();
 }

--- a/pkgs/dartpad_ui/lib/local_storage/stub.dart
+++ b/pkgs/dartpad_ui/lib/local_storage/stub.dart
@@ -7,10 +7,17 @@ import '../utils.dart';
 
 class LocalStorageImpl extends LocalStorage {
   String? _code;
+  String? _keyBinding;
 
   @override
   void saveUserCode(String code) => _code = code;
 
   @override
+  void saveUserKeybinding(String keybinding) => _keyBinding = keybinding;
+
+  @override
   String? getUserCode() => _code?.nullIfEmpty;
+
+  @override
+  String? getUserKeybinding() => _keyBinding?.nullIfEmpty;
 }

--- a/pkgs/dartpad_ui/lib/local_storage/web.dart
+++ b/pkgs/dartpad_ui/lib/local_storage/web.dart
@@ -8,6 +8,7 @@ import '../local_storage.dart';
 import '../utils.dart';
 
 const _userInputKey = 'user_';
+const _userKeybindingKey = 'user_keybinding_';
 
 class LocalStorageImpl extends LocalStorage {
   @override
@@ -17,4 +18,12 @@ class LocalStorageImpl extends LocalStorage {
   @override
   String? getUserCode() =>
       web.window.localStorage.getItem(_userInputKey)?.nullIfEmpty;
+
+  @override
+  void saveUserKeybinding(String keybinding) =>
+      web.window.localStorage.setItem(_userKeybindingKey, keybinding);
+
+  @override
+  String? getUserKeybinding() =>
+      web.window.localStorage.getItem(_userKeybindingKey)?.nullIfEmpty;
 }

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -279,6 +279,7 @@ class _DartPadMainPageState extends State<DartPadMainPage>
       sampleId: widget.builtinSampleId,
       flutterSampleId: widget.flutterSampleId,
       channel: widget.initialChannel,
+      keybinding: LocalStorage.instance.getUserKeybinding(),
       getFallback: () =>
           LocalStorage.instance.getUserCode() ?? Samples.defaultSnippet(),
     )

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -207,6 +207,7 @@ class AppServices {
     String? sampleId,
     String? flutterSampleId,
     String? channel,
+    String? keybinding,
     required String Function() getFallback,
   }) async {
     // Delay a bit for codemirror to initialize.
@@ -292,6 +293,10 @@ class AppServices {
       }
 
       return;
+    }
+
+    if (keybinding != null && keybinding == 'vim') {
+      appModel.vimKeymapsEnabled.value = true;
     }
 
     // Neither gistId nor flutterSampleId were passed in.


### PR DESCRIPTION
This PR aims to close #3124 by saving the keybinding preference in browsers local storage and restoring it on the next launch.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
