### PR TITLE
Branch validation on SDK version.

### DIFF
--- a/pkgs/dart_services/lib/src/sdk.dart
+++ b/pkgs/dart_services/lib/src/sdk.dart
@@ -171,4 +171,6 @@ final class Sdk {
         _dartVersionMatch.firstMatch(dartVersion)!.group(2)!;
     return int.parse(dartVersionString);
   }
+
+  bool get useNewDdcSdk => dartMajorVersion >= 3 && dartMinorVersion >= 8;
 }

--- a/pkgs/dart_services/tool/grind.dart
+++ b/pkgs/dart_services/tool/grind.dart
@@ -24,8 +24,11 @@ Future<void> main(List<String> args) async {
 
 final List<String> compilationArtifacts = [
   'dart_sdk.js',
-  'dart_sdk_new.js',
   'flutter_web.js',
+];
+
+final List<String> compilationArtifactsNew = [
+  'dart_sdk_new.js',
   'flutter_web_new.js',
   'ddc_module_loader.js',
 ];
@@ -45,7 +48,8 @@ void validateStorageArtifacts() async {
       'validate-storage-artifacts version: ${sdk.dartVersion} bucket: $bucket');
 
   final urlBase = 'https://storage.googleapis.com/$bucket/';
-  for (final artifact in compilationArtifacts) {
+  for (final artifact
+      in sdk.useNewDdcSdk ? compilationArtifactsNew : compilationArtifacts) {
     await _validateExists(Uri.parse('$urlBase$version/$artifact'));
   }
 }
@@ -243,7 +247,7 @@ Future<String> _buildStorageArtifacts(
   copy(joinFile(dir, ['flutter_web.dill']), artifactsDir);
 
   // We only expect these hot reload artifacts to work at version 3.8 and later.
-  if (sdk.dartMajorVersion >= 3 && sdk.dartMinorVersion >= 8) {
+  if (sdk.useNewDdcSdk) {
     // Later versions of Flutter remove the "sound" suffix from the file. If
     // the suffixed version does not exist, the unsuffixed version is the sound
     // file.


### PR DESCRIPTION
Fix validation searching for missing files. The new SDK files are only generated when the version number is new enough so the validation file list should take this into account.