### PR TITLE
use more subtle progress when reloading

### DIFF
--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -37,11 +37,13 @@ class ExecutionServiceImpl implements ExecutionService {
     }
 
     return _send(reload ? 'executeReload' : 'execute', {
-      'js': _decorateJavaScript(javaScript,
-          modulesBaseUrl: modulesBaseUrl,
-          isNewDDC: isNewDDC,
-          reload: reload,
-          isFlutter: isFlutter),
+      'js': _decorateJavaScript(
+        javaScript,
+        modulesBaseUrl: modulesBaseUrl,
+        isNewDDC: isNewDDC,
+        reload: reload,
+        isFlutter: isFlutter,
+      ),
       if (engineVersion != null)
         'canvasKitBaseUrl': _canvasKitUrl(engineVersion),
     });
@@ -61,11 +63,13 @@ class ExecutionServiceImpl implements ExecutionService {
   @override
   Future<void> tearDown() => _reset();
 
-  String _decorateJavaScript(String javaScript,
-      {String? modulesBaseUrl,
-      required bool isNewDDC,
-      required bool reload,
-      required bool isFlutter}) {
+  String _decorateJavaScript(
+    String javaScript, {
+    String? modulesBaseUrl,
+    required bool isNewDDC,
+    required bool reload,
+    required bool isFlutter,
+  }) {
     if (reload) return javaScript;
 
     final script = StringBuffer();


### PR DESCRIPTION
Use more subtle progress when reloading:

- introduce a 3rd compiling state (none, compiling, and compiling as part of a reload)
- when reloading, use `'Reloading...'` as the text in the editor progress message
- when reloading, don't display a semi-opaque overlay over the execution area (this makes the reload update appear too heavy-weight)

There's likely some follow up wrt the run/reload buttons (we probably want to overload run for reload, perhaps change the button text depending on what would happen when you hit it, and slightly deemphasize the 'restart' button).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
