### PR TITLE
Update README with grind instructions #3116

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Some handy guides:
 - [Sharing Guide](https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide)
 - [Embedding Guide](https://github.com/dart-lang/dart-pad/wiki/Embedding-Guide)
 
+
+## Running Build Tasks with Grind
+
+Dart Services uses [Grinder](https://pub.dev/packages/grinder) to automate build tasks.
+
+To generate project templates and required artifacts, run:
+
+```sh
+dart tool/grind.dart build-project-templates
+dart tool/grind.dart build-storage-artifacts
+
+
 ## Issues and bugs
 
 Please file reports on the [GitHub Issue


### PR DESCRIPTION
Description:

This PR updates the README.md file to include instructions for running specific Grind tasks necessary for generating project templates and storage artifacts for the Dart Services server. These tasks are executed using the grind.dart tool. The addition helps developers to easily set up the required files for Dart Services.

Related Issue:
Fixes #3116
