### PR TITLE
Adds `package:dio` and its underlying `package:dio_web_adapter`

### DIFF
--- a/pkgs/dart_services/lib/src/project_templates.dart
+++ b/pkgs/dart_services/lib/src/project_templates.dart
@@ -89,6 +89,8 @@ const Set<String> supportedBasicDartPackages = {
   'convert',
   'cross_file',
   'dartz',
+  'dio',
+  'dio_web_adapter',
   'english_words',
   'equatable',
   'fast_immutable_collections',

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
@@ -20,6 +20,8 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
+  "dio": "5.8.0,
+  "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",
   "fake_async": "1.3.2",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0,
+  "dio": "5.8.0",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0,
+  "dio": "5.8.0",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
@@ -20,6 +20,8 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
+  "dio": "5.8.0,
+  "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",
   "fake_async": "1.3.3",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
@@ -20,6 +20,8 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
+  "dio": "5.8.0,
+  "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",
   "fake_async": "1.3.2",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0,
+  "dio": "5.8.0",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",


### PR DESCRIPTION
Enables Dio and its web adapter on DartPad.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
