### PR TITLE
Revert "Remove stack_trace formatting"

### DIFF
--- a/pkgs/dart_services/lib/src/common.dart
+++ b/pkgs/dart_services/lib/src/common.dart
@@ -9,8 +9,19 @@ const kBootstrapDart = 'bootstrap.dart';
 const kBootstrapDartCode = r'''
 import 'main.dart' as user_code;
 
+import 'package:stack_trace/stack_trace.dart';
+
 void main() {
-  user_code.main();
+  Chain.capture(user_code.main, onError: (error, chain) {
+    print('DartPad caught unhandled ${error.runtimeType}:');
+    print('$error');
+    final simplifiedChain = chain
+        .toString()
+        .split('\n')
+        .takeWhile((line) => !line.endsWith(r'main$'))
+        .join('\n');
+    print('$simplifiedChain\nStack trace truncated and adjusted by DartPad...');
+  });
 }
 ''';
 

--- a/pkgs/dart_services/lib/src/compiling.dart
+++ b/pkgs/dart_services/lib/src/compiling.dart
@@ -179,6 +179,9 @@ class Compiler {
       final response =
           await _ddcDriver.doWork(WorkRequest(arguments: arguments));
       if (response.exitCode != 0) {
+        if (response.output.contains("Undefined name 'main'")) {
+          return DDCCompilationResults._missingMain;
+        }
         return DDCCompilationResults.failed([
           CompilationProblem._(_rewritePaths(response.output)),
         ]);
@@ -260,6 +263,14 @@ class CompilationResults {
 
 /// The result of a DDC compile.
 class DDCCompilationResults {
+  static const DDCCompilationResults _missingMain =
+      DDCCompilationResults.failed([
+    CompilationProblem._(
+      "Invoked Dart programs must have a 'main' function defined.\n"
+      'To learn more, visit https://dart.dev/to/main-function.',
+    ),
+  ]);
+
   final String? compiledJS;
   final String? deltaDill;
   final String? modulesBaseUrl;

--- a/pkgs/dart_services/test/compiling_test.dart
+++ b/pkgs/dart_services/test/compiling_test.dart
@@ -132,9 +132,11 @@ void defineTests() {
           }
           expect(result.success, false);
           expect(result.problems.length, 1);
-          expect(result.problems.first.message,
-              contains("Error: Method not found: 'main'"));
-          expect(result.problems.first.message, startsWith('main.dart:'));
+          expect(
+            result.problems.first.message,
+            contains(
+                "Invoked Dart programs must have a 'main' function defined"),
+          );
         });
 
         test('with multiple errors', () async {


### PR DESCRIPTION
There's an issue with Cloud Build where dart_services can't find the pubspec for the workspace, we probably need to copy the entire dart-pad directory so that the Cloud Build runner can resolve packages:

```
Found a pubspec.yaml at /pkgs/dart_services. But it has resolution `workspace`.
But found no workspace root including it in parent directories.

See https://dart.dev/go/pub-workspaces for more information.
The command '/bin/sh -c dart pub get' returned a non-zero code: 66
```

Reverts dart-lang/dart-pad#3153