### PR TITLE
Remove manual web library deprecations

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -314,14 +314,6 @@ class AnalysisServerWrapper {
             correction: 'Try removing the import and usages of the library.',
             location: import.getLocation(source),
           ));
-        } else if (isDeprecatedCoreWebLibrary(libraryName)) {
-          importIssues.add(api.AnalysisIssue(
-            kind: 'info', // TODO(parlough): Expand to 'warning' in future.
-            message: "Deprecated core web library: 'dart:$libraryName'.",
-            correction: 'Try using static JS interop instead.',
-            url: 'https://dart.dev/go/next-gen-js-interop',
-            location: import.getLocation(source),
-          ));
         }
       } else if (import.packageImport) {
         final packageName = import.packageName;

--- a/pkgs/dart_services/lib/src/project_templates.dart
+++ b/pkgs/dart_services/lib/src/project_templates.dart
@@ -115,17 +115,7 @@ const Set<String> supportedBasicDartPackages = {
 };
 
 /// The set of all packages whose support in DartPad is deprecated.
-const Set<String> _deprecatedPackages = {
-  'js',
-};
-
-/// The set of core web libraries whose support in
-/// DartPad or Dart is deprecated.
-const Set<String> _deprecatedCoreWebLibraries = {
-  'js',
-  'html',
-  'js_util',
-};
+const Set<String> _deprecatedPackages = {};
 
 /// A set of all allowed `dart:` libraries, includes
 /// all libraries from "Core", some from "Web", and none from "VM".
@@ -139,18 +129,12 @@ const Set<String> _allowedCoreLibraries = {
   'typed_data',
   'js_interop',
   'js_interop_unsafe',
-  ..._deprecatedCoreWebLibraries,
   'ui',
 };
 
 /// Whether [libraryName] is the name of a supported `dart:` core library.
 bool isSupportedCoreLibrary(String libraryName) =>
     _allowedCoreLibraries.contains(libraryName);
-
-/// Whether [libraryName] is the name of a supported, but deprecated,
-/// `dart:` core web library.
-bool isDeprecatedCoreWebLibrary(String libraryName) =>
-    _deprecatedCoreWebLibraries.contains(libraryName);
 
 /// Whether [imports] denote use of Flutter Web.
 bool usesFlutterWeb(Iterable<ImportDirective> imports) =>

--- a/pkgs/dart_services/test/analysis_test.dart
+++ b/pkgs/dart_services/test/analysis_test.dart
@@ -83,15 +83,6 @@ void defineTests() {
       expect(issue.message, contains('Unsupported library on the web'));
     });
 
-    test('Warn on deprecated web library imports', () async {
-      final results = await analysisServer.analyze(deprecatedWebLibrary);
-
-      // Expect one or two deprecation messages.
-      expect(results.issues, anyOf(hasLength(1), hasLength(2)));
-      final issue = results.issues.first;
-      expect(issue.message, contains('Deprecated core web library'));
-    });
-
     test('import_dart_core_test', () async {
       // Ensure we can import dart: imports.
       final testCode = "import 'dart:c'; main() { int a = 0; a. }";

--- a/pkgs/dart_services/test/flutter_web_test.dart
+++ b/pkgs/dart_services/test/flutter_web_test.dart
@@ -24,13 +24,13 @@ void defineTests() {
 
     test('isFlutterWebImport', () {
       expect(isFlutterWebImport(''), isFalse);
-      expect(isFlutterWebImport('dart:html'), isFalse);
+      expect(isFlutterWebImport('dart:js_interop'), isFalse);
       expect(isFlutterWebImport('dart:ui'), isTrue);
       expect(isFlutterWebImport('package:flutter/'), isTrue);
     });
 
-    test('isSupportedCoreLibrary allows dart:html', () {
-      expect(isSupportedCoreLibrary('html'), isTrue);
+    test('isSupportedCoreLibrary allows dart:js_interop', () {
+      expect(isSupportedCoreLibrary('js_interop'), isTrue);
     });
 
     test('isSupportedCoreLibrary allows dart:ui', () {


### PR DESCRIPTION
As of Dart 3.7, these libraries are officially marked as deprecated, so this custom handling now results in duplicate diagnostics and is no longer necessary.