### PR TITLE
don't show a spinner over the execution area when reloading

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -290,12 +290,12 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         appServices.performCompileAndRun();
       }
     });
-    appModel.compilingBusy.addListener(_handleRunStarted);
+    appModel.compilingState.addListener(_handleRunStarted);
   }
 
   @override
   void dispose() {
-    appModel.compilingBusy.removeListener(_handleRunStarted);
+    appModel.compilingState.removeListener(_handleRunStarted);
 
     appServices.dispose();
     appModel.dispose();
@@ -442,12 +442,12 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         child: CallbackShortcuts(
           bindings: <ShortcutActivator, VoidCallback>{
             keys.runKeyActivator1: () {
-              if (!appModel.compilingBusy.value.busy) {
+              if (!appModel.compilingState.value.busy) {
                 appServices.performCompileAndRun();
               }
             },
             keys.runKeyActivator2: () {
-              if (!appModel.compilingBusy.value.busy) {
+              if (!appModel.compilingState.value.busy) {
                 appServices.performCompileAndRun();
               }
             },
@@ -513,7 +513,7 @@ class _DartPadMainPageState extends State<DartPadMainPage>
   void _handleRunStarted() {
     setState(() {
       // Switch to the application output tab.]
-      if (appModel.compilingBusy.value != CompilingState.none) {
+      if (appModel.compilingState.value != CompilingState.none) {
         tabController.animateTo(1);
       }
     });
@@ -532,18 +532,18 @@ class LoadingOverlay extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return ValueListenableBuilder<CompilingState>(
-      valueListenable: appModel.compilingBusy,
-      builder: (_, compiling, __) {
+      valueListenable: appModel.compilingState,
+      builder: (_, compilingState, __) {
         final color = theme.colorScheme.surface;
+        final compiling = compilingState == CompilingState.restarting;
 
         // If reloading, show a progress spinner. If restarting, also display a
         // semi-opaque overlay.
         return AnimatedContainer(
-          color: color.withValues(
-              alpha: compiling == CompilingState.compiling ? 0.8 : 0),
+          color: color.withValues(alpha: compiling ? 0.8 : 0),
           duration: animationDelay,
           curve: animationCurve,
-          child: compiling.busy
+          child: compiling
               ? const GoldenRatioCenter(child: CircularProgressIndicator())
               : const SizedBox(width: 1),
         );
@@ -733,7 +733,7 @@ class EditorWithButtons extends StatelessWidget {
                       const SizedBox(width: defaultSpacing),
                       // Run action
                       ValueListenableBuilder<CompilingState>(
-                        valueListenable: appModel.compilingBusy,
+                        valueListenable: appModel.compilingState,
                         builder: (_, compiling, __) {
                           return PointerInterceptor(
                             child: RunButton(

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -54,7 +54,7 @@ class AppModel {
   final ValueNotifier<String> consoleOutput = ValueNotifier('');
 
   final ValueNotifier<bool> formattingBusy = ValueNotifier(false);
-  final ValueNotifier<CompilingState> compilingBusy =
+  final ValueNotifier<CompilingState> compilingState =
       ValueNotifier(CompilingState.none);
   final ValueNotifier<bool> docHelpBusy = ValueNotifier(false);
 
@@ -85,10 +85,10 @@ class AppModel {
   AppModel() {
     consoleOutput.addListener(_recalcLayout);
     void updateCanReload() => canReload.value = hasRun.value &&
-        !compilingBusy.value.busy &&
+        !compilingState.value.busy &&
         currentDeltaDill.value != null;
     hasRun.addListener(updateCanReload);
-    compilingBusy.addListener(updateCanReload);
+    compilingState.addListener(updateCanReload);
     currentDeltaDill.addListener(updateCanReload);
 
     void updateShowReload() {
@@ -416,38 +416,38 @@ class AppServices {
 
   Future<CompileResponse> compile(CompileRequest request) async {
     try {
-      appModel.compilingBusy.value = CompilingState.compiling;
+      appModel.compilingState.value = CompilingState.restarting;
       return await services.compile(request);
     } finally {
-      appModel.compilingBusy.value = CompilingState.none;
+      appModel.compilingState.value = CompilingState.none;
     }
   }
 
   Future<CompileDDCResponse> _compileDDC(CompileRequest request) async {
     try {
-      appModel.compilingBusy.value = CompilingState.compiling;
+      appModel.compilingState.value = CompilingState.restarting;
       return await services.compileDDC(request);
     } finally {
-      appModel.compilingBusy.value = CompilingState.none;
+      appModel.compilingState.value = CompilingState.none;
     }
   }
 
   Future<CompileDDCResponse> _compileNewDDC(CompileRequest request) async {
     try {
-      appModel.compilingBusy.value = CompilingState.compiling;
+      appModel.compilingState.value = CompilingState.restarting;
       return await services.compileNewDDC(request);
     } finally {
-      appModel.compilingBusy.value = CompilingState.none;
+      appModel.compilingState.value = CompilingState.none;
     }
   }
 
   Future<CompileDDCResponse> _compileNewDDCReload(
       CompileRequest request) async {
     try {
-      appModel.compilingBusy.value = CompilingState.reloading;
+      appModel.compilingState.value = CompilingState.reloading;
       return await services.compileNewDDCReload(request);
     } finally {
-      appModel.compilingBusy.value = CompilingState.none;
+      appModel.compilingState.value = CompilingState.none;
     }
   }
 
@@ -589,8 +589,8 @@ enum SplitDragState { inactive, active }
 
 enum CompilingState {
   none(false),
-  compiling(true),
-  reloading(true);
+  reloading(true),
+  restarting(true);
 
   final bool busy;
 


### PR DESCRIPTION
- don't show a spinner over the execution area when reloading

This dials back the amount of UI we show when hot reloading - we no longer decorate the execution area.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
