### PR TITLE
Prevent iframe from being recreated on layout change

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -232,8 +232,7 @@ class _DartPadMainPageState extends State<DartPadMainPage>
   late final SplitViewController mainSplitter;
   late final TabController tabController;
 
-  final ValueKey<String> _executionWidgetKey =
-      const ValueKey('execution-widget');
+  final Key _executionWidgetKey = GlobalKey(debugLabel: 'execution-widget');
   final ValueKey<String> _loadingOverlayKey =
       const ValueKey('loading-overlay-widget');
   final ValueKey<String> _editorKey = const ValueKey('editor');


### PR DESCRIPTION
This fixes needing to rerun the app after changing between the wide and narrow layouts. This also fixes hot reloading after changing the layout, which is dependent on a consistent execution service.