### PR TITLE
Fix error reporting

### DIFF
--- a/pkgs/dart_services/lib/src/common.dart
+++ b/pkgs/dart_services/lib/src/common.dart
@@ -17,11 +17,11 @@ void main() {
 // This code should be kept up-to-date with
 // https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/web/bootstrap.dart#L236.
 const kBootstrapFlutterCode = r'''
-import 'package:flutter/foundation.dart';
 import 'dart:ui_web' as ui_web;
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 import 'generated_plugin_registrant.dart' as pluginRegistrant;

--- a/pkgs/dart_services/lib/src/common.dart
+++ b/pkgs/dart_services/lib/src/common.dart
@@ -17,6 +17,7 @@ void main() {
 // This code should be kept up-to-date with
 // https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/web/bootstrap.dart#L236.
 const kBootstrapFlutterCode = r'''
+import 'package:flutter/foundation.dart';
 import 'dart:ui_web' as ui_web;
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
@@ -29,7 +30,16 @@ import 'main.dart' as entrypoint;
 @JS('window')
 external JSObject get _window;
 
+@JS('reportFlutterError')
+external void _reportFlutterError(String message);
+
 Future<void> main() async {
+  // Capture errors and throw them to the JS console so DartPad can report them
+  // correctly.
+  FlutterError.onError = (details) {
+    _reportFlutterError(details.toString());
+  };
+
   // Mock DWDS indicators to allow Flutter to register hot reload 'reassemble'
   // extension.
   _window[r'$dwdsVersion'] = true.toJS;

--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -17,13 +17,11 @@ class ConsoleWidget extends StatefulWidget {
   final bool showDivider;
   final bool isError;
   final ValueNotifier<String> output;
-  final VoidCallback? onClearConsole;
 
   const ConsoleWidget({
     this.showDivider = false,
     this.isError = false,
     required this.output,
-    this.onClearConsole,
     super.key,
   });
 
@@ -127,10 +125,7 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
   }
 
   void _clearConsole() {
-    final onClear =widget.onClearConsole;
-    if (onClear != null) {
-      onClear();
-    }
+    widget.output.value = '';
   }
 
   void _scrollToEnd() {

--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -15,12 +15,10 @@ import 'widgets.dart';
 
 class ConsoleWidget extends StatefulWidget {
   final bool showDivider;
-  final bool isError;
-  final ValueNotifier<String> output;
+  final ConsoleNotifier output;
 
   const ConsoleWidget({
     this.showDivider = false,
-    this.isError = false,
     required this.output,
     super.key,
   });
@@ -67,20 +65,21 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
                 : null,
       ),
       padding: const EdgeInsets.all(denseSpacing),
-      child: ValueListenableBuilder(
-        valueListenable: widget.output,
-        builder: (context, consoleOutput, _) {
+      child: ListenableBuilder(
+        listenable: widget.output,
+        builder: (context, _) {
+          print('valueToDisplay = ${widget.output.valueToDisplay}');
           return Stack(
             children: [
               SizedBox.expand(
                 child: SingleChildScrollView(
                   controller: scrollController,
                   child: SelectableText(
-                    consoleOutput,
+                    widget.output.valueToDisplay,
                     maxLines: null,
                     style: GoogleFonts.robotoMono(
                       fontSize: theme.textTheme.bodyMedium?.fontSize,
-                      color: switch (widget.isError) {
+                      color: switch (widget.output.hasError) {
                         false => theme.textTheme.bodyMedium?.color,
                         true => theme.colorScheme.error.darker,
                       },
@@ -106,13 +105,16 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
                             () => suggestFix(
                               context: context,
                               appType: appModel.appType,
-                              errorMessage: consoleOutput,
+                              errorMessage: widget.output.error,
                             ),
                       ),
                     MiniIconButton(
                       icon: const Icon(Icons.playlist_remove),
                       tooltip: 'Clear console',
-                      onPressed: consoleOutput.isEmpty ? null : _clearConsole,
+                      onPressed:
+                          widget.output.isEmpty
+                              ? null
+                              : () => widget.output.clear(),
                     ),
                   ],
                 ),
@@ -122,10 +124,6 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
         },
       ),
     );
-  }
-
-  void _clearConsole() {
-    widget.output.value = '';
   }
 
   void _scrollToEnd() {

--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -10,14 +10,17 @@ import 'enable_gen_ai.dart';
 import 'model.dart';
 import 'suggest_fix.dart';
 import 'theme.dart';
+import 'utils.dart';
 import 'widgets.dart';
 
 class ConsoleWidget extends StatefulWidget {
   final bool showDivider;
+  final bool isError;
   final ValueNotifier<String> output;
 
   const ConsoleWidget({
     this.showDivider = true,
+    this.isError = false,
     required this.output,
     super.key,
   });
@@ -66,52 +69,57 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
       padding: const EdgeInsets.all(denseSpacing),
       child: ValueListenableBuilder(
         valueListenable: widget.output,
-        builder:
-            (context, consoleOutput, _) => Stack(
-              children: [
-                SizedBox.expand(
-                  child: SingleChildScrollView(
-                    controller: scrollController,
-                    child: SelectableText(
-                      consoleOutput,
-                      maxLines: null,
-                      style: GoogleFonts.robotoMono(
-                        fontSize: theme.textTheme.bodyMedium?.fontSize,
-                      ),
+        builder: (context, consoleOutput, _) {
+          return Stack(
+            children: [
+              SizedBox.expand(
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  child: SelectableText(
+                    consoleOutput,
+                    maxLines: null,
+                    style: GoogleFonts.robotoMono(
+                      fontSize: theme.textTheme.bodyMedium?.fontSize,
+                      color: switch (widget.isError) {
+                        false => theme.textTheme.bodyMedium?.color,
+                        true => theme.colorScheme.error.darker,
+                      },
                     ),
                   ),
                 ),
-                Padding(
-                  padding: const EdgeInsets.all(denseSpacing),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      if (genAiEnabled && appModel.consoleShowingError)
-                        MiniIconButton(
-                          icon: Image.asset(
-                            'gemini_sparkle_192.png',
-                            width: 16,
-                            height: 16,
-                          ),
-                          tooltip: 'Suggest fix',
-                          onPressed:
-                              () => suggestFix(
-                                context: context,
-                                appType: appModel.appType,
-                                errorMessage: consoleOutput,
-                              ),
-                        ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(denseSpacing),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (genAiEnabled && appModel.consoleShowingError)
                       MiniIconButton(
-                        icon: const Icon(Icons.playlist_remove),
-                        tooltip: 'Clear console',
-                        onPressed: consoleOutput.isEmpty ? null : _clearConsole,
+                        icon: Image.asset(
+                          'gemini_sparkle_192.png',
+                          width: 16,
+                          height: 16,
+                        ),
+                        tooltip: 'Suggest fix',
+                        onPressed:
+                            () => suggestFix(
+                              context: context,
+                              appType: appModel.appType,
+                              errorMessage: consoleOutput,
+                            ),
                       ),
-                    ],
-                  ),
+                    MiniIconButton(
+                      icon: const Icon(Icons.playlist_remove),
+                      tooltip: 'Clear console',
+                      onPressed: consoleOutput.isEmpty ? null : _clearConsole,
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -68,7 +68,6 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
       child: ListenableBuilder(
         listenable: widget.output,
         builder: (context, _) {
-          print('valueToDisplay = ${widget.output.valueToDisplay}');
           return Stack(
             children: [
               SizedBox.expand(

--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -17,11 +17,13 @@ class ConsoleWidget extends StatefulWidget {
   final bool showDivider;
   final bool isError;
   final ValueNotifier<String> output;
+  final VoidCallback? onClearConsole;
 
   const ConsoleWidget({
-    this.showDivider = true,
+    this.showDivider = false,
     this.isError = false,
     required this.output,
+    this.onClearConsole,
     super.key,
   });
 
@@ -125,7 +127,10 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
   }
 
   void _clearConsole() {
-    widget.output.value = '';
+    final onClear =widget.onClearConsole;
+    if (onClear != null) {
+      onClear();
+    }
   }
 
   void _scrollToEnd() {

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -254,7 +254,6 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         return;
       }
       final type = data['type'] as String?;
-      print('got message! $data');
 
       if (type == 'stderr') {
         // Ignore any exceptions before the iframe has completed

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -14,6 +14,8 @@ import '../model.dart';
 class ExecutionServiceImpl implements ExecutionService {
   final StreamController<String> _stdoutController =
       StreamController<String>.broadcast();
+  final StreamController<String> _stderrController =
+      StreamController<String>.broadcast();
 
   web.HTMLIFrameElement _frame;
   late String _frameSrc;
@@ -52,6 +54,9 @@ class ExecutionServiceImpl implements ExecutionService {
 
   @override
   Stream<String> get onStdout => _stdoutController.stream;
+
+  @override
+  Stream<String> get onStderr => _stderrController.stream;
 
   @override
   set ignorePointer(bool ignorePointer) {
@@ -254,7 +259,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         // Ignore any exceptions before the iframe has completed
         // initialization.
         if (_readyCompleter.isCompleted) {
-          _stdoutController.add(data['message'] as String);
+          _stderrController.add(data['message'] as String);
         }
       } else if (type == 'ready' && !_readyCompleter.isCompleted) {
         _readyCompleter.complete();

--- a/pkgs/dartpad_ui/lib/execution/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/frame.dart
@@ -254,6 +254,7 @@ require(["dartpad_main", "dart_sdk"], function(dartpad_main, dart_sdk) {
         return;
       }
       final type = data['type'] as String?;
+      print('got message! $data');
 
       if (type == 'stderr') {
         // Ignore any exceptions before the iframe has completed

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -348,7 +348,6 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         ValueListenableBuilder(
           valueListenable: appModel.layoutMode,
           builder: (context, LayoutMode mode, _) {
-            print('mode = $mode');
             return switch (mode) {
               LayoutMode.both => SplitView(
                 viewMode: SplitViewMode.Vertical,

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -542,82 +542,12 @@ class TabbedConsole extends StatefulWidget {
 
 class _TabbedConsoleState extends State<TabbedConsole>
     with SingleTickerProviderStateMixin {
-  late TabController _tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    _tabController = TabController(length: 2, vsync: this);
-    _tabController.addListener(_handleTabChange);
-    // Switch to the error tab  whenever a new error is received
-    widget.errorOutput.addListener(_switchToErrorTab);
-    if (widget.errorOutput.value.isNotEmpty) {
-      _switchToErrorTab();
-    }
-  }
-
-  @override
-  void dispose() {
-    _tabController.removeListener(_handleTabChange);
-    _tabController.dispose();
-    widget.errorOutput.removeListener(_switchToErrorTab);
-    super.dispose();
-  }
-
-  @override
-  void didUpdateWidget(TabbedConsole oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.errorOutput != widget.errorOutput) {
-      widget.errorOutput.removeListener(_switchToErrorTab);
-      widget.errorOutput.addListener(_switchToErrorTab);
-    }
-  }
-
-  void _handleTabChange() {
-    // Rebuild to trigger AnimatedSwitcher
-    setState(() {});
-  }
-
-  void _switchToErrorTab() {
-    _tabController.animateTo(1);
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Expanded(
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 300),
-            transitionBuilder: (Widget child, Animation<double> animation) {
-              return FadeTransition(opacity: animation, child: child);
-            },
-            child: _getTabView(_tabController.index),
-          ),
-        ),
-        TabBar(
-          controller: _tabController,
-          tabs: [Tab(text: 'Output'), Tab(text: 'Errors')],
-        ),
-      ],
-    );
-  }
-
-  Widget _getTabView(int index) {
+    final showError = widget.errorOutput.value.isNotEmpty;
     return ConsoleWidget(
-      key: ValueKey('ConsoleWidget $index'),
-      onClearConsole: () {
-        widget.output.value = '';
-        widget.errorOutput.value = '';
-      },
-      output: switch (index) {
-        0 => widget.output,
-        _ => widget.errorOutput,
-      },
-      isError: switch (index) {
-        0 => false,
-        _ => true,
-      },
+      isError: showError,
+      output: showError ? widget.errorOutput : widget.output,
     );
   }
 }

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -192,7 +192,7 @@ class AppServices {
   Timer? reanalysisDebouncer;
 
   static const Set<Channel> _hotReloadableChannels = {
-    // Channel.localhost,
+    Channel.localhost,
     Channel.main,
   };
 

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -669,7 +669,6 @@ class ConsoleNotifier extends ChangeNotifier {
   String get output => _output;
 
   set output(String value) {
-    print('output = $value');
     _output = value;
     notifyListeners();
   }

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -113,12 +113,10 @@ class AppModel {
   }
 
   void appendLineToConsole(String str) {
-    print('appendLineToConsole $str');
     consoleNotifier.output += '$str\n';
   }
 
   void appendError(String str) {
-    print('appendError $str');
     consoleNotifier.error += '$str\n';
   }
 

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -503,7 +503,6 @@ class AppServices {
     // register the new
     if (_executionService != null) {
       stdoutSub = _executionService!.onStdout.listen((msg) {
-        print('stdout: $msg');
         appModel.appendLineToConsole(msg);
       });
       stderrSub = _executionService!.onStderr.listen(

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -123,7 +123,6 @@ class AppModel {
   }
 
   void clearConsole() {
-    print('clearConsole');
     consoleOutput.value = '';
     errorOutput.value = '';
   }

--- a/pkgs/dartpad_ui/web/frame.js
+++ b/pkgs/dartpad_ui/web/frame.js
@@ -15,7 +15,7 @@ function replaceJavaScript(value) {
   scriptNode.async = false;
   scriptNode.text = value;
   document.head.appendChild(scriptNode);
-};
+}
 
 // Handles incoming messages.
 function messageHandler(e) {
@@ -26,7 +26,17 @@ function messageHandler(e) {
   } else if (obj.command === 'executeReload') {
     runFlutterApp(obj.js, obj.canvasKitBaseUrl, true);
   }
-};
+}
+
+// Used by the bootstrapped flutter script to report Flutter errors to DartPad
+// separately from console output.
+function reportFlutterError(e) {
+  parent.postMessage({
+    'sender': 'frame',
+    'type': 'stderr',
+    'message': e
+  }, '*');
+}
 
 function runFlutterApp(compiledScript, canvasKitBaseUrl, reload) {
   var blob = new Blob([compiledScript], { type: 'text/javascript' });


### PR DESCRIPTION
This adds support for displaying Dart or Flutter error messages in console and lets you drag to adjust the size. If an error message has been received since the user last cleared the console, we show that. If there's only normal output, we show that.

One potential issue with this approach: If there's an error being displayed, you can't go back to view view console output until you clear the console. We could add a tab bar to switch between the two, but this was the best I could do without adding extra UI components that take up space.

fixes #3008
fixes #3148

![dartpad-errors 2025-02-28 16_10_01](https://github.com/user-attachments/assets/5da41863-f776-4d1a-85cd-993660c199e4)
