### PR TITLE
Adjust Gemini variable name

### DIFF
--- a/pkgs/dart_services/README.md
+++ b/pkgs/dart_services/README.md
@@ -31,10 +31,10 @@ The server will run from port 8080 and export several JSON APIs, like
 
 To test Gemini API features on a local machine,
 get an API key from [Google AI Studio](https://aistudio.google.com)
-and set the `PK_GEMINI_API_KEY` environment variable before running:
+and set the `GEMINI_API_KEY` environment variable before running:
 
 ```
-export PK_GEMINI_API_KEY=<YOUR_API_KEY>
+export GEMINI_API_KEY=<YOUR_API_KEY>
 dart bin/server.dart
 ```
 

--- a/pkgs/dart_services/lib/src/generative_ai.dart
+++ b/pkgs/dart_services/lib/src/generative_ai.dart
@@ -15,7 +15,7 @@ import 'pub.dart';
 final _logger = Logger('gen-ai');
 
 class GenerativeAI {
-  static const _apiKeyVarName = 'PK_GEMINI_API_KEY';
+  static const _apiKeyVarName = 'GEMINI_API_KEY';
   static const _geminiModel = 'gemini-2.0-flash';
   late final String? _geminiApiKey;
 


### PR DESCRIPTION
This changes the variable name from PK_GEMINI_API_KEY to GEMINI_API_KEY to match the expected name in GCP.