### PR TITLE
Fix asset paths for gemini branch

### DIFF
--- a/pkgs/dartpad_ui/lib/console.dart
+++ b/pkgs/dartpad_ui/lib/console.dart
@@ -95,7 +95,7 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
                     if (genAiEnabled && appModel.consoleShowingError)
                       MiniIconButton(
                         icon: Image.asset(
-                          'gemini_sparkle_192.png',
+                          'assets/gemini_sparkle_192.png',
                           width: 16,
                           height: 16,
                         ),

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -1333,7 +1333,7 @@ class GeminiMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final image = Image.asset('gemini_sparkle_192.png', width: 24, height: 24);
+    final image = Image.asset('assets/gemini_sparkle_192.png', width: 24, height: 24);
 
     return MenuAnchor(
       builder: (context, MenuController controller, Widget? child) {

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -1333,7 +1333,11 @@ class GeminiMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final image = Image.asset('assets/gemini_sparkle_192.png', width: 24, height: 24);
+    final image = Image.asset(
+      'assets/gemini_sparkle_192.png',
+      width: 24,
+      height: 24,
+    );
 
     return MenuAnchor(
       builder: (context, MenuController controller, Widget? child) {

--- a/pkgs/dartpad_ui/lib/problems.dart
+++ b/pkgs/dartpad_ui/lib/problems.dart
@@ -115,7 +115,7 @@ class ProblemWidget extends StatelessWidget {
                       ),
                   tooltip: 'Suggest fix',
                   icon: Image.asset(
-                    'gemini_sparkle_192.png',
+                    'assets/gemini_sparkle_192.png',
                     width: 16,
                     height: 16,
                   ),

--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -22,11 +22,11 @@
   <link rel="manifest" href="manifest.json">
 
   <link href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap" rel="stylesheet">
-  <link href="/codemirror/codemirror.css" rel="stylesheet">
-  <link href="/styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
-  <link href="/styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
+  <link href="codemirror/codemirror.css" rel="stylesheet">
+  <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
+  <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
   <link href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css" rel="stylesheet">
-  <script src="/codemirror/codemirror.js"></script>
+  <script src="codemirror/codemirror.js"></script>
   <script src="ga.js" defer></script>
 
   <style>

--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -22,11 +22,11 @@
   <link rel="manifest" href="manifest.json">
 
   <link href="https://fonts.googleapis.com/css2?family=Roboto&family=Roboto+Mono&display=swap" rel="stylesheet">
-  <link href="codemirror/codemirror.css" rel="stylesheet">
-  <link href="styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
-  <link href="styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
+  <link href="/codemirror/codemirror.css" rel="stylesheet">
+  <link href="/styles/cm-dartpad-dark.css" rel="stylesheet" media="screen">
+  <link href="/styles/cm-dartpad-light.css" rel="stylesheet" media="screen">
   <link href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css" rel="stylesheet">
-  <script src="codemirror/codemirror.js"></script>
+  <script src="/codemirror/codemirror.js"></script>
   <script src="ga.js" defer></script>
 
   <style>


### PR DESCRIPTION
This fixes some issues that I found when deploying a preview version of the app to Firebase Hosting:

* adjusts codemirror path to work in different Firebase Hosting scenarios
* adjusts the asset configuration to make sure the Gemini logo loads when deployed to Firebase Hosting.