### PR TITLE
include import information in analyze rpc call

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -384,8 +384,16 @@ class AnalysisServerWrapper {
         );
       }
     }
+    final reportedImports =
+        imports
+            .where((import) => import.packageImport || import.dartImport)
+            .map((import) => import.uri.stringValue!)
+            .toList();
 
-    return api.AnalysisResponse(issues: [...importIssues, ...issues]);
+    return api.AnalysisResponse(
+      issues: [...importIssues, ...issues],
+      imports: reportedImports,
+    );
   }
 
   /// Cleanly shutdown the Analysis Server.

--- a/pkgs/dart_services/test/server_test.dart
+++ b/pkgs/dart_services/test/server_test.dart
@@ -83,6 +83,7 @@ class MyApp extends StatelessWidget {
       );
 
       expect(result, isNotNull);
+      expect(result.imports, contains('package:flutter/material.dart'));
       expect(result.issues, isEmpty);
     });
 

--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -29,7 +29,9 @@ class SourceRequest {
 class AnalysisResponse {
   final List<AnalysisIssue> issues;
 
-  AnalysisResponse({required this.issues});
+  final List<String>? imports;
+
+  AnalysisResponse({required this.issues, this.imports});
 
   factory AnalysisResponse.fromJson(Map<String, Object?> json) =>
       _$AnalysisResponseFromJson(json);

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -21,10 +21,12 @@ AnalysisResponse _$AnalysisResponseFromJson(Map<String, dynamic> json) =>
           (json['issues'] as List<dynamic>)
               .map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
               .toList(),
+      imports:
+          (json['imports'] as List<dynamic>?)?.map((e) => e as String).toList(),
     );
 
 Map<String, dynamic> _$AnalysisResponseToJson(AnalysisResponse instance) =>
-    <String, dynamic>{'issues': instance.issues};
+    <String, dynamic>{'issues': instance.issues, 'imports': instance.imports};
 
 AnalysisIssue _$AnalysisIssueFromJson(Map<String, dynamic> json) =>
     AnalysisIssue(

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -50,6 +50,7 @@ class AppModel {
   final ValueNotifier<bool> appReady = ValueNotifier(false);
 
   final ValueNotifier<List<AnalysisIssue>> analysisIssues = ValueNotifier([]);
+  final ValueNotifier<List<String>> packageImports = ValueNotifier([]);
 
   final ValueNotifier<String> title = ValueNotifier('');
 
@@ -550,6 +551,7 @@ class AppServices {
         SourceRequest(source: appModel.sourceCodeController.text),
       );
       appModel.analysisIssues.value = results.issues;
+      appModel.packageImports.value = results.imports ?? [];
     } catch (error) {
       appModel.analysisIssues.value = [
         AnalysisIssue(
@@ -558,6 +560,7 @@ class AppServices {
           location: Location(line: 0, column: 0),
         ),
       ];
+      appModel.packageImports.value = [];
     }
   }
 


### PR DESCRIPTION
- include import information in analyze rpc call
- keep as optional in the call for now so that new clients can talk to old servers (for the ~8 min update period)

This does not yet switch `appIsFlutter` and `usesPackageWeb` over to this info as we need to decide whether we're just relying on this info or also using the technique of scraping DDC output (`hasFlutterWebMarker`).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
