### PR TITLE
use the import information in the 'appIsFlutter' detection

### DIFF
--- a/pkgs/dartpad_shared/lib/model.dart
+++ b/pkgs/dartpad_shared/lib/model.dart
@@ -29,9 +29,9 @@ class SourceRequest {
 class AnalysisResponse {
   final List<AnalysisIssue> issues;
 
-  final List<String>? imports;
+  final List<String> imports;
 
-  AnalysisResponse({required this.issues, this.imports});
+  AnalysisResponse({required this.issues, required this.imports});
 
   factory AnalysisResponse.fromJson(Map<String, Object?> json) =>
       _$AnalysisResponseFromJson(json);

--- a/pkgs/dartpad_shared/lib/model.g.dart
+++ b/pkgs/dartpad_shared/lib/model.g.dart
@@ -22,7 +22,7 @@ AnalysisResponse _$AnalysisResponseFromJson(Map<String, dynamic> json) =>
               .map((e) => AnalysisIssue.fromJson(e as Map<String, dynamic>))
               .toList(),
       imports:
-          (json['imports'] as List<dynamic>?)?.map((e) => e as String).toList(),
+          (json['imports'] as List<dynamic>).map((e) => e as String).toList(),
     );
 
 Map<String, dynamic> _$AnalysisResponseToJson(AnalysisResponse instance) =>

--- a/pkgs/dartpad_ui/lib/utils.dart
+++ b/pkgs/dartpad_ui/lib/utils.dart
@@ -36,29 +36,12 @@ RelativeRect calculatePopupMenuPosition(
   );
 }
 
-bool hasFlutterWebMarker(String javaScript, {required bool isNewDDC}) {
-  const marker1 = 'window.flutterConfiguration';
-  if (javaScript.contains(marker1)) {
-    return true;
-  }
-  if (isNewDDC &&
-      javaScript.contains('defineLibrary(') &&
-      javaScript.contains('importLibrary("package:flutter/')) {
-    return true;
-    // define('dartpad_main', ['dart_sdk', 'flutter_web']
-  } else if (!isNewDDC &&
-      javaScript.contains("define('") &&
-      javaScript.contains("'flutter_web'")) {
-    return true;
-  }
-
-  return false;
+bool hasFlutterImports(List<String> imports) {
+  return imports.any((import) => import.startsWith('package:flutter/'));
 }
 
-bool hasPackageWebImport(String dartSource) {
-  // TODO(devoncarew): There are better ways to do this.
-  return dartSource.contains("import 'package:web/") ||
-      dartSource.contains('import "package:web/');
+bool hasPackageWebImport(List<String> imports) {
+  return imports.any((import) => import.startsWith('package:web/'));
 }
 
 extension ColorExtension on Color {


### PR DESCRIPTION
- use the import information in the 'appIsFlutter' detection
- make `AnalysisResponse.imports` non-nullable (the server now always provides this info)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
