### PR TITLE
Fix broken main.

### DIFF
--- a/pkgs/dart_services/README.md
+++ b/pkgs/dart_services/README.md
@@ -1,5 +1,3 @@
-do not merge
-
 # Dart Services
 
 A server backend to support DartPad.

--- a/pkgs/dart_services/README.md
+++ b/pkgs/dart_services/README.md
@@ -1,3 +1,5 @@
+do not merge
+
 # Dart Services
 
 A server backend to support DartPad.

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_beta.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0",
+  "dio": "5.8.0+1",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0",
+  "dio": "5.8.0+1",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_stable.json
@@ -20,7 +20,7 @@
   "csslib": "1.0.2",
   "dart_earcut": "1.2.0",
   "dartz": "0.10.1",
-  "dio": "5.8.0",
+  "dio": "5.8.0+1",
   "dio_web_adapter": "2.1.0",
   "english_words": "4.0.0",
   "equatable": "2.0.7",


### PR DESCRIPTION
https://github.com/dart-lang/dart-pad/actions/runs/13771805719/job/38511942985?pr=3195 :

```
Run dart run grinder build-project-templates
grinder running build-project-templates

build-project-templates
  flutter pub get:
    cwd: /home/runner/work/dart-pad/dart-pad/pkgs/dart_services/project_templates/dart_project
    env: {PUB_CACHE: /home/runner/work/dart-pad/dart-pad/pkgs/dart_services/local_pub_cache}
  Resolving dependencies...
  Because dartpad_sample depends on dio 5.8.0 which doesn't match any versions, version solving failed.
  
  
  You can try the following suggestion to make the pubspec resolve:
  * Try upgrading your constraint on dio: flutter pub add dio:'^5.8.0+1'
  Failed to update packages.

Bad state: pub get failed (1)
#0      ProjectCreator.buildDartProjectTemplate (package:dart_services/src/project_creator.dart:54:[7](https://github.com/dart-lang/dart-pad/actions/runs/13771805719/job/38511942985?pr=3195#step:8:8))
<asynchronous suspension>
#1      buildProjectTemplates (file:///home/runner/work/dart-pad/dart-pad/pkgs/dart_services/tool/grind.dart:90:3)
<asynchronous suspension>
#2      Grinder._invokeTask.<anon> (package:grinder/src/grinder.dart:221:24)
<asynchronous suspension>
#3      Future._kTrue (dart:async/future.dart:660:3)
<asynchronous suspension>
#4      _RootZone.bindUnaryCallbackGuarded.<anon> (dart:async/zone.dart:1[8](https://github.com/dart-lang/dart-pad/actions/runs/13771805719/job/38511942985?pr=3195#step:8:9)18:12)
<asynchronous suspension>
```