### PR TITLE
Consistently collapse buttons in mobile/narrow layouts

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -189,6 +189,11 @@ class _DartPadAppState extends State<DartPadApp> {
             foregroundColor: WidgetStatePropertyAll(darkLinkButtonColor),
           ),
         ),
+        iconButtonTheme: const IconButtonThemeData(
+          style: ButtonStyle(
+            foregroundColor: WidgetStatePropertyAll(darkLinkButtonColor),
+          ),
+        ),
         scaffoldBackgroundColor: darkScaffoldColor,
         menuButtonTheme: MenuButtonThemeData(
           style: MenuItemButton.styleFrom(
@@ -584,6 +589,8 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        final wideLayout = constraints.maxWidth > smallScreenWidth;
+
         return AppBar(
           backgroundColor: theme.colorScheme.surface,
           title: SizedBox(
@@ -599,16 +606,16 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
                   ),
                 ),
                 // Hide new snippet buttons when the screen width is too small.
-                if (constraints.maxWidth > smallScreenWidth) ...[
+                if (wideLayout) ...[
                   const SizedBox(width: defaultSpacing * 4),
                   NewSnippetWidget(appServices: appServices),
                   const SizedBox(width: denseSpacing),
                   const ListSamplesWidget(),
                 ] else ...[
                   const SizedBox(width: defaultSpacing),
-                  NewSnippetWidget(appServices: appServices, smallIcon: true),
+                  NewSnippetWidget(appServices: appServices, hideLabel: true),
                   const SizedBox(width: defaultSpacing),
-                  const ListSamplesWidget(smallIcon: true),
+                  const ListSamplesWidget(hideLabel: true),
                 ],
 
                 if (genAiEnabled) ...[
@@ -616,12 +623,13 @@ class DartPadAppBar extends StatelessWidget implements PreferredSizeWidget {
                   GeminiMenu(
                     generateNewCode: () => _generateNewCode(context),
                     updateExistingCode: () => _updateExistingCode(context),
+                    hideLabel: !wideLayout,
                   ),
                 ],
 
                 const SizedBox(width: defaultSpacing),
                 // Hide the snippet title when the screen width is too small.
-                if (constraints.maxWidth > smallScreenWidth)
+                if (wideLayout)
                   Expanded(
                     child: Center(
                       child: ValueListenableBuilder<String>(
@@ -1069,8 +1077,8 @@ class StatusLineWidget extends StatelessWidget {
             ),
           const Expanded(child: SizedBox(width: defaultSpacing)),
           VersionInfoWidget(appModel.runtimeVersions),
-          const SizedBox(width: defaultSpacing),
-          const SizedBox(height: 26, child: SelectChannelWidget()),
+          const SizedBox(width: denseSpacing),
+          SelectChannelWidget(hideLabel: mobileVersion),
         ],
       ),
     );
@@ -1118,7 +1126,7 @@ class SectionWidget extends StatelessWidget {
 
 class NewSnippetWidget extends StatelessWidget {
   final AppServices appServices;
-  final bool smallIcon;
+  final bool hideLabel;
 
   static const _menuItems = [
     (label: 'Dart snippet', icon: Logo(type: 'dart'), kind: 'dart'),
@@ -1127,26 +1135,21 @@ class NewSnippetWidget extends StatelessWidget {
 
   const NewSnippetWidget({
     required this.appServices,
-    this.smallIcon = false,
+    this.hideLabel = false,
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
     return MenuAnchor(
-      builder: (context, MenuController controller, Widget? child) {
-        if (smallIcon) {
-          return IconButton(
+      builder:
+          (_, MenuController controller, _) => CollapsibleIconToggleButton(
             icon: const Icon(Icons.add_circle),
-            onPressed: () => controller.toggleMenuState(),
-          );
-        }
-        return TextButton.icon(
-          onPressed: () => controller.toggleMenuState(),
-          icon: const Icon(Icons.add_circle),
-          label: const Text('New'),
-        );
-      },
+            label: const Text('New'),
+            tooltip: 'Create a new snippet',
+            hideLabel: hideLabel,
+            onToggle: controller.toggleMenuState,
+          ),
       menuChildren: [
         for (final item in _menuItems)
           PointerInterceptor(
@@ -1165,25 +1168,20 @@ class NewSnippetWidget extends StatelessWidget {
 }
 
 class ListSamplesWidget extends StatelessWidget {
-  final bool smallIcon;
-  const ListSamplesWidget({this.smallIcon = false, super.key});
+  final bool hideLabel;
+  const ListSamplesWidget({this.hideLabel = false, super.key});
 
   @override
   Widget build(BuildContext context) {
     return MenuAnchor(
-      builder: (context, MenuController controller, Widget? child) {
-        if (smallIcon) {
-          return IconButton(
+      builder:
+          (_, MenuController controller, _) => CollapsibleIconToggleButton(
             icon: const Icon(Icons.playlist_add_outlined),
-            onPressed: () => controller.toggleMenuState(),
-          );
-        }
-        return TextButton.icon(
-          onPressed: () => controller.toggleMenuState(),
-          icon: const Icon(Icons.playlist_add_outlined),
-          label: const Text('Samples'),
-        );
-      },
+            label: const Text('Samples'),
+            tooltip: 'Try out a sample',
+            hideLabel: hideLabel,
+            onToggle: controller.toggleMenuState,
+          ),
       menuChildren: _buildMenuItems(context),
     );
   }
@@ -1215,7 +1213,9 @@ class ListSamplesWidget extends StatelessWidget {
 }
 
 class SelectChannelWidget extends StatelessWidget {
-  const SelectChannelWidget({super.key});
+  const SelectChannelWidget({super.key, this.hideLabel = false});
+
+  final bool hideLabel;
 
   @override
   Widget build(BuildContext context) {
@@ -1226,13 +1226,15 @@ class SelectChannelWidget extends StatelessWidget {
       valueListenable: appServices.channel,
       builder:
           (context, Channel value, _) => MenuAnchor(
-            builder: (context, MenuController controller, Widget? child) {
-              return TextButton.icon(
-                onPressed: () => controller.toggleMenuState(),
-                icon: const Icon(Icons.tune, size: smallIconSize),
-                label: Text('${value.displayName} channel'),
-              );
-            },
+            builder:
+                (_, controller, _) => CollapsibleIconToggleButton(
+                  icon: const Icon(Icons.tune, size: smallIconSize),
+                  label: Text('${value.displayName} channel'),
+                  tooltip: 'Switch channels',
+                  hideLabel: hideLabel,
+                  compact: true,
+                  onToggle: controller.toggleMenuState,
+                ),
             menuChildren: [
               for (final channel in channels)
                 PointerInterceptor(
@@ -1340,9 +1342,11 @@ class GeminiMenu extends StatelessWidget {
   const GeminiMenu({
     required this.generateNewCode,
     required this.updateExistingCode,
+    required this.hideLabel,
     super.key,
   });
 
+  final bool hideLabel;
   final VoidCallback generateNewCode;
   final VoidCallback updateExistingCode;
 
@@ -1355,13 +1359,14 @@ class GeminiMenu extends StatelessWidget {
     );
 
     return MenuAnchor(
-      builder: (context, MenuController controller, Widget? child) {
-        return TextButton.icon(
-          onPressed: () => controller.toggleMenuState(),
-          icon: image,
-          label: const Text('Gemini'),
-        );
-      },
+      builder:
+          (_, MenuController controller, _) => CollapsibleIconToggleButton(
+            icon: image,
+            label: const Text('Gemini'),
+            tooltip: 'Generate code with Gemini',
+            hideLabel: hideLabel,
+            onToggle: controller.toggleMenuState,
+          ),
       menuChildren: [
         ...[
           MenuItemButton(

--- a/pkgs/dartpad_ui/lib/widgets.dart
+++ b/pkgs/dartpad_ui/lib/widgets.dart
@@ -780,3 +780,38 @@ class _AddImageWidget extends StatelessWidget {
     );
   }
 }
+
+class CollapsibleIconToggleButton extends StatelessWidget {
+  const CollapsibleIconToggleButton({
+    super.key,
+    required this.onToggle,
+    required this.icon,
+    required this.label,
+    required this.tooltip,
+    this.hideLabel = false,
+    this.compact = false,
+  });
+
+  final void Function() onToggle;
+  final Widget icon;
+  final Text label;
+  final String tooltip;
+  final bool hideLabel;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      waitDuration: tooltipDelay,
+      child:
+          hideLabel
+              ? IconButton(
+                icon: icon,
+                onPressed: onToggle,
+                visualDensity: compact ? VisualDensity.compact : null,
+              )
+              : TextButton.icon(icon: icon, label: label, onPressed: onToggle),
+    );
+  }
+}


### PR DESCRIPTION
- Updates the "Gemini" button to collapse to an icon in the mobile layout
  - This stops overflow in the top nav on mobile
- Updates the channels button to collapse to an icon in the mobile layout
  - Stops overflow of the bottom bar on mobile
- Create a new widget to extract the switching logic to
- Adds tooltips to the various icon buttons