### PR TITLE
Mark beta as supporting hot reload

### DIFF
--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -196,6 +196,7 @@ class AppServices {
 
   static const Set<Channel> _hotReloadableChannels = {
     Channel.localhost,
+    Channel.beta,
     Channel.main,
   };
 

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -211,6 +211,9 @@ class AppServices {
       appModel.useNewDDC.value = _hotReloadableChannels.contains(
         _channel.value,
       );
+
+      // Mark any current delta as invalid as it's from another channel.
+      appModel.currentDeltaDill.value = null;
     }
 
     updateUseNewDDC();


### PR DESCRIPTION
Resolves #3204 

However it might be better to check the backend to see if it supports hot reload, in case of changes and dart services instances without support sticking around.