### PR TITLE
Update beta channel SDK packaging to correctly use old module system.

### DIFF
--- a/pkgs/dart_services/lib/src/sdk.dart
+++ b/pkgs/dart_services/lib/src/sdk.dart
@@ -179,5 +179,12 @@ final class Sdk {
     return int.parse(dartVersionString);
   }
 
-  bool get useNewDdcSdk => dartMajorVersion >= 3 && dartMinorVersion >= 8;
+  // Currently we only allow using the new DDC module systme on the main or
+  // local channels.
+  bool get _channelSupportsNewDdcSdk => !stableChannel && !betaChannel;
+
+  bool get useNewDdcSdk =>
+      dartMajorVersion >= 3 &&
+      dartMinorVersion >= 8 &&
+      _channelSupportsNewDdcSdk;
 }


### PR DESCRIPTION
Resolves https://github.com/dart-lang/dart-pad/issues/3204 by correctly using old SDK on beta and stable channels.

This keeps the experimental feature scoped to the main channel for now.