### PR TITLE
Refresh code mirror when switching to editor tab

### DIFF
--- a/pkgs/dartpad_ui/lib/editor/editor.dart
+++ b/pkgs/dartpad_ui/lib/editor/editor.dart
@@ -186,6 +186,15 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
   }
 
   @override
+  void refreshViewAfterWait() {
+    // Use a longer delay so that the platform view is displayed
+    // correctly when compiled to Wasm.
+    Future<void>.delayed(const Duration(milliseconds: 80), () {
+      codeMirror?.refresh();
+    });
+  }
+
+  @override
   void initState() {
     super.initState();
     _autosaveTimer = Timer.periodic(const Duration(seconds: 5), _autosave);
@@ -217,12 +226,7 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
     // darkmode
     _updateCodemirrorMode(darkMode);
 
-    // Use a longer delay so that the platform view is displayed
-    // correctly when compiled to Wasm
-    Future.delayed(
-      const Duration(milliseconds: 80),
-      () => codeMirror!.refresh(),
-    );
+    refreshViewAfterWait();
 
     codeMirror!.on(
       'change',
@@ -280,12 +284,8 @@ class _EditorWidgetState extends State<EditorWidget> implements EditorService {
         for (final entry in entries.toDart) {
           if (entry.isIntersecting) {
             observer.unobserve(web.document.body!);
-            // Use a longer delay so that the platform view is displayed
-            // correctly when compiled to Wasm
-            Future.delayed(
-              const Duration(milliseconds: 80),
-              () => codeMirror!.refresh(),
-            );
+
+            refreshViewAfterWait();
             return;
           }
         }

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -303,6 +303,14 @@ class _DartPadMainPageState extends State<DartPadMainPage>
         });
     appModel.compilingState.addListener(_handleRunStarted);
 
+    tabController.addListener(() {
+      // Refresh the editor if switching to the code editor tab,
+      // to allow CodeMirror to update its custom rendering.
+      if (tabController.index == 0) {
+        appServices.editorService?.refreshViewAfterWait();
+      }
+    });
+
     debugPrint(
       'initialized: useGenui = ${widget.useGenui}, channel = $channel.',
     );
@@ -314,6 +322,8 @@ class _DartPadMainPageState extends State<DartPadMainPage>
 
     appServices.dispose();
     appModel.dispose();
+
+    tabController.dispose();
 
     super.dispose();
   }

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -39,6 +39,9 @@ abstract class EditorService {
   void jumpTo(AnalysisIssue issue);
   int get cursorOffset;
   void focus();
+
+  /// Let the editor know to account for any resizing or visibility changes.
+  void refreshViewAfterWait();
 }
 
 class AppModel {


### PR DESCRIPTION
CodeMirror 5's docs [mention](https://codemirror.net/5/doc/manual.html#:~:text=already%20listened%20for)%2C-,or%20unhides%20it,-%2C%20you%20should%20probably) we should call `refresh()` after unhiding it, as is the case when switching from the output tab to the editor tab in the mobile layout. 