### PR TITLE
Update deprecated Apple meta-tag

### DIFF
--- a/pkgs/dartpad_ui/web/index.html
+++ b/pkgs/dartpad_ui/web/index.html
@@ -9,7 +9,7 @@
   <meta name="description" content="An online Dart editor with support for console and Flutter apps.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="DartPad">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">

--- a/pkgs/samples/web/index.html
+++ b/pkgs/samples/web/index.html
@@ -21,7 +21,7 @@
   <meta name="description" content="A new Flutter project.">
 
   <!-- iOS meta tags & icons -->
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="samples">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">


### PR DESCRIPTION
Update deprecated Apple meta-tag, see: https://github.com/flutter/flutter/issues/154596

This is currently manifesting in an error in Chrome DevTools:

<img width="1283" alt="Screenshot 2025-03-25 at 12 40 52" src="https://github.com/user-attachments/assets/2eccdfeb-6eac-46d4-9be5-4019e6c17ed8" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
