### PR TITLE
Rename menu from 'Gemini' to 'Create with Gemini'

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -1382,7 +1382,7 @@ class GeminiMenu extends StatelessWidget {
       builder:
           (_, MenuController controller, _) => CollapsibleIconToggleButton(
             icon: image,
-            label: const Text('Gemini'),
+            label: const Text('Create with Gemini'),
             tooltip: 'Generate code with Gemini',
             hideLabel: hideLabel,
             onToggle: controller.toggleMenuState,


### PR DESCRIPTION
Based on discussion with @devoncarew and @malloc-error 

<img width="663" alt="Screenshot 2025-04-10 at 1 12 20 PM" src="https://github.com/user-attachments/assets/f45f5107-1043-4a56-bb2a-4a57f20081a4" />
