### PR TITLE
Increase spacing, because increased width of menu item causes overflow.

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -33,7 +33,7 @@ import 'utils.dart';
 import 'versions.dart';
 
 const appName = 'DartPad';
-const smallScreenWidth = 720;
+const smallScreenWidth = 840;
 
 void main() async {
   usePathUrlStrategy();


### PR DESCRIPTION
Before:

<img width="718" alt="Screenshot 2025-04-19 at 6 34 34 PM" src="https://github.com/user-attachments/assets/57f51d74-fe6d-4814-b915-be0598ef8b2a" />


After:


https://github.com/user-attachments/assets/dc03abf1-0509-4d0b-b833-790125bb4d9b

