### PR TITLE
Remove URL flag for genui.

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -131,7 +131,6 @@ class _DartPadAppState extends State<DartPadApp> {
     final channelParam = state.uri.queryParameters['channel'];
     final embedMode = state.uri.queryParameters['embed'] == 'true';
     final runOnLoad = state.uri.queryParameters['run'] == 'true';
-    useGenUI = state.uri.queryParameters['genui'] == 'true';
 
     return DartPadMainPage(
       initialChannel: channelParam,

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -132,6 +132,9 @@ class _DartPadAppState extends State<DartPadApp> {
     final embedMode = state.uri.queryParameters['embed'] == 'true';
     final runOnLoad = state.uri.queryParameters['run'] == 'true';
 
+    // Uncomment this line to make genui default option.
+    // useGenUI = state.uri.queryParameters['genui'] != 'false';
+
     return DartPadMainPage(
       initialChannel: channelParam,
       embedMode: embedMode,


### PR DESCRIPTION
Address https://github.com/dart-lang/dart-pad/pull/3235#discussion_r2074000407

I created this flag when AI was not launched yet at all, so it seemed not to launch genai. But now I see it actually did. 
Sorry, for this. Removing.