### PR TITLE
Replace `localhost` with `127.0.0.1`. 

### DIFF
--- a/pkgs/dart_services/lib/server.dart
+++ b/pkgs/dart_services/lib/server.dart
@@ -6,7 +6,10 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:dartpad_shared/services.dart';
+import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_gzip/shelf_gzip.dart';
@@ -174,4 +177,32 @@ Middleware exceptionResponse() {
       }
     };
   };
+}
+
+@visibleForTesting
+class TestServerRunner {
+  late final ServicesClient client;
+  late final EndpointsServer _server;
+  final sdk = Sdk.fromLocalFlutter();
+
+  Completer<void>? _started;
+
+  Future<ServicesClient> start() async {
+    assert(_started == null, 'Server should not be started');
+    _started = Completer<void>();
+    _server = await EndpointsServer.serve(8080, sdk, null, 'nnbd_artifacts');
+    client = ServicesClient(
+      http.Client(),
+      rootUrl: 'http://localhost:${_server.port}/',
+    );
+    _started!.complete();
+    return client;
+  }
+
+  Future<void> stop() async {
+    assert(_started != null, 'Server should be started before stopping');
+    await _started!.future;
+    client.dispose();
+    await _server.close();
+  }
 }

--- a/pkgs/dart_services/lib/server.dart
+++ b/pkgs/dart_services/lib/server.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:dartpad_shared/services.dart';
+import 'package:dartpad_shared/simple_items.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -193,7 +194,7 @@ class TestServerRunner {
     _server = await EndpointsServer.serve(8080, sdk, null, 'nnbd_artifacts');
     client = ServicesClient(
       http.Client(),
-      rootUrl: 'http://localhost:${_server.port}/',
+      rootUrl: 'http://$localhostIp:${_server.port}/',
     );
     _started!.complete();
     return client;

--- a/pkgs/dart_services/test/server_test.dart
+++ b/pkgs/dart_services/test/server_test.dart
@@ -15,24 +15,16 @@ void main() => defineTests();
 
 void defineTests() {
   group('server', () {
-    final sdk = Sdk.fromLocalFlutter();
-    late final EndpointsServer server;
-    late final Client httpClient;
+    final runner = TestServerRunner();
     late final ServicesClient client;
 
     setUpAll(() async {
-      server = await EndpointsServer.serve(0, sdk, null, 'nnbd_artifacts');
-
-      httpClient = Client();
-      client = ServicesClient(
-        httpClient,
-        rootUrl: 'http://localhost:${server.port}/',
-      );
+      await runner.start();
+      client = runner.client;
     });
 
     tearDownAll(() async {
-      client.dispose();
-      await server.close();
+      await runner.stop();
     });
 
     test('version', () async {
@@ -344,7 +336,7 @@ void main() {
       (request) => client.compileDDC(request),
       expectDeltaDill: false,
     );
-    if (sdk.dartMajorVersion >= 3 && sdk.dartMinorVersion >= 8) {
+    if (runner.sdk.dartMajorVersion >= 3 && runner.sdk.dartMinorVersion >= 8) {
       testDDCEndpoint(
         'compileNewDDC',
         (request) => client.compileNewDDC(request),

--- a/pkgs/dartpad_shared/lib/simple_items.dart
+++ b/pkgs/dartpad_shared/lib/simple_items.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+const localhostIp = '127.0.0.1';

--- a/pkgs/dartpad_ui/lib/enable_gen_ai.dart
+++ b/pkgs/dartpad_ui/lib/enable_gen_ai.dart
@@ -14,7 +14,9 @@ bool useGenUI = false;
 /*
 
 There are two options to use gen AI: Gemini and GenUI. Gemini is the default.
-To run with GenUI, use corresponding VS Code configuration or the command line options:
+To run with GenUI, first uncomment the line in main.dart that sets useGenUI to true.
+
+Then use corresponding VS Code configuration or the command line options:
 
 1. With prod backend: add URL parameter `/?genui=true`
 

--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:dartpad_shared/services.dart';
+import 'package:dartpad_shared/simple_items.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
@@ -598,7 +599,7 @@ enum Channel {
   beta('Beta', 'https://beta.api.dartpad.dev/'),
   main('Main', 'https://master.api.dartpad.dev/'),
   // This channel is only used for local development.
-  localhost('Localhost', 'http://localhost:8080/');
+  localhost('Localhost', 'http://$localhostIp:8080/');
 
   final String displayName;
   final String url;


### PR DESCRIPTION
For some reasons it makes the difference to run unit tests against local backend.

Contributes to https://github.com/dart-lang/dart-pad/issues/3284