### PR TITLE
Update the DDC compile for hot reloads to target the 'main' library rather than 'bootstrap'.

### DIFF
--- a/pkgs/dart_services/lib/src/compiling.dart
+++ b/pkgs/dart_services/lib/src/compiling.dart
@@ -115,6 +115,11 @@ class Compiler {
   }
 
   /// Compile the given string and return the resulting [DDCCompilationResults].
+  ///
+  /// [useNew] determines whether or not to use the hot reload enabled module
+  /// system for DDC. When [useNew] is true, a null [deltaDill] will result in
+  /// a hot restart and a non-null [deltaDill] will result in a hot reload. If
+  /// [useNew] is false, the result will always be a hot restart.
   Future<DDCCompilationResults> _compileDDC(
     String source,
     DartPadRequestContext ctx, {

--- a/pkgs/dart_services/test/compiling_test.dart
+++ b/pkgs/dart_services/test/compiling_test.dart
@@ -130,13 +130,20 @@ void defineTests() {
             );
             result = await reloadEndpoint(sampleCodeNoMain, lastAcceptedDill);
           }
-          expect(result.success, false);
-          expect(result.problems.length, 1);
-          expect(
-            result.problems.first.message,
-            contains("Error: Method not found: 'main'"),
-          );
-          expect(result.problems.first.message, startsWith('main.dart:'));
+          if (reloadEndpoint != null) {
+            // Hot reload does not reload the bootstrap script so there is no
+            // new code trying to reference 'main'.
+            expect(result.success, true);
+            expect(result.problems.length, 0);
+          } else {
+            expect(result.success, false);
+            expect(result.problems.length, 1);
+            expect(
+              result.problems.first.message,
+              contains("Error: Method not found: 'main'"),
+            );
+            expect(result.problems.first.message, startsWith('main.dart:'));
+          }
         });
 
         test('with multiple errors', () async {


### PR DESCRIPTION
Hot reload requests were recompiling both `package:dartpad_sample/bootstrap.dart` and `package:dartpad_sample/main.dart` but the hot reload request only said it was recompiling the latter:
https://github.com/dart-lang/dart-pad/blob/main/pkgs/dartpad_ui/web/frame.js#L45

A new consistency check was recently added to the Dart SDK's `ddc_module_loader.js` to ensure that the set of pending hot reload libraries matched the set of libraries being loaded (and that the same library wasn't loaded more than once):
https://github.com/dart-lang/sdk/blob/main/pkg/dev_compiler/lib/js/ddc/ddc_module_loader.js#L1439

The extra `package:dartpad_sample/bootstrap.dart` was tripping this check and causing hot reloads to fail.

The fix here is to omit the `package:dartpad_sample/bootstrap.dart` sources in hot reload compiles so that only the generated JS doesn't include this extra library (only `package:dartpad_sample/main.dart`).


