### PR TITLE
Reorder loading of JS scripts for new DDC module system.

### DIFF
--- a/pkgs/dartpad_ui/lib/execution/view_factory/frame.dart
+++ b/pkgs/dartpad_ui/lib/execution/view_factory/frame.dart
@@ -135,14 +135,17 @@ function contextLoaded() {
   dartDevEmbedder.runMain('package:dartpad_sample/bootstrap.dart', {});
 }''');
       if (isFlutter) {
-        script.writeln(
-          'require(["dart_sdk_new", "flutter_web_new", "ddc_module_loader"], contextLoaded);',
-        );
+        script.writeln('''
+function moduleLoaderLoaded() {
+  require(["dart_sdk_new", "flutter_web_new"], contextLoaded);
+}''');
       } else {
-        script.writeln(
-          'require(["dart_sdk_new", "ddc_module_loader"], contextLoaded);',
-        );
+        script.writeln('''
+function moduleLoaderLoaded() {
+  require(["dart_sdk_new"], contextLoaded);
+}''');
       }
+      script.writeln('require(["ddc_module_loader"], moduleLoaderLoaded);');
     } else {
       // Redirect print messages to the host.
       script.writeln('''


### PR DESCRIPTION
Safari users are seeing a load ordering issue when loading DartPad with hot reload enabled.

The `ddc_module_loader.js` file puts the `dartDevEmbedder` into the page which is then used by the other loaded scripts.

This should ensure that `ddc_module_loader.js` is fully loaded into the page before loading the subsequent scripts that depend on it.