### PR TITLE
Wait until Flutter detection is done to inject DDC program

### DIFF
--- a/pkgs/dartpad_ui/lib/model.dart
+++ b/pkgs/dartpad_ui/lib/model.dart
@@ -550,14 +550,33 @@ class AppServices {
   }) {
     appModel._recalcLayout();
 
-    _executionService?.execute(
-      javaScript,
-      modulesBaseUrl: modulesBaseUrl,
-      engineVersion: engineVersion,
-      reload: reload,
-      isNewDDC: isNewDDC,
-      isFlutter: appModel.appIsFlutter.value ?? false,
-    );
+    void execute() {
+      _executionService?.execute(
+        javaScript,
+        modulesBaseUrl: modulesBaseUrl,
+        engineVersion: engineVersion,
+        reload: reload,
+        isNewDDC: isNewDDC,
+        isFlutter: appModel.appIsFlutter.value ?? false,
+      );
+    }
+
+    if (appModel.appIsFlutter.value == null) {
+      final completer = Completer<void>();
+      void listener() {
+        completer.complete();
+      }
+
+      final callback = listener;
+
+      appModel.appIsFlutter.addListener(callback);
+      completer.future.then((_) {
+        appModel.appIsFlutter.removeListener(callback);
+        execute();
+      });
+    } else {
+      execute();
+    }
   }
 
   void dispose() {


### PR DESCRIPTION
In order to generate the correct bootstrap code around DDC-generated code, the dartpad UI must know if the application is a Flutter application or not. This tells it to inject in a request for the Flutter SDK:
https://github.com/dart-lang/dart-pad/blob/main/pkgs/dartpad_ui/lib/execution/view_factory/frame.dart#L137

In some cases, especially when Dartpad is embedded, the compiled DDC code will be loaded before dartpad detects if the app is Flutter. This will result in the Flutter SDK not being loaded and a subsequent initialization error.

I believe this difference in timing may have been introduced by this change a few months ago:
https://github.com/dart-lang/dart-pad/pull/3191

The fix here is to ensure we're waiting for the `isFlutter` value to be set before loading the app.

Among other ways, this value is updated asynchronously as a result of the call to `_recalcLayout` a few lines earlier so a request for it to be set should always be in flight at least (if it isn't already set).