### PR TITLE
Hide 'Ask Gemini' text box in embed layout

### DIFF
--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -362,6 +362,7 @@ class DartPadMainPageState extends State<DartPadMainPage>
       onCompileAndRun: appServices.performCompileAndRun,
       onCompileAndReload: appServices.performCompileAndReload,
       key: _editorKey,
+      showCodeEditTool: !widget.embedMode,
     );
 
     final tabBar = TabBar(


### PR DESCRIPTION
As it's distracting in embedded versions of DartPad, which are often focused codelabs or tutorials. This change keeps gemini fixes for analysis errors though, only hiding the text box.