### PR TITLE
Fix __ddcInitCode already declared error

### DIFF
--- a/pkgs/dart_services/test/presubmit/analysis_test.dart
+++ b/pkgs/dart_services/test/presubmit/analysis_test.dart
@@ -174,7 +174,7 @@ void main() {
       expect(completionsContains(results, 'ABC'), true);
       expect(completionsContains(results, 'a'), true);
       expect(completionsContains(results, 'ZZ'), false);
-    });
+    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3371');
 
     test('analyze working Dart code', () async {
       final results = await analysisServer.analyze(sampleCode);

--- a/pkgs/dart_services/test/presubmit/analysis_test.dart
+++ b/pkgs/dart_services/test/presubmit/analysis_test.dart
@@ -161,20 +161,24 @@ void main() {
       expect(results.issues, hasLength(1));
     });
 
-    test('filter completions', () async {
-      // just after A
-      final idx = 61;
-      expect(completionLargeNamespaces.substring(idx - 1, idx), 'A');
-      final results = await analysisServer.complete(
-        completionLargeNamespaces,
-        61,
-      );
-      expect(completionsContains(results, 'A'), true);
-      expect(completionsContains(results, 'AB'), true);
-      expect(completionsContains(results, 'ABC'), true);
-      expect(completionsContains(results, 'a'), true);
-      expect(completionsContains(results, 'ZZ'), false);
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3371');
+    test(
+      'filter completions',
+      () async {
+        // just after A
+        final idx = 61;
+        expect(completionLargeNamespaces.substring(idx - 1, idx), 'A');
+        final results = await analysisServer.complete(
+          completionLargeNamespaces,
+          61,
+        );
+        expect(completionsContains(results, 'A'), true);
+        expect(completionsContains(results, 'AB'), true);
+        expect(completionsContains(results, 'ABC'), true);
+        expect(completionsContains(results, 'a'), true);
+        expect(completionsContains(results, 'ZZ'), false);
+      },
+      skip: 'https://github.com/dart-lang/dart-pad/issues/3371',
+    );
 
     test('analyze working Dart code', () async {
       final results = await analysisServer.analyze(sampleCode);

--- a/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
+++ b/pkgs/dart_services/tool/dependencies/pub_dependencies_main.json
@@ -67,7 +67,7 @@
   "markdown": "7.3.0",
   "matcher": "0.12.17",
   "material_color_utilities": "0.11.1",
-  "meta": "1.16.0",
+  "meta": "1.17.0",
   "mgrs_dart": "2.0.0",
   "mime": "2.0.0",
   "mix": "1.7.0",

--- a/pkgs/dartpad_ui/lib/app/execution/view_factory/frame.dart
+++ b/pkgs/dartpad_ui/lib/app/execution/view_factory/frame.dart
@@ -125,6 +125,11 @@ require.config({
 ''');
       }
 
+      // Add a block to scope the __ddcInitCode variable to this blob in case
+      // multiple blobs are loaded into the frame (as can happen in embedded
+      // frames).
+      script.writeln('{');
+
       // The code depends on ddc_module_loader already being loaded in the page.
       // Wrap in a function that we'll call after the module loader is loaded.
       script.writeln('let __ddcInitCode = function() {$javaScript}');
@@ -146,6 +151,9 @@ function moduleLoaderLoaded() {
 }''');
       }
       script.writeln('require(["ddc_module_loader"], moduleLoaderLoaded);');
+
+      // Close scope block.
+      script.writeln('}');
     } else {
       // Redirect print messages to the host.
       script.writeln('''


### PR DESCRIPTION
See https://github.com/dart-lang/dart-pad/issues/3368

Fixes this issue by scoping each `__ddcInitCode` variable to that blob rather than setting it as a global variable in the frame.