### PR TITLE
fix the returned cache control header

### DIFF
--- a/pkgs/dart_services/lib/src/common_server.dart
+++ b/pkgs/dart_services/lib/src/common_server.dart
@@ -464,7 +464,7 @@ Handler _serveCachedArtifacts(String artifactsPath) {
       response = response.change(
         headers: {
           // Allow Caching for one hour.
-          'Cache-Control': 'public, max-age=max-age=3600',
+          'Cache-Control': 'max-age=3600, public',
         },
       );
     }


### PR DESCRIPTION
- fix the returned cache control header (another follow-up to https://github.com/dart-lang/dart-pad/pull/3401)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
