### PR TITLE
Add copy functionality to the editor

### DIFF
--- a/pkgs/dartpad_ui/lib/app/genai_editing.dart
+++ b/pkgs/dartpad_ui/lib/app/genai_editing.dart
@@ -27,6 +27,7 @@ class EditorWithButtons extends StatefulWidget {
     this.showCodeEditTool = true,
     required this.appModel,
     required this.appServices,
+    required this.onCopy,
     required this.onFormat,
     required this.onCompileAndRun,
     required this.onCompileAndReload,
@@ -35,6 +36,7 @@ class EditorWithButtons extends StatefulWidget {
   final bool showCodeEditTool;
   final AppModel appModel;
   final AppServices appServices;
+  final VoidCallback onCopy;
   final VoidCallback onFormat;
   final VoidCallback onCompileAndRun;
   final VoidCallback onCompileAndReload;
@@ -127,6 +129,7 @@ class _EditorWithButtonsState extends State<EditorWithButtons> {
                   child: _EditingArea(
                     widget.appModel,
                     widget.appServices,
+                    onCopy: widget.onCopy,
                     onFormat: widget.onFormat,
                     onCompileAndReload: widget.onCompileAndReload,
                     onCompileAndRun: widget.onCompileAndRun,
@@ -658,6 +661,7 @@ class _EditingArea extends StatelessWidget {
   const _EditingArea(
     this.appModel,
     this.appServices, {
+    required this.onCopy,
     required this.onFormat,
     required this.onCompileAndReload,
     required this.onCompileAndRun,
@@ -665,6 +669,7 @@ class _EditingArea extends StatelessWidget {
 
   final AppModel appModel;
   final AppServices appServices;
+  final VoidCallback onCopy;
   final VoidCallback onFormat;
   final VoidCallback onCompileAndReload;
   final VoidCallback onCompileAndRun;
@@ -702,6 +707,16 @@ class _EditingArea extends StatelessWidget {
                       ),
                     );
                   },
+                ),
+                const SizedBox(width: denseSpacing),
+                // Copy button
+                PointerInterceptor(
+                  child: MiniIconButton(
+                    icon: const Icon(Icons.content_copy),
+                    tooltip: 'Copy code to clipboard',
+                    small: true,
+                    onPressed: onCopy,
+                  ),
                 ),
                 const SizedBox(width: denseSpacing),
                 // Format button

--- a/pkgs/dartpad_ui/lib/main.dart
+++ b/pkgs/dartpad_ui/lib/main.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:dartpad_shared/services.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/url_strategy.dart' show usePathUrlStrategy;
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -358,6 +359,7 @@ class DartPadMainPageState extends State<DartPadMainPage>
     final editor = EditorWithButtons(
       appModel: appModel,
       appServices: appServices,
+      onCopy: _handleCopy,
       onFormat: _handleFormatting,
       onCompileAndRun: appServices.performCompileAndRun,
       onCompileAndReload: appServices.performCompileAndReload,
@@ -520,6 +522,18 @@ class DartPadMainPageState extends State<DartPadMainPage>
         ),
       ),
     );
+  }
+
+  // TODO: Check if platform permission specific error needs to be handled.
+  Future<void> _handleCopy() async {
+    try {
+      final source = appModel.sourceCodeController.text;
+      await Clipboard.setData(ClipboardData(text: source));
+      appModel.editorStatus.showToast('Code copied to clipboard');
+    } catch (error) {
+      appModel.editorStatus.showToast('Error copying code');
+      appModel.appendError('Copy issue: $error');
+    }
   }
 
   Future<void> _handleFormatting() async {


### PR DESCRIPTION
 - Add "Copy to clipboard" button beside Format
 
<img height="300" alt="image" src="https://github.com/user-attachments/assets/76b462b9-9a82-45a6-90da-8aba549d988a" />

 - Reason: A few requests to directly open the embedded dartpad in new tab. After reading about the usage of git gists, it seemed difficult to right away provide it. The copy seems a low hanging fruit and an improved UI.
- More details https://github.com/dart-lang/dart-pad/issues/2702#issuecomment-3248443202

**TODO:**
 - Tests for this feature

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
