### PR TITLE
skip a failing test

### DIFF
--- a/pkgs/dart_services/test/probes_and_presubmit/server_testing.dart
+++ b/pkgs/dart_services/test/probes_and_presubmit/server_testing.dart
@@ -310,7 +310,7 @@ void main() {
         fix.edits.first.replacement,
         contains('// ignore: unused_local_variable'),
       );
-    });
+    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3484');
 
     test('fixes empty', () async {
       final result = await client.fixes(


### PR DESCRIPTION
We're seeing failures on stable; this skips the failing test. The issue is tracked at https://github.com/dart-lang/dart-pad/issues/3484.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
