### PR TITLE
feat: add minimal flutter hello world sample (#3512)

### DIFF
--- a/pkgs/dartpad_ui/lib/primitives/samples.g.dart
+++ b/pkgs/dartpad_ui/lib/primitives/samples.g.dart
@@ -32,17 +32,18 @@ class Sample {
 abstract final class Samples {
   static const List<Sample> all = [
     _fibonacci,
-    _helloWorld,
+    _helloDart,
     _dart,
     _flutter,
     _flameGame,
     _counter,
+    _helloFlutter,
     _sunflower,
   ];
 
   static const Map<String, List<Sample>> categories = {
-    'Dart': [_fibonacci, _helloWorld],
-    'Flutter': [_counter, _sunflower],
+    'Dart': [_fibonacci, _helloDart],
+    'Flutter': [_counter, _helloFlutter, _sunflower],
     'Ecosystem': [_flameGame],
   };
 
@@ -71,11 +72,11 @@ int fibonacci(int n) {
 ''',
 );
 
-const _helloWorld = Sample(
+const _helloDart = Sample(
   category: 'Dart',
   icon: 'dart',
   name: 'Hello world',
-  id: 'hello-world',
+  id: 'hello-world-dart',
   source: r'''
 void main() {
   for (var i = 0; i < 10; i++) {
@@ -534,6 +535,33 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+''',
+);
+
+const _helloFlutter = Sample(
+  category: 'Flutter',
+  icon: 'flutter',
+  name: 'Hello world',
+  id: 'hello-world-flutter',
+  source: r'''
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(child: Text('Hello World')),
       ),
     );
   }

--- a/pkgs/samples/README.md
+++ b/pkgs/samples/README.md
@@ -8,11 +8,12 @@ Sample code snippets for DartPad.
 | Category | Name | Sample | ID |
 | --- | --- | --- | --- |
 | Dart | Fibonacci | [fibonacci.dart](lib/fibonacci.dart) | `fibonacci` |
-| Dart | Hello world | [hello_world.dart](lib/hello_world.dart) | `hello-world` |
+| Dart | Hello world | [hello_world_dart.dart](lib/hello_world_dart.dart) | `hello-world-dart` |
 | Defaults | Dart snippet | [default_dart.dart](lib/default_dart.dart) | `dart` |
 | Defaults | Flutter snippet | [default_flutter.dart](lib/default_flutter.dart) | `flutter` |
 | Ecosystem | Flame game | [brick_breaker.dart](lib/brick_breaker.dart) | `flame-game` |
 | Flutter | Counter | [main.dart](lib/main.dart) | `counter` |
+| Flutter | Hello world | [hello_world_flutter.dart](lib/hello_world_flutter.dart) | `hello-world-flutter` |
 | Flutter | Sunflower | [sunflower.dart](lib/sunflower.dart) | `sunflower` |
 <!-- samples -->
 

--- a/pkgs/samples/lib/hello_world.dart
+++ b/pkgs/samples/lib/hello_world.dart
@@ -1,9 +1,0 @@
-// Copyright 2015 the Dart project authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
-
-void main() {
-  for (var i = 0; i < 10; i++) {
-    print('hello ${i + 1}');
-  }
-}

--- a/pkgs/samples/lib/hello_world_dart.dart
+++ b/pkgs/samples/lib/hello_world_dart.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+void main() {
+  for (var i = 0; i < 10; i++) {
+    print('hello ${i + 1}');
+  }
+}

--- a/pkgs/samples/lib/hello_world_flutter.dart
+++ b/pkgs/samples/lib/hello_world_flutter.dart
@@ -1,0 +1,20 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(body: Center(child: Text('Hello World'))),
+    );
+  }
+}

--- a/pkgs/samples/lib/samples.json
+++ b/pkgs/samples/lib/samples.json
@@ -16,8 +16,9 @@
   {
     "category": "Dart",
     "icon": "dart",
+    "id": "hello-world-dart",
     "name": "Hello world",
-    "path": "lib/hello_world.dart"
+    "path": "lib/hello_world_dart.dart"
   },
   {
     "category": "Dart",
@@ -36,6 +37,13 @@
     "icon": "flutter",
     "name": "Sunflower",
     "path": "lib/sunflower.dart"
+  },
+  {
+    "category": "Flutter",
+    "icon": "flutter",
+    "id": "hello-world-flutter",
+    "name": "Hello world",
+    "path": "lib/hello_world_flutter.dart"
   },
   {
     "category": "Ecosystem",


### PR DESCRIPTION
This PR adds a "Minimal Flutter" template to the samples dropdown, as discussed in #3512.

Changes:

    Created pkgs/samples/lib/hello_world_flutter.dart based on the --empty template logic.

    Updated samples.json to include the new sample in the Flutter category.

    Renamed the existing Dart "Hello World" sample internal ID to hello-world-dart for clarity.

    Re-generated pkgs/dartpad_ui/lib/primitives/samples.g.dart to sync changes.

This provides users with a clean-slate starting point for prototyping without the boilerplate of the counter app.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d99b6e6d-5ee1-4877-90a7-e7a472cbb142" />


Closes #3512

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
