### PR TITLE
Enhance app type detection logic to include prompt analysis for Flutter references and minor relaxation in system prompts

### DIFF
--- a/pkgs/dart_services/lib/src/generative_ai.dart
+++ b/pkgs/dart_services/lib/src/generative_ai.dart
@@ -310,6 +310,10 @@ the Flutter SDK API. You will produce a professional, release-ready Flutter
 application. All of the instructions below are required to be rigorously
 followed.
 
+If and only if the prompt explicitly forbids UI elements and strictly requests
+a pure Dart console/CLI program, you may deviate from this and generate a pure
+Dart program.
+
 Custom user interfaces add capabilities to apps so they can construct
 just-in-time user interfaces that utilize design aesthetics, meaningful
 information hierarchies, rich visual media, and allow for direct graphical
@@ -501,7 +505,8 @@ handle input/output in a clean and structured manner.
 
 - **No Flutter or UI code is allowed**: The generated program **must not**
 include any `flutter` imports, widget-based logic, or references to
-`MaterialApp`, `Widgets`, or UI-related libraries.
+`MaterialApp`, `Widgets`, or UI-related libraries, **unless the prompt
+explicitly and unambiguously requests a Flutter application**.
 
 - Programs must be **pure Dart**, using `dart:` libraries or explicitly allowed
 third-party packages.
@@ -539,7 +544,8 @@ prompt.
 
 ### INSTRUCTIONS FOR GENERATING CODE
 **DO NOT** include Flutter-related imports, widgets, UI components, or anything
-related to mobile app development.
+related to mobile app development, **unless the prompt explicitly and
+unambiguously requests a Flutter application**.
 
 You are generating a **pure Dart** program with a `main` function entry point.
 ''',


### PR DESCRIPTION
Fixes #3509 

This PR addresses the issue where the AI would sometimes incorrectly default to a pure Dart context (CLI/Console) when the user intended to build a Flutter app, particularly when starting from an empty editor.

## Changes
1.  **`pkgs/dartpad_ui/lib/app/genai_editing.dart`**: 
    * Improved the `_determineAppType` logic to inspect the prompt for keywords (e.g., `flutter`, `widget`, `app`, `custompainter`) if the source code is ambiguous or empty.
    * This ensures that prompts like "Create a Flutter app" correctly trigger the Flutter system prompt instead of the Dart system prompt.

2.  **`pkgs/dart_services/lib/src/generative_ai.dart`**:
    * Adjusted the system prompts to allow the model to deviate from the strict "No UI" or "Flutter Only" rules **if and only if** the user explicitly and unambiguously requests it.
    * This provides an "escape hatch" for power users who might want to generate a Dart script while in Flutter mode (or vice versa) without the model refusing the request.

## Verification
* Tested locally with prompts such as *"Create a Flutter app with a CustomPainter"* in an empty editor. The system correctly inferred `AppType.flutter` and generated the UI code.
* Verified that ambiguous prompts still default to safe baselines.

<img width="937" height="923" alt="image" src="https://github.com/user-attachments/assets/198d80c6-486e-45b5-9c3f-3a6de42893e3" />


---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.