### PR TITLE
Upgrade generative model to gemini-3-flash-preview

### DIFF
--- a/pkgs/dart_services/lib/src/generative_ai.dart
+++ b/pkgs/dart_services/lib/src/generative_ai.dart
@@ -15,9 +15,9 @@ import 'pub.dart';
 final DartPadLogger _logger = DartPadLogger('gen-ai');
 
 class GenerativeAI {
-  // Valid values here are 'models/gemini-2.0-flash' and
-  // 'models/gemini-2.5-flash'.
-  static const String _geminiModel = 'models/gemini-2.5-flash';
+  // Valid values here are 'models/gemini-2.5-flash' and
+  // 'models/gemini-3-flash-preview'.
+  static const String _geminiModel = 'models/gemini-3-flash-preview';
   static const String _apiKeyVarName = 'GEMINI_API_KEY';
 
   GenerativeService? gemini;


### PR DESCRIPTION
Closes #3555

Updated the `_geminiModel` constant to `models/gemini-3-flash-preview` as requested.
This is a new pr identical to the now withdrawn #3558 which had a branch issue.

## Verification
- Verified locally that `dart-services` starts correctly.
- Tested against the `/api/v3/suggestFix` endpoint and confirmed valid **200 OK** responses.
- Confirmed `models/gemini-3-flash-preview` is the required endpoint for the current API release (Jan 2026).
- 
<img width="1132" height="323" alt="image" src="https://github.com/user-attachments/assets/da78034b-c70a-4298-9118-e9f35b563f30" />


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.