### PR TITLE
consolidate use of package:analyzer APIs

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -6,15 +6,14 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:analysis_server_lib/analysis_server_lib.dart';
-import 'package:analyzer/dart/ast/ast.dart';
+
 import 'package:dartpad_shared/model.dart' as api;
 import 'package:path/path.dart' as path;
 
+import 'analyzer.dart';
 import 'common.dart';
-
 import 'logging.dart';
 import 'project_templates.dart';
-import 'pub.dart';
 import 'sdk.dart';
 import 'utils.dart' as utils;
 import 'utils.dart';
@@ -490,7 +489,7 @@ extension SourceChangeExtension on SourceChange {
   }
 }
 
-extension AnnotatedNodeExtension on AnnotatedNode {
+extension AnnotatedNodeExtension on ImportDirective {
   api.Location getLocation(String source) {
     final lines = Lines(source);
     final start = firstTokenAfterCommentAndMetadata;

--- a/pkgs/dart_services/lib/src/analyzer.dart
+++ b/pkgs/dart_services/lib/src/analyzer.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Entrypoint for uses of package:analyzer.
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+
+export 'package:analyzer/dart/ast/ast.dart' show ImportDirective;
+
+/// Extract all imports from [dartSource] source code.
+List<ImportDirective> getAllImportsFor(String dartSource) {
+  final unit = parseString(content: dartSource, throwIfDiagnostics: false).unit;
+  return unit.directives.whereType<ImportDirective>().toList();
+}
+
+extension ImportDirectiveExtension on ImportDirective {
+  bool get dartImport => Uri.parse(uri.stringValue!).scheme == 'dart';
+
+  bool get packageImport => Uri.parse(uri.stringValue!).scheme == 'package';
+
+  String get packageName => Uri.parse(uri.stringValue!).pathSegments.first;
+}

--- a/pkgs/dart_services/lib/src/compiling.dart
+++ b/pkgs/dart_services/lib/src/compiling.dart
@@ -9,11 +9,10 @@ import 'dart:io';
 import 'package:bazel_worker/driver.dart';
 import 'package:path/path.dart' as path;
 
+import 'analyzer.dart';
 import 'common.dart';
-
 import 'logging.dart';
 import 'project_templates.dart';
-import 'pub.dart';
 import 'sdk.dart';
 
 final DartPadLogger _logger = DartPadLogger('compiler');

--- a/pkgs/dart_services/lib/src/project_templates.dart
+++ b/pkgs/dart_services/lib/src/project_templates.dart
@@ -4,10 +4,10 @@
 
 import 'dart:io';
 
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
+import 'analyzer.dart';
 import 'utils.dart';
 
 /// Sets of project template directory paths.

--- a/pkgs/dart_services/lib/src/pub.dart
+++ b/pkgs/dart_services/lib/src/pub.dart
@@ -4,18 +4,10 @@
 
 import 'dart:io';
 
-import 'package:analyzer/dart/analysis/utilities.dart';
-import 'package:analyzer/dart/ast/ast.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 import 'project_templates.dart' as project;
-
-/// Extract all imports from [dartSource] source code.
-List<ImportDirective> getAllImportsFor(String dartSource) {
-  final unit = parseString(content: dartSource, throwIfDiagnostics: false).unit;
-  return unit.directives.whereType<ImportDirective>().toList();
-}
 
 /// Flutter packages which do not have version numbers in pubspec.lock.
 const _flutterPackages = [
@@ -65,12 +57,4 @@ Map<String, String> packageVersionsFromPubspecLock(String templatePath) {
   });
 
   return packageVersions;
-}
-
-extension ImportDirectiveExtension on ImportDirective {
-  bool get dartImport => Uri.parse(uri.stringValue!).scheme == 'dart';
-
-  bool get packageImport => Uri.parse(uri.stringValue!).scheme == 'package';
-
-  String get packageName => Uri.parse(uri.stringValue!).pathSegments.first;
 }

--- a/pkgs/dart_services/pubspec.yaml
+++ b/pkgs/dart_services/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   dartpad_shared:
     path: ../dartpad_shared
   encrypt: ^5.0.3
-  google_cloud_ai_generativelanguage_v1beta: ^0.4.0
-  google_cloud_rpc: ^0.4.0
+  google_cloud_ai_generativelanguage_v1beta: ^0.5.1
+  google_cloud_rpc: ^0.5.1
   http: ^1.6.0
   logging: ^1.3.0
   meta: ^1.17.0

--- a/pkgs/dart_services/test/presubmit/analysis_test.dart
+++ b/pkgs/dart_services/test/presubmit/analysis_test.dart
@@ -129,7 +129,7 @@ void main() {
         changes.map((e) => e.edits.first.replacement),
         contains(equals(';')),
       );
-    });
+    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3608');
 
     test('format simple', () async {
       final results = await analysisServer.format(badFormatCode, 0);

--- a/pkgs/dart_services/test/presubmit/analyzer_test.dart
+++ b/pkgs/dart_services/test/presubmit/analyzer_test.dart
@@ -2,11 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:dart_services/src/pub.dart';
+import 'package:dart_services/src/analyzer.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('pub', () {
+  group('analyzer', () {
     group('getAllImportsFor', () {
       test('empty', () {
         expect(getAllImportsFor(''), isEmpty);


### PR DESCRIPTION
When trying to update to the latest deps I noticed package:analyzer was constrained to v10 even through v13 is available (the constraint is through package:meta, pinned by flutter, so not something to resolve at the moment). I saw that we had imports of package:analyzer in a few different files; this consolidates our use of the analyzer APIs (a little easier to know what parts of the package we're using).

This PR also updates the (few) packages that we can upgrade.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
