### PR TITLE
remove the prompt to file an issue on a JS exception

### DIFF
--- a/pkgs/dartpad_ui/lib/app/console.dart
+++ b/pkgs/dartpad_ui/lib/app/console.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../model/model.dart';
 import '../primitives/enable_gen_ai.dart';
@@ -116,28 +115,6 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
                   ],
                 ),
               ),
-              // If there is a JS error, and the app type is Flutter, show a
-              // "File an issue" button. Uncaught exceptions are normal when
-              // executing Dart (non-Flutter) code in JavaScript.
-              if (widget.output.hasError &&
-                  widget.output.hasJavascriptError &&
-                  appModel.appIsFlutter.value == true)
-                Align(
-                  alignment: Alignment.bottomRight,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: [
-                      Text(
-                        'Oops! Something went wrong in the Dart toolchain.',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.tertiary,
-                        ),
-                      ),
-                      SizedBox(width: 12),
-                      FileIssueButton(errorMessage: widget.output.error),
-                    ],
-                  ),
-                ),
             ],
           );
         },
@@ -160,36 +137,5 @@ class _ConsoleWidgetState extends State<ConsoleWidget> {
         curve: animationCurve,
       );
     });
-  }
-}
-
-class FileIssueButton extends StatelessWidget {
-  final String errorMessage;
-  const FileIssueButton({super.key, required this.errorMessage});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return TextButton(
-      style: ButtonStyle(
-        backgroundColor: WidgetStateProperty.all(switch (theme.brightness) {
-          Brightness.light => theme.colorScheme.surface.darker,
-          _ => theme.colorScheme.surface.lighter,
-        }),
-        foregroundColor: WidgetStateProperty.all(theme.colorScheme.onPrimary),
-      ),
-      child: Text('File an issue'),
-      onPressed: () {
-        launchUrl(
-          Uri.https('github.com', 'dart-lang/dart-pad/issues/new', {
-            'template': '2-console-error.yml',
-            'title':
-                '[console error] Unexpected javascript error from running app',
-            'logs': errorMessage,
-          }),
-        );
-      },
-    );
   }
 }

--- a/pkgs/dartpad_ui/lib/model/model.dart
+++ b/pkgs/dartpad_ui/lib/model/model.dart
@@ -122,21 +122,14 @@ class AppModel {
 
   void appendLineToConsole(String str) {
     consoleNotifier.output += '$str\n';
-    consoleNotifier.hasJavascriptError = false;
   }
 
-  void appendError(String str, {bool isJavascript = false}) {
+  void appendError(String str) {
     consoleNotifier.error += '$str\n';
-    if (isJavascript) {
-      consoleNotifier.hasJavascriptError = true;
-    } else {
-      consoleNotifier.hasJavascriptError = false;
-    }
   }
 
   void clearConsole() {
     consoleNotifier.clear();
-    consoleNotifier.hasJavascriptError = false;
   }
 
   void dispose() {
@@ -585,7 +578,7 @@ class AppServices {
         (msg) => appModel.appendError(msg),
       );
       javascriptErrorSub = _executionService!.onJavascriptError.listen(
-        (msg) => appModel.appendError(msg, isJavascript: true),
+        (msg) => appModel.appendError(msg),
       );
     }
   }
@@ -731,7 +724,6 @@ class PromptDialogResponse {
 class ConsoleNotifier extends ChangeNotifier {
   String _output;
   String _error;
-  bool _hasJavascriptError = false;
 
   ConsoleNotifier(this._output, this._error);
 
@@ -745,12 +737,6 @@ class ConsoleNotifier extends ChangeNotifier {
   String get error => _error;
   set error(String value) {
     _error = value;
-    notifyListeners();
-  }
-
-  bool get hasJavascriptError => _hasJavascriptError;
-  set hasJavascriptError(bool value) {
-    _hasJavascriptError = value;
     notifyListeners();
   }
 


### PR DESCRIPTION
- remove the prompt to file an issue on a JS exception

We've been offering to report JavaScript exceptions since updating our DDC backend (w/ support of hot reload). I don't believe this is useful anymore - that backend pipeline has been in use for a while. Users can still file issues normally, we just won't prompt them for JS exceptions.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
