### PR TITLE
Ensure `getFixes` runs against fully analyzed view of file

### DIFF
--- a/pkgs/dart_services/lib/src/analysis.dart
+++ b/pkgs/dart_services/lib/src/analysis.dart
@@ -183,6 +183,14 @@ class AnalysisServerWrapper {
 
     await _loadSources({mainFile: src});
 
+    // Wait for analysis of the freshly-loaded overlay
+    // to complete before requesting fixes.
+    // Unlike `analysis.getErrors`, `edit.getFixes` doesn't
+    // delay its response until analysis results are up to date.
+    // Without this, it can compute fixes against a
+    // not yet fully analyzed view of the file, resulting in no fixes.
+    await analysisServer.analysis.getErrors(mainFile);
+
     final fixes = await analysisServer.edit.getFixes(mainFile, offset);
     final assists = await analysisServer.edit.getAssists(mainFile, offset, 1);
 

--- a/pkgs/dart_services/test/presubmit/analysis_test.dart
+++ b/pkgs/dart_services/test/presubmit/analysis_test.dart
@@ -129,7 +129,7 @@ void main() {
         changes.map((e) => e.edits.first.replacement),
         contains(equals(';')),
       );
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3608');
+    });
 
     test('format simple', () async {
       final results = await analysisServer.format(badFormatCode, 0);

--- a/pkgs/dart_services/test/probes_and_presubmit/server_testing.dart
+++ b/pkgs/dart_services/test/probes_and_presubmit/server_testing.dart
@@ -273,7 +273,7 @@ void main() {
         fix.edits.first.replacement,
         contains('// ignore: unused_local_variable'),
       );
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3484');
+    });
 
     test('fixes empty', () async {
       final result = await client.fixes(
@@ -312,7 +312,7 @@ void main() => print('hello world');
       expect(assist.linkedEditGroups, isEmpty);
       expect(assist.selectionOffset, greaterThan(0));
       expect(assist.edits.first.replacement, isNotEmpty);
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3484');
+    });
 
     testDDCEndpoint(
       'compileDDC',
@@ -390,8 +390,8 @@ void main() {
         ),
       );
 
-      expect(result.fixes, anyOf(hasLength(3), hasLength(4)));
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3484');
+      expect(result.fixes, hasLength(4));
+    });
 
     test('assists', () async {
       final result = await client.fixes(
@@ -404,7 +404,7 @@ void main() => print('hello world');
       );
 
       expect(result.assists, isNotEmpty);
-    }, skip: 'https://github.com/dart-lang/dart-pad/issues/3484');
+    });
 
     test('format', () async {
       final result = await client.format(


### PR DESCRIPTION
By first awaiting for `getErrors`, which does wait for completion, so `getFixes` runs on the fully analyzed overlay. Since our fix requests are called on demand in response to errors in small, singular files, I think this slight additional wait is worth it for the reliability improvements.

Resolves https://github.com/dart-lang/dart-pad/issues/3608
Resolves https://github.com/dart-lang/dart-pad/issues/3484