### PR TITLE
Add problems panel to DartPad preview

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -10,7 +10,8 @@ import 'package:logging/logging.dart';
 
 import 'features/editor/codemirror/code_mirror_tab.dart';
 import 'features/editor/codemirror/code_mirror_tab_adapter.dart';
-import 'features/editor/components/editor_shell.dart';
+import 'features/editor/components/editor_host.dart';
+import 'features/editor/view_models/editor_host_view_model.dart';
 import 'features/editor/view_models/tabs_view_model.dart';
 import 'features/filetree/file_tree_tabs_adapter.dart';
 import 'features/filetree/file_tree_view.dart';
@@ -37,6 +38,7 @@ class AppState extends State<App> {
   late final BrowserConsoleObserver _console;
   late final TabsViewModel _tabs;
   late final FileTreeViewModel _fileTree;
+  late final EditorHostViewModel _editorHost;
 
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
 
@@ -61,6 +63,7 @@ class AppState extends State<App> {
       workspace: _workspaceRepository.workspaceResourceApi,
       events: _events,
     );
+    _editorHost = EditorHostViewModel(tabs: _tabs);
 
     _console = BrowserConsoleObserver(_events);
 
@@ -93,6 +96,7 @@ class AppState extends State<App> {
       );
 
       _fileTree.languageServerClient = languageServerClient;
+      _editorHost.attachLanguageServer(languageServerClient);
 
       _analyzerSubscription = languageServerClient.analyzerActivityStream.listen(
         (activity) => _logAnalyzerActivity(languageServerClient, activity),
@@ -156,20 +160,11 @@ class AppState extends State<App> {
 
   @override
   Component build(BuildContext context) {
-    return ListenableBuilder(
-      listenable: _tabs,
-      builder: (context) {
-        return EditorShell(
-          openTabs: _tabs.openTabs,
-          activeFile: _tabs.activeFile,
-          errorMessage: _tabs.errorMessage,
-          warningMessage: _tabs.warningMessage,
-          fileTree: _buildFileTree(),
-          onSwitchFile: _tabs.switchFile,
-          onCloseFile: _tabs.closeFile,
-          bootstrapLabel: loadingStatus,
-        );
-      },
+    return EditorHost(
+      tabs: _tabs,
+      editorHostViewModel: _editorHost,
+      fileTree: _buildFileTree(),
+      bootstrapLabel: loadingStatus,
     );
   }
 
@@ -191,6 +186,7 @@ class AppState extends State<App> {
   }
 
   Future<void> _disposeResources() async {
+    _editorHost.dispose();
     _fileTree.dispose();
     _tabs.dispose();
     _console.dispose();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/component_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/component_styles.dart
@@ -43,6 +43,14 @@ List<StyleRule> get componentStyles => [
     flexDirection: .column,
     flex: const Flex(grow: 1),
   ),
+  css('.editor-area').styles(
+    display: .flex,
+    minWidth: .zero,
+    minHeight: .zero,
+    overflow: .hidden,
+    flexDirection: .column,
+    flex: const Flex(grow: 1, basis: .zero),
+  ),
   css('.status-bar').styles(
     minHeight: 24.px,
     padding: .symmetric(horizontal: 10.px),
@@ -405,4 +413,187 @@ List<StyleRule> get componentStyles => [
   css('.drag-handle.vertical:hover::after, .drag-handle.vertical.dragging::after').styles(
     backgroundColor: colorPrimary,
   ),
+
+  // Bottom Panel Styles
+  css('.bottom-panel').styles(
+    display: .flex,
+    height: 100.percent,
+    flexDirection: .column,
+    flex: const .shrink(0),
+  ),
+  css('.bottom-panel .bottom-panel-tabs').styles(
+    display: .flex,
+    border: .only(
+      bottom: .solid(color: colorBorder, width: 1.px),
+    ),
+    alignItems: .stretch,
+    flex: const .shrink(0),
+  ),
+  css('.bottom-panel .bottom-panel-content').styles(
+    display: .flex,
+    overflow: .hidden,
+    flexDirection: .column,
+    flex: const Flex(grow: 1, basis: .zero),
+  ),
+  css('.bottom-panel .problems-panel').styles(
+    height: 100.percent,
+    minHeight: .zero,
+    maxHeight: 100.percent,
+    margin: .zero,
+    flex: const Flex(grow: 1, basis: .zero),
+  ),
+  css('.bottom-panel .bottom-panel-tab').styles(
+    display: .inlineFlex,
+    padding: .symmetric(vertical: 7.px, horizontal: 14.px),
+    border: .none,
+    outline: const Outline(style: .none),
+    cursor: .pointer,
+    userSelect: .none,
+    transition: .combine([
+      Transition('background', duration: 150.ms, curve: .ease),
+      Transition('color', duration: 150.ms, curve: .ease),
+      Transition('border-color', duration: 150.ms, curve: .ease),
+    ]),
+    alignItems: .center,
+    gap: Gap.all(6.px),
+    color: colorOnSurfaceVariant,
+    fontSize: 12.px,
+    fontWeight: .w500,
+    backgroundColor: Colors.transparent,
+  ),
+  css('.bottom-panel .bottom-panel-tab:hover').styles(
+    color: colorOnSurface,
+    backgroundColor: colorOnSurface.withOpacity(0.06),
+  ),
+  css('.bottom-panel .bottom-panel-tab.active').styles(
+    color: colorOnSurface,
+    backgroundColor: colorContainer,
+  ),
+  css('.bottom-panel .bottom-panel-tab-count').styles(
+    display: .inlineFlex,
+    padding: .symmetric(vertical: 1.px, horizontal: 4.px),
+    radius: .circular(8.px),
+    justifyContent: .center,
+    alignItems: .center,
+    color: colorOnPrimary,
+    fontSize: 10.px,
+    fontWeight: .w600,
+    backgroundColor: colorPrimary,
+  ),
+  css('.bottom-panel .bottom-panel-tabs-spacer').styles(
+    flex: const Flex(grow: 1),
+  ),
+
+  // Problems Panel Styles
+  css('.problems-panel', [
+    css('&').styles(
+      display: .flex,
+      minHeight: 120.px,
+      maxHeight: 180.px,
+      margin: .only(bottom: 15.px),
+      overflow: .hidden,
+      flexDirection: .column,
+      flex: const .shrink(0),
+      backgroundColor: colorContainerLow,
+    ),
+    css('& .problems-list').styles(
+      minHeight: .zero,
+      overflow: const .only(y: .auto),
+      flex: const Flex(grow: 1, basis: .zero),
+    ),
+    css('& .problems-empty').styles(
+      display: .flex,
+      minHeight: 48.px,
+      padding: .symmetric(horizontal: 12.px),
+      alignItems: .center,
+      color: colorOnSurfaceVariant,
+      fontSize: 12.px,
+    ),
+    css('& .problem-row').styles(
+      display: .grid,
+      minHeight: 28.px,
+      padding: .symmetric(horizontal: 12.px),
+      border: .only(
+        left: .solid(color: Colors.transparent, width: 2.px),
+      ),
+      cursor: .pointer,
+      alignItems: .center,
+      gridTemplate: GridTemplate(
+        columns: GridTracks([
+          GridTrack(TrackSize(22.px)),
+          GridTrack(.minmax(TrackSize(0.px), const TrackSize.fr(1))),
+          const GridTrack(TrackSize(Unit.auto)),
+        ]),
+      ),
+      gap: .all(8.px),
+      fontSize: 12.px,
+    ),
+    css('& .problem-row:hover, & .problem-row:focus').styles(
+      outline: const Outline(style: .none),
+      backgroundColor: colorContainerHigh,
+    ),
+    css('& .problem-row.error').styles(
+      border: .only(
+        left: .solid(color: colorError, width: 2.px),
+      ),
+    ),
+    css('& .problem-row.warning').styles(
+      border: .only(
+        left: .solid(color: colorWarning, width: 2.px),
+      ),
+    ),
+    css('& .problem-row.info, & .problem-row.hint').styles(
+      border: .only(
+        left: .solid(color: colorInfo, width: 2.px),
+      ),
+    ),
+    css('& .problem-row.active-file').styles(
+      backgroundColor: colorContainerHigh.withOpacity(0.5),
+    ),
+    css('& .problem-severity-badge').styles(
+      display: .inlineFlex,
+      width: 18.px,
+      height: 18.px,
+      radius: .circular(999.px),
+      justifyContent: .center,
+      alignItems: .center,
+      fontSize: 11.px,
+      fontWeight: .w700,
+    ),
+    css('& .problem-severity-badge.error').styles(
+      color: colorOnSurface,
+      backgroundColor: colorError.withOpacity(0.2),
+    ),
+    css('& .problem-severity-badge.warning').styles(
+      color: colorOnSurface,
+      backgroundColor: colorWarning.withOpacity(0.2),
+    ),
+    css('& .problem-severity-badge.info, & .problem-severity-badge.hint').styles(
+      color: colorOnSurface,
+      backgroundColor: colorInfo.withOpacity(0.2),
+    ),
+    css('& .problem-message').styles(
+      minWidth: .zero,
+      overflow: .hidden,
+      textOverflow: .ellipsis,
+      whiteSpace: .noWrap,
+    ),
+    css('& .problem-actions').styles(
+      display: .flex,
+      justifyContent: .end,
+      alignItems: .center,
+    ),
+    css('& .problem-location').styles(
+      display: .inlineBlock,
+      color: colorOnSurfaceVariant,
+      fontFamily: const .list([FontFamilies.courierNew, FontFamilies.monospace]),
+      fontSize: 11.px,
+    ),
+    css('& .problem-row:hover .problem-location, & .problem-row:focus-within .problem-location').styles(
+      display: .none,
+    ),
+    css('& .problem-row:hover .fix-with-ai-btn, & .problem-row:focus-within .fix-with-ai-btn').styles(
+      display: .inlineFlex,
+    ),
+  ]),
 ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -1,0 +1,92 @@
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import 'problems_panel.dart';
+
+/// The bottom panel showing a "Problems" tab with diagnostics.
+class BottomPanel extends StatelessComponent {
+  const BottomPanel({
+    required this.diagnostics,
+    required this.activeFile,
+    required this.onOpenDiagnostic,
+    required this.showProblems,
+    required this.onShowProblems,
+    super.key,
+  });
+
+  /// All current diagnostics from the language server.
+  final List<DiagnosticEntry> diagnostics;
+
+  /// The currently active editor file path, used to highlight matching rows.
+  final String activeFile;
+
+  /// Called when the user clicks a diagnostic row.
+  final void Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
+
+  /// Whether the problems panel content is visible.
+  final bool showProblems;
+
+  /// Shows the problems panel.
+  final void Function() onShowProblems;
+
+  @override
+  Component build(BuildContext context) {
+    return div(classes: 'bottom-panel', [
+      _buildTabs(),
+      if (showProblems) _buildContent(),
+    ]);
+  }
+
+  Component _buildTabs() {
+    return div(classes: 'bottom-panel-tabs', [
+      _BottomPanelTabButton(
+        label: 'Problems',
+        countLabel: diagnostics.length.toString(),
+        active: showProblems,
+        onClick: onShowProblems,
+      ),
+    ]);
+  }
+
+  Component _buildContent() {
+    return div(
+      classes: 'bottom-panel-content',
+      [
+        ProblemsPanel(
+          diagnostics: diagnostics,
+          activeFile: activeFile,
+          onOpenDiagnostic: onOpenDiagnostic,
+        ),
+      ],
+    );
+  }
+}
+
+class _BottomPanelTabButton extends StatelessComponent {
+  const _BottomPanelTabButton({
+    required this.label,
+    this.countLabel,
+    required this.active,
+    this.onClick,
+  });
+
+  final String label;
+  final String? countLabel;
+  final bool active;
+  final void Function()? onClick;
+
+  @override
+  Component build(BuildContext context) {
+    final classes = active ? 'bottom-panel-tab active' : 'bottom-panel-tab';
+
+    return button(
+      classes: classes,
+      onClick: onClick,
+      [
+        span(classes: 'bottom-panel-tab-label', [.text(label)]),
+        if (countLabel case final countLabel?) span(classes: 'bottom-panel-tab-count', [.text(countLabel)]),
+      ],
+    );
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+class ProblemsPanel extends StatelessComponent {
+  const ProblemsPanel({
+    required this.diagnostics,
+    required this.activeFile,
+    required this.onOpenDiagnostic,
+    super.key,
+  });
+
+  final List<DiagnosticEntry> diagnostics;
+  final String activeFile;
+  final FutureOr<void> Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
+
+  @override
+  Component build(BuildContext context) {
+    return div(classes: 'problems-panel', [
+      div(classes: 'problems-list', [
+        if (diagnostics.isEmpty)
+          const div(classes: 'problems-empty', [.text('No problems')])
+        else
+          for (final entry in diagnostics)
+            _ProblemRow(
+              fileName: entry.fileName,
+              diagnostic: entry.diagnostic,
+              activeFile: activeFile,
+              onOpenDiagnostic: onOpenDiagnostic,
+            ),
+      ]),
+    ]);
+  }
+}
+
+class _ProblemRow extends StatelessComponent {
+  const _ProblemRow({
+    required this.fileName,
+    required this.diagnostic,
+    required this.activeFile,
+    required this.onOpenDiagnostic,
+  });
+
+  final String fileName;
+  final Diagnostic diagnostic;
+  final String activeFile;
+  final FutureOr<void> Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
+
+  @override
+  Component build(BuildContext context) {
+    final severityClass = diagnostic.severity.cssClass;
+    final severityLabel = diagnostic.severity.label;
+    final line = diagnostic.line + 1;
+    final character = diagnostic.character + 1;
+    final location = '$fileName:$line:$character';
+    final activeClass = fileName == activeFile ? ' active-file' : '';
+
+    return div(
+      key: ValueKey('problem-$location-${diagnostic.message}'),
+      classes: 'problem-row $severityClass$activeClass',
+      attributes: {
+        'title': '$severityLabel: ${diagnostic.message} ($location)',
+        'tabindex': '0',
+      },
+      events: {
+        'click': (_) {
+          onOpenDiagnostic(fileName, diagnostic);
+        },
+        'keydown': (e) {
+          final ke = e as web.KeyboardEvent;
+          if (ke.key == 'Enter' || ke.key == ' ') {
+            onOpenDiagnostic(fileName, diagnostic);
+          }
+        },
+      },
+      [
+        span(
+          classes: 'problem-severity-badge $severityClass',
+          [.text(diagnostic.severity.icon)],
+        ),
+        span(classes: 'problem-message', [.text(diagnostic.message)]),
+        span(classes: 'problem-actions', [
+          span(classes: 'problem-location', [.text(location)]),
+        ]),
+      ],
+    );
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:dartpad_editor/dartpad_editor.dart';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
@@ -95,6 +95,16 @@ final class CodeMirrorTab extends EditorTab<Component> {
     });
   }
 
+  /// Moves the cursor to [line] and [character] and keeps that position when
+  /// this tab has just been activated.
+  void goToPosition(int line, int character) {
+    // Activating a previously opened tab schedules its saved view state to be
+    // restored on the next event-loop turn. A deliberate navigation request
+    // supersedes that state and must not be overwritten by the pending restore.
+    _savedViewState = null;
+    editor.goToPosition(line, character);
+  }
+
   @override
   Future<void> save() async {
     if (!_isDirty) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_host.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_host.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/jaspr.dart';
+
+import '../../bottom_panel/views/bottom_panel.dart';
+import '../view_models/editor_host_view_model.dart';
+import '../view_models/tabs_view_model.dart';
+import 'editor_shell.dart';
+
+/// View counterpart to [EditorHostViewModel].
+///
+/// Assembles the [EditorShell] (tabs, editor stack) together with the
+/// [BottomPanel] (problems view) into a single layout.
+///
+/// Both [tabs] and [editorHostViewModel] are observed internally via
+/// [ListenableBuilder] so that only the affected subtrees rebuild.
+class EditorHost extends StatelessComponent {
+  const EditorHost({
+    required this.tabs,
+    required this.editorHostViewModel,
+    required this.fileTree,
+    required this.bootstrapLabel,
+    super.key,
+  });
+
+  /// The tabs view model providing open tabs, active file, and error state.
+  final TabsViewModel tabs;
+
+  /// The view model providing diagnostics and problems-panel state.
+  final EditorHostViewModel editorHostViewModel;
+
+  /// The workspace file tree component.
+  final Component fileTree;
+
+  /// Human-readable label for the current bootstrap status.
+  final String bootstrapLabel;
+
+  @override
+  Component build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: tabs,
+      builder: (context) => EditorShell(
+        openTabs: tabs.openTabs,
+        activeFile: tabs.activeFile,
+        errorMessage: tabs.errorMessage,
+        warningMessage: tabs.warningMessage,
+        fileTree: fileTree,
+        onSwitchFile: tabs.switchFile,
+        onCloseFile: tabs.closeFile,
+        bootstrapLabel: bootstrapLabel,
+        bottomPanel: ListenableBuilder(
+          listenable: editorHostViewModel,
+          builder: (context) => BottomPanel(
+            diagnostics: editorHostViewModel.diagnostics,
+            activeFile: tabs.activeFile,
+            showProblems: editorHostViewModel.showProblems,
+            onShowProblems: editorHostViewModel.showProblemsPanel,
+            onOpenDiagnostic: (fileName, diagnostic) {
+              unawaited(
+                editorHostViewModel.openDiagnostic(fileName, diagnostic),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -23,6 +23,7 @@ class EditorShell extends StatelessComponent {
     required this.onSwitchFile,
     required this.onCloseFile,
     required this.bootstrapLabel,
+    required this.bottomPanel,
     super.key,
   }) : assert(
          openTabs == null || (onSwitchFile != null && onCloseFile != null),
@@ -50,6 +51,9 @@ class EditorShell extends StatelessComponent {
   /// The workspace file tree.
   final Component fileTree;
 
+  /// Bottom panel (e.g. problems view) rendered below the editor.
+  final Component bottomPanel;
+
   /// Human-readable label for the current status.
   final String bootstrapLabel;
 
@@ -65,18 +69,28 @@ class EditorShell extends StatelessComponent {
           maxValue: 300,
           left: aside(classes: 'file-tree-pane', [fileTree]),
           right: main_(classes: 'editor-host', [
-            if (openTabs != null) ...[
-              EditorTabs(
-                openTabs: openTabs,
-                activeFile: activeFile,
-                onSwitchFile: onSwitchFile!,
-                onCloseFile: onCloseFile!,
-              ),
-              EditorStack(
-                openTabs: openTabs,
-                activeFile: activeFile,
-              ),
-            ],
+            SplitPanel(
+              isVertical: true,
+              useRatio: true,
+              initialValue: 0.75,
+              minValue: 0.3,
+              maxValue: 0.9,
+              left: div(classes: 'editor-area', [
+                if (openTabs != null) ...[
+                  EditorTabs(
+                    openTabs: openTabs,
+                    activeFile: activeFile,
+                    onSwitchFile: onSwitchFile!,
+                    onCloseFile: onCloseFile!,
+                  ),
+                  EditorStack(
+                    openTabs: openTabs,
+                    activeFile: activeFile,
+                  ),
+                ],
+              ]),
+              right: bottomPanel,
+            ),
           ]),
         ),
       ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/editor_host_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/editor_host_view_model.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// @docImport '../../../app.dart';
+library;
+
+import 'dart:async';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../codemirror/code_mirror_tab.dart';
+import 'tabs_view_model.dart';
+
+/// Manages the state for the editor host area: diagnostics from the language
+/// server and bottom-panel visibility.
+///
+/// Created by [AppState] and fed to the view layer via [ListenableBuilder].
+class EditorHostViewModel extends ChangeNotifier {
+  EditorHostViewModel({required this.tabs});
+
+  /// The editor tabs used to open and navigate to diagnostic locations.
+  final TabsViewModel tabs;
+
+  List<DiagnosticEntry> _diagnostics = const [];
+  bool _showProblems = true;
+
+  StreamSubscription<Map<String, dynamic>>? _diagnosticsSubscription;
+
+  /// All current diagnostics, sorted by severity then location.
+  List<DiagnosticEntry> get diagnostics => _diagnostics;
+
+  /// Whether the problems panel is visible.
+  bool get showProblems => _showProblems;
+
+  /// Opens the file for [diagnostic] and navigates to its source position.
+  Future<void> openDiagnostic(String fileName, Diagnostic diagnostic) async {
+    await tabs.openTextFile(fileName);
+    final tab = tabs.getTab(fileName);
+    if (tab is CodeMirrorTab) {
+      tab.goToPosition(diagnostic.line, diagnostic.character);
+    }
+  }
+
+  /// Subscribes to diagnostic updates from [lsc].
+  ///
+  /// Cancels any previous subscription before attaching to the new client.
+  void attachLanguageServer(LanguageServerClient lsc) {
+    _diagnosticsSubscription?.cancel();
+    _diagnostics = lsc.allDiagnostics;
+    _diagnosticsSubscription = lsc.diagnosticsStream.listen((_) {
+      _diagnostics = lsc.allDiagnostics;
+      notifyListeners();
+    });
+    notifyListeners();
+  }
+
+  /// Shows the problems panel.
+  void showProblemsPanel() {
+    _showProblems = true;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _diagnosticsSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -13,6 +13,7 @@ import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab.dart
 import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab_adapter.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_stack.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_tabs.dart';
+import 'package:dartpad_frontend/features/editor/view_models/editor_host_view_model.dart';
 import 'package:dartpad_frontend/features/editor/view_models/tabs_view_model.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
@@ -26,6 +27,7 @@ final class FakeWorkspaceController implements WorkspaceResourceApi {
     'lib/main.dart': 'void main() {}',
     'pubspec.yaml': 'name: test',
   };
+  Error? readError;
   Error? writeError;
 
   @override
@@ -41,7 +43,12 @@ final class FakeWorkspaceController implements WorkspaceResourceApi {
   Future<bool> folderExist(String uri) async => false;
 
   @override
-  Future<String> readFileAsText(String uri) async => files[uri]!;
+  Future<String> readFileAsText(String uri) async {
+    if (readError case final error?) {
+      throw error;
+    }
+    return files[uri]!;
+  }
 
   @override
   Future<void> writeFileFromText(String uri, String content) async {
@@ -63,6 +70,7 @@ void main() {
   late AppEventBus events;
   late FakeWorkspaceController workspace;
   TabsViewModel? tabs;
+  EditorHostViewModel? editorHost;
   late List<LogEvent> logs;
   late StreamSubscription<LogEvent> logSubscription;
 
@@ -86,10 +94,13 @@ void main() {
         CodeMirrorTabAdapter(),
       ],
     );
+    editorHost = EditorHostViewModel(tabs: tabs!);
     await openSampleProject(tabs!.openFile);
   });
 
   tearDown(() async {
+    editorHost?.dispose();
+    editorHost = null;
     tabs?.dispose();
     tabs = null;
     await logSubscription.cancel();
@@ -102,6 +113,44 @@ void main() {
       ['pubspec.yaml', 'lib/main.dart'],
     );
     expect(tabs!.activeFile, 'lib/main.dart');
+  });
+
+  test('diagnostic navigation activates the target and keeps the requested position', () async {
+    await editorHost!.openDiagnostic(
+      'pubspec.yaml',
+      const Diagnostic(
+        line: 0,
+        character: 4,
+        message: 'Test problem',
+        severity: DiagnosticSeverity.error,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(tabs!.activeFile, 'pubspec.yaml');
+    final pubspecTab = tabs!.activeTab! as CodeMirrorTab;
+    expect(pubspecTab.editor.view.state.selection.main.head, 4);
+  });
+
+  test('diagnostic navigation reports read failures and keeps the active tab', () async {
+    workspace.files['broken.dart'] = 'void main() {}';
+    workspace.readError = StateError('internal read failure');
+
+    await editorHost!.openDiagnostic(
+      'broken.dart',
+      const Diagnostic(
+        line: 0,
+        character: 0,
+        message: 'Test problem',
+        severity: DiagnosticSeverity.error,
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(tabs!.errorMessage, 'Could not open broken.dart.');
+    expect(tabs!.activeFile, 'lib/main.dart');
+    expect(logs.single.error, isA<StateError>());
+    expect(logs.single.stackTrace, isNotNull);
   });
 
   test('allows every clean tab including the last tab to close', () {


### PR DESCRIPTION
## Summary

- add a bottom Problems panel backed by language-server diagnostics
- let users open a diagnostic and jump to its source position
- integrate the panel into the resizable editor layout

## Stack

Depends on #3648. The base branch is intentionally `add-dartpad-preview-ui-filetree`.
