### PR TITLE
Load project from archive url

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -20,13 +20,19 @@ dart run jaspr_cli:jaspr serve -v
 
 ## Query Parameters
 
-The frontend supports the following URL query parameters to load external projects at startup:
+The frontend supports the following URL query parameters to load external
+projects at startup:
 
-* `archive`: A URI-encoded URL of a .tar/tar.gz archive containing the project files. When provided, the frontend downloads, extracts, and loads this project into the workspace.
-* `path`: A URI-encoded relative path of the file to open in the editor workspace once the project is loaded (e.g., `lib/main.dart`).
+* `archive`: A URI-encoded URL of a .tar/tar.gz archive containing the
+project files. When provided, the frontend downloads, extracts, and loads
+this project into the workspace.
+* `path`: A URI-encoded relative path of the file to open in the editor
+workspace once the project is loaded (e.g., `lib/main.dart`).
 
 > [!NOTE]
-> Both `archive` and `path` query parameters must be provided together. If either is missing, the application will fall back to loading the default sample project.
+> Both `archive` and `path` query parameters must be provided together. If
+either is missing, the application will fall back to loading the default
+sample project.
 
 Example:
 ```url

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -18,6 +18,21 @@ Run the project using:
 dart run jaspr_cli:jaspr serve -v
 ```
 
+## Query Parameters
+
+The frontend supports the following URL query parameters to load external projects at startup:
+
+* `archive`: A URI-encoded URL of a .tar/tar.gz archive containing the project files. When provided, the frontend downloads, extracts, and loads this project into the workspace.
+* `path`: A URI-encoded relative path of the file to open in the editor workspace once the project is loaded (e.g., `lib/main.dart`).
+
+> [!NOTE]
+> Both `archive` and `path` query parameters must be provided together. If either is missing, the application will fall back to loading the default sample project.
+
+Example:
+```url
+http://localhost:8080/?archive=https://pub.dev/api/archives/material_ui-0.0.3.tar.gz&path=example/README.md
+```
+
 ## SDK assets
 
 The generated worker and Flutter SDK artifacts are collected under the single

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -19,6 +19,7 @@ import 'features/shared/app_event_bus.dart';
 import 'features/shared/browser_console_observer.dart';
 import 'features/shared/events/log_event.dart';
 import 'features/shared/events/workspace_event.dart';
+import 'features/startup/archive_loader.dart';
 import 'features/startup/sample_project.dart';
 import 'features/workspace/data/workspace_repository.dart';
 
@@ -64,6 +65,8 @@ class AppState extends State<App> {
 
     _console = BrowserConsoleObserver(_events);
 
+    final projectFuture = loadProject();
+
     _events.on<WorkspaceLoadedEvent>().listen((event) async {
       if (!mounted) {
         return;
@@ -98,6 +101,8 @@ class AppState extends State<App> {
         (activity) => _logAnalyzerActivity(languageServerClient, activity),
       );
 
+      await projectFuture;
+
       setState(() {
         loadingStatus = 'Running Pub Get...';
       });
@@ -110,11 +115,22 @@ class AppState extends State<App> {
         loadingStatus = 'Analyzing Project...';
       });
     });
+  }
 
-    Future(() async {
+  Future<void> loadProject() async {
+    final params = Uri.base.queryParameters;
+
+    if (params case {
+      'archive': final String archiveUrl,
+      'path': final String filePath,
+      //'main': final String? mainPath,
+    }) {
+      final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
+      await loader.loadArchive(_workspaceRepository.root, _tabs.openFile);
+    } else {
       await createSampleProject(_workspaceRepository.root);
       await openSampleProject(_tabs.openFile);
-    });
+    }
   }
 
   void _logAnalyzerActivity(LanguageServerClient languageServerClient, AnalyzerActivity activity) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -124,23 +124,23 @@ class AppState extends State<App> {
     if (params case {
       'archive': final String archiveUrlParam,
       'path': final String filePathParam,
-      //'main': final String? mainPath,
     }) {
       final archiveUrl = Uri.decodeComponent(archiveUrlParam);
       final filePath = Uri.decodeComponent(filePathParam);
       final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
-      final projectDir = await loader.loadArchive(_workspaceRepository.root, _tabs.openFile);
+      final projectDir = await loader.loadArchive(_workspaceRepository.root);
       setState(() {
         _projectDir = projectDir;
       });
       _fileTree.focusPath(projectDir);
+      unawaited(_tabs.openFile(workspaceContext.normalize(filePath)));
     } else {
       await createSampleProject(_workspaceRepository.root);
-      await openSampleProject(_tabs.openFile);
       setState(() {
         _projectDir = '';
       });
       _fileTree.focusPath('');
+      unawaited(openSampleProject(_tabs.openFile));
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -42,6 +42,7 @@ class AppState extends State<App> {
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
 
   String loadingStatus = 'Loading Workspace...';
+  String _projectDir = '';
 
   @override
   void initState() {
@@ -107,7 +108,7 @@ class AppState extends State<App> {
         loadingStatus = 'Running Pub Get...';
       });
 
-      await _workspaceRepository.pubGet();
+      await _workspaceRepository.pubGet(path: _projectDir);
 
       codemirrorAdapter.attachLanguageServerClient(languageServerClient);
 
@@ -126,10 +127,18 @@ class AppState extends State<App> {
       //'main': final String? mainPath,
     }) {
       final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
-      await loader.loadArchive(_workspaceRepository.root, _tabs.openFile);
+      final projectDir = await loader.loadArchive(_workspaceRepository.root, _tabs.openFile);
+      setState(() {
+        _projectDir = projectDir;
+      });
+      _fileTree.focusPath(projectDir);
     } else {
       await createSampleProject(_workspaceRepository.root);
       await openSampleProject(_tabs.openFile);
+      setState(() {
+        _projectDir = '';
+      });
+      _fileTree.focusPath('');
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -122,10 +122,12 @@ class AppState extends State<App> {
     final params = Uri.base.queryParameters;
 
     if (params case {
-      'archive': final String archiveUrl,
-      'path': final String filePath,
+      'archive': final String archiveUrlParam,
+      'path': final String filePathParam,
       //'main': final String? mainPath,
     }) {
+      final archiveUrl = Uri.decodeComponent(archiveUrlParam);
+      final filePath = Uri.decodeComponent(filePathParam);
       final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
       final projectDir = await loader.loadArchive(_workspaceRepository.root, _tabs.openFile);
       setState(() {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
@@ -53,7 +53,55 @@ class FileTreeFileItem extends StatefulComponent {
 }
 
 class _FileTreeFileItemState extends State<FileTreeFileItem> {
+  final _rowKey = GlobalNodeKey<web.HTMLElement>();
   bool _isRenaming = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final path = component.node.resource.path;
+    final active = component.selectedPath == null && component.state.activeFile == path;
+    if (active) {
+      _scrollIntoView();
+    }
+  }
+
+  @override
+  void didUpdateComponent(FileTreeFileItem oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    final path = component.node.resource.path;
+    final active = component.selectedPath == null && component.state.activeFile == path;
+    final oldActive = oldComponent.selectedPath == null && oldComponent.state.activeFile == path;
+    if (active && !oldActive) {
+      _scrollIntoView();
+    }
+  }
+
+  void _scrollIntoView() {
+    unawaited(
+      Future<void>.delayed(Duration.zero, () {
+        final node = _rowKey.currentNode;
+        final root = node?.closest('.file-tree-list');
+        if (node != null) {
+          node.scrollIntoView(
+            web.ScrollIntoViewOptions(
+              behavior: 'instant',
+              block: 'start',
+            ),
+          );
+          if (root != null) {
+            // Scroll up to account for sticky parent folder items.
+            root.scrollBy(
+              web.ScrollToOptions(
+                top: -25 * component.depth,
+                behavior: 'instant',
+              ),
+            );
+          }
+        }
+      }),
+    );
+  }
 
   @override
   Component build(BuildContext context) {
@@ -88,6 +136,7 @@ class _FileTreeFileItemState extends State<FileTreeFileItem> {
     }
 
     return FileTreeRow(
+      key: _rowKey,
       depth: component.depth,
       classes: [
         'file-tree-item file',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/components/file_icon.dart';
@@ -30,6 +31,7 @@ class FileTreeFolderItem extends StatefulComponent {
     required this.onConfirmCreate,
     required this.onCancelCreate,
     this.confirmDelete,
+    this.collapseAllCount = 0,
     super.key,
   });
 
@@ -66,6 +68,9 @@ class FileTreeFolderItem extends StatefulComponent {
   /// Optional callback to confirm deletion of this folder and its contents.
   final bool Function(String message)? confirmDelete;
 
+  /// Trigger generation counter to collapse all folders recursively.
+  final int collapseAllCount;
+
   @override
   State<FileTreeFolderItem> createState() => _FileTreeFolderItemState();
 }
@@ -78,7 +83,18 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
   @override
   void initState() {
     super.initState();
-    _isCollapsed = component.node.isIgnored;
+    final expectedLibPath = workspaceContext.join(component.state.focusedPath, 'lib');
+    final activeFile = component.state.activeFile;
+    final folderPath = component.node.resource.path;
+    final isActiveParent = folderPath.isNotEmpty &&
+        workspaceContext.isWithinFolder(activeFile, folderPath) &&
+        activeFile != folderPath;
+
+    if (folderPath == expectedLibPath || isActiveParent) {
+      _isCollapsed = false;
+    } else {
+      _isCollapsed = true;
+    }
   }
 
   void _toggleCollapsed() {
@@ -96,6 +112,19 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
     if (component.creatingEntry != null && component.creatingInFolder == component.node.resource.path) {
       _isCollapsed = false;
       _scrollTopIntoView();
+    }
+    if (component.collapseAllCount != oldComponent.collapseAllCount) {
+      _isCollapsed = true;
+    }
+
+    final activeFile = component.state.activeFile;
+    final folderPath = component.node.resource.path;
+    final isActiveParent = folderPath.isNotEmpty &&
+        workspaceContext.isWithinFolder(activeFile, folderPath) &&
+        activeFile != folderPath;
+
+    if (isActiveParent && activeFile != oldComponent.state.activeFile) {
+      _isCollapsed = false;
     }
   }
 
@@ -279,6 +308,7 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
                 onConfirmCreate: component.onConfirmCreate,
                 onCancelCreate: component.onCancelCreate,
                 confirmDelete: component.confirmDelete,
+                collapseAllCount: component.collapseAllCount,
               );
             }),
             if (component.creatingEntry == FileTreeEntryKind.file && component.creatingInFolder == path)

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
@@ -86,9 +86,8 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
     final expectedLibPath = workspaceContext.join(component.state.focusedPath, 'lib');
     final activeFile = component.state.activeFile;
     final folderPath = component.node.resource.path;
-    final isActiveParent = folderPath.isNotEmpty &&
-        workspaceContext.isWithinFolder(activeFile, folderPath) &&
-        activeFile != folderPath;
+    final isActiveParent =
+        folderPath.isNotEmpty && workspaceContext.isWithinFolder(activeFile, folderPath) && activeFile != folderPath;
 
     if (folderPath == expectedLibPath || isActiveParent) {
       _isCollapsed = false;
@@ -119,9 +118,8 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
 
     final activeFile = component.state.activeFile;
     final folderPath = component.node.resource.path;
-    final isActiveParent = folderPath.isNotEmpty &&
-        workspaceContext.isWithinFolder(activeFile, folderPath) &&
-        activeFile != folderPath;
+    final isActiveParent =
+        folderPath.isNotEmpty && workspaceContext.isWithinFolder(activeFile, folderPath) && activeFile != folderPath;
 
     if (isActiveParent && activeFile != oldComponent.state.activeFile) {
       _isCollapsed = false;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
@@ -77,6 +77,22 @@ final class FileTreeFolderNode extends FileTreeNode {
     }
     return false;
   }
+
+  /// Recursively finds a folder in this subtree with the given [path].
+  FileTreeFolderNode? findFolder(String path) {
+    if (resource.path == path) {
+      return this;
+    }
+    for (final child in children) {
+      if (child is FileTreeFolderNode) {
+        final found = child.findFolder(path);
+        if (found != null) {
+          return found;
+        }
+      }
+    }
+    return null;
+  }
 }
 
 /// The kind of workspace entry being created.
@@ -98,6 +114,7 @@ final class FileTreeState {
     required this.busy,
     required this.protectedEntries,
     required this.dirtyEntries,
+    required this.focusedPath,
   });
 
   /// The root node whose children are displayed in the tree.
@@ -117,6 +134,9 @@ final class FileTreeState {
 
   /// File and ancestor folder paths containing unsaved changes.
   final Set<String> dirtyEntries;
+
+  /// The path of the folder currently focused in the file tree.
+  final String focusedPath;
 
   /// Checks if creating or renaming an entry with [newName] at [currentPath] conflicts
   /// with any existing resource in the root folder.
@@ -148,6 +168,7 @@ final class FileTreeActions {
     required this.moveEntry,
     required this.openFile,
     required this.clearOperationError,
+    required this.navigateUp,
   });
 
   /// Creates a file in the selected folder.
@@ -176,4 +197,7 @@ final class FileTreeActions {
 
   /// Clears the current operation error.
   final void Function() clearOperationError;
+
+  /// Navigates to the parent folder of the currently focused folder.
+  final void Function() navigateUp;
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -50,6 +50,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
   FileTreeEntryKind? _creatingEntry;
   bool _isRootDropTarget = false;
   int _dragEnterCount = 0;
+  int _collapseAllCount = 0;
 
   @override
   void didUpdateComponent(FileTreeView oldComponent) {
@@ -71,20 +72,32 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         const span(classes: 'file-tree-title', [.text('Files')]),
         div(classes: 'file-tree-toolbar', [
           _toolbarButton(
+            title: 'Navigate up',
+            disabled: state.busy || state.focusedPath.isEmpty,
+            icon: const Icon('arrow_upward', size: 16),
+            onClick: actions.navigateUp,
+          ),
+          _toolbarButton(
+            title: 'Collapse all',
+            disabled: state.busy,
+            icon: const Icon('unfold_less', size: 16),
+            onClick: () {
+              setState(() {
+                _collapseAllCount++;
+              });
+            },
+          ),
+          _toolbarButton(
             title: 'New file',
             disabled: state.busy,
-            icon: const Icon(
-              'note_add',
-              size: 16,
-              classes: 'file-tree-icon file-icon',
-            ),
+            icon: const Icon('note_add', size: 16),
             onClick: () {
               setState(() {
                 _creatingEntry = FileTreeEntryKind.file;
                 final path = _selectedPath ?? '';
                 _selectedPath = null;
                 if (path.isEmpty) {
-                  _creatingInFolder = '';
+                  _creatingInFolder = state.focusedPath;
                 } else if (state.root.isFolder(path)) {
                   _creatingInFolder = path;
                 } else {
@@ -96,18 +109,14 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
           _toolbarButton(
             title: 'New folder',
             disabled: state.busy,
-            icon: const Icon(
-              'create_new_folder',
-              size: 16,
-              classes: 'file-tree-icon folder-icon',
-            ),
+            icon: const Icon('create_new_folder', size: 16),
             onClick: () {
               setState(() {
                 _creatingEntry = FileTreeEntryKind.folder;
                 final path = _selectedPath ?? '';
                 _selectedPath = null;
                 if (path.isEmpty) {
-                  _creatingInFolder = '';
+                  _creatingInFolder = state.focusedPath;
                 } else if (state.root.isFolder(path)) {
                   _creatingInFolder = path;
                 } else {
@@ -168,12 +177,12 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
             final dragEvent = event as web.DragEvent;
             final sourcePath = dragEvent.dataTransfer?.getData('text/plain');
             if (sourcePath != null && sourcePath.isNotEmpty) {
-              unawaited(actions.moveEntry(sourcePath, ''));
+              unawaited(actions.moveEntry(sourcePath, state.focusedPath));
             }
           },
         },
         [
-          if (_creatingEntry != null && _creatingInFolder == '')
+          if (_creatingEntry != null && _creatingInFolder == state.focusedPath)
             FileTreeInputItem(
               placeholder: _creatingEntry == FileTreeEntryKind.folder ? 'folder' : 'file',
               depth: 0,
@@ -190,22 +199,24 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
                     ),
               confirmOnBlur: true,
               checkConflict: (name) {
-                if (state.root.exists(name)) {
-                  return 'A file or folder already exists at "$name".';
+                final targetPath = state.focusedPath.isEmpty ? name : '${state.focusedPath}/$name';
+                if (state.root.exists(targetPath)) {
+                  return 'A file or folder already exists at "$targetPath".';
                 }
                 return null;
               },
               onConfirm: (name) async {
                 final kind = _creatingEntry!;
+                final targetPath = state.focusedPath.isEmpty ? name : '${state.focusedPath}/$name';
                 setState(() {
                   _creatingEntry = null;
                   _creatingInFolder = null;
-                  _selectedPath = name;
+                  _selectedPath = targetPath;
                 });
                 if (kind == FileTreeEntryKind.folder) {
-                  await actions.createFolder('', name);
+                  await actions.createFolder(state.focusedPath, name);
                 } else {
-                  await actions.createFile('', name);
+                  await actions.createFile(state.focusedPath, name);
                 }
               },
               onCancel: () {
@@ -231,6 +242,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
                 },
                 creatingInFolder: _creatingInFolder,
                 creatingEntry: _creatingEntry,
+                collapseAllCount: _collapseAllCount,
                 onConfirmCreate: (name) async {
                   final parentPath = _creatingInFolder!;
                   final kind = _creatingEntry!;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
@@ -22,7 +22,7 @@ final class FileTreeViewModel extends ChangeNotifier {
     required this.tabs,
     required this.workspace,
     required this.events,
-  }) : _root = FileTreeFolderNode(workspace.root) {
+  }) : _fullRoot = FileTreeFolderNode(workspace.root) {
     tabs.addListener(_handleTabsChanged);
     _workspaceSubscription = workspace.changeEvents.listen(_handleWorkspaceEvent);
     unawaited(refresh());
@@ -49,7 +49,8 @@ final class FileTreeViewModel extends ChangeNotifier {
   /// The language server client used to coordinate file rename refactorings.
   LanguageServerClient? languageServerClient;
 
-  FileTreeFolderNode _root;
+  FileTreeFolderNode _fullRoot;
+  String _focusedPath = '';
   StreamSubscription<WorkspaceChangeEvent>? _workspaceSubscription;
   Timer? _refreshDebounce;
   int _refreshGeneration = 0;
@@ -57,14 +58,22 @@ final class FileTreeViewModel extends ChangeNotifier {
   bool _busy = false;
   String? _operationError;
 
+  FileTreeFolderNode get _focusedRoot {
+    if (_focusedPath.isEmpty) {
+      return _fullRoot;
+    }
+    return _fullRoot.findFolder(_focusedPath) ?? _fullRoot;
+  }
+
   /// The current immutable state consumed by the file-tree view.
   FileTreeState get state => FileTreeState(
-    root: _root,
+    root: _focusedRoot,
     activeFile: tabs.activeFile,
     operationError: _operationError,
     busy: _busy,
     protectedEntries: _protectedEntries,
     dirtyEntries: Set.unmodifiable(_pathsWithAncestors(tabs.dirtyFiles)),
+    focusedPath: _focusedPath,
   );
 
   /// The actions that the file-tree view can invoke.
@@ -78,6 +87,7 @@ final class FileTreeViewModel extends ChangeNotifier {
     moveEntry: moveEntry,
     openFile: tabs.openTextFile,
     clearOperationError: clearOperationError,
+    navigateUp: navigateUp,
   );
 
   /// Whether the file at [path] is required by DartPad Preview.
@@ -251,6 +261,17 @@ final class FileTreeViewModel extends ChangeNotifier {
     _notify();
   }
 
+  void focusPath(String path) {
+    _focusedPath = workspaceContext.normalize(path);
+    _notify();
+  }
+
+  void navigateUp() {
+    if (_focusedPath.isNotEmpty) {
+      focusPath(workspaceContext.dirname(_focusedPath));
+    }
+  }
+
   Future<void> _runMutation(Future<void> Function() operation) async {
     if (_busy) {
       return;
@@ -290,7 +311,7 @@ final class FileTreeViewModel extends ChangeNotifier {
     if (_disposed || generation != _refreshGeneration) {
       return;
     }
-    _root = tree;
+    _fullRoot = tree;
     _notify();
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -8,18 +8,29 @@ import 'package:archive/archive.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:http/http.dart' as http;
 
+/// A loader that downloads a (gzipped) tar archive from a remote URL,
+/// extracts all of its files into a virtual workspace folder, and opens a
+/// target file.
 class ArchiveLoader {
+  /// Creates an archive loader.
   const ArchiveLoader({
     required this.archiveUrl,
     required this.filePath,
-    this.mainPath,
   });
 
+  /// The absolute URL pointing to the tar or gzipped tar archive.
   final String archiveUrl;
-  final String filePath;
-  final String? mainPath;
 
-  Future<String> loadArchive(WorkspaceFolder root, Future<void> Function(String path) openFile) async {
+  /// The workspace-relative file path within the project to open after extraction.
+  final String filePath;
+
+  /// Downloads, decompresses, and extracts all files from the [archiveUrl]
+  /// into the workspace [root].
+  ///
+  /// Scans the archive files to find the nearest parent directory of [filePath]
+  /// that contains a `pubspec.yaml` file. Returns the path to that directory
+  /// relative to the archive root.
+  Future<String> loadArchive(WorkspaceFolder root) async {
     final Uri uri = Uri.parse(archiveUrl);
     if (!uri.isAbsolute) {
       throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
@@ -110,7 +121,6 @@ class ArchiveLoader {
       await root.workspace.writeFileFromBytes(root.getFile(name).path, fileBytes);
     }
 
-    await openFile(normalizedFilePath);
     return rootProjectDir;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -1,0 +1,119 @@
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:http/http.dart' as http;
+
+class ArchiveLoader {
+  const ArchiveLoader({
+    required this.archiveUrl,
+    required this.filePath,
+    this.mainPath,
+  });
+
+  final String archiveUrl;
+  final String filePath;
+  final String? mainPath;
+
+  Future<void> loadArchive(WorkspaceFolder root, Future<void> Function(String path) openFile) async {
+    final Uri uri = Uri.parse(archiveUrl);
+    if (!uri.isAbsolute) {
+      throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
+    }
+
+    final http.Response response = await http.get(uri);
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load archive');
+    }
+
+    final Uint8List bytes = response.bodyBytes;
+    List<int> tarBytes = bytes;
+    if (bytes.length >= 2 && bytes[0] == 0x1F && bytes[1] == 0x8B) {
+      tarBytes = const GZipDecoder().decodeBytes(bytes);
+    }
+
+    final Archive archive = TarDecoder().decodeBytes(tarBytes);
+
+    final String normalizedFilePath = workspaceContext.normalize(filePath);
+    final Set<String> archivePaths = <String>{};
+    for (final ArchiveFile file in archive.files) {
+      String name = file.name;
+      if (name.startsWith('./')) {
+        name = name.substring(2);
+      } else if (name.startsWith('/')) {
+        name = name.substring(1);
+      }
+      archivePaths.add(name);
+    }
+
+    final List<String> segments = normalizedFilePath.split('/');
+    String? rootProjectDir;
+
+    for (int i = segments.length - 1; i >= 0; i--) {
+      final String parentDir = segments.sublist(0, i).join('/');
+      final String pubspecPath = parentDir.isEmpty ? 'pubspec.yaml' : '$parentDir/pubspec.yaml';
+      if (archivePaths.contains(pubspecPath)) {
+        rootProjectDir = parentDir;
+        break;
+      }
+    }
+
+    if (rootProjectDir == null) {
+      throw Exception('Could not find pubspec.yaml in any parent directory of $filePath');
+    }
+
+    final String prefix = rootProjectDir.isEmpty ? '' : '$rootProjectDir/';
+    final List<ArchiveFile> filesToExtract = <ArchiveFile>[];
+    final Set<String> foldersToCreate = <String>{};
+
+    for (final ArchiveFile file in archive.files) {
+      if (!file.isFile) {
+        continue;
+      }
+
+      String name = file.name;
+      if (name.startsWith('./')) {
+        name = name.substring(2);
+      } else if (name.startsWith('/')) {
+        name = name.substring(1);
+      }
+
+      if (rootProjectDir.isEmpty || name.startsWith(prefix)) {
+        filesToExtract.add(file);
+
+        final String relativePath = rootProjectDir.isEmpty ? name : name.substring(prefix.length);
+        String dir = workspaceContext.dirname(relativePath);
+        while (dir.isNotEmpty && dir != '.') {
+          foldersToCreate.add(dir);
+          dir = workspaceContext.dirname(dir);
+        }
+      }
+    }
+
+    final List<String> sortedFolders = foldersToCreate.toList()
+      ..sort((String a, String b) => a.length.compareTo(b.length));
+    for (final String folderPath in sortedFolders) {
+      await root.getFolder(folderPath).create();
+    }
+
+    for (final ArchiveFile file in filesToExtract) {
+      String name = file.name;
+      if (name.startsWith('./')) {
+        name = name.substring(2);
+      } else if (name.startsWith('/')) {
+        name = name.substring(1);
+      }
+
+      final String relativePath = rootProjectDir.isEmpty ? name : name.substring(prefix.length);
+      final dynamic content = file.content;
+      final Uint8List fileBytes = content is Uint8List ? content : Uint8List.fromList(content as List<int>);
+
+      await root.workspace.writeFileFromBytes(root.getFile(relativePath).path, fileBytes);
+    }
+
+    await root.getFile('pubspec_overrides.yaml').writeContent('workspace:\n');
+
+    final String openedPath = rootProjectDir.isEmpty ? normalizedFilePath : normalizedFilePath.substring(prefix.length);
+    await openFile(openedPath);
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -15,7 +15,7 @@ class ArchiveLoader {
   final String filePath;
   final String? mainPath;
 
-  Future<void> loadArchive(WorkspaceFolder root, Future<void> Function(String path) openFile) async {
+  Future<String> loadArchive(WorkspaceFolder root, Future<void> Function(String path) openFile) async {
     final Uri uri = Uri.parse(archiveUrl);
     if (!uri.isAbsolute) {
       throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
@@ -62,7 +62,6 @@ class ArchiveLoader {
       throw Exception('Could not find pubspec.yaml in any parent directory of $filePath');
     }
 
-    final String prefix = rootProjectDir.isEmpty ? '' : '$rootProjectDir/';
     final List<ArchiveFile> filesToExtract = <ArchiveFile>[];
     final Set<String> foldersToCreate = <String>{};
 
@@ -78,15 +77,12 @@ class ArchiveLoader {
         name = name.substring(1);
       }
 
-      if (rootProjectDir.isEmpty || name.startsWith(prefix)) {
-        filesToExtract.add(file);
+      filesToExtract.add(file);
 
-        final String relativePath = rootProjectDir.isEmpty ? name : name.substring(prefix.length);
-        String dir = workspaceContext.dirname(relativePath);
-        while (dir.isNotEmpty && dir != '.') {
-          foldersToCreate.add(dir);
-          dir = workspaceContext.dirname(dir);
-        }
+      String dir = workspaceContext.dirname(name);
+      while (dir.isNotEmpty && dir != '.') {
+        foldersToCreate.add(dir);
+        dir = workspaceContext.dirname(dir);
       }
     }
 
@@ -104,16 +100,13 @@ class ArchiveLoader {
         name = name.substring(1);
       }
 
-      final String relativePath = rootProjectDir.isEmpty ? name : name.substring(prefix.length);
       final dynamic content = file.content;
       final Uint8List fileBytes = content is Uint8List ? content : Uint8List.fromList(content as List<int>);
 
-      await root.workspace.writeFileFromBytes(root.getFile(relativePath).path, fileBytes);
+      await root.workspace.writeFileFromBytes(root.getFile(name).path, fileBytes);
     }
 
-    await root.getFile('pubspec_overrides.yaml').writeContent('workspace:\n');
-
-    final String openedPath = rootProjectDir.isEmpty ? normalizedFilePath : normalizedFilePath.substring(prefix.length);
-    await openFile(openedPath);
+    await openFile(normalizedFilePath);
+    return rootProjectDir;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/sample_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/sample_project.dart
@@ -14,8 +14,6 @@ Future<void> createSampleProject(WorkspaceFolder root) async {
 
 /// Opens the default sample files and leaves the Dart source active.
 Future<void> openSampleProject(Future<void> Function(String path) openFile) async {
-  // TODO: Remove this once we have the filetree in place.
-  await openFile(_samplePubspecPath);
   await openFile(_sampleMainPath);
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -56,10 +56,10 @@ final class WorkspaceRepository {
     );
   }
 
-  Future<void> pubGet() async {
+  Future<void> pubGet({String path = ''}) async {
     events.dispatch(const LogEvent('Running pub get...'));
     final workspace = await _workspaceFuture;
-    final result = await workspace.pub(command: 'get');
+    final result = await workspace.pub(uri: path, command: 'get');
     events.dispatch(LogEvent('pub get finished.\n${result.log}'));
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
+++ b/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
@@ -9,9 +9,11 @@ environment:
 resolution: workspace
 
 dependencies:
+  archive: ^4.0.9
   codemirror_dart: any
   dartpad: any
   dartpad_editor: any
+  http: ^1.6.0
   jaspr: ^0.23.2
   jaspr_content: ^0.5.3
   jaspr_router: ^0.8.2

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -96,15 +96,16 @@ void main() {
     await events.dispose();
   });
 
-  test('opens main.dart and pubspec.yaml with main.dart active', () {
+  test('opens main.dart with main.dart active', () {
     expect(
       tabs!.openTabs.map((tab) => tab.path),
-      ['pubspec.yaml', 'lib/main.dart'],
+      ['lib/main.dart'],
     );
     expect(tabs!.activeFile, 'lib/main.dart');
   });
 
-  test('allows every clean tab including the last tab to close', () {
+  test('allows every clean tab including the last tab to close', () async {
+    await tabs!.openFile('pubspec.yaml');
     expect(tabs!.closeFile('lib/main.dart'), isTrue);
     expect(tabs!.activeFile, 'pubspec.yaml');
 
@@ -131,7 +132,7 @@ void main() {
   });
 
   test('save-all writes dirty YAML without formatting', () async {
-    tabs!.switchFile('pubspec.yaml');
+    await tabs!.openFile('pubspec.yaml');
     final pubspecTab = tabs!.activeTab! as CodeMirrorTab;
     pubspecTab.editor.text = '${pubspecTab.content}\nversion: 1.0.0';
 
@@ -146,7 +147,7 @@ void main() {
   });
 
   test('save-all errors hide internal details but retain them in logs', () async {
-    tabs!.switchFile('pubspec.yaml');
+    await tabs!.openFile('pubspec.yaml');
     final pubspecTab = tabs!.activeTab! as CodeMirrorTab;
     pubspecTab.editor.text = '${pubspecTab.content}\nversion: 1.0.0';
     workspace.writeError = StateError('internal write failure');
@@ -163,7 +164,9 @@ void main() {
     expect(logs.single.stackTrace, isNotNull);
   });
 
-  testClient('renders one dirty indicator and a close action for every tab', (tester) {
+  testClient('renders one dirty indicator and a close action for every tab', (tester) async {
+    await tabs!.openFile('pubspec.yaml');
+    tabs!.switchFile('lib/main.dart');
     final mainTab = tabs!.activeTab! as CodeMirrorTab;
     mainTab.editor.text = '${mainTab.content}\n// dirty';
 
@@ -209,6 +212,7 @@ void main() {
   });
 
   testClient('closing all tabs leaves an empty editor stack', (tester) async {
+    await tabs!.openFile('pubspec.yaml');
     tabs!
       ..closeFile('lib/main.dart')
       ..closeFile('pubspec.yaml');

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
@@ -374,4 +374,60 @@ void main() {
     expect(workspace.folders, contains('assets'));
     expect(operationLog, isEmpty);
   });
+
+  test('focuses on a subfolder and exposes it as the root of the tree', () async {
+    workspace
+      ..addTextFile('my_project/pubspec.yaml', 'name: my_project')
+      ..addTextFile('my_project/lib/main.dart', 'void main() {}')
+      ..addTextFile('other_dir/other.dart', 'void main() {}');
+    await viewModel.refresh();
+
+    // Default root is ''
+    expect(viewModel.state.focusedPath, '');
+    expect(viewModel.state.root.resource.path, '');
+
+    viewModel.focusPath('my_project');
+    expect(viewModel.state.focusedPath, 'my_project');
+    expect(viewModel.state.root.resource.path, 'my_project');
+    
+    // Root children should be my_project's children ('lib' and 'pubspec.yaml')
+    final rootChildren = viewModel.state.root.children;
+    expect(rootChildren.map((node) => node.resource.path), containsAll(['my_project/lib', 'my_project/pubspec.yaml']));
+  });
+
+  test('navigates up until the full filesystem (workspace root) is shown', () async {
+    workspace
+      ..addTextFile('a/b/c/project/pubspec.yaml', 'name: project')
+      ..addTextFile('a/b/c/project/lib/main.dart', 'void main() {}');
+    await viewModel.refresh();
+
+    viewModel.focusPath('a/b/c/project');
+    expect(viewModel.state.focusedPath, 'a/b/c/project');
+    expect(viewModel.state.root.resource.path, 'a/b/c/project');
+
+    // Navigate up to a/b/c
+    viewModel.navigateUp();
+    expect(viewModel.state.focusedPath, 'a/b/c');
+    expect(viewModel.state.root.resource.path, 'a/b/c');
+
+    // Navigate up to a/b
+    viewModel.navigateUp();
+    expect(viewModel.state.focusedPath, 'a/b');
+    expect(viewModel.state.root.resource.path, 'a/b');
+
+    // Navigate up to a
+    viewModel.navigateUp();
+    expect(viewModel.state.focusedPath, 'a');
+    expect(viewModel.state.root.resource.path, 'a');
+
+    // Navigate up to workspace root
+    viewModel.navigateUp();
+    expect(viewModel.state.focusedPath, '');
+    expect(viewModel.state.root.resource.path, '');
+
+    // Navigate up further does nothing
+    viewModel.navigateUp();
+    expect(viewModel.state.focusedPath, '');
+    expect(viewModel.state.root.resource.path, '');
+  });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
@@ -389,7 +389,7 @@ void main() {
     viewModel.focusPath('my_project');
     expect(viewModel.state.focusedPath, 'my_project');
     expect(viewModel.state.root.resource.path, 'my_project');
-    
+
     // Root children should be my_project's children ('lib' and 'pubspec.yaml')
     final rootChildren = viewModel.state.root.children;
     expect(rootChildren.map((node) => node.resource.path), containsAll(['my_project/lib', 'my_project/pubspec.yaml']));

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
@@ -92,6 +92,7 @@ FileTreeState _state(
     busy: false,
     protectedEntries: const {},
     dirtyEntries: dirty ? const {path} : const {},
+    focusedPath: '',
   );
 }
 
@@ -108,6 +109,7 @@ FileTreeActions _actions({
     moveEntry: (_, _) async {},
     openFile: (_) {},
     clearOperationError: () {},
+    navigateUp: () {},
   );
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -42,7 +42,7 @@ void main() {
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
       expect(
-        () => loader.loadArchive(api.root, (String path) async {}),
+        () => loader.loadArchive(api.root),
         throwsArgumentError,
       );
     });
@@ -57,7 +57,7 @@ void main() {
       await http.runWithClient(
         () async {
           expect(
-            () => loader.loadArchive(api.root, (String path) async {}),
+            () => loader.loadArchive(api.root),
             throwsException,
           );
         },
@@ -67,7 +67,7 @@ void main() {
       );
     });
 
-    test('downloads, decompresses .tar.gz, finds pubspec, extracts files and opens relative path', () async {
+    test('downloads, decompresses .tar.gz, finds pubspec and extracts files', () async {
       final Map<String, String> archiveFiles = {
         'my_project/pubspec.yaml': 'name: my_project\n',
         'my_project/lib/main.dart': 'void main() {}',
@@ -82,12 +82,9 @@ void main() {
       );
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
-      String? openedPath;
       await http.runWithClient(
         () async {
-          await loader.loadArchive(api.root, (String path) async {
-            openedPath = path;
-          });
+          await loader.loadArchive(api.root);
         },
         () => MockClient((http.Request request) async {
           expect(request.url.toString(), absoluteUrl);
@@ -106,9 +103,6 @@ void main() {
       expect(await api.readFileAsText('my_project/pubspec.yaml'), 'name: my_project\n');
       expect(await api.readFileAsText('my_project/lib/main.dart'), 'void main() {}');
       expect(await api.readFileAsText('my_project/lib/src/helper.dart'), 'class Helper {}');
-
-      // Verify that opened path is relative to the root project directory
-      expect(openedPath, 'my_project/lib/main.dart');
     });
 
     test('downloads and extracts uncompressed .tar files', () async {
@@ -124,12 +118,9 @@ void main() {
       );
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
-      String? openedPath;
       await http.runWithClient(
         () async {
-          await loader.loadArchive(api.root, (String path) async {
-            openedPath = path;
-          });
+          await loader.loadArchive(api.root);
         },
         () => MockClient((http.Request request) async {
           return http.Response.bytes(archiveBytes, 200);
@@ -139,7 +130,6 @@ void main() {
       expect(await api.fileExist('project/pubspec.yaml'), isTrue);
       expect(await api.fileExist('project/lib/main.dart'), isTrue);
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
-      expect(openedPath, 'project/lib/main.dart');
     });
 
     test('throws Exception if no pubspec.yaml is found in the walk', () async {
@@ -157,7 +147,7 @@ void main() {
       await http.runWithClient(
         () async {
           expect(
-            () => loader.loadArchive(api.root, (String path) async {}),
+            () => loader.loadArchive(api.root),
             throwsException,
           );
         },

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -54,14 +54,17 @@ void main() {
       );
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
-      await http.runWithClient(() async {
-        expect(
-          () => loader.loadArchive(api.root, (String path) async {}),
-          throwsException,
-        );
-      }, () => MockClient((http.Request request) async {
-        return http.Response('Not Found', 404);
-      }));
+      await http.runWithClient(
+        () async {
+          expect(
+            () => loader.loadArchive(api.root, (String path) async {}),
+            throwsException,
+          );
+        },
+        () => MockClient((http.Request request) async {
+          return http.Response('Not Found', 404);
+        }),
+      );
     });
 
     test('downloads, decompresses .tar.gz, finds pubspec, extracts files and opens relative path', () async {
@@ -80,14 +83,17 @@ void main() {
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
       String? openedPath;
-      await http.runWithClient(() async {
-        await loader.loadArchive(api.root, (String path) async {
-          openedPath = path;
-        });
-      }, () => MockClient((http.Request request) async {
-        expect(request.url.toString(), absoluteUrl);
-        return http.Response.bytes(archiveBytes, 200);
-      }));
+      await http.runWithClient(
+        () async {
+          await loader.loadArchive(api.root, (String path) async {
+            openedPath = path;
+          });
+        },
+        () => MockClient((http.Request request) async {
+          expect(request.url.toString(), absoluteUrl);
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
 
       // Verify that the files were extracted under the workspace root, relative to the project root 'my_project/'
       expect(await api.fileExist('my_project/pubspec.yaml'), isTrue);
@@ -119,13 +125,16 @@ void main() {
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
       String? openedPath;
-      await http.runWithClient(() async {
-        await loader.loadArchive(api.root, (String path) async {
-          openedPath = path;
-        });
-      }, () => MockClient((http.Request request) async {
-        return http.Response.bytes(archiveBytes, 200);
-      }));
+      await http.runWithClient(
+        () async {
+          await loader.loadArchive(api.root, (String path) async {
+            openedPath = path;
+          });
+        },
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
 
       expect(await api.fileExist('project/pubspec.yaml'), isTrue);
       expect(await api.fileExist('project/lib/main.dart'), isTrue);
@@ -145,14 +154,17 @@ void main() {
       );
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
-      await http.runWithClient(() async {
-        expect(
-          () => loader.loadArchive(api.root, (String path) async {}),
-          throwsException,
-        );
-      }, () => MockClient((http.Request request) async {
-        return http.Response.bytes(archiveBytes, 200);
-      }));
+      await http.runWithClient(
+        () async {
+          expect(
+            () => loader.loadArchive(api.root, (String path) async {}),
+            throwsException,
+          );
+        },
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
     });
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -90,20 +90,19 @@ void main() {
       }));
 
       // Verify that the files were extracted under the workspace root, relative to the project root 'my_project/'
-      expect(await api.fileExist('pubspec.yaml'), isTrue);
-      expect(await api.fileExist('lib/main.dart'), isTrue);
-      expect(await api.fileExist('lib/src/helper.dart'), isTrue);
-      expect(await api.fileExist('assets/image.png'), isTrue);
-      expect(await api.fileExist('pubspec_overrides.yaml'), isTrue);
+      expect(await api.fileExist('my_project/pubspec.yaml'), isTrue);
+      expect(await api.fileExist('my_project/lib/main.dart'), isTrue);
+      expect(await api.fileExist('my_project/lib/src/helper.dart'), isTrue);
+      expect(await api.fileExist('my_project/assets/image.png'), isTrue);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
 
       // Verify content
-      expect(await api.readFileAsText('pubspec.yaml'), 'name: my_project\n');
-      expect(await api.readFileAsText('lib/main.dart'), 'void main() {}');
-      expect(await api.readFileAsText('lib/src/helper.dart'), 'class Helper {}');
-      expect(await api.readFileAsText('pubspec_overrides.yaml'), 'workspace:\n');
+      expect(await api.readFileAsText('my_project/pubspec.yaml'), 'name: my_project\n');
+      expect(await api.readFileAsText('my_project/lib/main.dart'), 'void main() {}');
+      expect(await api.readFileAsText('my_project/lib/src/helper.dart'), 'class Helper {}');
 
       // Verify that opened path is relative to the root project directory
-      expect(openedPath, 'lib/main.dart');
+      expect(openedPath, 'my_project/lib/main.dart');
     });
 
     test('downloads and extracts uncompressed .tar files', () async {
@@ -128,11 +127,10 @@ void main() {
         return http.Response.bytes(archiveBytes, 200);
       }));
 
-      expect(await api.fileExist('pubspec.yaml'), isTrue);
-      expect(await api.fileExist('lib/main.dart'), isTrue);
-      expect(await api.fileExist('pubspec_overrides.yaml'), isTrue);
-      expect(await api.readFileAsText('pubspec_overrides.yaml'), 'workspace:\n');
-      expect(openedPath, 'lib/main.dart');
+      expect(await api.fileExist('project/pubspec.yaml'), isTrue);
+      expect(await api.fileExist('project/lib/main.dart'), isTrue);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+      expect(openedPath, 'project/lib/main.dart');
     });
 
     test('throws Exception if no pubspec.yaml is found in the walk', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -1,0 +1,160 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/startup/archive_loader.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ArchiveLoader', () {
+    const String absoluteUrl = 'https://example.com/archive.tar.gz';
+
+    Uint8List createTarArchive(Map<String, String> files) {
+      final Archive archive = Archive();
+      for (final MapEntry<String, String> entry in files.entries) {
+        final List<int> contentBytes = entry.value.codeUnits;
+        archive.addFile(ArchiveFile(entry.key, contentBytes.length, contentBytes));
+      }
+      final List<int> encoded = TarEncoder().encode(archive);
+      return Uint8List.fromList(encoded);
+    }
+
+    Uint8List createTarGzArchive(Map<String, String> files) {
+      final Uint8List tarBytes = createTarArchive(files);
+      final List<int> encoded = const GZipEncoder().encode(tarBytes);
+      return Uint8List.fromList(encoded);
+    }
+
+    test('throws ArgumentError if URL is not absolute', () async {
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: 'relative/url',
+        filePath: 'lib/main.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      expect(
+        () => loader.loadArchive(api.root, (String path) async {}),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws Exception if HTTP response is not 200', () async {
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'lib/main.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(() async {
+        expect(
+          () => loader.loadArchive(api.root, (String path) async {}),
+          throwsException,
+        );
+      }, () => MockClient((http.Request request) async {
+        return http.Response('Not Found', 404);
+      }));
+    });
+
+    test('downloads, decompresses .tar.gz, finds pubspec, extracts files and opens relative path', () async {
+      final Map<String, String> archiveFiles = {
+        'my_project/pubspec.yaml': 'name: my_project\n',
+        'my_project/lib/main.dart': 'void main() {}',
+        'my_project/lib/src/helper.dart': 'class Helper {}',
+        'my_project/assets/image.png': 'binary_content_here',
+      };
+      final Uint8List archiveBytes = createTarGzArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'my_project/lib/main.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      String? openedPath;
+      await http.runWithClient(() async {
+        await loader.loadArchive(api.root, (String path) async {
+          openedPath = path;
+        });
+      }, () => MockClient((http.Request request) async {
+        expect(request.url.toString(), absoluteUrl);
+        return http.Response.bytes(archiveBytes, 200);
+      }));
+
+      // Verify that the files were extracted under the workspace root, relative to the project root 'my_project/'
+      expect(await api.fileExist('pubspec.yaml'), isTrue);
+      expect(await api.fileExist('lib/main.dart'), isTrue);
+      expect(await api.fileExist('lib/src/helper.dart'), isTrue);
+      expect(await api.fileExist('assets/image.png'), isTrue);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isTrue);
+
+      // Verify content
+      expect(await api.readFileAsText('pubspec.yaml'), 'name: my_project\n');
+      expect(await api.readFileAsText('lib/main.dart'), 'void main() {}');
+      expect(await api.readFileAsText('lib/src/helper.dart'), 'class Helper {}');
+      expect(await api.readFileAsText('pubspec_overrides.yaml'), 'workspace:\n');
+
+      // Verify that opened path is relative to the root project directory
+      expect(openedPath, 'lib/main.dart');
+    });
+
+    test('downloads and extracts uncompressed .tar files', () async {
+      final Map<String, String> archiveFiles = {
+        'project/pubspec.yaml': 'name: project\n',
+        'project/lib/main.dart': 'void main() {}',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'project/lib/main.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      String? openedPath;
+      await http.runWithClient(() async {
+        await loader.loadArchive(api.root, (String path) async {
+          openedPath = path;
+        });
+      }, () => MockClient((http.Request request) async {
+        return http.Response.bytes(archiveBytes, 200);
+      }));
+
+      expect(await api.fileExist('pubspec.yaml'), isTrue);
+      expect(await api.fileExist('lib/main.dart'), isTrue);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isTrue);
+      expect(await api.readFileAsText('pubspec_overrides.yaml'), 'workspace:\n');
+      expect(openedPath, 'lib/main.dart');
+    });
+
+    test('throws Exception if no pubspec.yaml is found in the walk', () async {
+      final Map<String, String> archiveFiles = {
+        'my_project/lib/main.dart': 'void main() {}',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'my_project/lib/main.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(() async {
+        expect(
+          () => loader.loadArchive(api.root, (String path) async {}),
+          throwsException,
+        );
+      }, () => MockClient((http.Request request) async {
+        return http.Response.bytes(archiveBytes, 200);
+      }));
+    });
+  });
+}


### PR DESCRIPTION
Adds ability to load a project from an archive url and path as specified here: https://docs.google.com/document/d/1jVeeX6XiaWKcVUATYW5b8cR7vTvoih-pF_wNq3mA_pc/edit?tab=t.0

E.g. `<domain>?archive=https://pub.dev/api/archives/flutter_card_swiper-7.2.0.tar.gz&path=example/lib/main.dart`

Additionally improves the `FileTree` component to better handle large projects:
- Adds a `focusPath` property that by default is set to the detected package path of the loaded file, according to the above document. And a `navigate up` icon that allows to explore the parent level in the file tree.
- Folders are automatically collapsed at the start, except for the root `lib/` folder.
- The file tree is automatically scrolled to the active file when switching tabs.
- Adds a button to collapse all folders.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
