### PR TITLE
feat (dartpad_preview): load project from package name

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -21,24 +21,41 @@ dart run jaspr_cli:jaspr serve -v
 
 ## Query Parameters
 
-The frontend supports the following URL query parameters to load external
-projects at startup:
+The frontend supports loading external projects at startup using URL query
+parameters.
 
-* `archive`: A URI-encoded URL of a .tar/tar.gz archive containing the
-project files. When provided, the frontend downloads, extracts, and loads
-this project into the workspace.
-* `path`: A URI-encoded relative path of the file to open in the editor
-workspace once the project is loaded (e.g., `lib/main.dart`).
+### Loading from Archive
 
-> [!NOTE]
-> Both `archive` and `path` query parameters must be provided together. If
-either is missing, the application will fall back to loading the default
-sample project.
+To load a project from an arbitrary archive URL, you must provide both of the
+following parameters:
+
+* `archive`: A URI-encoded URL of a `.tar` or `.tar.gz` archive containing the
+project files. The frontend downloads and extracts this project into the workspace.
+* `path`: A URI-encoded relative path of the file to open in the editor workspace
+once the project is loaded (e.g., `lib/main.dart`).
 
 Example:
 ```url
 http://localhost:8080/?archive=https://pub.dev/api/archives/material_ui-0.0.3.tar.gz&path=example/README.md
 ```
+
+### Loading from Package Name
+
+To load the example project of a package published on pub.dev, use the
+following parameter:
+
+* `package`: The name of the package. The frontend fetches the latest version
+of the package, extracts its archive, automatically locates the package's example
+file (e.g., `example/main.dart` or `example/example.dart`), and opens it.
+
+Example:
+```url
+http://localhost:8080/?package=material_ui
+```
+
+> [!NOTE]
+> If neither of these parameter combinations is matched at startup, the
+application falls back to loading the default sample project.
 
 ## SDK assets
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -44,6 +44,7 @@ class AppState extends State<App> {
 
   String loadingStatus = 'Loading Workspace...';
   String _projectDir = '';
+  String? _errorMessage;
 
   @override
   void initState() {
@@ -132,38 +133,59 @@ class AppState extends State<App> {
   Future<void> loadProject() async {
     final params = Uri.base.queryParameters;
 
-    if (params case {
-      'archive': final String archiveUrlParam,
-      'path': final String filePathParam,
-    }) {
-      final archiveUrl = Uri.decodeComponent(archiveUrlParam);
-      final filePath = Uri.decodeComponent(filePathParam);
-      final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
-      final (projectDir, targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
-      setState(() {
-        _projectDir = projectDir;
-      });
-      _fileTree.focusPath(projectDir);
-      if (targetFilePath != null) {
-        unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
+    try {
+      if (params case {
+        'archive': final String archiveUrlParam,
+        'path': final String filePathParam,
+      }) {
+        setState(() {
+          loadingStatus = 'Downloading Archive...';
+          _errorMessage = null;
+        });
+        final archiveUrl = Uri.decodeComponent(archiveUrlParam);
+        final filePath = Uri.decodeComponent(filePathParam);
+        final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
+        final (:projectDir, :targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
+        setState(() {
+          _projectDir = projectDir;
+        });
+        _fileTree.focusPath(projectDir);
+        if (targetFilePath != null) {
+          unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
+        }
+      } else if (params case {'package': final String packageName}) {
+        setState(() {
+          loadingStatus = 'Resolving Package...';
+          _errorMessage = null;
+        });
+        final loader = await ArchiveLoader.forPackage(packageName);
+        setState(() {
+          loadingStatus = 'Downloading Package...';
+        });
+        final (:projectDir, :targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
+        setState(() {
+          _projectDir = projectDir;
+        });
+        _fileTree.focusPath(projectDir);
+        if (targetFilePath != null) {
+          unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
+        }
+      } else {
+        setState(() {
+          loadingStatus = 'Creating Sample Project...';
+          _errorMessage = null;
+        });
+        await createSampleProject(_workspaceRepository.root);
+        setState(() {
+          _projectDir = '';
+        });
+        _fileTree.focusPath('');
+        unawaited(openSampleProject(_tabs.openFile));
       }
-    } else if (params case {'package': final String packageName}) {
-      final loader = await ArchiveLoader.forPackage(packageName);
-      final (projectDir, targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
+    } catch (error) {
       setState(() {
-        _projectDir = projectDir;
+        _errorMessage = 'Failed to load project: $error';
       });
-      _fileTree.focusPath(projectDir);
-      if (targetFilePath != null) {
-        unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
-      }
-    } else {
-      await createSampleProject(_workspaceRepository.root);
-      setState(() {
-        _projectDir = '';
-      });
-      _fileTree.focusPath('');
-      unawaited(openSampleProject(_tabs.openFile));
     }
   }
 
@@ -189,7 +211,7 @@ class AppState extends State<App> {
       builder: (context) => EditorShell(
         openTabs: _tabs.openTabs,
         activeFile: _tabs.activeFile,
-        errorMessage: _tabs.errorMessage,
+        errorMessage: _errorMessage ?? _tabs.errorMessage,
         warningMessage: _tabs.warningMessage,
         fileTree: _buildFileTree(),
         onSwitchFile: _tabs.switchFile,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -139,12 +139,24 @@ class AppState extends State<App> {
       final archiveUrl = Uri.decodeComponent(archiveUrlParam);
       final filePath = Uri.decodeComponent(filePathParam);
       final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
-      final projectDir = await loader.loadArchive(_workspaceRepository.root);
+      final (projectDir, targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
       setState(() {
         _projectDir = projectDir;
       });
       _fileTree.focusPath(projectDir);
-      unawaited(_tabs.openFile(workspaceContext.normalize(filePath)));
+      if (targetFilePath != null) {
+        unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
+      }
+    } else if (params case {'package': final String packageName}) {
+      final loader = await ArchiveLoader.forPackage(packageName);
+      final (projectDir, targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
+      setState(() {
+        _projectDir = projectDir;
+      });
+      _fileTree.focusPath(projectDir);
+      if (targetFilePath != null) {
+        unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
+      }
     } else {
       await createSampleProject(_workspaceRepository.root);
       setState(() {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
@@ -15,14 +16,33 @@ class ArchiveLoader {
   /// Creates an archive loader.
   const ArchiveLoader({
     required this.archiveUrl,
-    required this.filePath,
+    this.packageName,
+    this.filePath,
   });
+
+  static Future<ArchiveLoader> forPackage(String packageName) async {
+    final String url = 'https://pub.dev/api/packages/$packageName';
+    final http.Response response = await http.get(Uri.parse(url));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load package $packageName');
+    }
+
+    final Map<String, dynamic> json = jsonDecode(response.body) as Map<String, dynamic>;
+    if (json case {'latest': {'archive_url': final String archiveUrl}}) {
+      return ArchiveLoader(archiveUrl: archiveUrl, packageName: packageName);
+    }
+
+    throw Exception('Failed to load package $packageName: Unexpected JSON response.');
+  }
 
   /// The absolute URL pointing to the tar or gzipped tar archive.
   final String archiveUrl;
 
+  /// The name of the package that the archive belongs to.
+  final String? packageName;
+
   /// The workspace-relative file path within the project to open after extraction.
-  final String filePath;
+  final String? filePath;
 
   /// Downloads, decompresses, and extracts all files from the [archiveUrl]
   /// into the workspace [root].
@@ -30,7 +50,7 @@ class ArchiveLoader {
   /// Scans the archive files to find the nearest parent directory of [filePath]
   /// that contains a `pubspec.yaml` file. Returns the path to that directory
   /// relative to the archive root.
-  Future<String> loadArchive(WorkspaceFolder root) async {
+  Future<(String, String?)> loadArchive(WorkspaceFolder root) async {
     final Uri uri = Uri.parse(archiveUrl);
     if (!uri.isAbsolute) {
       throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
@@ -49,32 +69,32 @@ class ArchiveLoader {
 
     final Archive archive = TarDecoder().decodeBytes(tarBytes);
 
-    final String normalizedFilePath = workspaceContext.normalize(filePath);
-    final Set<String> archivePaths = <String>{};
-    for (final ArchiveFile file in archive.files) {
-      String name = file.name;
-      if (name.startsWith('./')) {
-        name = name.substring(2);
-      } else if (name.startsWith('/')) {
-        name = name.substring(1);
+    final targetFilePath = filePath ?? findExampleFile(archive);
+    String projectDir = '';
+
+    if (targetFilePath != null) {
+      final String normalizedFilePath = workspaceContext.normalize(targetFilePath);
+      final Set<String> archivePaths = <String>{};
+      for (final ArchiveFile file in archive.files) {
+        String name = file.name;
+        if (name.startsWith('./')) {
+          name = name.substring(2);
+        } else if (name.startsWith('/')) {
+          name = name.substring(1);
+        }
+        archivePaths.add(name);
       }
-      archivePaths.add(name);
-    }
 
-    final List<String> segments = normalizedFilePath.split('/');
-    String? rootProjectDir;
+      final List<String> segments = normalizedFilePath.split('/');
 
-    for (int i = segments.length - 1; i >= 0; i--) {
-      final String parentDir = segments.sublist(0, i).join('/');
-      final String pubspecPath = parentDir.isEmpty ? 'pubspec.yaml' : '$parentDir/pubspec.yaml';
-      if (archivePaths.contains(pubspecPath)) {
-        rootProjectDir = parentDir;
-        break;
+      for (int i = segments.length - 1; i >= 0; i--) {
+        final String parentDir = segments.sublist(0, i).join('/');
+        final String pubspecPath = parentDir.isEmpty ? 'pubspec.yaml' : '$parentDir/pubspec.yaml';
+        if (archivePaths.contains(pubspecPath)) {
+          projectDir = parentDir;
+          break;
+        }
       }
-    }
-
-    if (rootProjectDir == null) {
-      throw Exception('Could not find pubspec.yaml in any parent directory of $filePath');
     }
 
     final List<ArchiveFile> filesToExtract = <ArchiveFile>[];
@@ -121,6 +141,33 @@ class ArchiveLoader {
       await root.workspace.writeFileFromBytes(root.getFile(name).path, fileBytes);
     }
 
-    return rootProjectDir;
+    return (projectDir, targetFilePath);
+  }
+
+  /// Finds the example file in the archive, returning null if not found.
+  String? findExampleFile(Archive archive) {
+    final List<String> exampleFilenames = [
+      'example/main.dart',
+      'example/lib/main.dart',
+      if (packageName != null) ...[
+        'example/$packageName.dart',
+        'example/lib/$packageName.dart',
+        'example/${packageName}_example.dart',
+        'example/lib/${packageName}_example.dart',
+      ],
+      'example/example.dart',
+      'example/lib/example.dart',
+      'example/example.md',
+      'example/README.md',
+    ];
+
+    for (final String exampleFilename in exampleFilenames) {
+      final ArchiveFile? file = archive.find(exampleFilename);
+      if (file != null) {
+        return exampleFilename;
+      }
+    }
+
+    return null;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -27,7 +27,7 @@ class ArchiveLoader {
       throw Exception('Failed to load package $packageName');
     }
 
-    final Map<String, dynamic> json = jsonDecode(response.body) as Map<String, dynamic>;
+    final Map<String, Object?> json = jsonDecode(response.body) as Map<String, Object?>;
     if (json case {'latest': {'archive_url': final String archiveUrl}}) {
       return ArchiveLoader(archiveUrl: archiveUrl, packageName: packageName);
     }
@@ -47,10 +47,15 @@ class ArchiveLoader {
   /// Downloads, decompresses, and extracts all files from the [archiveUrl]
   /// into the workspace [root].
   ///
-  /// Scans the archive files to find the nearest parent directory of [filePath]
-  /// that contains a `pubspec.yaml` file. Returns the path to that directory
-  /// relative to the archive root.
-  Future<(String, String?)> loadArchive(WorkspaceFolder root) async {
+  /// Scans the archive files to find the nearest parent directory containing
+  /// a `pubspec.yaml` file for the active target file.
+  ///
+  /// Returns a record containing:
+  /// - `projectDir`: The path to the project directory relative to the archive root.
+  /// - `targetFilePath`: The path to the file to open after extraction, which is
+  ///   either the provided [filePath] or resolved by searching the archive for
+  ///   well-known example files.
+  Future<({String projectDir, String? targetFilePath})> loadArchive(WorkspaceFolder root) async {
     final Uri uri = Uri.parse(archiveUrl);
     if (!uri.isAbsolute) {
       throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
@@ -141,7 +146,7 @@ class ArchiveLoader {
       await root.workspace.writeFileFromBytes(root.getFile(name).path, fileBytes);
     }
 
-    return (projectDir, targetFilePath);
+    return (projectDir: projectDir, targetFilePath: targetFilePath);
   }
 
   /// Finds the example file in the archive, returning null if not found.

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -151,7 +151,8 @@ void main() {
         }),
       );
 
-      expect(result, ('', 'my_project/lib/main.dart'));
+      expect(result.projectDir, '');
+      expect(result.targetFilePath, 'my_project/lib/main.dart');
       expect(await api.fileExist('my_project/lib/main.dart'), isTrue);
       expect(await api.readFileAsText('my_project/lib/main.dart'), 'void main() {}');
     });

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -132,7 +132,7 @@ void main() {
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
     });
 
-    test('throws Exception if no pubspec.yaml is found in the walk', () async {
+    test('falls back to root folder if no pubspec.yaml is found', () async {
       final Map<String, String> archiveFiles = {
         'my_project/lib/main.dart': 'void main() {}',
       };
@@ -144,17 +144,16 @@ void main() {
       );
       final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
 
-      await http.runWithClient(
-        () async {
-          expect(
-            () => loader.loadArchive(api.root),
-            throwsException,
-          );
-        },
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
         () => MockClient((http.Request request) async {
           return http.Response.bytes(archiveBytes, 200);
         }),
       );
+
+      expect(result, ('', 'my_project/lib/main.dart'));
+      expect(await api.fileExist('my_project/lib/main.dart'), isTrue);
+      expect(await api.readFileAsText('my_project/lib/main.dart'), 'void main() {}');
     });
   });
 }


### PR DESCRIPTION
Convenience PR to load a project from a package name. The archive url is automatically determined via the pub.dev api, and the target file is determined by looking for well-known example files as described here: https://dart.dev/tools/pub/package-layout#examples

E.g. http://localhost:8080/?package=material_ui

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
