### PR TITLE
feat(dartpad_preview): setup preview panel

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -20,8 +20,11 @@ import 'features/editor/view_models/tabs_view_model.dart';
 import 'features/filetree/file_tree_tabs_adapter.dart';
 import 'features/filetree/file_tree_view.dart';
 import 'features/filetree/file_tree_view_model.dart';
+import 'features/preview/view/preview_container.dart';
+import 'features/preview/view_models/preview_view_model.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/footer.dart';
+import 'features/shared/components/split_panel.dart';
 import 'features/shared/events/log_event.dart';
 import 'features/shared/events/workspace_event.dart';
 import 'features/startup/archive_loader.dart';
@@ -47,6 +50,7 @@ class AppState extends State<App> {
   late final FileTreeViewModel _fileTree;
   late final DiagnosticsViewModel _diagnostics;
   late final DebugConsoleViewModel _debugConsole;
+  late final PreviewViewModel _preview;
 
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
 
@@ -75,6 +79,8 @@ class AppState extends State<App> {
       workspace: _workspaceRepository.workspaceResourceApi,
     );
     _diagnostics = DiagnosticsViewModel(tabs: _tabs);
+
+    _preview = PreviewViewModel(workspaceRepository: _workspaceRepository, eventBus: _events);
 
     final projectFuture = loadProject();
 
@@ -231,14 +237,23 @@ class AppState extends State<App> {
       listenable: _tabs,
       builder: (context) => div(classes: 'app-shell', [
         div(classes: 'app-workspace', [
-          EditorShell(
-            openTabs: _tabs.openTabs,
-            activeFile: _tabs.activeFile,
-            fileTree: _buildFileTree(),
-            editorOverlay: _buildEditorOverlay(),
-            onSwitchFile: _tabs.switchFile,
-            onCloseFile: _tabs.closeFile,
-            bottomPanel: _buildBottomPanel(),
+          SplitPanel(
+            left: EditorShell(
+              openTabs: _tabs.openTabs,
+              activeFile: _tabs.activeFile,
+              fileTree: _buildFileTree(),
+              editorOverlay: _buildEditorOverlay(),
+              onSwitchFile: _tabs.switchFile,
+              onCloseFile: _tabs.closeFile,
+              bottomPanel: _buildBottomPanel(),
+            ),
+            right: ListenableBuilder(
+              listenable: _preview,
+              builder: (context) => PreviewContainer(
+                preview: _preview,
+                activeFile: _tabs.activeFile,
+              ),
+            ),
           ),
         ]),
         Footer(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -238,6 +238,7 @@ class AppState extends State<App> {
       builder: (context) => div(classes: 'app-shell', [
         div(classes: 'app-workspace', [
           SplitPanel(
+            initialValue: 0.7,
             left: EditorShell(
               openTabs: _tabs.openTabs,
               activeFile: _tabs.activeFile,
@@ -247,13 +248,7 @@ class AppState extends State<App> {
               onCloseFile: _tabs.closeFile,
               bottomPanel: _buildBottomPanel(),
             ),
-            right: ListenableBuilder(
-              listenable: _preview,
-              builder: (context) => PreviewContainer(
-                preview: _preview,
-                activeFile: _tabs.activeFile,
-              ),
-            ),
+            right: _buildPreviewPanel(),
           ),
         ]),
         Footer(
@@ -301,6 +296,16 @@ class AppState extends State<App> {
       builder: (context) => FileTreeView(
         state: _fileTree.state,
         actions: _fileTree.actions,
+      ),
+    );
+  }
+
+  Component _buildPreviewPanel() {
+    return ListenableBuilder(
+      listenable: _preview,
+      builder: (context) => PreviewContainer(
+        preview: _preview,
+        activeFile: _tabs.activeFile,
       ),
     );
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -51,61 +51,52 @@ class EditorShell extends StatelessComponent {
   @override
   Component build(BuildContext context) {
     final openTabs = this.openTabs;
-    return div(classes: 'ide-shell', [
-      div(classes: 'workspace-shell', [
-        SplitPanel(
-          initialValue: 200,
-          useRatio: false,
-          minValue: 150,
-          maxValue: 300,
-          left: aside(classes: 'file-tree-pane', [fileTree]),
-          right: main_(classes: 'editor-host', [
-            SplitPanel(
-              isVertical: true,
-              useRatio: true,
-              initialValue: 0.75,
-              minValue: 0.3,
-              maxValue: 0.9,
-              left: div(classes: 'editor-area', [
-                if (openTabs != null) ...[
-                  EditorTabs(
-                    openTabs: openTabs,
-                    activeFile: activeFile,
-                    onSwitchFile: onSwitchFile!,
-                    onCloseFile: onCloseFile!,
-                  ),
-                  EditorStack(
-                    openTabs: openTabs,
-                    activeFile: activeFile,
-                    overlay: editorOverlay,
-                  ),
-                ],
-              ]),
-              right: bottomPanel,
-            ),
-          ]),
-        ),
-      ]),
+    return div(classes: 'editor-shell', [
+      SplitPanel(
+        initialValue: 200,
+        useRatio: false,
+        minValue: 150,
+        maxValue: 300,
+        left: aside(classes: 'file-tree-pane', [fileTree]),
+        right: main_(classes: 'editor-host', [
+          SplitPanel(
+            isVertical: true,
+            useRatio: true,
+            initialValue: 0.75,
+            minValue: 0.3,
+            maxValue: 0.9,
+            left: div(classes: 'editor-area', [
+              if (openTabs != null) ...[
+                EditorTabs(
+                  openTabs: openTabs,
+                  activeFile: activeFile,
+                  onSwitchFile: onSwitchFile!,
+                  onCloseFile: onCloseFile!,
+                ),
+                EditorStack(
+                  openTabs: openTabs,
+                  activeFile: activeFile,
+                  overlay: editorOverlay,
+                ),
+              ],
+            ]),
+            right: bottomPanel,
+          ),
+        ]),
+      ),
     ]);
   }
 
   @css
   static List<StyleRule> get styles => [
-    css('.ide-shell').styles(
+    css('.editor-shell').styles(
       display: .flex,
       width: 100.percent,
       height: 100.percent,
       minWidth: .zero,
       minHeight: .zero,
-      flexDirection: .column,
       flex: const Flex(grow: 1, basis: .zero),
       backgroundColor: const Color('#1e1e1e'),
-    ),
-    css('.workspace-shell').styles(
-      display: .flex,
-      minWidth: .zero,
-      minHeight: .zero,
-      flex: const Flex(grow: 1, basis: .zero),
     ),
     css('.file-tree-pane').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
@@ -103,7 +103,7 @@ final class EditorTabs extends StatelessComponent {
     css('.editor-tabs', [
       css('&').styles(
         display: .flex,
-        minHeight: 36.px,
+        minHeight: 38.px,
         overflow: const .only(x: .auto, y: .hidden),
         flex: const .shrink(0),
         backgroundColor: const Color('#181818'),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -1,0 +1,99 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../shared/icons.dart';
+import '../view_models/preview_view_model.dart';
+
+/// A button component used to trigger preview runtime actions
+/// (Start, Restart, Hot Reload, Stop).
+class RuntimeButton extends StatelessComponent {
+  /// Creates a runtime button with direct configurations.
+  const RuntimeButton({
+    required this.title,
+    required this.icon,
+    required this.isEnabled,
+    required this.onClick,
+    super.key,
+  });
+
+  /// Factory constructor for a 'Start' button that runs the [activeFile]
+  /// or falls back to 'lib/main.dart' if no active file is present.
+  factory RuntimeButton.start({
+    required PreviewViewModel previewViewModel,
+    required String activeFile,
+  }) {
+    return RuntimeButton(
+      title: 'Start',
+      icon: 'play_arrow',
+      isEnabled: previewViewModel.canStart,
+      onClick: () => previewViewModel.runCode(
+        activeFile.isNotEmpty ? activeFile : 'lib/main.dart',
+      ),
+    );
+  }
+
+  /// Factory constructor for a 'Restart' button that restarts execution of
+  /// the currently running entrypoint, skipping recompilation.
+  factory RuntimeButton.restart({required PreviewViewModel previewViewModel}) {
+    return RuntimeButton(
+      title: 'Restart',
+      icon: 'restart_alt',
+      isEnabled: previewViewModel.canRestart,
+      onClick: () => previewViewModel.runCode(
+        previewViewModel.state.entrypoint ?? 'lib/main.dart',
+        skipRecompilation: true,
+      ),
+    );
+  }
+
+  /// Factory constructor for a 'Hot Reload' button that hot reloads changes
+  /// in the currently running entrypoint.
+  factory RuntimeButton.hotReload({required PreviewViewModel previewViewModel}) {
+    return RuntimeButton(
+      title: 'Hot Reload',
+      icon: 'bolt',
+      isEnabled: previewViewModel.canHotReload,
+      onClick: () => previewViewModel.hotReloadCode(),
+    );
+  }
+
+  /// Factory constructor for a 'Stop' button that terminates execution
+  /// and stops the running application preview.
+  factory RuntimeButton.stop({required PreviewViewModel previewViewModel}) {
+    return RuntimeButton(
+      title: 'Stop',
+      icon: 'stop',
+      isEnabled: previewViewModel.canStop,
+      onClick: () => previewViewModel.stopCode(),
+    );
+  }
+
+  /// The tooltip/accessible title of the button.
+  final String title;
+
+  /// The name of the icon to render within the button.
+  final String icon;
+
+  /// Whether the button is enabled for interaction.
+  final bool isEnabled;
+
+  /// Callback executed when the button is clicked.
+  final Future<void> Function() onClick;
+
+  @override
+  Component build(BuildContext context) {
+    //final previewViewModel = context.watch<PreviewViewModel>();
+    //final enabled = type.isEnabled(previewViewModel);
+
+    return button(
+      onClick: onClick,
+      [
+        Icon(icon),
+      ],
+    );
+    // label: type.title,
+    // icon: type.icon,
+    // disabled: !enabled,
+    // tooltip: type.title,
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -1,7 +1,12 @@
-import 'package:jaspr/dom.dart';
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
 import 'package:jaspr/jaspr.dart';
 
-import '../../shared/icons.dart';
+import '../../shared/components/icon_button.dart';
 import '../view_models/preview_view_model.dart';
 
 /// A button component used to trigger preview runtime actions
@@ -82,18 +87,12 @@ class RuntimeButton extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    //final previewViewModel = context.watch<PreviewViewModel>();
-    //final enabled = type.isEnabled(previewViewModel);
-
-    return button(
-      onClick: onClick,
-      [
-        Icon(icon),
-      ],
+    return IconButton(
+      label: title,
+      icon: icon,
+      disabled: !isEnabled,
+      tooltip: title,
+      onClick: (_) => onClick(),
     );
-    // label: type.title,
-    // icon: type.icon,
-    // disabled: !enabled,
-    // tooltip: type.title,
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/compiler_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/compiler_session.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad/dartpad.dart';
+
+/// Represents a hot-reload compilation session.
+abstract interface class CompilerSession {
+  Future<({String? code, List<String> compiledLibraryUris, String? log})> compile();
+  Future<void> close();
+}
+
+/// A wrapper around [HotReloadCompiler] implementing [CompilerSession].
+class RealCompilerSession implements CompilerSession {
+  RealCompilerSession(this._compiler);
+
+  final HotReloadCompiler _compiler;
+
+  @override
+  Future<({String? code, List<String> compiledLibraryUris, String? log})> compile() => _compiler.compile();
+
+  @override
+  Future<void> close() => _compiler.close();
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_sandbox.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_sandbox.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad/dartpad.dart';
+
+/// A sandboxed environment for code preview.
+abstract interface class PreviewSandbox {
+  void dispose();
+  Future<void> loadModule({required String code});
+  Future<void> runApp(Uri libraryUri);
+  Future<void> hotReload({required String? code, required List<Uri> librariesToReload});
+  Stream<ConsoleMessage> get onConsole;
+  Stream<({String message})> get onError;
+  Stream<({String message})> get onUnhandledRejection;
+}
+
+/// A wrapper around [Sandbox] implementing [PreviewSandbox].
+class RealPreviewSandbox implements PreviewSandbox {
+  RealPreviewSandbox(this._sandbox);
+
+  final Sandbox _sandbox;
+
+  @override
+  void dispose() => _sandbox.dispose();
+
+  @override
+  Future<void> loadModule({required String code}) => _sandbox.loadModule(code: code);
+
+  @override
+  Future<void> runApp(Uri libraryUri) => _sandbox.runApp(libraryUri);
+
+  @override
+  Future<void> hotReload({required String? code, required List<Uri> librariesToReload}) =>
+      _sandbox.hotReload(code: code, librariesToReload: librariesToReload);
+
+  @override
+  Stream<ConsoleMessage> get onConsole => _sandbox.onConsole;
+
+  @override
+  Stream<({String message})> get onError => _sandbox.onError;
+
+  @override
+  Stream<({String message})> get onUnhandledRejection => _sandbox.onUnhandledRejection;
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
@@ -1,0 +1,54 @@
+/// Base sealed class representing the current visual and execution state of
+/// the preview.
+sealed class PreviewState {
+  /// The entrypoint path associated with this state, if any; otherwise `null`.
+  String? get entrypoint => null;
+}
+
+/// The initial state when no preview has started yet.
+class PreviewInitial extends PreviewState {}
+
+/// Base class for states that represent an active preview session executing a
+/// specific [entrypoint].
+class _ActivePreviewState extends PreviewState {
+  _ActivePreviewState(this.entrypoint);
+
+  @override
+  final String entrypoint;
+}
+
+/// State representing a fresh startup compilation and execution lifecycle.
+class PreviewStarting extends _ActivePreviewState {
+  PreviewStarting(super.entrypoint);
+}
+
+/// State representing an active running application preview.
+class PreviewRunning extends _ActivePreviewState {
+  PreviewRunning(super.entrypoint);
+}
+
+/// State representing a restart of the application execution using cached
+/// compiled assets.
+class PreviewRestarting extends _ActivePreviewState {
+  PreviewRestarting(super.entrypoint);
+}
+
+/// State representing a compiler session hot-reloading code modifications.
+class PreviewHotReloading extends _ActivePreviewState {
+  PreviewHotReloading(super.entrypoint);
+}
+
+/// State representing an active stop/shutdown execution process.
+class PreviewStopping extends PreviewState {}
+
+/// State representing a compiler or runtime failure while compiling the
+/// [entrypoint].
+class PreviewCompileError extends PreviewState {
+  PreviewCompileError(this.entrypoint, this.message);
+
+  @override
+  final String entrypoint;
+
+  /// The error message describing the failure.
+  final String message;
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 /// Base sealed class representing the current visual and execution state of
 /// the preview.
 sealed class PreviewState {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -64,7 +64,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
 
     return div(classes: 'preview-container', [
       div(classes: 'preview-toolbar', [
-        div(classes: 'left-controls', [
+        div(classes: 'preview-controls', [
           ButtonGroup(
             children: [
               if (isRunning)
@@ -108,13 +108,6 @@ class _PreviewContainerState extends State<PreviewContainer> {
         flex: const .grow(1),
         backgroundColor: colorContainerLow,
       ),
-      css('.active-icon-btn').styles(
-        color: colorOnPrimary,
-        backgroundColor: colorPrimary,
-      ),
-      css('.active-icon-btn:not(.disabled):hover').styles(
-        backgroundColor: colorPrimary,
-      ),
       css('.preview-toolbar', [
         css('&').styles(
           display: .flex,
@@ -127,21 +120,8 @@ class _PreviewContainerState extends State<PreviewContainer> {
           flex: const .shrink(0),
           backgroundColor: colorContainerLow,
         ),
-        css('.left-controls').styles(
+        css('.preview-controls').styles(
           display: .flex,
-          alignItems: .center,
-          flex: const .grow(1),
-          raw: {'flex-basis': '0%'},
-        ),
-        css('.center-controls').styles(
-          display: .flex,
-          justifyContent: .center,
-          alignItems: .center,
-          raw: {'flex-shrink': '0'},
-        ),
-        css('.right-controls').styles(
-          display: .flex,
-          justifyContent: .end,
           alignItems: .center,
           flex: const .grow(1),
           raw: {'flex-basis': '0%'},
@@ -213,22 +193,6 @@ class _PreviewContainerState extends State<PreviewContainer> {
           css('&.preview-toast-error').styles(
             backgroundColor: const Color('rgba(127, 29, 29, 0.9)'),
           ),
-          css('.preview-toast-action', [
-            css('&').styles(
-              padding: .symmetric(vertical: 4.px, horizontal: 10.px),
-              border: .all(color: const Color('rgba(255, 255, 255, 0.3)'), width: 1.px),
-              radius: .circular(4.px),
-              cursor: .pointer,
-              color: Colors.white,
-              fontSize: 12.px,
-              fontWeight: .w600,
-              backgroundColor: Colors.transparent,
-              raw: {'outline': 'none'},
-            ),
-            css('&:hover').styles(
-              backgroundColor: const Color('rgba(255, 255, 255, 0.15)'),
-            ),
-          ]),
         ]),
         css('.preview-placeholder').styles(
           display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -118,7 +118,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
       css('.preview-toolbar', [
         css('&').styles(
           display: .flex,
-          padding: .symmetric(vertical: 10.px, horizontal: 12.px),
+          padding: .symmetric(vertical: 4.px, horizontal: 12.px),
           border: .only(
             bottom: .solid(color: colorBorder, width: 1.px),
           ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -1,0 +1,240 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../../app_styles.dart';
+import '../../shared/components/button_group.dart';
+import '../../shared/node_container.dart';
+import '../components/runtime_button.dart';
+import '../models/preview_state.dart';
+import '../view_models/preview_view_model.dart';
+
+/// A container component that hosts the preview frame toolbar, status toast
+/// messages, and the sandbox node where the compiled application runs.
+class PreviewContainer extends StatefulComponent {
+  const PreviewContainer({
+    required this.preview,
+    required this.activeFile,
+    super.key,
+  });
+
+  /// The view model that manages compilation and run operations for the preview.
+  final PreviewViewModel preview;
+
+  /// The path of the currently active file in the editor workspace.
+  final String activeFile;
+
+  @override
+  State<PreviewContainer> createState() => _PreviewContainerState();
+
+  @css
+  static List<StyleRule> get styles => _PreviewContainerState.styles;
+}
+
+class _PreviewContainerState extends State<PreviewContainer> {
+  @override
+  Component build(BuildContext context) {
+    final viewModel = component.preview;
+    final state = viewModel.state;
+    final isRunning = viewModel.isRunning;
+
+    final statusToast = switch (state) {
+      PreviewStarting() => const div(classes: 'preview-toast', [
+        div(classes: 'status-spinner', []),
+        span([.text('Starting...')]),
+      ]),
+      PreviewRestarting() => const div(classes: 'preview-toast', [
+        div(classes: 'status-spinner', []),
+        span([.text('Restarting...')]),
+      ]),
+      PreviewHotReloading() => null,
+      PreviewStopping() => const div(classes: 'preview-toast', [
+        div(classes: 'status-spinner', []),
+        span([.text('Stopping...')]),
+      ]),
+      PreviewCompileError() => const div(classes: 'preview-toast preview-toast-error', [
+        span(classes: 'status-icon', [.text('⚠️')]),
+        span([.text('Start failed')]),
+      ]),
+      _ => null,
+    };
+
+    return div(classes: 'preview-container', [
+      div(classes: 'preview-toolbar', [
+        div(classes: 'left-controls', [
+          ButtonGroup(
+            children: [
+              if (isRunning)
+                RuntimeButton.restart(previewViewModel: viewModel)
+              else
+                RuntimeButton.start(
+                  previewViewModel: viewModel,
+                  activeFile: component.activeFile,
+                ),
+              RuntimeButton.hotReload(previewViewModel: viewModel),
+              RuntimeButton.stop(previewViewModel: viewModel),
+            ],
+          ),
+        ]),
+      ]),
+      div(
+        classes: 'preview-content ${!isRunning ? 'status-stopped' : ''}',
+        [
+          NodeContainer(viewModel.containerElement),
+          if (state is PreviewInitial)
+            const div(classes: 'preview-placeholder', [
+              span([.text('Start your app to see the preview.')]),
+            ]),
+          ?statusToast,
+        ],
+      ),
+    ]);
+  }
+
+  static List<StyleRule> get styles => [
+    css.keyframes('spin', {
+      '0%': Styles(transform: .rotate(0.deg)),
+      '100%': Styles(transform: .rotate(360.deg)),
+    }),
+    css('.preview-container', [
+      css('&').styles(
+        display: .flex,
+        position: const .relative(),
+        overflow: .hidden,
+        flexDirection: .column,
+        flex: const .grow(1),
+        backgroundColor: colorContainerLow,
+      ),
+      css('.active-icon-btn').styles(
+        color: colorOnPrimary,
+        backgroundColor: colorPrimary,
+      ),
+      css('.active-icon-btn:not(.disabled):hover').styles(
+        backgroundColor: colorPrimary,
+      ),
+      css('.preview-toolbar', [
+        css('&').styles(
+          display: .flex,
+          padding: .symmetric(vertical: 10.px, horizontal: 12.px),
+          border: .only(
+            bottom: .solid(color: colorBorder, width: 1.px),
+          ),
+          justifyContent: .spaceBetween,
+          alignItems: .center,
+          flex: const .shrink(0),
+          backgroundColor: colorContainerLow,
+        ),
+        css('.left-controls').styles(
+          display: .flex,
+          alignItems: .center,
+          flex: const .grow(1),
+          raw: {'flex-basis': '0%'},
+        ),
+        css('.center-controls').styles(
+          display: .flex,
+          justifyContent: .center,
+          alignItems: .center,
+          raw: {'flex-shrink': '0'},
+        ),
+        css('.right-controls').styles(
+          display: .flex,
+          justifyContent: .end,
+          alignItems: .center,
+          flex: const .grow(1),
+          raw: {'flex-basis': '0%'},
+        ),
+      ]),
+      css('.preview-content', [
+        css('&').styles(
+          display: .flex,
+          position: const .relative(),
+          padding: Padding.zero,
+          boxSizing: .borderBox,
+          justifyContent: .center,
+          alignItems: .center,
+          flex: const .grow(1),
+        ),
+        css('& .preview, & iframe').styles(
+          width: 100.percent,
+          height: 100.percent,
+          border: .none,
+        ),
+        css('&.status-stopped > .preview').styles(
+          visibility: .hidden,
+        ),
+        css('& > .preview').styles(
+          width: 100.percent,
+          height: 100.percent,
+          border: .none,
+          radius: .circular(0.px),
+          shadow: .none,
+        ),
+        css('.preview-toast', [
+          css('&').styles(
+            display: .flex,
+            position: .absolute(top: 16.px, left: 16.px),
+            zIndex: const ZIndex(10),
+            padding: .symmetric(vertical: 8.px, horizontal: 16.px),
+            border: const .all(color: Color('rgba(255, 255, 255, 0.12)')),
+            radius: .circular(8.px),
+            shadow: BoxShadow(
+              offsetX: 0.px,
+              offsetY: 4.px,
+              blur: 12.px,
+              color: Colors.black.withOpacity(0.3),
+            ),
+            backdropFilter: .blur(8.px),
+            alignItems: .center,
+            gap: .all(8.px),
+            color: colorOnSurface,
+            fontSize: 14.px,
+            fontWeight: .w500,
+            backgroundColor: const Color('rgba(15, 23, 42, 0.8)'),
+          ),
+          css('.status-spinner').styles(
+            width: 14.px,
+            height: 14.px,
+            border: .only(
+              top: .solid(color: Colors.white, width: 2.px),
+              right: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
+              bottom: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
+              left: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
+            ),
+            radius: .circular(50.percent),
+            animation: Animation(name: 'spin', duration: 1.seconds, curve: .linear, count: 10e6),
+          ),
+          css('.status-icon').styles(
+            display: .flex,
+            alignItems: .center,
+          ),
+          css('&.preview-toast-error').styles(
+            backgroundColor: const Color('rgba(127, 29, 29, 0.9)'),
+          ),
+          css('.preview-toast-action', [
+            css('&').styles(
+              padding: .symmetric(vertical: 4.px, horizontal: 10.px),
+              border: .all(color: const Color('rgba(255, 255, 255, 0.3)'), width: 1.px),
+              radius: .circular(4.px),
+              cursor: .pointer,
+              color: Colors.white,
+              fontSize: 12.px,
+              fontWeight: .w600,
+              backgroundColor: Colors.transparent,
+              raw: {'outline': 'none'},
+            ),
+            css('&:hover').styles(
+              backgroundColor: const Color('rgba(255, 255, 255, 0.15)'),
+            ),
+          ]),
+        ]),
+        css('.preview-placeholder').styles(
+          display: .flex,
+          position: .absolute(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
+          justifyContent: .center,
+          alignItems: .center,
+          color: colorOnSurfaceVariant,
+          fontSize: 14.px,
+        ),
+      ]),
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -391,4 +391,3 @@ class PreviewViewModel extends ChangeNotifier {
     super.dispose();
   }
 }
-

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -12,9 +12,9 @@ import 'package:web/web.dart' as web;
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
 import '../../workspace/data/workspace_repository.dart';
-import '../models/preview_state.dart';
-import '../models/preview_sandbox.dart';
 import '../models/compiler_session.dart';
+import '../models/preview_sandbox.dart';
+import '../models/preview_state.dart';
 
 /// View model managing compiler sessions, iframe sandbox state, console
 /// stream bindings, and reactive state updates for the application

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -13,6 +13,8 @@ import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
 import '../../workspace/data/workspace_repository.dart';
 import '../models/preview_state.dart';
+import '../models/preview_sandbox.dart';
+import '../models/compiler_session.dart';
 
 /// View model managing compiler sessions, iframe sandbox state, console
 /// stream bindings, and reactive state updates for the application
@@ -21,6 +23,7 @@ class PreviewViewModel extends ChangeNotifier {
   PreviewViewModel({
     required this.workspaceRepository,
     required this.eventBus,
+    this.createSandbox = _createRealSandbox,
   });
 
   /// Repository for working with file systems, compiler sessions, and
@@ -30,8 +33,17 @@ class PreviewViewModel extends ChangeNotifier {
   /// Global event bus for logging and UI command dispatching.
   final AppEventBus eventBus;
 
-  Sandbox? _sandbox;
-  HotReloadCompiler? _hotReloadCompiler;
+  /// Creates a sandboxed environment for execution.
+  final Future<PreviewSandbox> Function(web.Node, {required Uri assetBaseUrl}) createSandbox;
+
+  static Future<PreviewSandbox> _createRealSandbox(web.Node container, {required Uri assetBaseUrl}) async {
+    final sandbox = await Sandbox.createIFrame(container, assetBaseUrl: assetBaseUrl);
+    return RealPreviewSandbox(sandbox);
+  }
+
+  PreviewSandbox? _sandbox;
+  CompilerSession? _hotReloadCompiler;
+  bool _disposed = false;
   StreamSubscription<dynamic>? _sandboxConsoleSubscription;
   StreamSubscription<dynamic>? _sandboxErrorSubscription;
   StreamSubscription<dynamic>? _sandboxRejectionSubscription;
@@ -137,7 +149,7 @@ class PreviewViewModel extends ChangeNotifier {
         if (!_isCurrentOperation(operationId)) {
           return;
         }
-        eventBus.dispatch(LogEvent(result.log));
+        eventBus.dispatch(LogEvent(result.log ?? ''));
         eventBus.dispatch(const LogEvent('Compilation succeeded.'));
         _lastCompiledCode = result.code;
         codeToLoad = result.code!;
@@ -157,7 +169,7 @@ class PreviewViewModel extends ChangeNotifier {
       }
 
       eventBus.dispatch(const LogEvent('Creating preview sandbox...'));
-      final sandbox = await Sandbox.createIFrame(
+      final sandbox = await createSandbox(
         _container,
         assetBaseUrl: assetBaseUrl,
       );
@@ -203,7 +215,9 @@ class PreviewViewModel extends ChangeNotifier {
         _state = PreviewCompileError(entrypoint, e.toString());
       }
     } finally {
-      notifyListeners();
+      if (!_disposed) {
+        notifyListeners();
+      }
     }
   }
 
@@ -248,7 +262,7 @@ class PreviewViewModel extends ChangeNotifier {
       if (!_isCurrentOperation(operationId)) {
         return;
       }
-      eventBus.dispatch(LogEvent(result.log));
+      eventBus.dispatch(LogEvent(result.log ?? ''));
 
       eventBus.dispatch(const LogEvent('Applying hot reload...'));
       await sandbox.hotReload(
@@ -277,7 +291,9 @@ class PreviewViewModel extends ChangeNotifier {
         _state = PreviewCompileError(entry, e.toString());
       }
     } finally {
-      notifyListeners();
+      if (!_disposed) {
+        notifyListeners();
+      }
     }
   }
 
@@ -316,10 +332,12 @@ class PreviewViewModel extends ChangeNotifier {
     }
 
     _state = PreviewInitial();
-    notifyListeners();
+    if (!_disposed) {
+      notifyListeners();
+    }
   }
 
-  Future<void> _attachSandboxConsole(Sandbox sandbox) async {
+  Future<void> _attachSandboxConsole(PreviewSandbox sandbox) async {
     await _detachSandboxConsole();
     _sandboxConsoleSubscription = sandbox.onConsole.listen((event) {
       final level = switch (event.level.name) {
@@ -352,7 +370,7 @@ class PreviewViewModel extends ChangeNotifier {
 
   bool _isCurrentOperation(int operationId) => _operationId == operationId;
 
-  Future<void> _disposeCurrentSandbox(Sandbox sandbox) async {
+  Future<void> _disposeCurrentSandbox(PreviewSandbox sandbox) async {
     if (!identical(_sandbox, sandbox)) {
       return;
     }
@@ -363,6 +381,7 @@ class PreviewViewModel extends ChangeNotifier {
 
   @override
   void dispose() {
+    _disposed = true;
     _operationId++;
     unawaited(_detachSandboxConsole());
     _sandbox?.dispose();
@@ -372,3 +391,4 @@ class PreviewViewModel extends ChangeNotifier {
     super.dispose();
   }
 }
+

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 
 import 'package:dartpad/dartpad.dart';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -1,0 +1,370 @@
+import 'dart:async';
+
+import 'package:dartpad/dartpad.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:logging/logging.dart';
+import 'package:web/web.dart' as web;
+
+import '../../shared/app_event_bus.dart';
+import '../../shared/events/log_event.dart';
+import '../../workspace/data/workspace_repository.dart';
+import '../models/preview_state.dart';
+
+/// View model managing compiler sessions, iframe sandbox state, console
+/// stream bindings, and reactive state updates for the application
+/// preview panel.
+class PreviewViewModel extends ChangeNotifier {
+  PreviewViewModel({
+    required this.workspaceRepository,
+    required this.eventBus,
+  });
+
+  /// Repository for working with file systems, compiler sessions, and
+  /// package properties.
+  final WorkspaceRepository workspaceRepository;
+
+  /// Global event bus for logging and UI command dispatching.
+  final AppEventBus eventBus;
+
+  Sandbox? _sandbox;
+  HotReloadCompiler? _hotReloadCompiler;
+  StreamSubscription<dynamic>? _sandboxConsoleSubscription;
+  StreamSubscription<dynamic>? _sandboxErrorSubscription;
+  StreamSubscription<dynamic>? _sandboxRejectionSubscription;
+
+  /// The root HTML container element where the preview iframe sandbox is hosted.
+  web.Element get containerElement => _container;
+  final web.Element _container = web.document.createElement('div')..className = 'preview';
+
+  /// The current state of compiling, validation, running, or stopping the preview.
+  PreviewState get state => _state;
+  PreviewState _state = PreviewInitial();
+
+  /// Whether the compiler or execution setup can be started.
+  bool get canStart => !_busy && (_state is PreviewInitial || _state is PreviewCompileError);
+
+  /// Whether the running preview can be restarted.
+  bool get canRestart => !_busy && _state is PreviewRunning;
+
+  /// Whether the running preview can accept a hot reload.
+  bool get canHotReload => !_busy && _state is PreviewRunning;
+
+  /// Whether the preview run process can be stopped.
+  bool get canStop => _state is! PreviewStopping && (_busy || _sandbox != null);
+
+  /// Whether the application preview is currently running or executing restarts/reloads.
+  bool get isRunning => _state is PreviewRunning || state is PreviewRestarting || state is PreviewHotReloading;
+
+  bool get _busy =>
+      _state is PreviewStarting ||
+      _state is PreviewRestarting ||
+      _state is PreviewHotReloading ||
+      _state is PreviewStopping;
+
+  // Monotonically increasing token for preview operations.
+  //
+  // Async start/hot-reload steps must still own the current token before mutating state,
+  // so stale work cannot revive the preview after a stop or newer run.
+  int _operationId = 0;
+
+  String? _lastCompiledCode;
+
+  /// Starts the preview for [entrypoint].
+  ///
+  /// By default this creates a fresh compiler session, compiles the current
+  /// sources, loads the resulting module into a new sandbox, and runs the app.
+  ///
+  /// If [skipRecompilation] is `true`, this skips recompilation and reuses the
+  /// last successfully compiled module from [_lastCompiledCode] instead. This is
+  /// used for restart semantics where we want to recreate the sandbox and reset
+  /// runtime state without recompiling unchanged code.
+  ///
+  /// If no cached artifact is available yet, the code is compiled even when
+  /// [skipRecompilation] is `true`.
+  Future<void> runCode(String entrypoint, {bool skipRecompilation = false}) async {
+    if (_busy) {
+      return;
+    }
+
+    final operationId = _beginOperation();
+
+    final compileNeeded = !skipRecompilation || _lastCompiledCode == null;
+    eventBus.dispatch(LogEvent('Run $entrypoint'));
+    if (compileNeeded) {
+      eventBus.dispatch(const LogEvent('Starting compiler...'));
+    }
+
+    if (_state is PreviewRunning ||
+        _state is PreviewRestarting ||
+        _state is PreviewHotReloading ||
+        _state is PreviewStopping) {
+      _state = PreviewRestarting(entrypoint);
+    } else {
+      _state = PreviewStarting(entrypoint);
+    }
+    notifyListeners();
+
+    try {
+      final String codeToLoad;
+
+      if (compileNeeded) {
+        final previousCompiler = _hotReloadCompiler;
+        if (previousCompiler != null) {
+          eventBus.dispatch(const LogEvent('Closing previous compiler session...'));
+          _hotReloadCompiler = null;
+          await previousCompiler.close();
+          if (!_isCurrentOperation(operationId)) {
+            return;
+          }
+        }
+
+        eventBus.dispatch(const LogEvent('Creating hot reload compiler...'));
+        final compiler = await workspaceRepository.startHotReloadCompiler(
+          Uri.parse(entrypoint),
+        );
+        if (!_isCurrentOperation(operationId)) {
+          await compiler.close();
+          return;
+        }
+        _hotReloadCompiler = compiler;
+
+        eventBus.dispatch(const LogEvent('Compiling application...'));
+        final result = await compiler.compile();
+        if (!_isCurrentOperation(operationId)) {
+          return;
+        }
+        eventBus.dispatch(LogEvent(result.log));
+        eventBus.dispatch(const LogEvent('Compilation succeeded.'));
+        _lastCompiledCode = result.code;
+        codeToLoad = result.code!;
+      } else {
+        codeToLoad = _lastCompiledCode!;
+      }
+
+      final assetBaseUrl = Uri.parse(web.document.baseURI).resolve('dartpad/flutter/');
+
+      final previousSandbox = _sandbox;
+      if (previousSandbox != null) {
+        eventBus.dispatch(const LogEvent('Disposing previous preview sandbox...'));
+        await _disposeCurrentSandbox(previousSandbox);
+        if (!_isCurrentOperation(operationId)) {
+          return;
+        }
+      }
+
+      eventBus.dispatch(const LogEvent('Creating preview sandbox...'));
+      final sandbox = await Sandbox.createIFrame(
+        _container,
+        assetBaseUrl: assetBaseUrl,
+      );
+      if (!_isCurrentOperation(operationId)) {
+        sandbox.dispose();
+        return;
+      }
+      _sandbox = sandbox;
+      await _attachSandboxConsole(sandbox);
+      if (!_isCurrentOperation(operationId)) {
+        await _disposeCurrentSandbox(sandbox);
+        return;
+      }
+
+      eventBus.dispatch(const LogEvent('Loading compiled module...'));
+      await sandbox.loadModule(code: codeToLoad);
+      if (!_isCurrentOperation(operationId)) {
+        await _disposeCurrentSandbox(sandbox);
+        return;
+      }
+
+      final libraryUri = await workspaceRepository.convertToPackageUri(entrypoint);
+
+      eventBus.dispatch(const LogEvent('Running application...'));
+      await sandbox.runApp(libraryUri);
+      if (!_isCurrentOperation(operationId)) {
+        await _disposeCurrentSandbox(sandbox);
+        return;
+      }
+      eventBus.dispatch(const LogEvent('App is running.'));
+
+      _state = PreviewRunning(entrypoint);
+    } on CompilationFailedException catch (e, st) {
+      if (_isCurrentOperation(operationId)) {
+        eventBus.dispatch(
+          LogEvent('Compilation failed', level: Level.SEVERE, error: e, stackTrace: st),
+        );
+        _state = PreviewCompileError(entrypoint, e.message);
+      }
+    } catch (e, st) {
+      if (_isCurrentOperation(operationId)) {
+        eventBus.dispatch(LogEvent('Run failed', level: Level.SEVERE, error: e, stackTrace: st));
+        _state = PreviewCompileError(entrypoint, e.toString());
+      }
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  /// Hot reloads the currently active execution session compiler changes into
+  /// the sandbox.
+  Future<void> hotReloadCode() async {
+    final entry = state.entrypoint;
+    if (entry == null) {
+      return;
+    }
+    if (_busy) {
+      return;
+    }
+    final operationId = _beginOperation();
+    final sandbox = _sandbox;
+    if (sandbox == null) {
+      return;
+    }
+    eventBus.dispatch(LogEvent('Hot reload $entry'));
+    eventBus.dispatch(const LogEvent('Starting hot reload...'));
+
+    _state = PreviewHotReloading(entry);
+    notifyListeners();
+
+    try {
+      eventBus.dispatch(const LogEvent('Preparing compiler...'));
+      var compiler = _hotReloadCompiler;
+      if (compiler == null) {
+        final newCompiler = await workspaceRepository.startHotReloadCompiler(
+          Uri.parse(entry),
+        );
+        if (!_isCurrentOperation(operationId)) {
+          await newCompiler.close();
+          return;
+        }
+        _hotReloadCompiler = newCompiler;
+        compiler = newCompiler;
+      }
+
+      eventBus.dispatch(const LogEvent('Compiling changes...'));
+      final result = await compiler.compile();
+      if (!_isCurrentOperation(operationId)) {
+        return;
+      }
+      eventBus.dispatch(LogEvent(result.log));
+
+      eventBus.dispatch(const LogEvent('Applying hot reload...'));
+      await sandbox.hotReload(
+        code: result.code,
+        librariesToReload: result.compiledLibraryUris.map(Uri.parse).toList(),
+      );
+      if (!_isCurrentOperation(operationId)) {
+        return;
+      }
+
+      eventBus.dispatch(const LogEvent('Hot reload completed successfully.'));
+      _lastCompiledCode = result.code;
+      _state = PreviewRunning(entry);
+    } on HotReloadRejectedException catch (e, st) {
+      if (_isCurrentOperation(operationId)) {
+        eventBus.dispatch(
+          LogEvent('Hot reload rejected', level: Level.WARNING, error: e, stackTrace: st),
+        );
+        _state = PreviewCompileError(entry, e.message);
+      }
+    } catch (e, st) {
+      if (_isCurrentOperation(operationId)) {
+        eventBus.dispatch(
+          LogEvent('Hot reload failed', level: Level.SEVERE, error: e, stackTrace: st),
+        );
+        _state = PreviewCompileError(entry, e.toString());
+      }
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  /// Terminates execution, disposes the preview sandbox, and closes compiler
+  /// sessions.
+  Future<void> stopCode() async {
+    if (_state is PreviewStopping) {
+      return;
+    }
+    final operationId = _beginOperation();
+    eventBus.dispatch(const LogEvent('Stopping app...'));
+    _state = PreviewStopping();
+    _lastCompiledCode = null;
+    notifyListeners();
+    var operationStillCurrent = true;
+
+    try {
+      final sandbox = _sandbox;
+      if (sandbox != null) {
+        await _disposeCurrentSandbox(sandbox);
+      } else {
+        await _detachSandboxConsole();
+      }
+      final hotReloadCompiler = _hotReloadCompiler;
+      _hotReloadCompiler = null;
+      if (hotReloadCompiler != null) {
+        await hotReloadCompiler.close();
+      }
+      eventBus.dispatch(const LogEvent('Stopped app.'));
+    } finally {
+      operationStillCurrent = _isCurrentOperation(operationId);
+    }
+
+    if (!operationStillCurrent) {
+      return;
+    }
+
+    _state = PreviewInitial();
+    notifyListeners();
+  }
+
+  Future<void> _attachSandboxConsole(Sandbox sandbox) async {
+    await _detachSandboxConsole();
+    _sandboxConsoleSubscription = sandbox.onConsole.listen((event) {
+      final level = switch (event.level.name) {
+        'warn' => Level.WARNING,
+        'error' => Level.SEVERE,
+        'info' || 'log' => Level.INFO,
+        _ => Level.INFO,
+      };
+
+      eventBus.dispatch(LogEvent('[app] ${event.message}', level: level));
+    });
+    _sandboxErrorSubscription = sandbox.onError.listen((event) {
+      eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+    });
+    _sandboxRejectionSubscription = sandbox.onUnhandledRejection.listen((event) {
+      eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+    });
+  }
+
+  Future<void> _detachSandboxConsole() async {
+    await _sandboxConsoleSubscription?.cancel();
+    _sandboxConsoleSubscription = null;
+    await _sandboxErrorSubscription?.cancel();
+    _sandboxErrorSubscription = null;
+    await _sandboxRejectionSubscription?.cancel();
+    _sandboxRejectionSubscription = null;
+  }
+
+  int _beginOperation() => ++_operationId;
+
+  bool _isCurrentOperation(int operationId) => _operationId == operationId;
+
+  Future<void> _disposeCurrentSandbox(Sandbox sandbox) async {
+    if (!identical(_sandbox, sandbox)) {
+      return;
+    }
+    await _detachSandboxConsole();
+    _sandbox = null;
+    sandbox.dispose();
+  }
+
+  @override
+  void dispose() {
+    _operationId++;
+    unawaited(_detachSandboxConsole());
+    _sandbox?.dispose();
+    _sandbox = null;
+    unawaited(_hotReloadCompiler?.close());
+    _hotReloadCompiler = null;
+    super.dispose();
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
@@ -1,0 +1,73 @@
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../../app_styles.dart';
+
+/// A component that groups multiple buttons or items horizontally with cohesive
+/// styling and borders.
+class ButtonGroup extends StatelessComponent {
+  const ButtonGroup({
+    required this.children,
+    this.classes,
+    super.key,
+  });
+
+  /// The list of buttons or components aligned in the group.
+  final List<Component> children;
+
+  /// Optional extra CSS classes to apply to the button group container.
+  final String? classes;
+
+  @override
+  Component build(BuildContext context) {
+    final classNames = [
+      'button-group',
+      if (classes case final extraClasses? when extraClasses.isNotEmpty) extraClasses,
+    ].join(' ');
+
+    return div(
+      classes: classNames,
+      children,
+    );
+  }
+
+  @css
+  static List<StyleRule> get styles => [
+    css('.button-group', [
+      css('&').styles(
+        display: .inlineFlex,
+        margin: .symmetric(horizontal: 4.px),
+        border: .all(color: colorBorder, width: 1.px),
+        radius: .circular(6.px),
+        alignItems: .center,
+        backgroundColor: colorContainer,
+      ),
+      css('& > *, & .icon-button, & .text-button, & .device-dropdown-trigger').styles(
+        border: .none,
+        radius: .circular(0.px),
+      ),
+      css(
+        '& > *:first-child, & > *:first-child .icon-button, & > *:first-child .text-button, & > *:first-child .device-dropdown-trigger',
+      ).styles(
+        radius: .only(topLeft: .circular(5.px), bottomLeft: .circular(5.px)),
+      ),
+      css(
+        '& > *:last-child, & > *:last-child .icon-button, & > *:last-child .text-button, & > *:last-child .device-dropdown-trigger',
+      ).styles(
+        radius: .only(topRight: .circular(5.px), bottomRight: .circular(5.px)),
+      ),
+      css('& > *:not(:last-child)').styles(
+        border: .only(
+          right: .solid(color: colorBorder, width: 1.px),
+        ),
+      ),
+      css('& .text-button').styles(
+        height: 28.px,
+        padding: .symmetric(horizontal: 10.px),
+      ),
+      css('& .text-button:not(:disabled):hover').styles(
+        border: .none,
+      ),
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/icon_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/icon_button.dart
@@ -1,0 +1,258 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import '../icons.dart';
+
+/// A button component displaying an icon or a custom child component,
+/// with support for tooltips, labels, and disabled states.
+class IconButton extends StatefulComponent {
+  const IconButton({
+    this.icon,
+    this.child,
+    this.onClick,
+    this.disabled = false,
+    this.tooltip,
+    this.classes,
+    this.iconSize = 18.0,
+    this.label,
+    super.key,
+  }) : assert(icon != null || child != null, 'Either icon or child must be provided.');
+
+  final String? icon;
+  final Component? child;
+  final FutureOr<void> Function(web.Event event)? onClick;
+  final bool disabled;
+  final String? tooltip;
+  final String? classes;
+  final double iconSize;
+  final String? label;
+
+  @override
+  State<IconButton> createState() => _IconButtonState();
+
+  @css
+  static List<StyleRule> get styles => _IconButtonState.styles;
+}
+
+class _IconButtonState extends State<IconButton> {
+  final GlobalNodeKey<web.HTMLElement> _buttonKey = GlobalNodeKey();
+  Timer? _showTimer;
+  bool _isTooltipVisible = false;
+
+  static Timer? _cooldownTimer;
+  static bool _showImmediately = false;
+
+  static void _startCooldown() {
+    _cooldownTimer?.cancel();
+    _cooldownTimer = Timer(const Duration(milliseconds: 500), () {
+      _showImmediately = false;
+    });
+  }
+
+  static void _enterButton() {
+    _cooldownTimer?.cancel();
+  }
+
+  void _onMouseEnter() {
+    final tooltipText = component.tooltip ?? component.label;
+    if (tooltipText == null) {
+      return;
+    }
+
+    _enterButton();
+
+    if (_showImmediately) {
+      setState(() {
+        _isTooltipVisible = true;
+      });
+      context.binding.addPostFrameCallback(_adjustTooltipPosition);
+    } else {
+      _showTimer?.cancel();
+      _showTimer = Timer(const Duration(milliseconds: 500), () {
+        setState(() {
+          _isTooltipVisible = true;
+          _showImmediately = true;
+        });
+        context.binding.addPostFrameCallback(_adjustTooltipPosition);
+      });
+    }
+  }
+
+  void _onMouseLeave() {
+    _showTimer?.cancel();
+    if (_isTooltipVisible) {
+      setState(() {
+        _isTooltipVisible = false;
+      });
+      _startCooldown();
+    }
+  }
+
+  void _adjustTooltipPosition() {
+    if (!mounted || !_isTooltipVisible) {
+      return;
+    }
+    final buttonElement = _buttonKey.currentNode;
+    if (buttonElement == null) {
+      return;
+    }
+    final tooltip = buttonElement.querySelector('.custom-tooltip') as web.HTMLElement?;
+    if (tooltip == null) {
+      return;
+    }
+
+    final buttonRect = buttonElement.getBoundingClientRect();
+    final tooltipRect = tooltip.getBoundingClientRect();
+    final windowWidth = web.window.innerWidth;
+    final windowHeight = web.window.innerHeight;
+
+    final buttonCenter = buttonRect.left + buttonRect.width / 2;
+    double left = buttonCenter - tooltipRect.width / 2;
+
+    if (left < 8) {
+      left = 8;
+    } else if (left + tooltipRect.width > windowWidth - 8) {
+      left = windowWidth - tooltipRect.width - 8.0;
+    }
+
+    double top = buttonRect.bottom + 4.0;
+    if (top + tooltipRect.height > windowHeight - 8) {
+      top = buttonRect.top - tooltipRect.height - 4.0;
+    }
+
+    tooltip.style.setProperty('left', '${left}px');
+    tooltip.style.setProperty('top', '${top}px');
+  }
+
+  @override
+  void dispose() {
+    _showTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final classNames = [
+      'icon-button',
+      if (component.classes case final extraClasses? when extraClasses.isNotEmpty) extraClasses,
+    ].join(' ');
+
+    final attributes = <String, String>{};
+    final tooltipText = component.tooltip ?? component.label;
+    if (tooltipText != null) {
+      attributes['aria-label'] = tooltipText;
+    }
+    if (component.disabled) {
+      attributes['disabled'] = 'true';
+    }
+
+    return button(
+      key: _buttonKey,
+      classes: classNames,
+      attributes: attributes,
+      events: {
+        if (component.onClick != null && !component.disabled) 'click': component.onClick!,
+        'mouseenter': (event) => _onMouseEnter(),
+        'mouseleave': (event) => _onMouseLeave(),
+      },
+      [
+        if (component.child != null)
+          component.child!
+        else if (component.icon != null)
+          Icon(
+            component.icon!,
+            size: component.iconSize,
+          ),
+        if (_isTooltipVisible && tooltipText != null)
+          div(
+            classes: 'custom-tooltip${tooltipText.contains('\n') ? ' rich-tooltip' : ''}',
+            [
+              if (tooltipText.contains('\n')) ...[
+                span(classes: 'tooltip-title', [.text(tooltipText.split('\n')[0])]),
+                span(classes: 'tooltip-desc', [.text(tooltipText.substring(tooltipText.indexOf('\n') + 1))]),
+              ] else
+                .text(tooltipText),
+            ],
+          ),
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css.keyframes('tooltip-fade-in', {
+      '0%': const Styles(opacity: 0),
+      '100%': const Styles(opacity: 1),
+    }),
+    css('.icon-button', [
+      css('&').styles(
+        display: .flex,
+        position: const .relative(),
+        width: 28.px,
+        height: 28.px,
+        padding: .zero,
+        border: .none,
+        radius: .circular(4.px),
+        cursor: .pointer,
+        transition: Transition('background-color', duration: 150.ms, curve: .ease),
+        justifyContent: .center,
+        alignItems: .center,
+        color: colorOnSurface,
+        backgroundColor: Colors.transparent,
+      ),
+      css('& > *').styles(
+        raw: {'flex-shrink': '0'},
+      ),
+      css('&:not(:disabled):hover').styles(
+        backgroundColor: colorContainerHigh,
+      ),
+      css('&:disabled').styles(
+        cursor: .notAllowed,
+      ),
+      css('&:disabled > *:not(.custom-tooltip)').styles(
+        opacity: 0.5,
+      ),
+      css('.custom-tooltip').styles(
+        position: .fixed(left: (-9999).px, top: (-9999).px),
+        zIndex: const ZIndex(2000),
+        padding: .symmetric(vertical: 4.px, horizontal: 8.px),
+        border: .all(color: colorBorder, width: 1.px),
+        radius: .circular(4.px),
+        pointerEvents: .none,
+        animation: Animation(name: 'tooltip-fade-in', duration: 120.ms, curve: .easeOut, fillMode: .forwards),
+        color: colorOnSurface,
+        fontSize: 12.px,
+        fontWeight: .w500,
+        whiteSpace: .noWrap,
+        backgroundColor: colorContainerLow,
+      ),
+      css('.custom-tooltip.rich-tooltip').styles(
+        display: .flex,
+        width: 220.px,
+        padding: Padding.all(8.px),
+        flexDirection: .column,
+        alignItems: .center,
+        gap: Gap.all(2.px),
+        whiteSpace: .normal,
+      ),
+      css('.tooltip-title').styles(
+        color: colorOnSurface,
+        fontSize: 11.5.px,
+        fontWeight: .w600,
+      ),
+      css('.tooltip-desc').styles(
+        color: colorOnSurfaceVariant,
+        fontSize: 11.px,
+        fontWeight: .w400,
+        lineHeight: 1.4.em,
+      ),
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:web/web.dart' as web;
@@ -90,6 +92,83 @@ final class WorkspaceRepository {
   Future<void> close() async {
     await workspaceResourceApi.dispose();
     await dartpad?.dispose();
+  }
+
+  Future<HotReloadCompiler> startHotReloadCompiler(Uri uri) async {
+    final workspace = await _workspaceFuture;
+    return await workspace.startHotReloadCompiler(uri);
+  }
+
+  /// Converts a workspace [filePath] to a `package:` URI based on the nearest
+  /// resolved package configuration or pubspec.yaml.
+  Future<Uri> convertToPackageUri(String filePath) async {
+    String? resolvedPackageName;
+    WorkspaceFolder? resolvedFolder;
+
+    // 1. Search for package_config.json in all parent folders (from bottom to top)
+    WorkspaceFolder folder = root.getFile(filePath).parent;
+    while (true) {
+      final config = folder.getFile('.dart_tool/package_config.json');
+      if (await config.exists()) {
+        try {
+          final content = await config.readContent();
+          final configJson = json.decode(content) as Map<String, dynamic>;
+          final packages = configJson['packages'] as List<dynamic>?;
+          if (packages != null) {
+            for (final pkg in packages) {
+              final map = pkg as Map<String, dynamic>;
+              if (map['rootUri'] == '../') {
+                resolvedPackageName = map['name'] as String;
+                resolvedFolder = folder;
+                break;
+              }
+            }
+          }
+        } catch (_) {
+          // Fall through.
+        }
+      }
+      if (resolvedPackageName != null) {
+        break;
+      }
+
+      if (folder.isRoot) {
+        break;
+      }
+      folder = folder.parent;
+    }
+
+    // 2. Search for pubspec.yaml in all parent folders (from bottom to top)
+    if (resolvedPackageName == null) {
+      folder = root.getFile(filePath).parent;
+      while (true) {
+        final pubspec = folder.getFile('pubspec.yaml');
+        if (await pubspec.exists()) {
+          final content = await pubspec.readContent();
+          final match = RegExp(r'^name:\s*(\S+)', multiLine: true).firstMatch(content);
+          if (match != null) {
+            resolvedPackageName = match.group(1)!.replaceAll(RegExp(r'''^['"]|['"]$'''), '');
+            resolvedFolder = folder;
+            break;
+          }
+        }
+
+        if (folder.isRoot) {
+          break;
+        }
+        folder = folder.parent;
+      }
+    }
+
+    final packageName = resolvedPackageName ?? 'app';
+    final packageFolder = resolvedFolder ?? root;
+
+    final libFolder = workspaceContext.join(packageFolder.path, 'lib');
+    final relativePath = workspacePath.relative(filePath, from: libFolder);
+    return Uri(
+      scheme: 'package',
+      path: workspacePath.join(packageName, relativePath),
+    );
   }
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -11,10 +11,11 @@ import 'package:web/web.dart' as web;
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
 import '../../shared/events/workspace_event.dart';
+import '../../preview/models/compiler_session.dart';
 
 /// Owns the complete worker-side workspace lifecycle for the transient app.
-final class WorkspaceRepository {
-  WorkspaceRepository._({
+class WorkspaceRepository {
+  WorkspaceRepository({
     required this.events,
     required this.workspaceResourceApi,
     required this._workspaceFuture,
@@ -49,7 +50,7 @@ final class WorkspaceRepository {
         events.dispatch(WorkspaceLoadedEvent(ws));
       });
     });
-    return repository = WorkspaceRepository._(
+    return repository = WorkspaceRepository(
       events: events,
       workspaceResourceApi: api,
       workspaceFuture: workspaceFuture,
@@ -94,9 +95,10 @@ final class WorkspaceRepository {
     await dartpad?.dispose();
   }
 
-  Future<HotReloadCompiler> startHotReloadCompiler(Uri uri) async {
+  Future<CompilerSession> startHotReloadCompiler(Uri uri) async {
     final workspace = await _workspaceFuture;
-    return await workspace.startHotReloadCompiler(uri);
+    final compiler = await workspace.startHotReloadCompiler(uri);
+    return RealCompilerSession(compiler);
   }
 
   /// Converts a workspace [filePath] to a `package:` URI based on the nearest
@@ -190,3 +192,4 @@ Future<void> runWorkspacePubGet({
     events.dispatch(LogEvent(log));
   }
 }
+

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -8,10 +8,10 @@ import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:web/web.dart' as web;
 
+import '../../preview/models/compiler_session.dart';
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
 import '../../shared/events/workspace_event.dart';
-import '../../preview/models/compiler_session.dart';
 
 /// Owns the complete worker-side workspace lifecycle for the transient app.
 class WorkspaceRepository {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -192,4 +192,3 @@ Future<void> runWorkspacePubGet({
     events.dispatch(LogEvent(log));
   }
 }
-

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
@@ -1,0 +1,498 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+
+import 'package:dartpad/dartpad.dart';
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/preview/models/compiler_session.dart';
+import 'package:dartpad_frontend/features/preview/models/preview_sandbox.dart';
+import 'package:dartpad_frontend/features/preview/models/preview_state.dart';
+import 'package:dartpad_frontend/features/preview/view_models/preview_view_model.dart';
+import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/events/log_event.dart';
+import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+final class FakeWorkspaceResourceApi implements WorkspaceResourceApi {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<void> pump() => Future<void>.delayed(const Duration(milliseconds: 50));
+
+class FakeCompilerSession implements CompilerSession {
+  int compileCount = 0;
+  int closeCount = 0;
+
+  FutureOr<({String? code, List<String> compiledLibraryUris, String? log})> Function()? onCompile;
+  Future<void> Function()? onClose;
+
+  @override
+  Future<({String? code, List<String> compiledLibraryUris, String? log})> compile() async {
+    compileCount++;
+    if (onCompile != null) {
+      return onCompile!();
+    }
+    return (code: 'compiled_code', compiledLibraryUris: <String>['package:app/main.dart'], log: 'compiled log');
+  }
+
+  @override
+  Future<void> close() async {
+    closeCount++;
+    if (onClose != null) {
+      await onClose!();
+    }
+  }
+}
+
+class FakePreviewSandbox implements PreviewSandbox {
+  int disposeCount = 0;
+  int loadModuleCount = 0;
+  int runAppCount = 0;
+  int hotReloadCount = 0;
+
+  final consoleController = StreamController<ConsoleMessage>.broadcast();
+  final errorController = StreamController<({String message})>.broadcast();
+  final rejectionController = StreamController<({String message})>.broadcast();
+
+  String? loadedCode;
+  Uri? runUri;
+  String? reloadedCode;
+  List<Uri>? reloadedLibraries;
+
+  Future<void> Function({required String code})? onLoadModule;
+  Future<void> Function(Uri libraryUri)? onRunApp;
+  Future<void> Function({required String? code, required List<Uri> librariesToReload})? onHotReload;
+
+  @override
+  void dispose() {
+    disposeCount++;
+    consoleController.close();
+    errorController.close();
+    rejectionController.close();
+  }
+
+  @override
+  Future<void> loadModule({required String code}) async {
+    loadModuleCount++;
+    loadedCode = code;
+    if (onLoadModule != null) {
+      await onLoadModule!(code: code);
+    }
+  }
+
+  @override
+  Future<void> runApp(Uri libraryUri) async {
+    runAppCount++;
+    runUri = libraryUri;
+    if (onRunApp != null) {
+      await onRunApp!(libraryUri);
+    }
+  }
+
+  @override
+  Future<void> hotReload({required String? code, required List<Uri> librariesToReload}) async {
+    hotReloadCount++;
+    reloadedCode = code;
+    reloadedLibraries = librariesToReload;
+    if (onHotReload != null) {
+      await onHotReload!(code: code, librariesToReload: librariesToReload);
+    }
+  }
+
+  @override
+  Stream<ConsoleMessage> get onConsole => consoleController.stream;
+
+  @override
+  Stream<({String message})> get onError => errorController.stream;
+
+  @override
+  Stream<({String message})> get onUnhandledRejection => rejectionController.stream;
+}
+
+class FakeWorkspaceRepository extends WorkspaceRepository {
+  FakeWorkspaceRepository(AppEventBus events, WorkspaceResourceApi workspaceResourceApi)
+    : super(
+        events: events,
+        workspaceResourceApi: workspaceResourceApi,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+  int startHotReloadCompilerCount = 0;
+  int convertToPackageUriCount = 0;
+
+  CompilerSession Function(Uri uri)? onStartHotReloadCompiler;
+  Uri Function(String filePath)? onConvertToPackageUri;
+
+  @override
+  Future<CompilerSession> startHotReloadCompiler(Uri uri) async {
+    startHotReloadCompilerCount++;
+    if (onStartHotReloadCompiler != null) {
+      return onStartHotReloadCompiler!(uri);
+    }
+    return FakeCompilerSession();
+  }
+
+  @override
+  Future<Uri> convertToPackageUri(String filePath) async {
+    convertToPackageUriCount++;
+    if (onConvertToPackageUri != null) {
+      return onConvertToPackageUri!(filePath);
+    }
+    return Uri.parse('package:app/main.dart');
+  }
+}
+
+void main() {
+  group('PreviewViewModel', () {
+    late AppEventBus events;
+    late FakeWorkspaceRepository repository;
+    late List<LogEvent> loggedEvents;
+    late StreamSubscription<LogEvent> logSubscription;
+
+    setUp(() {
+      events = AppEventBus();
+      loggedEvents = [];
+      logSubscription = events.on<LogEvent>().listen(loggedEvents.add);
+      repository = FakeWorkspaceRepository(events, FakeWorkspaceResourceApi());
+    });
+
+    tearDown(() async {
+      await logSubscription.cancel();
+      await events.dispose();
+    });
+
+    test('initial state is correct', () {
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+      );
+
+      expect(viewModel.state, isA<PreviewInitial>());
+      expect(viewModel.canStart, isTrue);
+      expect(viewModel.canRestart, isFalse);
+      expect(viewModel.canHotReload, isFalse);
+      expect(viewModel.canStop, isFalse);
+      expect(viewModel.isRunning, isFalse);
+
+      viewModel.dispose();
+    });
+
+    test('runCode compiles and runs successfully', () async {
+      final fakeSandbox = FakePreviewSandbox();
+      final fakeCompiler = FakeCompilerSession();
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      final stateChanges = <PreviewState>[];
+      viewModel.addListener(() {
+        stateChanges.add(viewModel.state);
+      });
+
+      await viewModel.runCode('lib/main.dart');
+      await pump();
+
+      expect(stateChanges, [
+        isA<PreviewStarting>(),
+        isA<PreviewRunning>(),
+      ]);
+
+      expect(viewModel.state, isA<PreviewRunning>());
+      expect(viewModel.canStart, isFalse);
+      expect(viewModel.canRestart, isTrue);
+      expect(viewModel.canHotReload, isTrue);
+      expect(viewModel.canStop, isTrue);
+      expect(viewModel.isRunning, isTrue);
+
+      expect(fakeCompiler.compileCount, 1);
+      expect(fakeSandbox.loadModuleCount, 1);
+      expect(fakeSandbox.loadedCode, 'compiled_code');
+      expect(fakeSandbox.runAppCount, 1);
+      expect(fakeSandbox.runUri, Uri.parse('package:app/main.dart'));
+
+      final logMessages = loggedEvents.map((e) => e.message).toList();
+      expect(
+        logMessages,
+        containsAll([
+          'Run lib/main.dart',
+          'Starting compiler...',
+          'Creating hot reload compiler...',
+          'Compilation succeeded.',
+          'Running application...',
+          'App is running.',
+        ]),
+      );
+
+      viewModel.dispose();
+      expect(fakeCompiler.closeCount, 1);
+      expect(fakeSandbox.disposeCount, 1);
+    });
+
+    test('runCode fails compilation with CompilationFailedException', () async {
+      final fakeCompiler = FakeCompilerSession()..onCompile = () => throw CompilationFailedException('syntax error');
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      await pump();
+
+      expect(viewModel.state, isA<PreviewCompileError>());
+      final errState = viewModel.state as PreviewCompileError;
+      expect(errState.message, 'syntax error');
+      expect(errState.entrypoint, 'lib/main.dart');
+
+      expect(loggedEvents.any((e) => e.message == 'Compilation failed' && e.level == Level.SEVERE), isTrue);
+
+      viewModel.dispose();
+    });
+
+    test('runCode fails with generic runtime error', () async {
+      final fakeSandbox = FakePreviewSandbox()..onRunApp = (_) => throw Exception('load crash');
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      await pump();
+
+      expect(viewModel.state, isA<PreviewCompileError>());
+      final errState = viewModel.state as PreviewCompileError;
+      expect(errState.message, contains('load crash'));
+
+      expect(loggedEvents.any((e) => e.message == 'Run failed' && e.level == Level.SEVERE), isTrue);
+
+      viewModel.dispose();
+    });
+
+    test('runCode skipRecompilation = true reuses previous compilation', () async {
+      final fakeSandbox1 = FakePreviewSandbox();
+      final fakeSandbox2 = FakePreviewSandbox();
+      final fakeCompiler = FakeCompilerSession();
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      var currentSandboxIndex = 0;
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async {
+          currentSandboxIndex++;
+          return currentSandboxIndex == 1 ? fakeSandbox1 : fakeSandbox2;
+        },
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      expect(fakeCompiler.compileCount, 1);
+      expect(fakeSandbox1.loadModuleCount, 1);
+
+      // Trigger restart which skips recompilation
+      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+
+      // Compiler should NOT be called again
+      expect(fakeCompiler.compileCount, 1);
+      expect(fakeSandbox1.disposeCount, 1);
+      expect(fakeSandbox2.loadModuleCount, 1);
+      expect(fakeSandbox2.loadedCode, 'compiled_code'); // Reuses compiled code
+
+      viewModel.dispose();
+    });
+
+    test('hotReloadCode compiles and reloads successfully', () async {
+      final fakeSandbox = FakePreviewSandbox();
+      final fakeCompiler = FakeCompilerSession();
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      expect(viewModel.state, isA<PreviewRunning>());
+
+      // Modify compilation output for reload
+      fakeCompiler.onCompile = () =>
+          (code: 'updated_code', compiledLibraryUris: <String>['package:app/main.dart'], log: 'reload compile log');
+
+      final stateChanges = <PreviewState>[];
+      viewModel.addListener(() {
+        stateChanges.add(viewModel.state);
+      });
+
+      await viewModel.hotReloadCode();
+      await pump();
+
+      expect(stateChanges, [
+        isA<PreviewHotReloading>(),
+        isA<PreviewRunning>(),
+      ]);
+
+      expect(fakeCompiler.compileCount, 2);
+      expect(fakeSandbox.hotReloadCount, 1);
+      expect(fakeSandbox.reloadedCode, 'updated_code');
+      expect(fakeSandbox.reloadedLibraries, [Uri.parse('package:app/main.dart')]);
+
+      expect(loggedEvents.map((e) => e.message), contains('Hot reload completed successfully.'));
+
+      viewModel.dispose();
+    });
+
+    test('hotReloadCode handles HotReloadRejectedException', () async {
+      final fakeSandbox = FakePreviewSandbox()
+        ..onHotReload = ({code, required librariesToReload}) => throw HotReloadRejectedException('rejected reload');
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      await viewModel.hotReloadCode();
+      await pump();
+
+      expect(viewModel.state, isA<PreviewCompileError>());
+      expect((viewModel.state as PreviewCompileError).message, 'rejected reload');
+
+      expect(loggedEvents.any((e) => e.message == 'Hot reload rejected' && e.level == Level.WARNING), isTrue);
+
+      viewModel.dispose();
+    });
+
+    test('stopCode stops and resets everything', () async {
+      final fakeSandbox = FakePreviewSandbox();
+      final fakeCompiler = FakeCompilerSession();
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      expect(viewModel.state, isA<PreviewRunning>());
+
+      final stateChanges = <PreviewState>[];
+      viewModel.addListener(() {
+        stateChanges.add(viewModel.state);
+      });
+
+      await viewModel.stopCode();
+
+      expect(stateChanges, [
+        isA<PreviewStopping>(),
+        isA<PreviewInitial>(),
+      ]);
+
+      expect(viewModel.state, isA<PreviewInitial>());
+      expect(fakeSandbox.disposeCount, 1);
+      expect(fakeCompiler.closeCount, 1);
+
+      // Subsequent skipRecompilation should trigger compile since cache was cleared
+      fakeSandbox.loadModuleCount = 0;
+      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      expect(fakeCompiler.compileCount, 2);
+
+      viewModel.dispose();
+    });
+
+    test('forwards sandbox console events correctly', () async {
+      final fakeSandbox = FakePreviewSandbox();
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+
+      fakeSandbox.consoleController.add((level: ConsoleLevel.warn, message: 'warning message'));
+      await pump();
+      fakeSandbox.consoleController.add((level: ConsoleLevel.error, message: 'error message'));
+      await pump();
+      fakeSandbox.consoleController.add((level: ConsoleLevel.info, message: 'info message'));
+      await pump();
+      fakeSandbox.consoleController.add((level: ConsoleLevel.log, message: 'log message'));
+      await pump();
+
+      fakeSandbox.errorController.add((message: 'critical runtime error'));
+      await pump();
+      fakeSandbox.rejectionController.add((message: 'unhandled promise rejection'));
+      await pump();
+
+      final appLogs = loggedEvents.where((e) => e.message.startsWith('[app] ')).toList();
+      expect(appLogs.map((e) => e.message), [
+        '[app] warning message',
+        '[app] error message',
+        '[app] info message',
+        '[app] log message',
+        '[app] critical runtime error',
+        '[app] unhandled promise rejection',
+      ]);
+
+      expect(appLogs[0].level, Level.WARNING);
+      expect(appLogs[1].level, Level.SEVERE);
+      expect(appLogs[2].level, Level.INFO);
+      expect(appLogs[3].level, Level.INFO);
+      expect(appLogs[4].level, Level.SEVERE);
+      expect(appLogs[5].level, Level.SEVERE);
+
+      viewModel.dispose();
+    });
+
+    test('runCode aborts and cleans up if disposed during compilation', () async {
+      final compiler = FakeCompilerSession();
+      final compilerCompleter = Completer<({String? code, List<String> compiledLibraryUris, String? log})>();
+      compiler.onCompile = () => compilerCompleter.future;
+
+      repository.onStartHotReloadCompiler = (_) => compiler;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+      );
+
+      final runFuture = viewModel.runCode('lib/main.dart');
+
+      // Dispose the view model while compilation is pending
+      viewModel.dispose();
+
+      // Complete compilation
+      compilerCompleter.complete((
+        code: 'some_code',
+        compiledLibraryUris: <String>['package:app/main.dart'],
+        log: 'log',
+      ));
+
+      await runFuture;
+
+      // The compiler should have been closed/disposed because the view model was disposed
+      expect(compiler.closeCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
Setup the preview panel with the sandbox iframe.

For now when pressing start, the currently open file in the editor is used as entrypoint. When no file is open it falls back to trying 'lib/main.dart'.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
