### PR TITLE
feat(dartpad-preview): Add dartpad theming

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/THIRD_PARTY_NOTICES.txt
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/THIRD_PARTY_NOTICES.txt
@@ -1121,40 +1121,6 @@ THE SOFTWARE.
 
 ---
 
-Name: @codemirror/theme-one-dark
-Version: 6.1.3
-License: MIT
-Private: false
-Description: One Dark theme for the CodeMirror code editor
-Repository: https://github.com/codemirror/theme-one-dark.git
-Author: Marijn Haverbeke <marijn@haverbeke.berlin> (http://marijnhaverbeke.nl)
-License Text:
-===
-
-MIT License
-
-Copyright (C) 2018-2021 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----
-
 Name: marked
 Version: 15.0.12
 License: MIT

--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -35356,113 +35356,131 @@
         ])
     ])();
 
-    // Using https://github.com/one-dark/vscode-one-dark-theme/ as reference for the colors
-    const chalky = "#e5c07b", coral = "#e06c75", cyan = "#56b6c2", invalid = "#ffffff", ivory = "#abb2bf", stone = "#7d8799", // Brightened compared to original to increase contrast
-    malibu = "#61afef", sage = "#98c379", whiskey = "#d19a66", violet = "#c678dd", darkBackground = "#21252b", highlightBackground = "#2c313a", background = "#282c34", tooltipBackground = "#353a42", selection = "#3E4451", cursor = "#528bff";
-    /**
-    The editor theme styles for One Dark.
-    */
-    const oneDarkTheme = /*@__PURE__*/EditorView.theme({
+    const dartpadTheme = EditorView.theme({
         "&": {
-            color: ivory,
-            backgroundColor: background
+            fontFamily: "'Roboto Mono', monospace",
+            fontWeight: "400",
+            // Default to Light Mode variables and styles
+            backgroundColor: "#fff",
+            color: "#4a4a4a",
+            "--cm-builtin": "#4a4a4a",
+            "--cm-comment": "#5F6368",
+            "--cm-keyword": "#007a27",
+            "--cm-atom": "#2f4960",
+            "--cm-variable": "#0E161F",
+            "--cm-variable2": "#a54a78",
+            "--cm-string": "#bc0056",
+            "--cm-string2": "#983ab3",
+            "--cm-number": "#00786d",
+            "--cm-attribute": "#0E161F",
+            "--cm-qualifier": "#d32923",
+            "--cm-meta": "#00786d",
+            "--cm-header": "#0E161F",
+            "--cm-operator": "#4a4a4a",
+            "--cm-def": "#4a4a4a",
+            "--cm-tag": "#007a27",
+            "--cm-property": "#a54a78",
         },
+        // Light Mode Scoped Styles
         ".cm-content": {
-            caretColor: cursor
+            caretColor: "#4a4a4a",
         },
-        ".cm-cursor, .cm-dropCursor": { borderLeftColor: cursor },
-        "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": { backgroundColor: selection },
-        ".cm-panels": { backgroundColor: darkBackground, color: ivory },
-        ".cm-panels.cm-panels-top": { borderBottom: "2px solid black" },
-        ".cm-panels.cm-panels-bottom": { borderTop: "2px solid black" },
-        ".cm-searchMatch": {
-            backgroundColor: "#72a1ff59",
-            outline: "1px solid #457dff"
+        ".cm-cursor, .cm-dropCursor": {
+            borderLeft: "1px solid #4a4a4a",
         },
-        ".cm-searchMatch.cm-searchMatch-selected": {
-            backgroundColor: "#6199ff2f"
-        },
-        ".cm-activeLine": { backgroundColor: "#6699ff0b" },
-        ".cm-selectionMatch": { backgroundColor: "#aafe661a" },
-        "&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
-            backgroundColor: "#bad0f847"
+        ".cm-selectionBackground, .cm-content ::selection": {
+            backgroundColor: "#e8e8e8 !important",
         },
         ".cm-gutters": {
-            backgroundColor: background,
-            color: stone,
-            border: "none"
+            backgroundColor: "#fff !important",
+            color: "#d0d0d2",
+            borderRight: "none",
+        },
+        "&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
+            outline: "1px solid #606060",
+            color: "#a54a78 !important",
+        },
+        ".cm-activeLine": {
+            backgroundColor: "rgba(27, 134, 245, 0.035)",
         },
         ".cm-activeLineGutter": {
-            backgroundColor: highlightBackground
+            backgroundColor: "rgba(27, 134, 245, 0.07)",
         },
+        // Dark Mode Overrides (triggered by data-theme="dark" on ancestor html or body)
+        '[data-theme="dark"] &': {
+            backgroundColor: "#0E161F",
+            color: "#FFFFFF",
+            "--cm-builtin": "#FFFFFF",
+            "--cm-comment": "#909CC3",
+            "--cm-keyword": "#50E191",
+            "--cm-atom": "#FF916E",
+            "--cm-variable": "#00D2FA",
+            "--cm-variable2": "#FF916E",
+            "--cm-string": "#FA557D",
+            "--cm-string2": "#FF00FA",
+            "--cm-number": "#909090",
+            "--cm-attribute": "#00D2FA",
+            "--cm-qualifier": "#FF9B00",
+            "--cm-meta": "#909090",
+            "--cm-header": "#00D2FA",
+            "--cm-operator": "#FFFFFF",
+            "--cm-def": "#FFFFFF",
+            "--cm-tag": "#50E191",
+            "--cm-property": "#FF2D64",
+        },
+        '[data-theme="dark"] & .cm-content': {
+            caretColor: "white",
+        },
+        '[data-theme="dark"] & .cm-cursor, [data-theme="dark"] & .cm-dropCursor': {
+            borderLeft: "1px solid white",
+        },
+        '[data-theme="dark"] & .cm-selectionBackground, [data-theme="dark"] & .cm-content ::selection': {
+            backgroundColor: "#23364D !important",
+        },
+        '[data-theme="dark"] & .cm-gutters': {
+            backgroundColor: "#0E161F !important",
+            color: "#909090",
+            borderRight: "none",
+        },
+        '[data-theme="dark"] &.cm-focused .cm-matchingBracket, [data-theme="dark"] &.cm-focused .cm-nonmatchingBracket': {
+            outline: "1px solid #606060",
+            color: "#FF2D64 !important",
+        },
+        '[data-theme="dark"] & .cm-activeLine': {
+            backgroundColor: "rgba(32, 143, 253, 0.035)",
+        },
+        '[data-theme="dark"] & .cm-activeLineGutter': {
+            backgroundColor: "rgba(32, 143, 253, 0.07)",
+        },
+        // Shared Styles
         ".cm-foldPlaceholder": {
-            backgroundColor: "transparent",
-            border: "none",
-            color: "#ddd"
-        },
-        ".cm-tooltip": {
-            border: "none",
-            backgroundColor: tooltipBackground
-        },
-        ".cm-tooltip .cm-tooltip-arrow:before": {
-            borderTopColor: "transparent",
-            borderBottomColor: "transparent"
-        },
-        ".cm-tooltip .cm-tooltip-arrow:after": {
-            borderTopColor: tooltipBackground,
-            borderBottomColor: tooltipBackground
-        },
-        ".cm-tooltip-autocomplete": {
-            "& > ul > li[aria-selected]": {
-                backgroundColor: highlightBackground,
-                color: ivory
-            }
-        }
-    }, { dark: true });
-    /**
-    The highlighting style for code in the One Dark theme.
-    */
-    const oneDarkHighlightStyle = /*@__PURE__*/HighlightStyle.define([
-        { tag: tags$1.keyword,
-            color: violet },
-        { tag: [tags$1.name, tags$1.deleted, tags$1.character, tags$1.propertyName, tags$1.macroName],
-            color: coral },
-        { tag: [/*@__PURE__*/tags$1.function(tags$1.variableName), tags$1.labelName],
-            color: malibu },
-        { tag: [tags$1.color, /*@__PURE__*/tags$1.constant(tags$1.name), /*@__PURE__*/tags$1.standard(tags$1.name)],
-            color: whiskey },
-        { tag: [/*@__PURE__*/tags$1.definition(tags$1.name), tags$1.separator],
-            color: ivory },
-        { tag: [tags$1.typeName, tags$1.className, tags$1.number, tags$1.changed, tags$1.annotation, tags$1.modifier, tags$1.self, tags$1.namespace],
-            color: chalky },
-        { tag: [tags$1.operator, tags$1.operatorKeyword, tags$1.url, tags$1.escape, tags$1.regexp, tags$1.link, /*@__PURE__*/tags$1.special(tags$1.string)],
-            color: cyan },
-        { tag: [tags$1.meta, tags$1.comment],
-            color: stone },
-        { tag: tags$1.strong,
-            fontWeight: "bold" },
-        { tag: tags$1.emphasis,
-            fontStyle: "italic" },
-        { tag: tags$1.strikethrough,
-            textDecoration: "line-through" },
-        { tag: tags$1.link,
-            color: stone,
-            textDecoration: "underline" },
-        { tag: tags$1.heading,
+            backgroundColor: "rgb(82, 192, 155)",
+            color: "#000",
             fontWeight: "bold",
-            color: coral },
-        { tag: [tags$1.atom, tags$1.bool, /*@__PURE__*/tags$1.special(tags$1.variableName)],
-            color: whiskey },
-        { tag: [tags$1.processingInstruction, tags$1.string, tags$1.inserted],
-            color: sage },
-        { tag: tags$1.invalid,
-            color: invalid },
+            border: "none",
+            padding: "0 3px",
+        },
+    });
+    const dartpadHighlightStyle = HighlightStyle.define([
+        { tag: tags$1.keyword, color: "var(--cm-keyword)" },
+        { tag: [tags$1.comment, tags$1.lineComment, tags$1.blockComment], color: "var(--cm-comment)" },
+        { tag: tags$1.standard(tags$1.name), color: "var(--cm-builtin)" },
+        { tag: [tags$1.atom, tags$1.bool, tags$1.null], color: "var(--cm-atom)" },
+        { tag: tags$1.variableName, color: "var(--cm-variable)" },
+        { tag: [tags$1.typeName, tags$1.className], color: "var(--cm-variable2)" },
+        { tag: tags$1.string, color: "var(--cm-string)" },
+        { tag: tags$1.special(tags$1.string), color: "var(--cm-string2)" },
+        { tag: tags$1.number, color: "var(--cm-number)" },
+        { tag: tags$1.attributeName, color: "var(--cm-attribute)" },
+        { tag: [tags$1.namespace, tags$1.modifier], color: "var(--cm-qualifier)" },
+        { tag: [tags$1.meta, tags$1.annotation], color: "var(--cm-meta)" },
+        { tag: tags$1.heading, color: "var(--cm-header)", fontWeight: "bold" },
+        { tag: [tags$1.operator, tags$1.operatorKeyword], color: "var(--cm-operator)" },
+        { tag: [tags$1.definition(tags$1.name), tags$1.definition(tags$1.variableName)], color: "var(--cm-def)" },
+        { tag: tags$1.tagName, color: "var(--cm-tag)" },
+        { tag: tags$1.propertyName, color: "var(--cm-property)" },
     ]);
-    /**
-    Extension to enable the One Dark theme (both the editor theme and
-    the highlight style).
-    */
-    const oneDark = [oneDarkTheme, /*@__PURE__*/syntaxHighlighting(oneDarkHighlightStyle)];
+    const dartpad = [dartpadTheme, syntaxHighlighting(dartpadHighlightStyle)];
 
     /**
      * marked v15.0.12 - a markdown parser
@@ -40131,7 +40149,7 @@ ${text}</tr>
         LSPPlugin,
         formatDocument,
         formatDocumentAsync,
-        oneDark,
+        dartpadTheme: dartpad,
         showPanel,
         syntaxHighlighting,
         toggleLineComment,

--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -35356,6 +35356,9 @@
         ])
     ])();
 
+    // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
     const dartpadTheme = EditorView.theme({
         "&": {
             fontFamily: "'Roboto Mono', monospace",
@@ -35463,7 +35466,10 @@
     });
     const dartpadHighlightStyle = HighlightStyle.define([
         { tag: tags$1.keyword, color: "var(--cm-keyword)" },
-        { tag: [tags$1.comment, tags$1.lineComment, tags$1.blockComment], color: "var(--cm-comment)" },
+        {
+            tag: [tags$1.comment, tags$1.lineComment, tags$1.blockComment],
+            color: "var(--cm-comment)",
+        },
         { tag: tags$1.standard(tags$1.name), color: "var(--cm-builtin)" },
         { tag: [tags$1.atom, tags$1.bool, tags$1.null], color: "var(--cm-atom)" },
         { tag: tags$1.variableName, color: "var(--cm-variable)" },
@@ -35476,11 +35482,17 @@
         { tag: [tags$1.meta, tags$1.annotation], color: "var(--cm-meta)" },
         { tag: tags$1.heading, color: "var(--cm-header)", fontWeight: "bold" },
         { tag: [tags$1.operator, tags$1.operatorKeyword], color: "var(--cm-operator)" },
-        { tag: [tags$1.definition(tags$1.name), tags$1.definition(tags$1.variableName)], color: "var(--cm-def)" },
+        {
+            tag: [tags$1.definition(tags$1.name), tags$1.definition(tags$1.variableName)],
+            color: "var(--cm-def)",
+        },
         { tag: tags$1.tagName, color: "var(--cm-tag)" },
         { tag: tags$1.propertyName, color: "var(--cm-property)" },
     ]);
-    const dartpad = [dartpadTheme, syntaxHighlighting(dartpadHighlightStyle)];
+    const dartpad = [
+        dartpadTheme,
+        syntaxHighlighting(dartpadHighlightStyle),
+    ];
 
     /**
      * marked v15.0.12 - a markdown parser

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
@@ -20,7 +20,7 @@ external JSAny get basicSetup;
 external JSAny get defaultHighlightStyle;
 
 @JS()
-external JSAny get oneDark;
+external JSAny get dartpadTheme;
 
 /// Options for the `syntaxHighlighting` function.
 ///

--- a/pkgs/dartpad_preview/codemirror-dart/package.json
+++ b/pkgs/dartpad_preview/codemirror-dart/package.json
@@ -29,7 +29,6 @@
     "@codemirror/lint": "^6.9.5",
     "@codemirror/lsp-client": "^6.2.3",
     "@codemirror/state": "^6.6.0",
-    "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.1",
     "@lezer/common": "^1.2.1",
     "@lezer/highlight": "^1.2.0",

--- a/pkgs/dartpad_preview/codemirror-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from "@codemirror/state";
 import { EditorView, keymap, showPanel } from "@codemirror/view";
 import { basicSetup } from "codemirror";
-import { oneDark } from "@codemirror/theme-one-dark";
+import { dartpad as dartpadTheme } from "./theme";
 import { indentWithTab, toggleLineComment } from "@codemirror/commands";
 import {
   syntaxHighlighting,
@@ -54,7 +54,7 @@ declare global {
       LSPPlugin: typeof LSPPlugin;
       formatDocument: typeof formatDocument;
       formatDocumentAsync: typeof formatDocumentAsync;
-      oneDark: Extension;
+      dartpadTheme: Extension;
       showPanel: typeof showPanel;
       syntaxHighlighting: (style: any, options?: any) => Extension;
       toggleLineComment: any;
@@ -98,7 +98,7 @@ window._codemirror = {
   LSPPlugin,
   formatDocument,
   formatDocumentAsync,
-  oneDark,
+  dartpadTheme,
   showPanel,
   syntaxHighlighting,
   toggleLineComment,

--- a/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
@@ -1,0 +1,134 @@
+import { EditorView } from "@codemirror/view";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags } from "@lezer/highlight";
+
+export const dartpadTheme = EditorView.theme({
+  "&": {
+    fontFamily: "'Roboto Mono', monospace",
+    fontWeight: "400",
+    // Default to Light Mode variables and styles
+    backgroundColor: "#fff",
+    color: "#4a4a4a",
+    "--cm-builtin": "#4a4a4a",
+    "--cm-comment": "#5F6368",
+    "--cm-keyword": "#007a27",
+    "--cm-atom": "#2f4960",
+    "--cm-variable": "#0E161F",
+    "--cm-variable2": "#a54a78",
+    "--cm-string": "#bc0056",
+    "--cm-string2": "#983ab3",
+    "--cm-number": "#00786d",
+    "--cm-attribute": "#0E161F",
+    "--cm-qualifier": "#d32923",
+    "--cm-meta": "#00786d",
+    "--cm-header": "#0E161F",
+    "--cm-operator": "#4a4a4a",
+    "--cm-def": "#4a4a4a",
+    "--cm-tag": "#007a27",
+    "--cm-property": "#a54a78",
+  },
+
+  // Light Mode Scoped Styles
+  ".cm-content": {
+    caretColor: "#4a4a4a",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeft: "1px solid #4a4a4a",
+  },
+  ".cm-selectionBackground, .cm-content ::selection": {
+    backgroundColor: "#e8e8e8 !important",
+  },
+  ".cm-gutters": {
+    backgroundColor: "#fff !important",
+    color: "#d0d0d2",
+    borderRight: "none",
+  },
+  "&.cm-focused .cm-matchingBracket, &.cm-focused .cm-nonmatchingBracket": {
+    outline: "1px solid #606060",
+    color: "#a54a78 !important",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "rgba(27, 134, 245, 0.035)",
+  },
+  ".cm-activeLineGutter": {
+    backgroundColor: "rgba(27, 134, 245, 0.07)",
+  },
+
+  // Dark Mode Overrides (triggered by data-theme="dark" on ancestor html or body)
+  '[data-theme="dark"] &': {
+    backgroundColor: "#0E161F",
+    color: "#FFFFFF",
+    "--cm-builtin": "#FFFFFF",
+    "--cm-comment": "#909CC3",
+    "--cm-keyword": "#50E191",
+    "--cm-atom": "#FF916E",
+    "--cm-variable": "#00D2FA",
+    "--cm-variable2": "#FF916E",
+    "--cm-string": "#FA557D",
+    "--cm-string2": "#FF00FA",
+    "--cm-number": "#909090",
+    "--cm-attribute": "#00D2FA",
+    "--cm-qualifier": "#FF9B00",
+    "--cm-meta": "#909090",
+    "--cm-header": "#00D2FA",
+    "--cm-operator": "#FFFFFF",
+    "--cm-def": "#FFFFFF",
+    "--cm-tag": "#50E191",
+    "--cm-property": "#FF2D64",
+  },
+  '[data-theme="dark"] & .cm-content': {
+    caretColor: "white",
+  },
+  '[data-theme="dark"] & .cm-cursor, [data-theme="dark"] & .cm-dropCursor': {
+    borderLeft: "1px solid white",
+  },
+  '[data-theme="dark"] & .cm-selectionBackground, [data-theme="dark"] & .cm-content ::selection': {
+    backgroundColor: "#23364D !important",
+  },
+  '[data-theme="dark"] & .cm-gutters': {
+    backgroundColor: "#0E161F !important",
+    color: "#909090",
+    borderRight: "none",
+  },
+  '[data-theme="dark"] &.cm-focused .cm-matchingBracket, [data-theme="dark"] &.cm-focused .cm-nonmatchingBracket': {
+    outline: "1px solid #606060",
+    color: "#FF2D64 !important",
+  },
+  '[data-theme="dark"] & .cm-activeLine': {
+    backgroundColor: "rgba(32, 143, 253, 0.035)",
+  },
+  '[data-theme="dark"] & .cm-activeLineGutter': {
+    backgroundColor: "rgba(32, 143, 253, 0.07)",
+  },
+
+  // Shared Styles
+  ".cm-foldPlaceholder": {
+    backgroundColor: "rgb(82, 192, 155)",
+    color: "#000",
+    fontWeight: "bold",
+    border: "none",
+    padding: "0 3px",
+  },
+});
+
+export const dartpadHighlightStyle = HighlightStyle.define([
+  { tag: tags.keyword, color: "var(--cm-keyword)" },
+  { tag: [tags.comment, tags.lineComment, tags.blockComment], color: "var(--cm-comment)" },
+  { tag: tags.standard(tags.name), color: "var(--cm-builtin)" },
+  { tag: [tags.atom, tags.bool, tags.null], color: "var(--cm-atom)" },
+  { tag: tags.variableName, color: "var(--cm-variable)" },
+  { tag: [tags.typeName, tags.className], color: "var(--cm-variable2)" },
+  { tag: tags.string, color: "var(--cm-string)" },
+  { tag: tags.special(tags.string), color: "var(--cm-string2)" },
+  { tag: tags.number, color: "var(--cm-number)" },
+  { tag: tags.attributeName, color: "var(--cm-attribute)" },
+  { tag: [tags.namespace, tags.modifier], color: "var(--cm-qualifier)" },
+  { tag: [tags.meta, tags.annotation], color: "var(--cm-meta)" },
+  { tag: tags.heading, color: "var(--cm-header)", fontWeight: "bold" },
+  { tag: [tags.operator, tags.operatorKeyword], color: "var(--cm-operator)" },
+  { tag: [tags.definition(tags.name), tags.definition(tags.variableName)], color: "var(--cm-def)" },
+  { tag: tags.tagName, color: "var(--cm-tag)" },
+  { tag: tags.propertyName, color: "var(--cm-property)" },
+]);
+
+export const dartpad = [dartpadTheme, syntaxHighlighting(dartpadHighlightStyle)];

--- a/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
@@ -86,18 +86,20 @@ export const dartpadTheme = EditorView.theme({
   '[data-theme="dark"] & .cm-cursor, [data-theme="dark"] & .cm-dropCursor': {
     borderLeft: "1px solid white",
   },
-  '[data-theme="dark"] & .cm-selectionBackground, [data-theme="dark"] & .cm-content ::selection': {
-    backgroundColor: "#23364D !important",
-  },
+  '[data-theme="dark"] & .cm-selectionBackground, [data-theme="dark"] & .cm-content ::selection':
+    {
+      backgroundColor: "#23364D !important",
+    },
   '[data-theme="dark"] & .cm-gutters': {
     backgroundColor: "#0E161F !important",
     color: "#909090",
     borderRight: "none",
   },
-  '[data-theme="dark"] &.cm-focused .cm-matchingBracket, [data-theme="dark"] &.cm-focused .cm-nonmatchingBracket': {
-    outline: "1px solid #606060",
-    color: "#FF2D64 !important",
-  },
+  '[data-theme="dark"] &.cm-focused .cm-matchingBracket, [data-theme="dark"] &.cm-focused .cm-nonmatchingBracket':
+    {
+      outline: "1px solid #606060",
+      color: "#FF2D64 !important",
+    },
   '[data-theme="dark"] & .cm-activeLine': {
     backgroundColor: "rgba(32, 143, 253, 0.035)",
   },
@@ -117,7 +119,10 @@ export const dartpadTheme = EditorView.theme({
 
 export const dartpadHighlightStyle = HighlightStyle.define([
   { tag: tags.keyword, color: "var(--cm-keyword)" },
-  { tag: [tags.comment, tags.lineComment, tags.blockComment], color: "var(--cm-comment)" },
+  {
+    tag: [tags.comment, tags.lineComment, tags.blockComment],
+    color: "var(--cm-comment)",
+  },
   { tag: tags.standard(tags.name), color: "var(--cm-builtin)" },
   { tag: [tags.atom, tags.bool, tags.null], color: "var(--cm-atom)" },
   { tag: tags.variableName, color: "var(--cm-variable)" },
@@ -130,9 +135,15 @@ export const dartpadHighlightStyle = HighlightStyle.define([
   { tag: [tags.meta, tags.annotation], color: "var(--cm-meta)" },
   { tag: tags.heading, color: "var(--cm-header)", fontWeight: "bold" },
   { tag: [tags.operator, tags.operatorKeyword], color: "var(--cm-operator)" },
-  { tag: [tags.definition(tags.name), tags.definition(tags.variableName)], color: "var(--cm-def)" },
+  {
+    tag: [tags.definition(tags.name), tags.definition(tags.variableName)],
+    color: "var(--cm-def)",
+  },
   { tag: tags.tagName, color: "var(--cm-tag)" },
   { tag: tags.propertyName, color: "var(--cm-property)" },
 ]);
 
-export const dartpad = [dartpadTheme, syntaxHighlighting(dartpadHighlightStyle)];
+export const dartpad = [
+  dartpadTheme,
+  syntaxHighlighting(dartpadHighlightStyle),
+];

--- a/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import { EditorView } from "@codemirror/view";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { tags } from "@lezer/highlight";

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -31,7 +31,7 @@ void main() {
       'linter',
       'LSPPlugin',
       'formatDocument',
-      'oneDark',
+      'dartpadTheme',
       'showPanel',
       'syntaxHighlighting',
       'toggleLineComment',

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -64,7 +64,7 @@ final class CodeMirrorEditor {
           cm.basicSetup,
           cm.gotoDefinitionOnClick(),
           cm.keymapOf([cm.indentWithTab as cm.KeyBinding].toJS),
-          cm.oneDark,
+          cm.dartpadTheme,
           cm.lintGutter(),
           cm.linter(null),
           cm.syntaxHighlighting(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
@@ -6,17 +6,13 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr_content/theme.dart';
 
 final colorPrimary = const ColorToken('primary', Color('#1B86F5'), dark: Color('#208FFD'));
-final colorOnPrimary = const ColorToken('on-primary', Color('#000000'));
+final colorOnPrimary = const ColorToken('on-primary', Color('#FFFFFF'), dark: Color('#0C141D'));
 final colorSurface = const ColorToken('surface', Color('#F5F5F7'), dark: Color('#1D2834'));
 final colorOnSurface = const ColorToken('on-surface', Color('#445F91'), dark: Color('#FFFFFF'));
 final colorContainer = const ColorToken('container', Color('#FFFFFF'), dark: Color('#0C141D'));
 final colorOnContainer = const ColorToken('on-container', Color('#000000'), dark: Color('#FFFFFF'));
 
-final colorBorder = colorSurface;
-final colorOnSurfaceVariant = Color('#FF00FF');
-final colorContainerLow = Color('#003300');
-final colorContainerHigh = Color('#006600');
-final colorInfo = Color('#FFFF00');
+final colorBorder = colorSurface.highlight(colorOnSurface, 0.05);
 
 extension ColorHighlight on Color {
   Color highlight(Color overlay, double amount) {
@@ -25,7 +21,10 @@ extension ColorHighlight on Color {
 }
 
 final colorError = const ColorToken('error', Color('#F44336'));
+final colorErrorSurface = const ColorToken('error-surface', Color('#FFEBE9'), dark: Color('#351f1f'));
 final colorWarning = const ColorToken('warning', Color('#FBC02C'), dark: Color('#FFEB3A'));
+final colorInfo = const ColorToken('info', Color('#208FFD'));
+final colorSuccess = const ColorToken('success', Color('#4CAF50'));
 
 /// Global styles that establish the document-level application layout.
 @css
@@ -52,7 +51,9 @@ List<StyleRule> get appStyles => [
     colorContainer,
     colorOnContainer,
     colorError,
+    colorErrorSurface,
     colorWarning,
-    colorBorder,
+    colorInfo,
+    colorSuccess,
   ].build(),
 ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
@@ -3,24 +3,29 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:jaspr/dom.dart';
+import 'package:jaspr_content/theme.dart';
 
-// TODO: Implement proper dartpad theming.
-const colorPrimary = Color.variable('--color-primary');
-const colorOnPrimary = Color.variable('--color-on-primary');
-const colorSurface = Color.variable('--color-surface');
-const colorOnSurface = Color.variable('--color-on-surface');
-const colorOnSurfaceVariant = Color.variable('--color-on-surface-variant');
-const colorContainer = Color.variable('--color-container');
-const colorContainerLow = Color.variable('--color-container-low');
-const colorContainerHigh = Color.variable('--color-container-high');
-const colorBorder = Color.variable('--color-border');
+final colorPrimary = const ColorToken('primary', Color('#1B86F5'), dark: Color('#208FFD'));
+final colorOnPrimary = const ColorToken('on-primary', Color('#000000'));
+final colorSurface = const ColorToken('surface', Color('#F5F5F7'), dark: Color('#1D2834'));
+final colorOnSurface = const ColorToken('on-surface', Color('#445F91'), dark: Color('#FFFFFF'));
+final colorContainer = const ColorToken('container', Color('#FFFFFF'), dark: Color('#0C141D'));
+final colorOnContainer = const ColorToken('on-container', Color('#000000'), dark: Color('#FFFFFF'));
 
-const colorError = Color.variable('--color-error');
-const colorWarning = Color.variable('--color-warning');
-const colorSuccess = Color.variable('--color-success');
-const colorInfo = Color.variable('--color-info');
-const colorPurple = Color.variable('--color-purple');
-const colorGray = Color.variable('--color-gray');
+final colorBorder = colorSurface;
+final colorOnSurfaceVariant = Color('#FF00FF');
+final colorContainerLow = Color('#003300');
+final colorContainerHigh = Color('#006600');
+final colorInfo = Color('#FFFF00');
+
+extension ColorHighlight on Color {
+  Color highlight(Color overlay, double amount) {
+    return Color('color-mix(in hsl, $value, ${overlay.value} ${amount * 100}%)');
+  }
+}
+
+final colorError = const ColorToken('error', Color('#F44336'));
+final colorWarning = const ColorToken('warning', Color('#FBC02C'), dark: Color('#FFEB3A'));
 
 /// Global styles that establish the document-level application layout.
 @css
@@ -31,29 +36,23 @@ List<StyleRule> get appStyles => [
     padding: .zero,
     margin: .zero,
     overflow: .hidden,
-    color: const Color('#d4d4d4'),
+    color: colorOnSurface,
     fontFamily: const .list([
       FontFamily('Inter'),
       FontFamily('Segoe UI'),
       FontFamilies.sansSerif,
     ]),
-    backgroundColor: const Color('#1e1e1e'),
+    backgroundColor: colorSurface,
   ),
-  css(':root').styles(
-    raw: {
-      '--color-primary': '#4285f4', // Google Blue
-      '--color-on-primary': '#ffffff',
-      '--color-surface': '#121212', // Dark background
-      '--color-on-surface': '#f5f5f5', // White foreground
-      '--color-on-surface-variant': '#9e9e9e', // Muted text
-      '--color-container': '#1e1e1e', // Panels, editor container, etc.
-      '--color-container-low': '#161616', // Sidebar, tabs bg
-      '--color-container-high': '#2a2a2a', // Buttons, active items, hover
-      '--color-border': '#2d2d2d',
-      '--color-error': '#ea4335', // Google Red
-      '--color-warning': '#fbbc05', // Google Yellow
-      '--color-success': '#34a853', // Google Green
-      '--color-info': '#4285f4', // Google Blue
-    },
-  ),
+  ...[
+    colorPrimary,
+    colorOnPrimary,
+    colorSurface,
+    colorOnSurface,
+    colorContainer,
+    colorOnContainer,
+    colorError,
+    colorWarning,
+    colorBorder,
+  ].build(),
 ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
@@ -80,7 +80,7 @@ class BottomPanelTabs extends StatelessComponent {
       ]),
       alignItems: .center,
       gap: Gap.all(6.px),
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       fontSize: 12.px,
       fontWeight: .w500,
       backgroundColor: Colors.transparent,
@@ -117,12 +117,12 @@ class BottomPanelTabs extends StatelessComponent {
       justifyContent: .center,
       alignItems: .center,
       alignSelf: .center,
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       backgroundColor: Colors.transparent,
     ),
     css('.bottom-panel-clear-btn:hover').styles(
       color: colorOnSurface,
-      backgroundColor: colorOnSurface.withOpacity(0.08),
+      backgroundColor: colorOnSurface.highlight(colorOnSurface, 0.1),
     ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/debug_console_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/debug_console_panel.dart
@@ -78,7 +78,7 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
       overflow: .hidden,
       flexDirection: .column,
       flex: const Flex(grow: 1, basis: .zero),
-      backgroundColor: colorContainerLow,
+      backgroundColor: colorContainer,
     ),
     css('.debug-console-list').styles(
       minHeight: .zero,
@@ -90,7 +90,7 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
       minHeight: 48.px,
       padding: .symmetric(horizontal: 12.px),
       alignItems: .center,
-      color: colorOnSurfaceVariant,
+      color: colorOnContainer,
       fontSize: 12.px,
     ),
     css('.log-row').styles(
@@ -118,7 +118,7 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
     css('.log-message').styles(
       margin: .zero,
       overflow: const .only(x: .auto),
-      color: colorOnSurface.withOpacity(0.82),
+      color: colorOnContainer,
       fontFamily: const .list([FontFamilies.courierNew, FontFamilies.monospace]),
       fontSize: 12.px,
       lineHeight: 18.px,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -106,7 +106,7 @@ class ProblemsPanel extends StatelessComponent {
       ),
       css('& .problem-row:hover, & .problem-row:focus').styles(
         outline: const Outline(style: .none),
-        backgroundColor: colorContainerHigh,
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
       ),
       css('& .problem-row.error').styles(
         border: .only(
@@ -124,7 +124,7 @@ class ProblemsPanel extends StatelessComponent {
         ),
       ),
       css('& .problem-row.active-file').styles(
-        backgroundColor: colorContainerHigh.withOpacity(0.5),
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
       ),
       css('& .problem-severity-badge').styles(
         display: .inlineFlex,
@@ -161,7 +161,7 @@ class ProblemsPanel extends StatelessComponent {
       ),
       css('& .problem-location').styles(
         display: .inlineBlock,
-        color: colorOnSurfaceVariant,
+        color: colorOnSurface,
         fontFamily: const .list([
           FontFamilies.courierNew,
           FontFamilies.monospace,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -61,7 +61,7 @@ class ProblemsPanel extends StatelessComponent {
         overflow: .hidden,
         flexDirection: .column,
         flex: const .shrink(0),
-        backgroundColor: colorContainerLow,
+        backgroundColor: colorContainer,
       ),
       css('& .problems-list').styles(
         minHeight: .zero,
@@ -82,7 +82,7 @@ class ProblemsPanel extends StatelessComponent {
         minHeight: 48.px,
         padding: .symmetric(horizontal: 12.px),
         alignItems: .center,
-        color: colorOnSurfaceVariant,
+        color: colorOnContainer,
         fontSize: 12.px,
       ),
       css('& .problem-row').styles(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
@@ -24,7 +24,7 @@ List<StyleRule> get codemirrorStyles => [
     minWidth: .zero,
     overflow: .hidden,
     flex: const Flex(grow: 1, basis: .zero),
-    backgroundColor: const Color('#1e1e1e'),
+    backgroundColor: colorContainer,
   ),
   css('.editor-container .cm-editor').styles(
     position: const .relative(),
@@ -55,7 +55,7 @@ List<StyleRule> get codemirrorStyles => [
     color: colorOnSurface,
     fontSize: 13.px,
     fontWeight: .w500,
-    backgroundColor: colorContainerHigh,
+    backgroundColor: colorSurface,
     raw: {
       'background-image': 'none',
     },
@@ -78,7 +78,7 @@ List<StyleRule> get codemirrorStyles => [
     height: 1.px,
     margin: .symmetric(vertical: 8.px, horizontal: (-12).px),
     border: .none,
-    backgroundColor: colorOnSurfaceVariant,
+    backgroundColor: colorOnSurface,
   ),
   css('.editor-container .cm-lsp-hover-tooltip p').styles(
     margin: .only(top: 0.px, right: 0.px, bottom: 8.px, left: 0.px),
@@ -108,7 +108,7 @@ List<StyleRule> get codemirrorStyles => [
       FontFamilies.courierNew,
       FontFamilies.monospace,
     ]),
-    backgroundColor: colorContainerLow,
+    backgroundColor: colorContainer,
   ),
   css('.editor-container .cm-panel.cm-lsp-rename-panel').styles(
     display: .flex,
@@ -116,7 +116,7 @@ List<StyleRule> get codemirrorStyles => [
     flexDirection: .row,
     alignItems: .center,
     gap: .all(10.px),
-    color: colorOnSurface,
+    color: colorOnContainer,
     fontFamily: const .list([FontFamily('Inter'), FontFamilies.sansSerif]),
     fontSize: 13.px,
     backgroundColor: colorContainer,
@@ -146,9 +146,9 @@ List<StyleRule> get codemirrorStyles => [
     border: .all(color: colorBorder, width: 1.px),
     radius: .circular(4.px),
     outline: const Outline(style: .none),
-    color: colorOnSurface,
+    color: colorOnContainer,
     fontSize: 13.px,
-    backgroundColor: colorContainerLow,
+    backgroundColor: colorContainer,
   ),
   css('.editor-container .cm-panel.cm-lsp-rename-panel .cm-textfield:focus').styles(
     border: .all(color: colorPrimary, width: 1.px),
@@ -158,13 +158,13 @@ List<StyleRule> get codemirrorStyles => [
     margin: .zero,
     alignItems: .center,
     gap: .all(6.px),
-    color: colorOnSurfaceVariant,
+    color: colorOnContainer,
     fontWeight: .w500,
   ),
   css('.editor-container .cm-panel.cm-search').styles(
     position: const .relative(),
     padding: .symmetric(vertical: 8.px, horizontal: 12.px),
-    color: colorOnSurface,
+    color: colorOnContainer,
     fontFamily: const .list([FontFamily('Inter'), FontFamilies.sansSerif]),
     fontSize: 13.px,
     backgroundColor: colorContainer,
@@ -183,13 +183,13 @@ List<StyleRule> get codemirrorStyles => [
     ]),
     justifyContent: .center,
     alignItems: .center,
-    color: colorOnSurfaceVariant,
+    color: colorOnContainer,
     fontSize: 16.px,
     backgroundColor: Colors.transparent,
   ),
   css('.editor-container .cm-panel.cm-search [name=close]:hover').styles(
-    color: colorOnSurface,
-    backgroundColor: colorContainerHigh,
+    color: colorOnContainer,
+    backgroundColor: colorContainer,
   ),
   css(
     '.editor-container .cm-panel.cm-search input, .editor-container .cm-panel.cm-search button, .editor-container .cm-panel.cm-search label',
@@ -214,9 +214,9 @@ List<StyleRule> get codemirrorStyles => [
     radius: .circular(4.px),
     outline: const Outline(style: .none),
     transition: Transition('border-color', duration: 200.ms),
-    color: colorOnSurface,
+    color: colorOnContainer,
     fontSize: 13.px,
-    backgroundColor: colorContainerLow,
+    backgroundColor: colorContainer,
   ),
   css(
     '.editor-container .cm-panel.cm-search input[type=text]:focus, .editor-container .cm-panel.cm-search .cm-textfield:focus',
@@ -229,14 +229,14 @@ List<StyleRule> get codemirrorStyles => [
     flexDirection: .row,
     alignItems: .center,
     gap: .all(4.px),
-    color: colorOnSurfaceVariant,
+    color: colorOnSurface,
     fontSize: 12.px,
   ),
   css('.editor-container .cm-panels').styles(
     border: .only(
       top: .solid(color: colorBorder, width: 1.px),
     ),
-    backgroundColor: colorContainerLow,
+    backgroundColor: colorContainer,
   ),
   css('.editor-container .cm-tooltip').styles(
     maxWidth: 450.px,
@@ -259,7 +259,7 @@ List<StyleRule> get codemirrorStyles => [
     ]),
     fontSize: 13.px,
     lineHeight: 1.4.em,
-    backgroundColor: colorContainerHigh,
+    backgroundColor: colorSurface,
   ),
   css('.editor-container .cm-tooltip a').styles(
     color: colorPrimary,
@@ -280,14 +280,14 @@ List<StyleRule> get codemirrorStyles => [
   ),
   css('.editor-container .cm-tooltip-arrow::after').styles(
     raw: {
-      'border-top-color': 'var(--color-container-high)',
-      'border-bottom-color': 'var(--color-container-high)',
+      'border-top-color': colorContainer.value,
+      'border-bottom-color': colorContainer.value,
     },
   ),
   css('.editor-container .cm-tooltip-arrow::before').styles(
     raw: {
-      'border-top-color': 'var(--color-border)',
-      'border-bottom-color': 'var(--color-border)',
+      'border-top-color': colorBorder.value,
+      'border-bottom-color': colorBorder.value,
     },
   ),
   css('.editor-container .cm-selection-action-tooltip').styles(
@@ -334,7 +334,7 @@ List<StyleRule> get codemirrorStyles => [
     padding: .symmetric(vertical: 4.px, horizontal: 6.px),
     radius: .circular(6.px),
     gap: .all(6.px),
-    backgroundColor: colorContainerHigh,
+    backgroundColor: colorContainer,
   ),
   css('.editor-container .cm-diagnostic-toolbar-btn').styles(
     display: .inlineFlex,
@@ -352,7 +352,7 @@ List<StyleRule> get codemirrorStyles => [
     color: colorPrimary,
     fontSize: 12.px,
     fontWeight: .w500,
-    backgroundColor: colorContainerHigh,
+    backgroundColor: colorContainer,
     raw: {
       'background-image': 'none',
     },
@@ -366,7 +366,7 @@ List<StyleRule> get codemirrorStyles => [
     border: .all(color: colorBorder, width: 1.px),
     opacity: .5,
     cursor: .notAllowed,
-    color: colorOnSurfaceVariant,
-    backgroundColor: colorContainerLow,
+    color: colorOnContainer,
+    backgroundColor: colorContainer,
   ),
 ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -6,6 +6,7 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
+import '../../../app_styles.dart';
 import '../../shared/components/split_panel.dart';
 import 'editor_stack.dart';
 import 'editor_tabs.dart';
@@ -96,18 +97,13 @@ class EditorShell extends StatelessComponent {
       minWidth: .zero,
       minHeight: .zero,
       flex: const Flex(grow: 1, basis: .zero),
-      backgroundColor: const Color('#1e1e1e'),
     ),
     css('.file-tree-pane').styles(
       display: .flex,
       minWidth: 100.px,
       minHeight: .zero,
-      border: .only(
-        right: .solid(color: const Color('#303030'), width: 1.px),
-      ),
       overflow: .hidden,
       flexDirection: .column,
-      backgroundColor: const Color('#181818'),
     ),
     css('.editor-host').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -97,6 +97,7 @@ class EditorShell extends StatelessComponent {
       minWidth: .zero,
       minHeight: .zero,
       flex: const Flex(grow: 1, basis: .zero),
+      backgroundColor: colorContainer,
     ),
     css('.file-tree-pane').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
@@ -7,6 +7,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
+import '../../../app_styles.dart';
 import '../../shared/icons.dart';
 
 /// Renders a tab bar for switching between and closing open editor files.
@@ -106,7 +107,7 @@ final class EditorTabs extends StatelessComponent {
         minHeight: 38.px,
         overflow: const .only(x: .auto, y: .hidden),
         flex: const .shrink(0),
-        backgroundColor: const Color('#181818'),
+        backgroundColor: colorSurface,
       ),
       css('.editor-tab', [
         css('&').styles(
@@ -115,24 +116,24 @@ final class EditorTabs extends StatelessComponent {
           maxWidth: 180.px,
           padding: .only(left: 12.px, right: 8.px),
           border: .only(
-            right: .solid(color: const Color('#303030'), width: 1.px),
+            right: .solid(color: colorBorder, width: 1.px),
             top: .solid(color: Colors.transparent, width: 2.px),
           ),
           cursor: .pointer,
           userSelect: .none,
           alignItems: .center,
           gap: .all(6.px),
-          color: const Color('#a8a8a8'),
-          backgroundColor: const Color('#181818'),
+          color: colorOnSurface,
+          backgroundColor: colorSurface,
         ),
         css('&.active').styles(
           border: .only(
-            top: .solid(color: const Color('#7aa2f7'), width: 2.px),
+            top: .solid(color: colorPrimary, width: 2.px),
           ),
-          color: const Color('#e8e8e8'),
-          backgroundColor: const Color('#1e1e1e'),
+          color: colorOnContainer,
+          backgroundColor: colorContainer,
         ),
-        css('&:hover').styles(backgroundColor: const Color('#252525')),
+        css('&:hover').styles(backgroundColor: colorSurface.highlight(colorOnSurface, 0.1)),
         css('.editor-tab-name').styles(
           minWidth: .zero,
           overflow: .hidden,
@@ -147,7 +148,7 @@ final class EditorTabs extends StatelessComponent {
           height: 7.px,
           radius: .circular(4.px),
           flex: const .shrink(0),
-          backgroundColor: const Color('#d4d4d4'),
+          backgroundColor: colorPrimary,
         ),
         css('.editor-tab-action', [
           css('&').styles(
@@ -160,7 +161,7 @@ final class EditorTabs extends StatelessComponent {
             cursor: .pointer,
             justifyContent: .center,
             alignItems: .center,
-            color: const Color('#b8b8b8'),
+            color: colorOnSurface,
             fontSize: 11.px,
             backgroundColor: Colors.transparent,
           ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
@@ -116,15 +116,17 @@ final class EditorTabs extends StatelessComponent {
           maxWidth: 180.px,
           padding: .only(left: 12.px, right: 8.px),
           border: .only(
-            right: .solid(color: colorBorder, width: 1.px),
             top: .solid(color: Colors.transparent, width: 2.px),
           ),
           cursor: .pointer,
           userSelect: .none,
           alignItems: .center,
           gap: .all(6.px),
-          color: colorOnSurface,
-          backgroundColor: colorSurface,
+          color: colorOnContainer,
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
+        ),
+        css('&:hover').styles(
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.15),
         ),
         css('&.active').styles(
           border: .only(
@@ -133,7 +135,9 @@ final class EditorTabs extends StatelessComponent {
           color: colorOnContainer,
           backgroundColor: colorContainer,
         ),
-        css('&:hover').styles(backgroundColor: colorSurface.highlight(colorOnSurface, 0.1)),
+        css('&.active:hover').styles(
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.05),
+        ),
         css('.editor-tab-name').styles(
           minWidth: .zero,
           overflow: .hidden,
@@ -170,8 +174,8 @@ final class EditorTabs extends StatelessComponent {
             backgroundColor: const Color('#3a3a3a'),
           ),
           css('&.close:hover').styles(
-            color: const Color('#ff8a8a'),
-            backgroundColor: const Color('#4a2525'),
+            color: colorError,
+            backgroundColor: colorSurface,
           ),
         ]),
       ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -9,6 +9,7 @@ import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/components/file_icon.dart';
 import 'package:web/web.dart' as web;
 
+import '../../app_styles.dart';
 import '../shared/icons.dart';
 import 'components/file_tree_file_item.dart';
 import 'components/file_tree_folder_item.dart';
@@ -314,20 +315,21 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         minHeight: .zero,
         overflow: .hidden,
         flexDirection: .column,
-        backgroundColor: const Color('#181818'),
+        backgroundColor: colorContainer,
       ),
       css('.file-tree-header').styles(
         display: .flex,
         minHeight: 38.px,
         padding: .symmetric(horizontal: 10.px),
         border: .only(
-          bottom: .solid(color: const Color('#303030'), width: 1.px),
+          bottom: .solid(color: colorBorder, width: 1.px),
         ),
         justifyContent: .spaceBetween,
         alignItems: .center,
+        backgroundColor: colorSurface,
       ),
       css('.file-tree-title').styles(
-        color: const Color('#d4d4d4'),
+        color: colorOnSurface,
         fontSize: 11.px,
         fontWeight: FontWeight.w600,
         textTransform: .upperCase,
@@ -342,13 +344,12 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         cursor: .pointer,
         justifyContent: .center,
         alignItems: .center,
-        color: const Color('#a8a8a8'),
+        color: colorOnSurface,
         backgroundColor: Colors.transparent,
       ),
       css('.file-tree-toolbar-button').styles(width: 24.px, height: 24.px),
       css('.file-tree-toolbar-button:hover, .file-tree-action:hover, .file-tree-disclosure:hover').styles(
-        color: const Color('#ffffff'),
-        backgroundColor: const Color('#353535'),
+        backgroundColor: colorSurface.highlight(colorOnSurface, 0.1),
       ),
       css('.file-tree-toolbar-button:disabled, .file-tree-action:disabled').styles(
         opacity: 0.45,
@@ -385,14 +386,16 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
           userSelect: .none,
           alignItems: .center,
           gap: .all(5.px),
-          color: const Color('#c5c5c5'),
+          color: colorOnContainer,
           fontSize: 12.px,
-          backgroundColor: const Color('#181818'),
+          backgroundColor: colorContainer,
         ),
 
-        css('&:hover').styles(backgroundColor: const Color('#252525')),
+        css('&:hover').styles(
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
+        ),
         css('&.active').styles(
-          backgroundColor: const Color('#333333'),
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
         ),
         css('&.dim .file-tree-name').styles(
           opacity: 0.4,
@@ -405,13 +408,13 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         ),
         css('&.selected').styles(
           outline: Outline(
-            color: const Color('#7aa2f7'),
+            color: colorPrimary,
             style: OutlineStyle.solid,
             width: OutlineWidth(1.px),
             offset: (-1).px,
           ),
-          color: const Color('#ffffff'),
-          backgroundColor: const Color('#303747'),
+          color: colorOnContainer,
+          backgroundColor: colorContainer.highlight(colorPrimary, 0.4),
         ),
 
         css('&.dragging').styles(opacity: 0.45),
@@ -432,21 +435,21 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         ),
         width: 1.px,
         opacity: 0,
-        backgroundColor: const Color('#444444'),
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.3),
         raw: {'z-index': 'calc(100 - var(--tree-depth) - 1)'},
       ),
       css(
         '.file-tree-folder:has(>.file-tree-item.selected, >.file-tree-folder-children >.file-tree-item.selected)::after',
       ).styles(
-        backgroundColor: const Color('#666666'),
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.5),
       ),
       css('.file-tree-folder.drop-target').styles(
         border: .none,
         outline: const Outline(style: .none),
-        backgroundColor: const Color('#333333'),
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
       ),
       css('.file-tree-folder.drop-target .file-tree-item').styles(
-        backgroundColor: const Color('#333333'),
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
       ),
       css('.file-tree-folder.drop-target > .file-tree-item *').styles(
         pointerEvents: .none,
@@ -462,7 +465,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         width: 12.px,
         height: 12.px,
         flex: const .shrink(0),
-        color: const Color('#858585'),
+        color: colorOnContainer,
         raw: const {'vertical-align': 'middle'},
       ),
       css('.file-tree-icon.file-icon-dart').styles(color: const Color('#5da9e9')),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -392,10 +392,10 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         ),
 
         css('&:hover').styles(
-          backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.05),
         ),
         css('&.active').styles(
-          backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
+          backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
         ),
         css('&.dim .file-tree-name').styles(
           opacity: 0.4,
@@ -465,10 +465,10 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         width: 12.px,
         height: 12.px,
         flex: const .shrink(0),
-        color: colorOnContainer,
+        color: colorOnSurface,
         raw: const {'vertical-align': 'middle'},
       ),
-      css('.file-tree-icon.file-icon-dart').styles(color: const Color('#5da9e9')),
+      css('.file-tree-icon.file-icon-dart').styles(color: colorPrimary),
       css('.file-tree-icon.file-icon-yaml').styles(color: const Color('#c586c0')),
       css('.file-tree-name').styles(
         minWidth: .zero,
@@ -485,14 +485,8 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
           height: 20.px,
           flex: const .shrink(0),
         ),
-        css('&.delete:hover').styles(
-          color: const Color('#ff8a8a'),
-          backgroundColor: const Color('#4a2525'),
-        ),
-        css('&.confirm:hover').styles(
-          color: const Color('#9ece6a'),
-          backgroundColor: const Color('#243a2a'),
-        ),
+        css('&.delete:hover').styles(color: colorError, backgroundColor: colorSurface),
+        css('&.confirm:hover').styles(color: colorSuccess, backgroundColor: colorSurface),
       ]),
 
       css('.file-tree-action-icon').styles(
@@ -504,23 +498,23 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         css('&').styles(
           height: 20.px,
           minWidth: .zero,
-          border: .all(color: const Color('#7aa2f7'), width: 1.px),
+          border: .all(color: colorBorder, width: 1.px),
           radius: .circular(2.px),
           outline: const Outline(style: .none),
           flex: const Flex(grow: 1, basis: .zero),
-          color: const Color('#ffffff'),
+          color: colorOnContainer,
           fontSize: 1.em,
-          backgroundColor: const Color('#202020'),
+          backgroundColor: colorContainer,
         ),
         css('&.invalid').styles(
-          border: .all(color: const Color('#ff6b6b'), width: 1.px),
+          border: .all(color: colorError, width: 1.px),
         ),
       ]),
       css('.file-tree-validation, .file-tree-error').styles(
         padding: .symmetric(horizontal: 8.px, vertical: 5.px),
-        color: const Color('#ff9a9a'),
+        color: colorError,
         fontSize: 11.px,
-        backgroundColor: const Color('#351f1f'),
+        backgroundColor: colorErrorSurface,
       ),
       css('.file-tree-validation').styles(
         position: .absolute(top: 24.px, left: 22.px, right: 6.px),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -106,7 +106,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
         overflow: .hidden,
         flexDirection: .column,
         flex: const .grow(1),
-        backgroundColor: colorContainerLow,
+        backgroundColor: colorContainer,
       ),
       css('.preview-toolbar', [
         css('&').styles(
@@ -118,7 +118,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
           justifyContent: .spaceBetween,
           alignItems: .center,
           flex: const .shrink(0),
-          backgroundColor: colorContainerLow,
+          backgroundColor: colorSurface,
         ),
         css('.preview-controls').styles(
           display: .flex,
@@ -199,7 +199,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
           position: .absolute(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
           justifyContent: .center,
           alignItems: .center,
-          color: colorOnSurfaceVariant,
+          color: colorOnSurface,
           fontSize: 14.px,
         ),
       ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -108,6 +108,13 @@ class _PreviewContainerState extends State<PreviewContainer> {
         flex: const .grow(1),
         backgroundColor: colorContainer,
       ),
+      css('.active-icon-btn').styles(
+        color: colorOnPrimary,
+        backgroundColor: colorPrimary,
+      ),
+      css('.active-icon-btn:not(.disabled):hover').styles(
+        backgroundColor: colorPrimary,
+      ),
       css('.preview-toolbar', [
         css('&').styles(
           display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button.dart
@@ -48,23 +48,22 @@ class Button extends StatelessComponent {
     css('.dp-button', [
       css('&').styles(
         display: .inlineFlex,
-        padding: .symmetric(vertical: 5.px, horizontal: 8.px),
-        border: .all(color: colorBorder, width: 1.px),
+        padding: .symmetric(vertical: 8.px, horizontal: 12.px),
+        border: .none,
         radius: .circular(5.px),
         outline: const Outline(style: .none),
         cursor: .pointer,
         justifyContent: .center,
         alignItems: .center,
-        color: colorOnSurface,
+        color: colorOnPrimary,
         fontSize: 12.px,
         fontWeight: FontWeight.w500,
         whiteSpace: .noWrap,
-        backgroundColor: colorContainerHigh,
+        backgroundColor: colorPrimary,
       ),
       css('&:not(:disabled):hover').styles(
-        border: .all(color: colorPrimary, width: 1.px),
         color: colorOnPrimary,
-        backgroundColor: const Color('#353535'),
+        backgroundColor: colorPrimary.highlight(colorOnPrimary, 0.1),
       ),
       css('&:disabled').styles(
         opacity: 0.45,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:js_interop';
-import 'package:jaspr_content/components/theme_toggle.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
@@ -12,6 +11,8 @@ import 'package:web/web.dart' as web;
 import '../../../app_styles.dart';
 import '../icons.dart';
 import '../runtime_versions.dart';
+import 'icon_button.dart';
+import 'theme_toggle.dart';
 
 /// The application footer with links, runtime information, and shortcuts.
 final class Footer extends StatefulComponent {
@@ -97,11 +98,16 @@ class _FooterState extends State<Footer> {
     return Component.fragment([
       footer(classes: 'app-footer', [
         div(classes: 'app-footer-buttons', [
-          _buildShortcutsButton(),
+          IconButton(
+            icon: 'keyboard',
+            label: 'Keyboard shortcuts',
+            tooltip: 'Keyboard shortcuts',
+            onClick: (_) => _openShortcuts(),
+          ),
+          const ThemeToggle(),
           _buildPrivacyNoticeLink(),
           _buildFeedbackLink(),
         ]),
-        ThemeToggle(),
         div(
           classes: 'app-footer-runtime-versions',
           attributes: {'aria-label': 'Runtime versions'},
@@ -115,18 +121,6 @@ class _FooterState extends State<Footer> {
       ]),
       if (_showShortcuts) _buildShortcutsDialog(),
     ]);
-  }
-
-  Component _buildShortcutsButton() {
-    return button(
-      classes: 'app-footer-icon-button',
-      attributes: const {
-        'title': 'Keyboard shortcuts',
-        'aria-label': 'Keyboard shortcuts',
-      },
-      onClick: _openShortcuts,
-      [const Icon('keyboard', size: 18)],
-    );
   }
 
   Component _buildPrivacyNoticeLink() {
@@ -177,14 +171,10 @@ class _FooterState extends State<Footer> {
           const h2(id: 'app-footer-shortcuts-title', [
             .text('Keyboard shortcuts'),
           ]),
-          button(
-            classes: 'app-footer-icon-button',
-            attributes: const {
-              'title': 'Close',
-              'aria-label': 'Close shortcuts dialog',
-            },
-            onClick: _closeShortcuts,
-            [const Icon('close', size: 18)],
+          IconButton(
+            icon: 'close',
+            label: 'Close shortcuts dialog',
+            onClick: (_) => _closeShortcuts(),
           ),
         ]),
         div(classes: 'app-footer-shortcuts-list', [
@@ -224,7 +214,7 @@ class _FooterState extends State<Footer> {
       display: .flex,
       minWidth: .zero,
       alignItems: .center,
-      gap: Gap.all(20.px),
+      gap: Gap.all(10.px),
     ),
     css('.app-footer .material-symbols-outlined').styles(
       display: .block,
@@ -232,6 +222,7 @@ class _FooterState extends State<Footer> {
     ),
     css('.app-footer-link').styles(
       display: .inlineFlex,
+      padding: .symmetric(horizontal: 8.px),
       alignItems: .center,
       gap: Gap.all(4.px),
       color: colorOnSurface,
@@ -254,31 +245,6 @@ class _FooterState extends State<Footer> {
       fontSize: 11.px,
       textOverflow: .ellipsis,
       whiteSpace: .noWrap,
-    ),
-    css('.app-footer-icon-button').styles(
-      display: .inlineFlex,
-      width: 24.px,
-      height: 24.px,
-      padding: .zero,
-      border: .none,
-      radius: .circular(4.px),
-      cursor: .pointer,
-      justifyContent: .center,
-      alignItems: .center,
-      color: colorOnSurface,
-      backgroundColor: Colors.transparent,
-    ),
-    css('.app-footer-icon-button:hover').styles(
-      color: colorOnSurface,
-      backgroundColor: colorOnSurface.withOpacity(0.08),
-    ),
-    css('.app-footer-icon-button:focus-visible').styles(
-      outline: Outline(
-        color: colorPrimary,
-        style: OutlineStyle.solid,
-        width: OutlineWidth(2.px),
-        offset: 2.px,
-      ),
     ),
     css('.app-footer-shortcuts-dialog::backdrop').styles(
       backgroundColor: const Color('rgba(0, 0, 0, 0.55)'),
@@ -328,10 +294,11 @@ class _FooterState extends State<Footer> {
       padding: .symmetric(vertical: 2.px, horizontal: 6.px),
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(4.px),
-      color: colorOnSurface,
+      color: colorOnContainer,
       fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
       fontSize: 11.px,
       whiteSpace: .noWrap,
+      backgroundColor: colorContainer,
     ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:js_interop';
-
+import 'package:jaspr_content/components/theme_toggle.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
@@ -101,6 +101,7 @@ class _FooterState extends State<Footer> {
           _buildPrivacyNoticeLink(),
           _buildFeedbackLink(),
         ]),
+        ThemeToggle(),
         div(
           classes: 'app-footer-runtime-versions',
           attributes: {'aria-label': 'Runtime versions'},
@@ -215,9 +216,9 @@ class _FooterState extends State<Footer> {
       alignItems: .center,
       gap: Gap.all(10.px),
       flex: const .shrink(0),
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       fontSize: 11.px,
-      backgroundColor: colorContainerLow,
+      backgroundColor: colorSurface,
     ),
     css('.app-footer-buttons').styles(
       display: .flex,
@@ -233,7 +234,7 @@ class _FooterState extends State<Footer> {
       display: .inlineFlex,
       alignItems: .center,
       gap: Gap.all(4.px),
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       textDecoration: .none,
       whiteSpace: .noWrap,
     ),
@@ -242,7 +243,6 @@ class _FooterState extends State<Footer> {
       minWidth: .zero,
       margin: const Margin.only(left: Unit.auto),
       overflow: .hidden,
-      color: colorOnSurfaceVariant,
       textOverflow: .ellipsis,
       whiteSpace: .noWrap,
     ),
@@ -251,7 +251,6 @@ class _FooterState extends State<Footer> {
       minWidth: 120.px,
       margin: Margin.only(left: 10.px),
       overflow: .hidden,
-      color: colorOnSurface,
       fontSize: 11.px,
       textOverflow: .ellipsis,
       whiteSpace: .noWrap,
@@ -266,7 +265,7 @@ class _FooterState extends State<Footer> {
       cursor: .pointer,
       justifyContent: .center,
       alignItems: .center,
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       backgroundColor: Colors.transparent,
     ),
     css('.app-footer-icon-button:hover').styles(
@@ -329,7 +328,7 @@ class _FooterState extends State<Footer> {
       padding: .symmetric(vertical: 2.px, horizontal: 6.px),
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(4.px),
-      color: colorOnSurfaceVariant,
+      color: colorOnSurface,
       fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
       fontSize: 11.px,
       whiteSpace: .noWrap,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/icon_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/icon_button.dart
@@ -62,7 +62,7 @@ class _IconButtonState extends State<IconButton> {
   }
 
   void _onMouseEnter() {
-    final tooltipText = component.tooltip ?? component.label;
+    final tooltipText = component.tooltip;
     if (tooltipText == null) {
       return;
     }
@@ -146,9 +146,9 @@ class _IconButtonState extends State<IconButton> {
     ].join(' ');
 
     final attributes = <String, String>{};
-    final tooltipText = component.tooltip ?? component.label;
-    if (tooltipText != null) {
-      attributes['aria-label'] = tooltipText;
+    final tooltipText = component.tooltip;
+    if (component.label case final label? when label.isNotEmpty) {
+      attributes['aria-label'] = label;
     }
     if (component.disabled) {
       attributes['disabled'] = 'true';
@@ -211,7 +211,7 @@ class _IconButtonState extends State<IconButton> {
         raw: {'flex-shrink': '0'},
       ),
       css('&:not(:disabled):hover').styles(
-        backgroundColor: colorContainerHigh,
+        backgroundColor: colorSurface.highlight(colorOnSurface, 0.1),
       ),
       css('&:disabled').styles(
         cursor: .notAllowed,
@@ -231,7 +231,7 @@ class _IconButtonState extends State<IconButton> {
         fontSize: 12.px,
         fontWeight: .w500,
         whiteSpace: .noWrap,
-        backgroundColor: colorContainerLow,
+        backgroundColor: colorSurface,
       ),
       css('.custom-tooltip.rich-tooltip').styles(
         display: .flex,
@@ -248,7 +248,7 @@ class _IconButtonState extends State<IconButton> {
         fontWeight: .w600,
       ),
       css('.tooltip-desc').styles(
-        color: colorOnSurfaceVariant,
+        color: colorOnSurface,
         fontSize: 11.px,
         fontWeight: .w400,
         lineHeight: 1.4.em,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
@@ -206,6 +206,8 @@ class _SplitPanelState extends State<SplitPanel> {
     ]);
   }
 
+  static const width = 10;
+
   static List<StyleRule> get styles => [
     css('.drag-handle').styles(
       position: const .relative(),
@@ -216,34 +218,34 @@ class _SplitPanelState extends State<SplitPanel> {
     ),
     // Horizontal Specific Styles
     css('.drag-handle.horizontal').styles(
-      width: 6.px,
-      margin: Margin.symmetric(horizontal: (-3).px),
+      width: width.px,
+      margin: Margin.symmetric(horizontal: (-2).px),
       cursor: .colResize,
     ),
     css('.drag-handle.horizontal::after').styles(
       content: '',
       position: .absolute(top: 0.px, bottom: 0.px, left: 2.px),
-      width: 2.px,
-      transition: Transition('background-color', duration: 150.ms, curve: .ease),
+      width: (width - 4).px,
       backgroundColor: colorBorder,
     ),
     css('.drag-handle.horizontal:hover::after, .drag-handle.horizontal.dragging::after').styles(
+      transition: Transition('background-color', duration: 150.ms, curve: .ease),
       backgroundColor: colorPrimary,
     ),
     // Vertical Specific Styles
     css('.drag-handle.vertical').styles(
-      height: 6.px,
-      margin: Margin.symmetric(vertical: (-3).px),
+      height: width.px,
+      margin: Margin.symmetric(vertical: (-2).px),
       cursor: .rowResize,
     ),
     css('.drag-handle.vertical::after').styles(
       content: '',
       position: .absolute(left: 0.px, right: 0.px, top: 2.px),
-      height: 2.px,
-      transition: Transition('background-color', duration: 150.ms, curve: .ease),
+      height: (width - 4).px,
       backgroundColor: colorBorder,
     ),
     css('.drag-handle.vertical:hover::after, .drag-handle.vertical.dragging::after').styles(
+      transition: Transition('background-color', duration: 150.ms, curve: .ease),
       backgroundColor: colorPrimary,
     ),
   ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/theme_toggle.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/theme_toggle.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import 'icon_button.dart';
+
+/// A theme toggle button.
+class ThemeToggle extends StatefulComponent {
+  const ThemeToggle({super.key});
+
+  @override
+  State createState() => ThemeToggleState();
+}
+
+class ThemeToggleState extends State<ThemeToggle> {
+  bool isDark = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    isDark = web.document.documentElement!.getAttribute('data-theme') == 'dark';
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return Component.fragment([
+      Document.html(attributes: {'data-theme': isDark ? 'dark' : 'light'}),
+      IconButton(
+        icon: !isDark ? 'dark_mode' : 'light_mode',
+        tooltip: 'Toggle Theme',
+        label: 'Theme Toggle',
+        onClick: (_) {
+          setState(() {
+            isDark = !isDark;
+          });
+          web.window.localStorage.setItem('dartpad:theme', isDark ? 'dark' : 'light');
+        },
+      ),
+    ]);
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/theme_toggle_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/theme_toggle_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/theme_toggle.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  setUp(() {
+    web.window.localStorage.removeItem('dartpad:theme');
+    web.document.documentElement!.removeAttribute('data-theme');
+  });
+
+  testClient('defaults to light theme if no attribute or localStorage is set', (tester) async {
+    tester.pumpComponent(const ThemeToggle());
+
+    // Verify initial attribute on documentElement is light
+    expect(web.document.documentElement!.getAttribute('data-theme'), 'light');
+
+    // The button icon should be 'dark_mode' (since clicking it toggles to dark)
+    final button = web.document.querySelector('.icon-button')! as web.HTMLButtonElement;
+    expect(button.getAttribute('aria-label'), 'Theme Toggle');
+    expect(button.textContent, contains('dark_mode'));
+  });
+
+  testClient('initializes from document element attribute data-theme="dark"', (tester) async {
+    web.document.documentElement!.setAttribute('data-theme', 'dark');
+
+    tester.pumpComponent(const ThemeToggle());
+
+    // Verify attribute on documentElement is dark
+    expect(web.document.documentElement!.getAttribute('data-theme'), 'dark');
+
+    // The button icon should be 'light_mode'
+    final button = web.document.querySelector('.icon-button')! as web.HTMLButtonElement;
+    expect(button.textContent, contains('light_mode'));
+  });
+
+  testClient('clicking the toggle switches the theme and stores choice in localStorage', (tester) async {
+    tester.pumpComponent(const ThemeToggle());
+
+    final button = web.document.querySelector('.icon-button')! as web.HTMLButtonElement;
+
+    // Initially light
+    expect(web.document.documentElement!.getAttribute('data-theme'), 'light');
+    expect(button.textContent, contains('dark_mode'));
+    expect(web.window.localStorage.getItem('dartpad:theme'), isNull);
+
+    // Toggle to dark
+    await tester.click(find.byType(ThemeToggle));
+
+    expect(web.document.documentElement!.getAttribute('data-theme'), 'dark');
+    expect(button.textContent, contains('light_mode'));
+    expect(web.window.localStorage.getItem('dartpad:theme'), 'dark');
+
+    // Toggle back to light
+    await tester.click(find.byType(ThemeToggle));
+
+    expect(web.document.documentElement!.getAttribute('data-theme'), 'light');
+    expect(button.textContent, contains('dark_mode'));
+    expect(web.window.localStorage.getItem('dartpad:theme'), 'light');
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/web/index.html
+++ b/pkgs/dartpad_preview/dartpad_frontend/web/index.html
@@ -12,7 +12,20 @@
         <link rel="stylesheet" href="main.css">
 
         <!-- Material Symbols -->
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+        <link rel="stylesheet"
+            href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+
+        <!-- Theme initialization - runs before dart code loads -->
+        <script>
+            let userTheme = window.localStorage.getItem('dartpad:theme');
+            if (userTheme != null) {
+                document.documentElement.setAttribute('data-theme', userTheme);
+            } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        </script>
 
         <!-- CodeMirror must be installed on globalThis before Dart interop loads. -->
         <script src="packages/codemirror_dart/assets/codemirror-dart.bundle.js"></script>


### PR DESCRIPTION
Adjust the theme to follow current dartpads colors and style.
Adds light/dark mode toggle.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
