### PR TITLE
Add GitHub Gist project loading to DartPad preview

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -62,9 +62,11 @@ http://localhost:8080/?package=material_ui
 
 To load a GitHub gist, provide its ID using the following parameter:
 
-* `gist`: The ID from the GitHub Gist URL. The gist's flat file list is
-preserved at the workspace root. `main.dart`, then the sole Dart file, or
-finally `README.md` is opened automatically when present.
+* `gist`: The ID from the GitHub Gist URL. Dart files from the gist's flat
+file list are placed under `lib/`, so `main.dart` becomes `lib/main.dart`;
+non-Dart files such as `pubspec.yaml` remain at the workspace root. The
+resulting `lib/main.dart`, then the sole Dart file, or finally `README.md` is
+opened automatically when present.
 
 Example:
 ```url

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -34,6 +34,11 @@ project files. The frontend downloads and extracts this project into the workspa
 * `path`: A URI-encoded relative path of the file to open in the editor workspace
 once the project is loaded (e.g., `lib/main.dart`).
 
+> [!NOTE]
+> Both `archive` and `path` query parameters must be provided together. If
+> either is missing, the application will fall back to loading the default
+> sample project unless a `package` or `gist` parameter is provided.
+
 Example:
 ```url
 http://localhost:8080/?archive=https://pub.dev/api/archives/material_ui-0.0.3.tar.gz&path=example/README.md
@@ -53,8 +58,23 @@ Example:
 http://localhost:8080/?package=material_ui
 ```
 
+### Loading from Gist
+
+To load a GitHub gist, provide its ID using the following parameter:
+
+* `gist`: The ID from the GitHub Gist URL. Dart files from the gist's flat
+file list are placed under `lib/`, so `main.dart` becomes `lib/main.dart`;
+non-Dart files such as `pubspec.yaml` remain at the workspace root. The
+resulting `lib/main.dart`, then the sole Dart file, or finally `README.md` is
+opened automatically when present.
+
+Example:
+```url
+http://localhost:8080/?gist=b6af57de480a26e2bf98daf235491fbc
+```
+
 > [!NOTE]
-> If neither of these parameter combinations is matched at startup, the
+> If none of these parameter combinations is matched at startup, the
 application falls back to loading the default sample project.
 
 ## SDK assets

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -62,11 +62,9 @@ http://localhost:8080/?package=material_ui
 
 To load a GitHub gist, provide its ID using the following parameter:
 
-* `gist`: The ID from the GitHub Gist URL. Dart files from the gist's flat
-file list are placed under `lib/`, so `main.dart` becomes `lib/main.dart`;
-non-Dart files such as `pubspec.yaml` remain at the workspace root. The
-resulting `lib/main.dart`, then the sole Dart file, or finally `README.md` is
-opened automatically when present.
+* `gist`: The ID from the GitHub Gist URL. The gist's flat file list is
+preserved at the workspace root. `main.dart`, then the sole Dart file, or
+finally `README.md` is opened automatically when present.
 
 Example:
 ```url
@@ -83,8 +81,8 @@ The generated worker and Flutter SDK artifacts are collected under the single
 ignored directory `web/dartpad/`. They must be built from this exact compatible
 pair:
 
-- Dart SDK `682f45325f17dc10c33dd07c485256154715ddb9`
-- Flutter `d776076fe2f7470f4da43cc6084137e5bbe35b6d`
+- Dart SDK `941e2ec4ff23b3c8f4292ddf802a91c026937195`
+- Flutter `d4e7f9ae4c9d728718871d5929f47c8491df3976`
 
 From this package directory run:
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -28,6 +28,8 @@ import 'features/shared/components/split_panel.dart';
 import 'features/shared/events/log_event.dart';
 import 'features/shared/events/workspace_event.dart';
 import 'features/startup/archive_loader.dart';
+import 'features/startup/gist_loader.dart';
+import 'features/startup/project_loader.dart';
 import 'features/startup/sample_project.dart';
 import 'features/workspace/data/workspace_repository.dart';
 
@@ -89,30 +91,32 @@ class AppState extends State<App> {
         return;
       }
 
-      await projectFuture;
+      final project = await projectFuture;
 
       if (!mounted) {
         return;
       }
 
-      setState(() {
-        loadingStatus = 'Running Pub Get...';
-      });
+      if (project?.packageRoot case final String packageRoot) {
+        setState(() {
+          loadingStatus = 'Running Pub Get...';
+        });
 
-      try {
-        await _workspaceRepository.pubGet(
-          path: _projectDir,
-          projectRoot: _projectDir,
-        );
-      } catch (error, stackTrace) {
-        _events.dispatch(
-          LogEvent(
-            'Pub get failed.',
-            level: Level.SEVERE,
-            error: error,
-            stackTrace: stackTrace,
-          ),
-        );
+        try {
+          await _workspaceRepository.pubGet(
+            path: packageRoot,
+            projectRoot: packageRoot,
+          );
+        } catch (error, stackTrace) {
+          _events.dispatch(
+            LogEvent(
+              'Pub get failed.',
+              level: Level.SEVERE,
+              error: error,
+              stackTrace: stackTrace,
+            ),
+          );
+        }
       }
 
       if (!mounted) {
@@ -157,10 +161,11 @@ class AppState extends State<App> {
     });
   }
 
-  Future<void> loadProject() async {
+  Future<LoadedProject?> loadProject() async {
     final params = Uri.base.queryParameters;
 
     try {
+      final LoadedProject project;
       if (params case {
         'archive': final String archiveUrlParam,
         'path': final String filePathParam,
@@ -172,14 +177,7 @@ class AppState extends State<App> {
         final archiveUrl = Uri.decodeComponent(archiveUrlParam);
         final filePath = Uri.decodeComponent(filePathParam);
         final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
-        final (:projectDir, :targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
-        setState(() {
-          _projectDir = projectDir;
-        });
-        _fileTree.focusPath(projectDir);
-        if (targetFilePath != null) {
-          unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
-        }
+        project = await loader.loadArchive(_workspaceRepository.root);
       } else if (params case {'package': final String packageName}) {
         setState(() {
           loadingStatus = 'Resolving Package...';
@@ -189,30 +187,47 @@ class AppState extends State<App> {
         setState(() {
           loadingStatus = 'Downloading Package...';
         });
-        final (:projectDir, :targetFilePath) = await loader.loadArchive(_workspaceRepository.root);
+        project = await loader.loadArchive(_workspaceRepository.root);
+      } else if (params['gist'] case final String gistId) {
         setState(() {
-          _projectDir = projectDir;
+          loadingStatus = 'Downloading Gist...';
+          _errorMessage = null;
         });
-        _fileTree.focusPath(projectDir);
-        if (targetFilePath != null) {
-          unawaited(_tabs.openFile(workspaceContext.normalize(targetFilePath)));
-        }
+        final loader = GistLoader(gistId: gistId);
+        project = await loader.loadGist(_workspaceRepository.root);
       } else {
         setState(() {
           loadingStatus = 'Creating Sample Project...';
           _errorMessage = null;
         });
         await createSampleProject(_workspaceRepository.root);
-        setState(() {
-          _projectDir = '';
-        });
-        _fileTree.focusPath('');
-        unawaited(openSampleProject(_tabs.openFile));
+        project = const LoadedProject(
+          projectDir: '',
+          entryPath: sampleProjectEntryPath,
+          packageRoot: '',
+        );
       }
-    } catch (error) {
+
+      if (!mounted) {
+        return project;
+      }
+
       setState(() {
-        _errorMessage = 'Failed to load project: $error';
+        _projectDir = project.projectDir;
       });
+      _fileTree.focusPath(project.projectDir);
+      if (project.entryPath case final String entryPath) {
+        unawaited(_tabs.openFile(entryPath));
+      }
+
+      return project;
+    } catch (error) {
+      if (mounted) {
+        setState(() {
+          _errorMessage = 'Failed to load project: $error';
+        });
+      }
+      return null;
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -9,6 +9,8 @@ import 'package:archive/archive.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:http/http.dart' as http;
 
+import 'project_loader.dart';
+
 /// A loader that downloads a (gzipped) tar archive from a remote URL,
 /// extracts all of its files into a virtual workspace folder, and opens a
 /// target file.
@@ -50,12 +52,9 @@ class ArchiveLoader {
   /// Scans the archive files to find the nearest parent directory containing
   /// a `pubspec.yaml` file for the active target file.
   ///
-  /// Returns a record containing:
-  /// - `projectDir`: The path to the project directory relative to the archive root.
-  /// - `targetFilePath`: The path to the file to open after extraction, which is
-  ///   either the provided [filePath] or resolved by searching the archive for
-  ///   well-known example files.
-  Future<({String projectDir, String? targetFilePath})> loadArchive(WorkspaceFolder root) async {
+  /// The returned entrypoint is either [filePath] or a well-known example file
+  /// discovered in package archives.
+  Future<LoadedProject> loadArchive(WorkspaceFolder root) async {
     final Uri uri = Uri.parse(archiveUrl);
     if (!uri.isAbsolute) {
       throw ArgumentError('archiveUrl must be absolute: $archiveUrl');
@@ -75,78 +74,37 @@ class ArchiveLoader {
     final Archive archive = TarDecoder().decodeBytes(tarBytes);
 
     final targetFilePath = filePath ?? findExampleFile(archive);
-    String projectDir = '';
-
-    if (targetFilePath != null) {
-      final String normalizedFilePath = workspaceContext.normalize(targetFilePath);
-      final Set<String> archivePaths = <String>{};
-      for (final ArchiveFile file in archive.files) {
-        String name = file.name;
-        if (name.startsWith('./')) {
-          name = name.substring(2);
-        } else if (name.startsWith('/')) {
-          name = name.substring(1);
-        }
-        archivePaths.add(name);
-      }
-
-      final List<String> segments = normalizedFilePath.split('/');
-
-      for (int i = segments.length - 1; i >= 0; i--) {
-        final String parentDir = segments.sublist(0, i).join('/');
-        final String pubspecPath = parentDir.isEmpty ? 'pubspec.yaml' : '$parentDir/pubspec.yaml';
-        if (archivePaths.contains(pubspecPath)) {
-          projectDir = parentDir;
-          break;
-        }
-      }
-    }
-
-    final List<ArchiveFile> filesToExtract = <ArchiveFile>[];
-    final Set<String> foldersToCreate = <String>{};
-
+    final files = <ProjectFile>[];
     for (final ArchiveFile file in archive.files) {
       if (!file.isFile) {
         continue;
       }
 
-      String name = file.name;
-      if (name.startsWith('./')) {
-        name = name.substring(2);
-      } else if (name.startsWith('/')) {
-        name = name.substring(1);
-      }
-
-      filesToExtract.add(file);
-
-      String dir = workspaceContext.dirname(name);
-      while (dir.isNotEmpty && dir != '.') {
-        foldersToCreate.add(dir);
-        dir = workspaceContext.dirname(dir);
-      }
+      files.add(
+        ProjectFile(path: _relativePath(file.name), bytes: file.content),
+      );
     }
 
-    final List<String> sortedFolders = foldersToCreate.toList()
-      ..sort((String a, String b) => a.length.compareTo(b.length));
-    for (final String folderPath in sortedFolders) {
-      await root.getFolder(folderPath).create();
+    final entryPath = targetFilePath == null ? null : ProjectLoader.normalizePath(targetFilePath);
+    final projectDir = entryPath == null ? '' : ProjectLoader.findProjectDirectory(files, entryPath) ?? '';
+
+    await ProjectLoader.writeFiles(root, files);
+
+    return LoadedProject(
+      projectDir: projectDir,
+      entryPath: entryPath,
+      packageRoot: projectDir,
+    );
+  }
+
+  String _relativePath(String path) {
+    if (path.startsWith('./')) {
+      return path.substring(2);
     }
-
-    for (final ArchiveFile file in filesToExtract) {
-      String name = file.name;
-      if (name.startsWith('./')) {
-        name = name.substring(2);
-      } else if (name.startsWith('/')) {
-        name = name.substring(1);
-      }
-
-      final dynamic content = file.content;
-      final Uint8List fileBytes = content is Uint8List ? content : Uint8List.fromList(content as List<int>);
-
-      await root.workspace.writeFileFromBytes(root.getFile(name).path, fileBytes);
+    if (path.startsWith('/')) {
+      return path.substring(1);
     }
-
-    return (projectDir: projectDir, targetFilePath: targetFilePath);
+    return path;
   }
 
   /// Finds the example file in the archive, returning null if not found.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
@@ -50,14 +50,16 @@ class GistLoader {
     final fetchedFiles = await Future.wait(
       filesJson.values.map(_loadFile).toList(),
     );
-    final files = fetchedFiles
-        .map(
-          (file) => ProjectFile(
-            path: ProjectLoader.normalizePath(file.path),
-            bytes: file.bytes,
-          ),
-        )
-        .toList();
+    final files = _moveRootDartFilesIntoLib(
+      fetchedFiles
+          .map(
+            (file) => ProjectFile(
+              path: ProjectLoader.normalizePath(file.path),
+              bytes: file.bytes,
+            ),
+          )
+          .toList(),
+    );
     final entryPath = _findEntryPath(files);
     final packageRoot = entryPath == null ? null : ProjectLoader.findProjectDirectory(files, entryPath);
 
@@ -105,9 +107,22 @@ class GistLoader {
     );
   }
 
+  /// Converts the flat source layout supplied by GitHub Gists to a Dart
+  /// package layout. Non-Dart files, including pubspec.yaml and assets, stay
+  /// at the package root.
+  List<ProjectFile> _moveRootDartFilesIntoLib(List<ProjectFile> files) {
+    return [
+      for (final file in files)
+        if (workspaceContext.dirname(file.path).isEmpty && file.path.endsWith('.dart'))
+          ProjectFile(path: 'lib/${file.path}', bytes: file.bytes)
+        else
+          file,
+    ];
+  }
+
   String? _findEntryPath(List<ProjectFile> files) {
     final paths = files.map((file) => file.path).toSet();
-    for (final path in const ['main.dart', 'lib/main.dart']) {
+    for (final path in const ['lib/main.dart', 'main.dart']) {
       if (paths.contains(path)) {
         return path;
       }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:http/http.dart' as http;
+
+import 'project_loader.dart';
+
+/// Loads all files of a GitHub gist into a virtual workspace.
+class GistLoader {
+  const GistLoader({required this.gistId});
+
+  /// The GitHub gist identifier.
+  final String gistId;
+
+  /// Downloads the gist, writes its files into [root], and returns the
+  /// detected project directory and optional entry file.
+  Future<LoadedProject> loadGist(
+    WorkspaceFolder root,
+  ) async {
+    if (gistId.isEmpty) {
+      throw ArgumentError.value(gistId, 'gistId', 'must not be empty');
+    }
+
+    final response = await http.get(
+      Uri.https('api.github.com', '/gists/$gistId'),
+      headers: const {'Accept': 'application/vnd.github+json'},
+    );
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load gist $gistId (${response.statusCode})');
+    }
+
+    final json = jsonDecode(response.body);
+    if (json is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected gist response.');
+    }
+    if (json['truncated'] == true) {
+      throw const FormatException('The gist file list is truncated.');
+    }
+
+    final filesJson = json['files'];
+    if (filesJson is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected gist files response.');
+    }
+
+    final fetchedFiles = await Future.wait(
+      filesJson.values.map(_loadFile).toList(),
+    );
+    final files = fetchedFiles
+        .map(
+          (file) => ProjectFile(
+            path: ProjectLoader.normalizePath(file.path),
+            bytes: file.bytes,
+          ),
+        )
+        .toList();
+    final entryPath = _findEntryPath(files);
+    final packageRoot = entryPath == null ? null : ProjectLoader.findProjectDirectory(files, entryPath);
+
+    await ProjectLoader.writeFiles(root, files);
+    return LoadedProject(
+      projectDir: packageRoot ?? '',
+      entryPath: entryPath,
+      packageRoot: packageRoot,
+    );
+  }
+
+  Future<ProjectFile> _loadFile(dynamic value) async {
+    if (value is! Map<String, dynamic>) {
+      throw const FormatException('Unexpected gist file response.');
+    }
+
+    final filename = value['filename'];
+    if (filename is! String || filename.isEmpty) {
+      throw const FormatException('A gist file has no filename.');
+    }
+
+    if (value['truncated'] == true) {
+      final rawUrl = value['raw_url'];
+      if (rawUrl is! String) {
+        throw const FormatException('A truncated gist file has no raw URL.');
+      }
+      final rawUri = Uri.tryParse(rawUrl);
+      if (rawUri == null || !rawUri.isAbsolute) {
+        throw const FormatException('A truncated gist file has an invalid raw URL.');
+      }
+      final response = await http.get(rawUri);
+      if (response.statusCode != 200) {
+        throw Exception('Failed to load truncated gist file $filename.');
+      }
+      return ProjectFile(path: filename, bytes: response.bodyBytes);
+    }
+
+    final content = value['content'];
+    if (content is! String) {
+      throw FormatException('A gist file has no content: $filename');
+    }
+    return ProjectFile(
+      path: filename,
+      bytes: Uint8List.fromList(utf8.encode(content)),
+    );
+  }
+
+  String? _findEntryPath(List<ProjectFile> files) {
+    final paths = files.map((file) => file.path).toSet();
+    for (final path in const ['main.dart', 'lib/main.dart']) {
+      if (paths.contains(path)) {
+        return path;
+      }
+    }
+
+    final dartFiles = paths.where((path) => path.endsWith('.dart')).toList();
+    if (dartFiles.length == 1) {
+      return dartFiles.single;
+    }
+    return paths.contains('README.md') ? 'README.md' : null;
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+
+/// A file that can be imported into the virtual workspace.
+final class ProjectFile {
+  const ProjectFile({required this.path, required this.bytes});
+
+  /// The workspace-relative file path.
+  final String path;
+
+  /// The file contents.
+  final Uint8List bytes;
+}
+
+/// The workspace state produced by a project loader.
+///
+/// [projectDir] is the folder shown in the file tree. [packageRoot] is null
+/// when the loaded files do not form a Dart package; it is an empty string for
+/// a package rooted at the workspace root.
+final class LoadedProject {
+  const LoadedProject({
+    required this.projectDir,
+    required this.entryPath,
+    required this.packageRoot,
+  });
+
+  final String projectDir;
+  final String? entryPath;
+  final String? packageRoot;
+}
+
+/// Shared workspace import operations for externally loaded projects.
+final class ProjectLoader {
+  /// Finds the nearest parent directory of [entryPath] containing pubspec.yaml.
+  ///
+  /// Returns null when no project root can be inferred.
+  static String? findProjectDirectory(
+    Iterable<ProjectFile> files,
+    String entryPath,
+  ) {
+    final filePaths = files.map((file) => normalizePath(file.path)).toSet();
+    final segments = normalizePath(entryPath).split('/');
+
+    for (var i = segments.length - 1; i >= 0; i--) {
+      final parentDirectory = segments.sublist(0, i).join('/');
+      final pubspecPath = parentDirectory.isEmpty ? 'pubspec.yaml' : '$parentDirectory/pubspec.yaml';
+      if (filePaths.contains(pubspecPath)) {
+        return parentDirectory;
+      }
+    }
+
+    return null;
+  }
+
+  /// Creates all folders and writes [files] into [root].
+  static Future<void> writeFiles(
+    WorkspaceFolder root,
+    Iterable<ProjectFile> files,
+  ) async {
+    final normalizedFiles = <ProjectFile>[];
+    final paths = <String>{};
+
+    for (final file in files) {
+      final path = normalizePath(file.path);
+      if (!paths.add(path)) {
+        throw ArgumentError('Multiple files resolve to the same path: $path');
+      }
+      normalizedFiles.add(ProjectFile(path: path, bytes: file.bytes));
+    }
+
+    final folders = <String>{};
+    for (final file in normalizedFiles) {
+      var directory = workspaceContext.dirname(file.path);
+      while (directory.isNotEmpty) {
+        folders.add(directory);
+        directory = workspaceContext.dirname(directory);
+      }
+    }
+
+    final sortedFolders = folders.toList()..sort((a, b) => a.length.compareTo(b.length));
+    for (final folder in sortedFolders) {
+      await root.getFolder(folder).create();
+    }
+
+    for (final file in normalizedFiles) {
+      await root.workspace.writeFileFromBytes(
+        root.getFile(file.path).path,
+        file.bytes,
+      );
+    }
+  }
+
+  /// Normalizes [path] and verifies that it remains inside the workspace.
+  static String normalizePath(String path) {
+    final normalized = workspaceContext.normalize(path);
+    if (normalized.isEmpty ||
+        workspacePath.isAbsolute(normalized) ||
+        normalized == '..' ||
+        normalized.startsWith('../')) {
+      throw ArgumentError('Path must be relative to the workspace: $path');
+    }
+    return normalized;
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/sample_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/sample_project.dart
@@ -9,15 +9,17 @@ Future<void> createSampleProject(WorkspaceFolder root) async {
   await root.getFolder('lib').create();
   await root.getFile(_samplePubspecPath).writeContent(samplePubspec.trimLeft());
   await root.getFile(_sampleAnalysisOptionsPath).writeContent(sampleAnalysisOptions.trimLeft());
-  await root.getFile(_sampleMainPath).writeContent(sampleMainDart.trimLeft());
+  await root.getFile(sampleProjectEntryPath).writeContent(sampleMainDart.trimLeft());
 }
+
+/// The first file opened for the default sample project.
+const String sampleProjectEntryPath = 'lib/main.dart';
 
 /// Opens the default sample files and leaves the Dart source active.
-Future<void> openSampleProject(Future<void> Function(String path) openFile) async {
-  await openFile(_sampleMainPath);
+Future<void> openSampleProject(Future<void> Function(String path) openFile) {
+  return openFile(sampleProjectEntryPath);
 }
 
-const String _sampleMainPath = 'lib/main.dart';
 const String _sampleAnalysisOptionsPath = 'analysis_options.yaml';
 const String _samplePubspecPath = 'pubspec.yaml';
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -84,7 +84,10 @@ void main() {
 
       await http.runWithClient(
         () async {
-          await loader.loadArchive(api.root);
+          final result = await loader.loadArchive(api.root);
+          expect(result.projectDir, 'my_project');
+          expect(result.entryPath, 'my_project/lib/main.dart');
+          expect(result.packageRoot, 'my_project');
         },
         () => MockClient((http.Request request) async {
           expect(request.url.toString(), absoluteUrl);
@@ -152,7 +155,8 @@ void main() {
       );
 
       expect(result.projectDir, '');
-      expect(result.targetFilePath, 'my_project/lib/main.dart');
+      expect(result.entryPath, 'my_project/lib/main.dart');
+      expect(result.packageRoot, '');
       expect(await api.fileExist('my_project/lib/main.dart'), isTrue);
       expect(await api.readFileAsText('my_project/lib/main.dart'), 'void main() {}');
     });

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
@@ -26,7 +26,7 @@ void main() {
       return jsonEncode({'truncated': truncated, 'files': files});
     }
 
-    test('preserves flat Gist files and finds a project root and entrypoint', () async {
+    test('moves flat Dart files into lib and finds a project root and entrypoint', () async {
       final api = MemoryWorkspaceResourceApi();
       const loader = GistLoader(gistId: gistId);
       final response = gistResponse({
@@ -40,7 +40,7 @@ void main() {
         () async {
           final result = await loader.loadGist(api.root);
           expect(result.projectDir, '');
-          expect(result.entryPath, 'main.dart');
+          expect(result.entryPath, 'lib/main.dart');
           expect(result.packageRoot, '');
         },
         () => MockClient((request) async {
@@ -51,10 +51,10 @@ void main() {
       );
 
       expect(await api.readFileAsText('pubspec.yaml'), 'name: gist_project');
-      expect(await api.readFileAsText('main.dart'), "import 'helper.dart'; void main() {}");
-      expect(await api.readFileAsText('helper.dart'), 'class Helper {}');
-      expect(await api.fileExist('lib/main.dart'), isFalse);
-      expect(await api.fileExist('lib/helper.dart'), isFalse);
+      expect(await api.readFileAsText('lib/main.dart'), "import 'helper.dart'; void main() {}");
+      expect(await api.readFileAsText('lib/helper.dart'), 'class Helper {}');
+      expect(await api.fileExist('main.dart'), isFalse);
+      expect(await api.fileExist('helper.dart'), isFalse);
       expect(await api.readFileAsText('README.md'), '# Gist');
     });
 
@@ -62,10 +62,10 @@ void main() {
       final testCases = <({Map<String, String> files, String? entryPath})>[
         (
           files: {'main.dart': 'void main() {}'},
-          entryPath: 'main.dart',
+          entryPath: 'lib/main.dart',
         ),
         (files: {'lib/main.dart': 'void main() {}'}, entryPath: 'lib/main.dart'),
-        (files: {'example.dart': 'void main() {}'}, entryPath: 'example.dart'),
+        (files: {'example.dart': 'void main() {}'}, entryPath: 'lib/example.dart'),
         (files: {'README.md': '# Read me'}, entryPath: 'README.md'),
         (files: {'notes.txt': 'No entrypoint'}, entryPath: null),
       ];
@@ -127,7 +127,7 @@ void main() {
       await http.runWithClient(
         () async {
           final result = await const GistLoader(gistId: gistId).loadGist(api.root);
-          expect(result.entryPath, 'main.dart');
+          expect(result.entryPath, 'lib/main.dart');
         },
         () => MockClient((request) async {
           if (request.url.toString() == gistUrl) {
@@ -138,7 +138,7 @@ void main() {
         }),
       );
 
-      expect(await api.readFileAsBytes('main.dart'), rawBytes);
+      expect(await api.readFileAsBytes('lib/main.dart'), rawBytes);
     });
 
     test('reports a failed raw URL response', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
@@ -1,0 +1,226 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/startup/gist_loader.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('GistLoader', () {
+    const gistId = 'aa5a315d61ae9438b18d';
+    const gistUrl = 'https://api.github.com/gists/$gistId';
+
+    String gistResponse(
+      Map<String, Map<String, Object?>> files, {
+      bool truncated = false,
+    }) {
+      return jsonEncode({'truncated': truncated, 'files': files});
+    }
+
+    test('imports all files and finds a project root and lib entrypoint', () async {
+      final api = MemoryWorkspaceResourceApi();
+      const loader = GistLoader(gistId: gistId);
+      final response = gistResponse({
+        'pubspec.yaml': {'filename': 'pubspec.yaml', 'content': 'name: gist_project'},
+        'lib/main.dart': {'filename': 'lib/main.dart', 'content': 'void main() {}'},
+        'lib/src/helper.dart': {'filename': 'lib/src/helper.dart', 'content': 'class Helper {}'},
+      });
+
+      await http.runWithClient(
+        () async {
+          final result = await loader.loadGist(api.root);
+          expect(result.projectDir, '');
+          expect(result.entryPath, 'lib/main.dart');
+          expect(result.packageRoot, '');
+        },
+        () => MockClient((request) async {
+          expect(request.url.toString(), gistUrl);
+          expect(request.headers['accept'], 'application/vnd.github+json');
+          return http.Response(response, 200);
+        }),
+      );
+
+      expect(await api.readFileAsText('pubspec.yaml'), 'name: gist_project');
+      expect(await api.readFileAsText('lib/main.dart'), 'void main() {}');
+      expect(await api.readFileAsText('lib/src/helper.dart'), 'class Helper {}');
+    });
+
+    test('uses the configured entrypoint fallbacks', () async {
+      final testCases = <({Map<String, String> files, String? entryPath})>[
+        (
+          files: {'main.dart': 'void main() {}', 'lib/main.dart': 'void main() {}'},
+          entryPath: 'main.dart',
+        ),
+        (files: {'lib/main.dart': 'void main() {}'}, entryPath: 'lib/main.dart'),
+        (files: {'example.dart': 'void main() {}'}, entryPath: 'example.dart'),
+        (files: {'README.md': '# Read me'}, entryPath: 'README.md'),
+        (files: {'notes.txt': 'No entrypoint'}, entryPath: null),
+      ];
+
+      for (final testCase in testCases) {
+        final files = testCase.files.map(
+          (name, content) => MapEntry(
+            name,
+            <String, Object?>{'filename': name, 'content': content},
+          ),
+        );
+        final api = MemoryWorkspaceResourceApi();
+
+        await http.runWithClient(
+          () async {
+            final result = await const GistLoader(gistId: gistId).loadGist(api.root);
+            expect(result.entryPath, testCase.entryPath);
+            expect(result.projectDir, '');
+            expect(result.packageRoot, isNull);
+          },
+          () => MockClient((request) async => http.Response(gistResponse(files), 200)),
+        );
+      }
+    });
+
+    test('finds the nearest pubspec directory of the selected entrypoint', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final response = gistResponse({
+        'packages/demo/pubspec.yaml': {'filename': 'packages/demo/pubspec.yaml', 'content': 'name: demo'},
+        'packages/demo/lib/main.dart': {
+          'filename': 'packages/demo/lib/main.dart',
+          'content': 'void main() {}',
+        },
+      });
+
+      await http.runWithClient(
+        () async {
+          final result = await const GistLoader(gistId: gistId).loadGist(api.root);
+          expect(result.projectDir, 'packages/demo');
+          expect(result.entryPath, 'packages/demo/lib/main.dart');
+          expect(result.packageRoot, 'packages/demo');
+        },
+        () => MockClient((request) async => http.Response(response, 200)),
+      );
+    });
+
+    test('loads a truncated file from its raw URL', () async {
+      final api = MemoryWorkspaceResourceApi();
+      const rawUrl = 'https://gist.githubusercontent.com/example/raw/main.dart';
+      final response = gistResponse({
+        'main.dart': {
+          'filename': 'main.dart',
+          'truncated': true,
+          'raw_url': rawUrl,
+        },
+      });
+      final rawBytes = Uint8List.fromList([0, 255, 42]);
+
+      await http.runWithClient(
+        () async {
+          final result = await const GistLoader(gistId: gistId).loadGist(api.root);
+          expect(result.entryPath, 'main.dart');
+        },
+        () => MockClient((request) async {
+          if (request.url.toString() == gistUrl) {
+            return http.Response(response, 200);
+          }
+          expect(request.url.toString(), rawUrl);
+          return http.Response.bytes(rawBytes, 200);
+        }),
+      );
+
+      expect(await api.readFileAsBytes('main.dart'), rawBytes);
+    });
+
+    test('reports a failed raw URL response', () async {
+      final api = MemoryWorkspaceResourceApi();
+      const rawUrl = 'https://gist.githubusercontent.com/example/raw/main.dart';
+      final response = gistResponse({
+        'main.dart': {
+          'filename': 'main.dart',
+          'truncated': true,
+          'raw_url': rawUrl,
+        },
+      });
+
+      await http.runWithClient(
+        () async {
+          await expectLater(
+            const GistLoader(gistId: gistId).loadGist(api.root),
+            throwsException,
+          );
+        },
+        () => MockClient((request) async {
+          if (request.url.toString() == gistUrl) {
+            return http.Response(response, 200);
+          }
+          expect(request.url.toString(), rawUrl);
+          return http.Response('Not Found', 404);
+        }),
+      );
+    });
+
+    test('rejects an unsafe file path before writing any files', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final response = gistResponse({
+        'valid.dart': {'filename': 'valid.dart', 'content': 'void main() {}'},
+        '../outside.dart': {'filename': '../outside.dart', 'content': 'unsafe'},
+      });
+
+      await http.runWithClient(
+        () async {
+          await expectLater(
+            const GistLoader(gistId: gistId).loadGist(api.root),
+            throwsArgumentError,
+          );
+        },
+        () => MockClient((request) async => http.Response(response, 200)),
+      );
+
+      expect(await api.fileExist('valid.dart'), isFalse);
+    });
+
+    test('rejects a truncated file list', () async {
+      final api = MemoryWorkspaceResourceApi();
+      await http.runWithClient(
+        () async {
+          await expectLater(
+            const GistLoader(gistId: gistId).loadGist(api.root),
+            throwsFormatException,
+          );
+        },
+        () => MockClient(
+          (request) async => http.Response(gistResponse({}, truncated: true), 200),
+        ),
+      );
+    });
+
+    test('reports failed and malformed gist responses', () async {
+      final api = MemoryWorkspaceResourceApi();
+      await http.runWithClient(
+        () async {
+          await expectLater(
+            const GistLoader(gistId: gistId).loadGist(api.root),
+            throwsException,
+          );
+        },
+        () => MockClient((request) async => http.Response('Not Found', 404)),
+      );
+
+      await http.runWithClient(
+        () async {
+          await expectLater(
+            const GistLoader(gistId: gistId).loadGist(api.root),
+            throwsFormatException,
+          );
+        },
+        () => MockClient((request) async => http.Response('not json', 200)),
+      );
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/gist_loader_test.dart
@@ -26,20 +26,21 @@ void main() {
       return jsonEncode({'truncated': truncated, 'files': files});
     }
 
-    test('imports all files and finds a project root and lib entrypoint', () async {
+    test('preserves flat Gist files and finds a project root and entrypoint', () async {
       final api = MemoryWorkspaceResourceApi();
       const loader = GistLoader(gistId: gistId);
       final response = gistResponse({
         'pubspec.yaml': {'filename': 'pubspec.yaml', 'content': 'name: gist_project'},
-        'lib/main.dart': {'filename': 'lib/main.dart', 'content': 'void main() {}'},
-        'lib/src/helper.dart': {'filename': 'lib/src/helper.dart', 'content': 'class Helper {}'},
+        'main.dart': {'filename': 'main.dart', 'content': "import 'helper.dart'; void main() {}"},
+        'helper.dart': {'filename': 'helper.dart', 'content': 'class Helper {}'},
+        'README.md': {'filename': 'README.md', 'content': '# Gist'},
       });
 
       await http.runWithClient(
         () async {
           final result = await loader.loadGist(api.root);
           expect(result.projectDir, '');
-          expect(result.entryPath, 'lib/main.dart');
+          expect(result.entryPath, 'main.dart');
           expect(result.packageRoot, '');
         },
         () => MockClient((request) async {
@@ -50,14 +51,17 @@ void main() {
       );
 
       expect(await api.readFileAsText('pubspec.yaml'), 'name: gist_project');
-      expect(await api.readFileAsText('lib/main.dart'), 'void main() {}');
-      expect(await api.readFileAsText('lib/src/helper.dart'), 'class Helper {}');
+      expect(await api.readFileAsText('main.dart'), "import 'helper.dart'; void main() {}");
+      expect(await api.readFileAsText('helper.dart'), 'class Helper {}');
+      expect(await api.fileExist('lib/main.dart'), isFalse);
+      expect(await api.fileExist('lib/helper.dart'), isFalse);
+      expect(await api.readFileAsText('README.md'), '# Gist');
     });
 
     test('uses the configured entrypoint fallbacks', () async {
       final testCases = <({Map<String, String> files, String? entryPath})>[
         (
-          files: {'main.dart': 'void main() {}', 'lib/main.dart': 'void main() {}'},
+          files: {'main.dart': 'void main() {}'},
           entryPath: 'main.dart',
         ),
         (files: {'lib/main.dart': 'void main() {}'}, entryPath: 'lib/main.dart'),

--- a/pkgs/dartpad_preview/dartpad_frontend/tool/build_sdk_assets.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/tool/build_sdk_assets.dart
@@ -9,8 +9,8 @@ import 'package:archive/archive.dart';
 import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as p;
 
-const dartRevision = '682f45325f17dc10c33dd07c485256154715ddb9';
-const flutterRevision = 'd776076fe2f7470f4da43cc6084137e5bbe35b6d';
+const dartRevision = '941e2ec4ff23b3c8f4292ddf802a91c026937195';
+const flutterRevision = 'd4e7f9ae4c9d728718871d5929f47c8491df3976';
 
 Future<void> main(List<String> args) async {
   final packageRoot = Directory.current.absolute;

--- a/pkgs/dartpad_preview/pubspec.yaml
+++ b/pkgs/dartpad_preview/pubspec.yaml
@@ -25,7 +25,7 @@ dependency_overrides:
     git:
       url: https://github.com/dart-lang/sdk
       path: pkg/dartpad
-      ref: 682f45325f17dc10c33dd07c485256154715ddb9
+      ref: 941e2ec4ff23b3c8f4292ddf802a91c026937195
   # TODO: Remove once https://github.com/dart-lang/webdev/issues/2854 is resolved.
   frontend_server_client:
     git:


### PR DESCRIPTION
## Summary

Adds GitHub Gist project loading via the `gist` URL parameter. Since Gists have a flat file structure, all root-level `.dart` files are placed under `lib/`, while files such as `pubspec.yaml` and `README.md` remain at the project root. This produces valid package URIs without changing the shared preview path resolution. The change reuses the existing project-loading flow and pins a compatible Dart/Flutter SDK pair.
