### PR TITLE
feat(dartpad-preview): Add image preview tabs

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -16,6 +16,7 @@ import 'features/editor/codemirror/code_mirror_tab.dart';
 import 'features/editor/codemirror/code_mirror_tab_adapter.dart';
 import 'features/editor/components/editor_shell.dart';
 import 'features/editor/components/pubspec_editor_actions.dart';
+import 'features/editor/image/image_tab.dart';
 import 'features/editor/view_models/tabs_view_model.dart';
 import 'features/filetree/file_tree_tabs_adapter.dart';
 import 'features/filetree/file_tree_view.dart';
@@ -73,7 +74,10 @@ class AppState extends State<App> {
 
     _tabs = TabsViewModel(
       workspaceResourceApi: _workspaceRepository.workspaceResourceApi,
-      adapters: [codemirrorAdapter],
+      adapters: [
+        ImageTabAdapter(workspaceResourceApi: _workspaceRepository.workspaceResourceApi),
+        codemirrorAdapter,
+      ],
     );
 
     _fileTree = FileTreeViewModel(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
@@ -37,7 +37,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
 
   /// Opens the file for [diagnostic] and navigates to its source position.
   Future<void> openDiagnostic(String fileName, Diagnostic diagnostic) async {
-    await tabs.openEditorFile(fileName);
+    await tabs.openFileWithErrorReporting(fileName);
     final tab = tabs.getTab(fileName);
     if (tab is CodeMirrorTab) {
       tab.goToPosition(diagnostic.line, diagnostic.character);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
@@ -37,7 +37,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
 
   /// Opens the file for [diagnostic] and navigates to its source position.
   Future<void> openDiagnostic(String fileName, Diagnostic diagnostic) async {
-    await tabs.openTextFile(fileName);
+    await tabs.openEditorFile(fileName);
     final tab = tabs.getTab(fileName);
     if (tab is CodeMirrorTab) {
       tab.goToPosition(diagnostic.line, diagnostic.character);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/image_preview.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/image_preview.dart
@@ -1,0 +1,123 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../shared/editable_text_file.dart';
+
+/// Renders an image file from the current workspace inside an editor tab.
+final class ImagePreview extends StatefulComponent {
+  /// Creates an image preview for [path].
+  const ImagePreview({
+    required this.path,
+    required this.workspaceResourceApi,
+    super.key,
+  });
+
+  /// The workspace-relative image path.
+  final String path;
+
+  /// Source of the image bytes.
+  final WorkspaceResourceApi workspaceResourceApi;
+
+  @override
+  State<ImagePreview> createState() => _ImagePreviewState();
+
+  @css
+  static List<StyleRule> get styles => _ImagePreviewState.styles;
+}
+
+final class _ImagePreviewState extends State<ImagePreview> {
+  String? _dataUrl;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadImage();
+  }
+
+  @override
+  void didUpdateComponent(ImagePreview oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (oldComponent.path != component.path) {
+      _loadImage();
+    }
+  }
+
+  Future<void> _loadImage() async {
+    setState(() {
+      _dataUrl = null;
+      _error = null;
+    });
+
+    try {
+      final bytes = await component.workspaceResourceApi.readFileAsBytes(component.path);
+      final mimeType = imageMimeTypeForPath(component.path);
+      if (mimeType == null) {
+        throw UnsupportedError('Unsupported image format.');
+      }
+      setState(() {
+        _dataUrl = 'data:$mimeType;base64,${base64Encode(bytes)}';
+      });
+    } catch (_) {
+      setState(() {
+        _error = 'Could not load image.';
+      });
+    }
+  }
+
+  @override
+  Component build(BuildContext context) {
+    if (_error != null) {
+      return div(classes: 'image-preview-status error', [Component.text(_error!)]);
+    }
+    if (_dataUrl == null) {
+      return const div(classes: 'image-preview-status', [Component.text('Loading image...')]);
+    }
+    return div(classes: 'image-preview-container', [
+      img(src: _dataUrl!, classes: 'image-preview-element'),
+    ]);
+  }
+
+  static List<StyleRule> get styles => [
+    css('.image-preview-container').styles(
+      display: .flex,
+      width: 100.percent,
+      height: 100.percent,
+      padding: .all(20.px),
+      boxSizing: .borderBox,
+      overflow: const .only(x: .auto, y: .auto),
+      justifyContent: .center,
+      alignItems: .center,
+      backgroundColor: const Color('#1e1e1e'),
+    ),
+    css('.image-preview-element').styles(
+      maxWidth: 100.percent,
+      maxHeight: 100.percent,
+      radius: .all(Radius.circular(4.px)),
+      shadow: BoxShadow(
+        offsetX: 0.px,
+        offsetY: 4.px,
+        blur: 12.px,
+        color: const Color.rgba(0, 0, 0, 0.15),
+      ),
+      raw: {'object-fit': 'contain'},
+    ),
+    css('.image-preview-status').styles(
+      display: .flex,
+      width: 100.percent,
+      height: 100.percent,
+      justifyContent: .center,
+      alignItems: .center,
+      color: const Color('#a8a8a8'),
+      fontSize: 14.px,
+    ),
+    css('.image-preview-status.error').styles(color: const Color('#ff8a8a')),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/image/image_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/image/image_tab.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../shared/editable_text_file.dart';
+import '../components/image_preview.dart';
+
+/// A read-only editor tab that displays a workspace image.
+final class ImageTab extends EditorTab<Component> {
+  /// Creates an image tab backed by [workspaceResourceApi].
+  ImageTab(super.path, {required this.workspaceResourceApi});
+
+  final WorkspaceResourceApi workspaceResourceApi;
+
+  @override
+  Component build() => ImagePreview(
+    path: path,
+    workspaceResourceApi: workspaceResourceApi,
+  );
+}
+
+/// Creates [ImageTab] instances for image files supported by the browser preview.
+final class ImageTabAdapter extends EditorTabAdapter<Component> {
+  /// Creates an adapter using [workspaceResourceApi] for each image tab.
+  const ImageTabAdapter({required this.workspaceResourceApi});
+
+  final WorkspaceResourceApi workspaceResourceApi;
+
+  @override
+  Future<EditorTab<Component>?> createTab(String path) async {
+    if (!isPreviewableImageFile(path)) {
+      return null;
+    }
+    return ImageTab(path, workspaceResourceApi: workspaceResourceApi);
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/tabs_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/tabs_view_model.dart
@@ -60,8 +60,8 @@ final class TabsViewModel extends ChangeNotifier with TabsController<Component> 
     }
   }
 
-  /// Opens the text file at [path] and reports failures to the user.
-  Future<void> openTextFile(String path) async {
+  /// Opens a supported editor file at [path] and reports failures to the user.
+  Future<void> openEditorFile(String path) async {
     try {
       await openFile(path);
       clearMessages();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/tabs_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/view_models/tabs_view_model.dart
@@ -60,8 +60,12 @@ final class TabsViewModel extends ChangeNotifier with TabsController<Component> 
     }
   }
 
-  /// Opens a supported editor file at [path] and reports failures to the user.
-  Future<void> openEditorFile(String path) async {
+  /// Opens the file at [path], reporting any failure as a user-facing error.
+  ///
+  /// This wraps [openFile] with error handling: on success the current
+  /// error/warning messages are cleared; on failure a message is shown to
+  /// the user.
+  Future<void> openFileWithErrorReporting(String path) async {
     try {
       await openFile(path);
       clearMessages();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_editor_delegate.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_editor_delegate.dart
@@ -12,7 +12,8 @@ abstract interface class FileTreeEditorDelegate implements Listenable {
   /// The paths of open files with unsaved changes.
   List<String> get dirtyFiles;
 
-  /// Opens the supported editor file at [path].
+  /// Opens the file at [path] in the appropriate tab, or reports a warning
+  /// if the file type is not supported for viewing.
   Future<void> openFile(String path);
 
   /// Persists all unsaved editor tabs.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_editor_delegate.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_editor_delegate.dart
@@ -12,8 +12,8 @@ abstract interface class FileTreeEditorDelegate implements Listenable {
   /// The paths of open files with unsaved changes.
   List<String> get dirtyFiles;
 
-  /// Opens the editable text file at [path].
-  Future<void> openTextFile(String path);
+  /// Opens the supported editor file at [path].
+  Future<void> openFile(String path);
 
   /// Persists all unsaved editor tabs.
   Future<void> saveAllTabs();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
@@ -30,7 +30,7 @@ final class FileTreeFileNode extends FileTreeNode {
     super.isIgnored = false,
   });
 
-  /// Whether the file can be opened in the text editor.
+  /// Whether the file can be opened in an editor or preview tab.
   final bool openable;
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_tabs_adapter.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_tabs_adapter.dart
@@ -33,11 +33,11 @@ final class FileTreeTabsAdapter implements FileTreeEditorDelegate {
 
   @override
   Future<void> openFile(String path) {
-    if (!isEditorOpenableFile(path)) {
+    if (!isSupportedFile(path)) {
       tabs.reportWarning('Binary preview is not available for $path.');
       return Future.value();
     }
-    return tabs.openEditorFile(path);
+    return tabs.openFileWithErrorReporting(path);
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_tabs_adapter.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_tabs_adapter.dart
@@ -32,12 +32,12 @@ final class FileTreeTabsAdapter implements FileTreeEditorDelegate {
   void clearMessages() => tabs.clearMessages();
 
   @override
-  Future<void> openTextFile(String path) {
-    if (!isEditableTextFile(path)) {
+  Future<void> openFile(String path) {
+    if (!isEditorOpenableFile(path)) {
       tabs.reportWarning('Binary preview is not available for $path.');
       return Future.value();
     }
-    return tabs.openTextFile(path);
+    return tabs.openEditorFile(path);
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
@@ -309,7 +309,7 @@ final class FileTreeViewModel extends ChangeNotifier {
             .add(
               FileTreeFileNode(
                 resource,
-                openable: isEditorOpenableFile(resource.path),
+                openable: isSupportedFile(resource.path),
                 isIgnored: isIgnored,
               ),
             );

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
@@ -78,7 +78,7 @@ final class FileTreeViewModel extends ChangeNotifier {
     deleteFile: deleteFile,
     deleteFolder: deleteFolder,
     moveEntry: moveEntry,
-    openFile: tabs.openTextFile,
+    openFile: tabs.openFile,
     clearOperationError: clearOperationError,
     navigateUp: navigateUp,
   );
@@ -113,7 +113,7 @@ final class FileTreeViewModel extends ChangeNotifier {
       final parent = workspace.root.getFolder(parentPath);
       await parent.getFile(name).writeContent('');
       await refresh();
-      await tabs.openTextFile(targetPath);
+      await tabs.openFile(targetPath);
     });
   }
 
@@ -309,7 +309,7 @@ final class FileTreeViewModel extends ChangeNotifier {
             .add(
               FileTreeFileNode(
                 resource,
-                openable: isEditableTextFile(resource.path),
+                openable: isEditorOpenableFile(resource.path),
                 isIgnored: isIgnored,
               ),
             );

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/editable_text_file.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/editable_text_file.dart
@@ -44,6 +44,35 @@ const Set<String> _binaryExtensions = {
   '.sqlite',
 };
 
+/// Browser MIME types for image extensions rendered in an editor preview tab.
+const Map<String, String> _imageMimeTypesByExtension = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+};
+
+/// Image extensions that can be rendered in an editor preview tab.
+final Set<String> supportedImageExtensions = Set.unmodifiable(
+  _imageMimeTypesByExtension.keys,
+);
+
+/// Returns the browser MIME type for a supported image file, if any.
+String? imageMimeTypeForPath(String path) {
+  final lower = path.toLowerCase();
+  final dot = lower.lastIndexOf('.');
+  if (dot == -1 || dot == lower.length - 1) {
+    return null;
+  }
+  return _imageMimeTypesByExtension[lower.substring(dot)];
+}
+
+/// Whether [path] can be displayed as an image preview in the editor.
+bool isPreviewableImageFile(String path) => imageMimeTypeForPath(path) != null;
+
 /// Whether [path] can be represented as editable text.
 bool isEditableTextFile(String path) {
   final lower = path.toLowerCase();
@@ -53,3 +82,6 @@ bool isEditableTextFile(String path) {
   }
   return !_binaryExtensions.contains(lower.substring(dot));
 }
+
+/// Whether [path] can be opened in either an editor or a preview tab.
+bool isEditorOpenableFile(String path) => isEditableTextFile(path) || isPreviewableImageFile(path);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/editable_text_file.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/editable_text_file.dart
@@ -83,5 +83,6 @@ bool isEditableTextFile(String path) {
   return !_binaryExtensions.contains(lower.substring(dot));
 }
 
-/// Whether [path] can be opened in either an editor or a preview tab.
-bool isEditorOpenableFile(String path) => isEditableTextFile(path) || isPreviewableImageFile(path);
+/// Whether [path] can be opened in a tab, either as editable text or
+/// as a read-only image preview.
+bool isSupportedFile(String path) => isEditableTextFile(path) || isPreviewableImageFile(path);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/image_tab_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/image_tab_test.dart
@@ -45,13 +45,13 @@ void main() {
 
     for (final entry in supportedFormats.entries) {
       expect(isPreviewableImageFile(entry.key), isTrue, reason: entry.key);
-      expect(isEditorOpenableFile(entry.key), isTrue, reason: entry.key);
+      expect(isSupportedFile(entry.key), isTrue, reason: entry.key);
       expect(imageMimeTypeForPath(entry.key), entry.value);
     }
 
     for (final path in ['logo.bmp', 'logo.avif', 'logo.pdf']) {
       expect(isPreviewableImageFile(path), isFalse, reason: path);
-      expect(isEditorOpenableFile(path), isFalse, reason: path);
+      expect(isSupportedFile(path), isFalse, reason: path);
       expect(imageMimeTypeForPath(path), isNull);
     }
   });

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/image_tab_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/image_tab_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:typed_data';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/editor/components/image_preview.dart';
+import 'package:dartpad_frontend/features/editor/image/image_tab.dart';
+import 'package:dartpad_frontend/features/shared/editable_text_file.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+final class _Workspace implements WorkspaceResourceApi {
+  _Workspace(this.bytes);
+
+  final Uint8List bytes;
+
+  @override
+  Future<Uint8List> readFileAsBytes(String uri) async => bytes;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  const supportedFormats = {
+    'logo.png': 'image/png',
+    'logo.JPG': 'image/jpeg',
+    'logo.Jpeg': 'image/jpeg',
+    'logo.gif': 'image/gif',
+    'logo.ICO': 'image/x-icon',
+    'logo.svg': 'image/svg+xml',
+    'logo.webp': 'image/webp',
+  };
+
+  test('recognizes exactly the supported image formats case-insensitively', () {
+    expect(
+      supportedImageExtensions,
+      supportedFormats.keys.map((path) => path.substring(path.lastIndexOf('.')).toLowerCase()).toSet(),
+    );
+
+    for (final entry in supportedFormats.entries) {
+      expect(isPreviewableImageFile(entry.key), isTrue, reason: entry.key);
+      expect(isEditorOpenableFile(entry.key), isTrue, reason: entry.key);
+      expect(imageMimeTypeForPath(entry.key), entry.value);
+    }
+
+    for (final path in ['logo.bmp', 'logo.avif', 'logo.pdf']) {
+      expect(isPreviewableImageFile(path), isFalse, reason: path);
+      expect(isEditorOpenableFile(path), isFalse, reason: path);
+      expect(imageMimeTypeForPath(path), isNull);
+    }
+  });
+
+  test('image tab adapter creates read-only tabs only for supported images', () async {
+    final workspace = _Workspace(Uint8List(0));
+    final adapter = ImageTabAdapter(workspaceResourceApi: workspace);
+
+    for (final path in supportedFormats.keys) {
+      final tab = await adapter.createTab(path);
+      expect(tab, isA<ImageTab>(), reason: path);
+      expect(tab!.hasUnsavedChanges, isFalse);
+      expect(tab.build(), isA<ImagePreview>());
+    }
+
+    expect(await adapter.createTab('logo.bmp'), isNull);
+    expect(await adapter.createTab('logo.avif'), isNull);
+  });
+
+  testClient('renders workspace bytes as a MIME-correct data URL', (tester) async {
+    tester.pumpComponent(
+      ImagePreview(
+        path: 'assets/logo.svg',
+        workspaceResourceApi: _Workspace(Uint8List.fromList('<svg/>'.codeUnits)),
+      ),
+    );
+    await pumpEventQueue();
+
+    final image = web.document.querySelector('.image-preview-element')!;
+    expect(image.getAttribute('src'), 'data:image/svg+xml;base64,PHN2Zy8+');
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
@@ -37,7 +37,7 @@ final class FakeTabs extends ChangeNotifier implements FileTreeEditorDelegate {
   void clearMessages() {}
 
   @override
-  Future<void> openTextFile(String path) async {
+  Future<void> openFile(String path) async {
     openedFiles.add(path);
     currentFile = path;
     notifyListeners();
@@ -219,8 +219,13 @@ void main() {
     expect(files.map((node) => node.resource.path), ['pubspec.yaml']);
   });
 
-  test('exposes presentation metadata without requiring view-model queries', () async {
-    workspace.addTextFile('assets/logo.png', 'binary');
+  test('marks text files and supported images as openable', () async {
+    for (final fileName in ['logo.png', 'photo.JPG', 'animation.gif', 'favicon.ico', 'logo.svg', 'image.webp']) {
+      workspace.addTextFile('assets/$fileName', 'binary');
+    }
+    workspace
+      ..addTextFile('assets/photo.bmp', 'binary')
+      ..addTextFile('assets/photo.avif', 'binary');
     tabs.dirty = ['lib/main.dart'];
     tabs.notifyListeners();
     await viewModel.refresh();
@@ -228,9 +233,15 @@ void main() {
     final assets = viewModel.state.root.children.whereType<FileTreeFolderNode>().singleWhere(
       (node) => node.resource.path == 'assets',
     );
-    final logo = assets.children.whereType<FileTreeFileNode>().single;
+    final files = assets.children.whereType<FileTreeFileNode>();
 
-    expect(logo.openable, isFalse);
+    for (final file in files.where(
+      (file) => !file.resource.path.endsWith('.bmp') && !file.resource.path.endsWith('.avif'),
+    )) {
+      expect(file.openable, isTrue, reason: file.resource.path);
+    }
+    expect(files.singleWhere((file) => file.resource.path.endsWith('.bmp')).openable, isFalse);
+    expect(files.singleWhere((file) => file.resource.path.endsWith('.avif')).openable, isFalse);
     expect(viewModel.state.protectedEntries, containsAll(['lib', 'lib/main.dart', 'pubspec.yaml']));
     expect(viewModel.state.dirtyEntries, containsAll(['lib', 'lib/main.dart']));
   });


### PR DESCRIPTION
## Summary

- Add read-only editor tabs for workspace images (PNG, JPEG, GIF, ICO, SVG, and WebP).
- Make supported image files openable from the file tree.