### PR TITLE
fix(dartpad-preview): toggle folders on single click

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
@@ -206,10 +206,6 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
         'click': (web.Event event) {
           event.stopPropagation();
           component.onSelect(path);
-        },
-        'dblclick': (web.Event event) {
-          event.stopPropagation();
-          component.onSelect(path);
           _toggleCollapsed();
         },
         'keydown': (web.Event event) {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
@@ -39,6 +39,33 @@ void main() {
     expect(file.classList.contains('binary'), isTrue);
   });
 
+  testClient('single click on a folder selects it and toggles collapsed state', (tester) async {
+    tester.pumpComponent(
+      FileTreeView(
+        state: _stateWithFolder(workspace),
+        actions: _actions(),
+      ),
+    );
+
+    final folder = web.document.querySelector('.file-tree-item.folder')!;
+
+    // The folder starts collapsed (aria-expanded="false") because it is not
+    // 'lib' and not a parent of the active file.
+    expect(folder.getAttribute('aria-expanded'), 'false');
+
+    // A single click should expand the folder.
+    (folder as web.HTMLElement).click();
+    await pumpEventQueue();
+
+    expect(folder.getAttribute('aria-expanded'), 'true');
+
+    // A second click should collapse the folder again.
+    folder.click();
+    await pumpEventQueue();
+
+    expect(folder.getAttribute('aria-expanded'), 'false');
+  });
+
   testClient('uses the injected delete confirmation callback', (tester) async {
     String? confirmationMessage;
     String? deletedPath;
@@ -92,6 +119,31 @@ FileTreeState _state(
     busy: false,
     protectedEntries: const {},
     dirtyEntries: dirty ? const {path} : const {},
+    focusedPath: '',
+  );
+}
+
+FileTreeState _stateWithFolder(WorkspaceResourceApi workspace) {
+  return FileTreeState(
+    root: FileTreeFolderNode(
+      WorkspaceFolder(workspace: workspace, path: ''),
+      children: [
+        FileTreeFolderNode(
+          WorkspaceFolder(workspace: workspace, path: 'src'),
+          children: [
+            FileTreeFileNode(
+              WorkspaceFile(workspace: workspace, path: 'src/utils.dart'),
+              openable: true,
+            ),
+          ],
+        ),
+      ],
+    ),
+    activeFile: '',
+    operationError: null,
+    busy: false,
+    protectedEntries: const {},
+    dirtyEntries: const {},
     focusedPath: '',
   );
 }


### PR DESCRIPTION
Before you needed to double click a folder to expand it which was not intuitive, now only a single click is needed.
