### PR TITLE
feat(dartpad_preview): add support for running pure-dart programs

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -9,7 +9,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:logging/logging.dart';
 
-import 'features/bottom_panel/view_models/debug_console_view_model.dart';
+import 'features/bottom_panel/view_models/console_view_model.dart';
 import 'features/bottom_panel/view_models/diagnostics_view_model.dart';
 import 'features/bottom_panel/views/bottom_panel.dart';
 import 'features/editor/codemirror/code_mirror_tab.dart';
@@ -51,7 +51,7 @@ class AppState extends State<App> {
   late final TabsViewModel _tabs;
   late final FileTreeViewModel _fileTree;
   late final DiagnosticsViewModel _diagnostics;
-  late final DebugConsoleViewModel _debugConsole;
+  late final ConsoleViewModel _debugConsole;
   late final PreviewViewModel _preview;
 
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
@@ -65,7 +65,7 @@ class AppState extends State<App> {
     super.initState();
     _events = AppEventBus();
 
-    _debugConsole = DebugConsoleViewModel(events: _events);
+    _debugConsole = ConsoleViewModel(events: _events);
 
     _workspaceRepository = WorkspaceRepository.create(events: _events);
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -51,7 +51,7 @@ class AppState extends State<App> {
   late final TabsViewModel _tabs;
   late final FileTreeViewModel _fileTree;
   late final DiagnosticsViewModel _diagnostics;
-  late final ConsoleViewModel _debugConsole;
+  late final ConsoleViewModel _console;
   late final PreviewViewModel _preview;
 
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
@@ -65,7 +65,7 @@ class AppState extends State<App> {
     super.initState();
     _events = AppEventBus();
 
-    _debugConsole = ConsoleViewModel(events: _events);
+    _console = ConsoleViewModel(events: _events);
 
     _workspaceRepository = WorkspaceRepository.create(events: _events);
 
@@ -275,15 +275,15 @@ class AppState extends State<App> {
 
   Component _buildBottomPanel() {
     return ListenableBuilder(
-      listenable: _debugConsole,
+      listenable: _console,
       builder: (context) => ListenableBuilder(
         listenable: _diagnostics,
         builder: (context) => BottomPanel(
           diagnostics: _diagnostics.diagnostics,
           hasMoreDiagnostics: _diagnostics.hasMoreDiagnostics,
           activeFile: _tabs.activeFile,
-          logs: _debugConsole.logs,
-          onClearDebugConsole: _debugConsole.clear,
+          logs: _console.logs,
+          onClearConsole: _console.clear,
           onOpenDiagnostic: (fileName, diagnostic) {
             unawaited(_diagnostics.openDiagnostic(fileName, diagnostic));
           },
@@ -333,7 +333,7 @@ class AppState extends State<App> {
 
   Future<void> _disposeResources() async {
     await _analyzerSubscription?.cancel();
-    _debugConsole.dispose();
+    _console.dispose();
     _diagnostics.dispose();
     _fileTree.dispose();
     _tabs.dispose();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/models/console_entry.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/models/console_entry.dart
@@ -4,9 +4,9 @@
 
 import 'package:logging/logging.dart';
 
-/// A single rendered line in the debug console.
-final class DebugConsoleEntry {
-  const DebugConsoleEntry({required this.message, required this.level});
+/// A single rendered line in the console.
+final class ConsoleEntry {
+  const ConsoleEntry({required this.message, required this.level});
 
   final String message;
   final Level level;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/console_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/console_view_model.dart
@@ -9,19 +9,19 @@ import 'package:logging/logging.dart';
 
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
-import '../models/debug_console_entry.dart';
+import '../models/console_entry.dart';
 
-/// Collects application log events for display in the debug console.
-class DebugConsoleViewModel extends ChangeNotifier {
-  DebugConsoleViewModel({required AppEventBus events}) {
+/// Collects application log events for display in the console.
+class ConsoleViewModel extends ChangeNotifier {
+  ConsoleViewModel({required AppEventBus events}) {
     _subscription = events.on<LogEvent>().listen(_handleLog);
   }
 
-  final List<DebugConsoleEntry> _logs = [];
+  final List<ConsoleEntry> _logs = [];
   late final StreamSubscription<LogEvent> _subscription;
 
   /// The collected log lines, in arrival order.
-  List<DebugConsoleEntry> get logs => List.unmodifiable(_logs);
+  List<ConsoleEntry> get logs => List.unmodifiable(_logs);
 
   void _handleLog(LogEvent event) {
     var changed = _appendLogText(event.message, event.level);
@@ -41,7 +41,7 @@ class DebugConsoleViewModel extends ChangeNotifier {
   bool _appendLogText(String text, Level level) {
     var changed = false;
     for (final line in _splitLogLines(text)) {
-      _logs.add(DebugConsoleEntry(message: line, level: level));
+      _logs.add(ConsoleEntry(message: line, level: level));
       changed = true;
     }
     return changed;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -28,7 +28,7 @@ class BottomPanel extends StatefulComponent {
     required this.activeFile,
     required this.onOpenDiagnostic,
     required this.logs,
-    required this.onClearDebugConsole,
+    required this.onClearConsole,
     super.key,
   });
 
@@ -48,7 +48,7 @@ class BottomPanel extends StatefulComponent {
   final List<ConsoleEntry> logs;
 
   /// Clears the debug output.
-  final void Function() onClearDebugConsole;
+  final void Function() onClearConsole;
 
   @override
   State<BottomPanel> createState() => _BottomPanelState();
@@ -73,7 +73,7 @@ class _BottomPanelState extends State<BottomPanel> {
         problemsCount: component.diagnostics.length,
         activeTab: _activeTab,
         onSelectTab: _selectTab,
-        onClearConsole: component.onClearDebugConsole,
+        onClearConsole: component.onClearConsole,
       ),
       _buildContent(),
     ]);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -6,9 +6,9 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
-import '../models/debug_console_entry.dart';
+import '../models/console_entry.dart';
 import 'bottom_panel_tabs.dart';
-import 'debug_console_panel.dart';
+import 'console_panel.dart';
 import 'problems_panel.dart';
 
 /// The available tabs in the bottom panel.
@@ -17,7 +17,7 @@ enum BottomPanelTab {
   problems,
 
   /// The debug console tab showing application logs.
-  debugConsole,
+  console,
 }
 
 /// The bottom panel showing tabs with associated content panes.
@@ -45,7 +45,7 @@ class BottomPanel extends StatefulComponent {
   final void Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
 
   /// Application log lines shown in the debug console.
-  final List<DebugConsoleEntry> logs;
+  final List<ConsoleEntry> logs;
 
   /// Clears the debug output.
   final void Function() onClearDebugConsole;
@@ -73,7 +73,7 @@ class _BottomPanelState extends State<BottomPanel> {
         problemsCount: component.diagnostics.length,
         activeTab: _activeTab,
         onSelectTab: _selectTab,
-        onClearDebugConsole: component.onClearDebugConsole,
+        onClearConsole: component.onClearDebugConsole,
       ),
       _buildContent(),
     ]);
@@ -88,7 +88,7 @@ class _BottomPanelState extends State<BottomPanel> {
           activeFile: component.activeFile,
           onOpenDiagnostic: component.onOpenDiagnostic,
         ),
-        BottomPanelTab.debugConsole => DebugConsolePanel(logs: component.logs),
+        BottomPanelTab.console => ConsolePanel(logs: component.logs),
       },
     ]);
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
@@ -15,7 +15,7 @@ class BottomPanelTabs extends StatelessComponent {
     required this.problemsCount,
     required this.activeTab,
     required this.onSelectTab,
-    required this.onClearDebugConsole,
+    required this.onClearConsole,
     super.key,
   });
 
@@ -28,8 +28,8 @@ class BottomPanelTabs extends StatelessComponent {
   /// Called when a tab is clicked.
   final void Function(BottomPanelTab tab) onSelectTab;
 
-  /// Clears the debug console's output.
-  final void Function() onClearDebugConsole;
+  /// Clears the console's output.
+  final void Function() onClearConsole;
 
   @override
   Component build(BuildContext context) {
@@ -41,16 +41,16 @@ class BottomPanelTabs extends StatelessComponent {
         onClick: () => onSelectTab(BottomPanelTab.problems),
       ),
       _BottomPanelTabButton(
-        label: 'Debug Console',
-        active: activeTab == BottomPanelTab.debugConsole,
-        onClick: () => onSelectTab(BottomPanelTab.debugConsole),
+        label: 'Console',
+        active: activeTab == BottomPanelTab.console,
+        onClick: () => onSelectTab(BottomPanelTab.console),
       ),
       const div(classes: 'bottom-panel-tabs-spacer', []),
-      if (activeTab == BottomPanelTab.debugConsole)
+      if (activeTab == BottomPanelTab.console)
         button(
           classes: 'bottom-panel-clear-btn',
           attributes: const {'title': 'Clear console', 'aria-label': 'Clear console'},
-          onClick: onClearDebugConsole,
+          onClick: onClearConsole,
           [const Icon('playlist_remove', size: 20)],
         ),
     ]);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/console_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/console_panel.dart
@@ -8,22 +8,22 @@ import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
-import '../models/debug_console_entry.dart';
+import '../models/console_entry.dart';
 
 /// Displays the application's structured log events.
-class DebugConsolePanel extends StatefulComponent {
-  const DebugConsolePanel({required this.logs, super.key});
+class ConsolePanel extends StatefulComponent {
+  const ConsolePanel({required this.logs, super.key});
 
-  final List<DebugConsoleEntry> logs;
+  final List<ConsoleEntry> logs;
 
   @override
-  State<DebugConsolePanel> createState() => _DebugConsolePanelState();
+  State<ConsolePanel> createState() => _DebugConsolePanelState();
 
   @css
   static List<StyleRule> get styles => _DebugConsolePanelState.styles;
 }
 
-class _DebugConsolePanelState extends State<DebugConsolePanel> {
+class _DebugConsolePanelState extends State<ConsolePanel> {
   final GlobalNodeKey<web.HTMLElement> _listKey = GlobalNodeKey();
 
   @override
@@ -35,7 +35,7 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
   }
 
   @override
-  void didUpdateComponent(covariant DebugConsolePanel oldComponent) {
+  void didUpdateComponent(covariant ConsolePanel oldComponent) {
     super.didUpdateComponent(oldComponent);
     if (component.logs.length != oldComponent.logs.length) {
       context.binding.addPostFrameCallback(_scrollToBottom);
@@ -54,16 +54,16 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'debug-console-panel', [
+    return div(classes: 'console-panel', [
       div(
         key: _listKey,
-        classes: 'debug-console-list',
+        classes: 'console-list',
         [
           if (component.logs.isEmpty)
-            const div(classes: 'debug-console-empty', [.text('No debug output yet')])
+            const div(classes: 'console-empty', [.text('No output yet')])
           else
             for (final log in component.logs)
-              div(classes: 'log-row ${log.level.debugConsoleCssClass}', [
+              div(classes: 'log-row ${log.level.consoleCssClass}', [
                 pre(classes: 'log-message', [.text(log.message)]),
               ]),
         ],
@@ -72,7 +72,7 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
   }
 
   static List<StyleRule> get styles => [
-    css('.debug-console-panel').styles(
+    css('.console-panel').styles(
       display: .flex,
       minHeight: .zero,
       overflow: .hidden,
@@ -80,12 +80,13 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
       flex: const Flex(grow: 1, basis: .zero),
       backgroundColor: colorContainer,
     ),
-    css('.debug-console-list').styles(
+    css('.console-list').styles(
       minHeight: .zero,
+      padding: .symmetric(vertical: 4.px),
       overflow: const .only(y: .auto),
       flex: const Flex(grow: 1, basis: .zero),
     ),
-    css('.debug-console-empty').styles(
+    css('.console-empty').styles(
       display: .flex,
       minHeight: 48.px,
       padding: .symmetric(horizontal: 12.px),
@@ -119,7 +120,6 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
       margin: .zero,
       overflow: const .only(x: .auto),
       color: colorOnContainer,
-      fontFamily: const .list([FontFamilies.courierNew, FontFamilies.monospace]),
       fontSize: 12.px,
       lineHeight: 18.px,
       whiteSpace: .preWrap,
@@ -127,8 +127,8 @@ class _DebugConsolePanelState extends State<DebugConsolePanel> {
   ];
 }
 
-extension DebugConsoleLevelStyling on Level {
-  String get debugConsoleCssClass {
+extension ConsoleLevelStyling on Level {
+  String get consoleCssClass {
     if (this > Level.WARNING) {
       return 'error';
     }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_sandbox.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_sandbox.dart
@@ -9,6 +9,7 @@ abstract interface class PreviewSandbox {
   void dispose();
   Future<void> loadModule({required String code});
   Future<void> runApp(Uri libraryUri);
+  Future<void> runMain(Uri libraryUri);
   Future<void> hotReload({required String? code, required List<Uri> librariesToReload});
   Stream<ConsoleMessage> get onConsole;
   Stream<({String message})> get onError;
@@ -29,6 +30,9 @@ class RealPreviewSandbox implements PreviewSandbox {
 
   @override
   Future<void> runApp(Uri libraryUri) => _sandbox.runApp(libraryUri);
+
+  @override
+  Future<void> runMain(Uri libraryUri) => _sandbox.runMain(libraryUri);
 
   @override
   Future<void> hotReload({required String? code, required List<Uri> librariesToReload}) =>

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -6,6 +6,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
 import '../../../app_styles.dart';
+import '../../bottom_panel/views/console_panel.dart';
 import '../../shared/components/button_group.dart';
 import '../../shared/node_container.dart';
 import '../components/runtime_button.dart';
@@ -81,13 +82,14 @@ class _PreviewContainerState extends State<PreviewContainer> {
         ]),
       ]),
       div(
-        classes: 'preview-content ${!isRunning ? 'status-stopped' : ''}',
+        classes: 'preview-content ${!isRunning ? 'status-stopped' : ''} ${!viewModel.isFlutter ? 'is-dart' : ''}',
         [
           NodeContainer(viewModel.containerElement),
           if (state is PreviewInitial)
             const div(classes: 'preview-placeholder', [
               span([.text('Start your app to see the preview.')]),
             ]),
+          if (isRunning && !viewModel.isFlutter) ConsolePanel(logs: viewModel.appLogs),
           ?statusToast,
         ],
       ),
@@ -151,6 +153,16 @@ class _PreviewContainerState extends State<PreviewContainer> {
         ),
         css('&.status-stopped > .preview').styles(
           visibility: .hidden,
+        ),
+        css('&.is-dart > .preview').styles(
+          position: const .absolute(),
+          width: .zero,
+          height: .zero,
+          visibility: .hidden,
+        ),
+        css('&.is-dart > .console-panel').styles(
+          width: 100.percent,
+          height: 100.percent,
         ),
         css('& > .preview').styles(
           width: 100.percent,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -9,6 +9,7 @@ import 'package:jaspr/jaspr.dart';
 import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
+import '../../bottom_panel/models/console_entry.dart';
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
 import '../../workspace/data/workspace_repository.dart';
@@ -55,6 +56,14 @@ class PreviewViewModel extends ChangeNotifier {
   /// The current state of compiling, validation, running, or stopping the preview.
   PreviewState get state => _state;
   PreviewState _state = PreviewInitial();
+
+  /// Whether the running app uses Flutter.
+  bool get isFlutter => _isFlutter;
+  bool _isFlutter = true;
+
+  /// Logs collected from the running application (used in pure Dart mode).
+  List<ConsoleEntry> get appLogs => List.unmodifiable(_appLogs);
+  final List<ConsoleEntry> _appLogs = [];
 
   /// Whether the compiler or execution setup can be started.
   bool get canStart => !_busy && (_state is PreviewInitial || _state is PreviewCompileError);
@@ -104,6 +113,8 @@ class PreviewViewModel extends ChangeNotifier {
 
     final operationId = _beginOperation();
 
+    _appLogs.clear();
+
     final compileNeeded = !skipRecompilation || _lastCompiledCode == null;
     eventBus.dispatch(LogEvent('Run $entrypoint'));
     if (compileNeeded) {
@@ -149,6 +160,7 @@ class PreviewViewModel extends ChangeNotifier {
         if (!_isCurrentOperation(operationId)) {
           return;
         }
+        print(result.compiledLibraryUris);
         eventBus.dispatch(LogEvent(result.log ?? ''));
         eventBus.dispatch(const LogEvent('Compilation succeeded.'));
         _lastCompiledCode = result.code;
@@ -192,9 +204,15 @@ class PreviewViewModel extends ChangeNotifier {
       }
 
       final libraryUri = await workspaceRepository.convertToPackageUri(entrypoint);
+      final isFlutter = await workspaceRepository.hasFlutterDependency(entrypoint);
+      _isFlutter = isFlutter;
 
       eventBus.dispatch(const LogEvent('Running application...'));
-      await sandbox.runApp(libraryUri);
+      if (isFlutter) {
+        await sandbox.runApp(libraryUri);
+      } else {
+        await sandbox.runMain(libraryUri);
+      }
       if (!_isCurrentOperation(operationId)) {
         await _disposeCurrentSandbox(sandbox);
         return;
@@ -347,13 +365,32 @@ class PreviewViewModel extends ChangeNotifier {
         _ => Level.INFO,
       };
 
-      eventBus.dispatch(LogEvent('[app] ${event.message}', level: level));
+      final isSystemLog =
+          event.message.startsWith('Starting application from') ||
+          event.message.startsWith('Hot restarting application from');
+
+      if (_isFlutter || isSystemLog) {
+        eventBus.dispatch(LogEvent('[app] ${event.message}', level: level));
+      } else {
+        _appLogs.add(ConsoleEntry(message: event.message, level: level));
+        notifyListeners();
+      }
     });
     _sandboxErrorSubscription = sandbox.onError.listen((event) {
-      eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+      if (_isFlutter) {
+        eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+      } else {
+        _appLogs.add(ConsoleEntry(message: event.message, level: Level.SEVERE));
+        notifyListeners();
+      }
     });
     _sandboxRejectionSubscription = sandbox.onUnhandledRejection.listen((event) {
-      eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+      if (_isFlutter) {
+        eventBus.dispatch(LogEvent('[app] ${event.message}', level: Level.SEVERE));
+      } else {
+        _appLogs.add(ConsoleEntry(message: event.message, level: Level.SEVERE));
+        notifyListeners();
+      }
     });
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -160,7 +160,6 @@ class PreviewViewModel extends ChangeNotifier {
         if (!_isCurrentOperation(operationId)) {
           return;
         }
-        print(result.compiledLibraryUris);
         eventBus.dispatch(LogEvent(result.log ?? ''));
         eventBus.dispatch(const LogEvent('Compilation succeeded.'));
         _lastCompiledCode = result.code;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -166,11 +166,49 @@ class WorkspaceRepository {
     final packageFolder = resolvedFolder ?? root;
 
     final libFolder = workspaceContext.join(packageFolder.path, 'lib');
-    final relativePath = workspacePath.relative(filePath, from: libFolder);
-    return Uri(
-      scheme: 'package',
-      path: workspacePath.join(packageName, relativePath),
-    );
+    if (workspacePath.isWithin(libFolder, filePath)) {
+      final relativePath = workspacePath.relative(filePath, from: libFolder);
+      return Uri(
+        scheme: 'package',
+        path: workspacePath.join(packageName, relativePath),
+      );
+    } else {
+      final ws = await _workspaceFuture;
+      return ws.workspaceFolder.resolve(filePath);
+    }
+  }
+
+  /// Checks if the project containing [filePath] has a dependency on the
+  /// flutter framework by reading its resolved `.dart_tool/package_config.json`.
+  Future<bool> hasFlutterDependency(String filePath) async {
+    WorkspaceFolder folder = root.getFile(filePath).parent;
+    while (true) {
+      final config = folder.getFile('.dart_tool/package_config.json');
+      if (await config.exists()) {
+        try {
+          final content = await config.readContent();
+          final configJson = json.decode(content) as Map<String, dynamic>;
+          final packages = configJson['packages'] as List<dynamic>?;
+          if (packages != null) {
+            for (final pkg in packages) {
+              final map = pkg as Map<String, dynamic>;
+              if (map['name'] == 'flutter') {
+                return true;
+              }
+            }
+            return false;
+          }
+        } catch (_) {
+          // Fall through.
+        }
+      }
+
+      if (folder.isRoot) {
+        break;
+      }
+      folder = folder.parent;
+    }
+    return false;
   }
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/console_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/console_view_model_test.dart
@@ -11,7 +11,7 @@ import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('DebugConsoleViewModel', () {
+  group('ConsoleViewModel', () {
     late AppEventBus events;
     late ConsoleViewModel viewModel;
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/debug_console_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/debug_console_view_model_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:dartpad_frontend/features/bottom_panel/view_models/debug_console_view_model.dart';
+import 'package:dartpad_frontend/features/bottom_panel/view_models/console_view_model.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
 import 'package:logging/logging.dart';
@@ -13,11 +13,11 @@ import 'package:test/test.dart';
 void main() {
   group('DebugConsoleViewModel', () {
     late AppEventBus events;
-    late DebugConsoleViewModel viewModel;
+    late ConsoleViewModel viewModel;
 
     setUp(() {
       events = AppEventBus();
-      viewModel = DebugConsoleViewModel(events: events);
+      viewModel = ConsoleViewModel(events: events);
     });
 
     tearDown(() async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -12,7 +12,7 @@ import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
 void main() {
-  testClient('switches to the debug console and invokes clear', (tester) async {
+  testClient('switches to the console and invokes clear', (tester) async {
     var clearCalls = 0;
     tester.pumpComponent(
       BottomPanel(
@@ -21,18 +21,18 @@ void main() {
         activeFile: '',
         logs: const [ConsoleEntry(message: 'Running pub get in /', level: Level.INFO)],
         onOpenDiagnostic: (_, _) {},
-        onClearDebugConsole: () => clearCalls++,
+        onClearConsole: () => clearCalls++,
       ),
     );
 
-    expect(web.document.querySelector('.debug-console-panel'), isNull);
+    expect(web.document.querySelector('.console-panel'), isNull);
     expect(web.document.querySelector('.bottom-panel-clear-btn'), isNull);
 
-    final debugTab = web.document.querySelector('.bottom-panel-tab:nth-child(2)')! as web.HTMLButtonElement;
-    debugTab.click();
+    final consoleTab = web.document.querySelector('.bottom-panel-tab:nth-child(2)')! as web.HTMLButtonElement;
+    consoleTab.click();
     await pumpEventQueue();
 
-    expect(web.document.querySelector('.debug-console-panel')!.textContent, contains('Running pub get in /'));
+    expect(web.document.querySelector('.console-panel')!.textContent, contains('Running pub get in /'));
     final clearButton = web.document.querySelector('.bottom-panel-clear-btn')! as web.HTMLButtonElement;
     expect(clearButton.disabled, isFalse);
 
@@ -41,7 +41,7 @@ void main() {
     expect(clearCalls, 1);
   });
 
-  testClient('keeps clear enabled when the debug console is empty', (tester) async {
+  testClient('keeps clear enabled when the console is empty', (tester) async {
     tester.pumpComponent(
       BottomPanel(
         diagnostics: const [],
@@ -49,12 +49,12 @@ void main() {
         activeFile: '',
         logs: const [],
         onOpenDiagnostic: (_, _) {},
-        onClearDebugConsole: () {},
+        onClearConsole: () {},
       ),
     );
 
-    final debugTab = web.document.querySelector('.bottom-panel-tab:nth-child(2)')! as web.HTMLButtonElement;
-    debugTab.click();
+    final consoleTab = web.document.querySelector('.bottom-panel-tab:nth-child(2)')! as web.HTMLButtonElement;
+    consoleTab.click();
     await pumpEventQueue();
 
     final clearButton = web.document.querySelector('.bottom-panel-clear-btn')! as web.HTMLButtonElement;
@@ -69,7 +69,7 @@ void main() {
         activeFile: '',
         logs: const [],
         onOpenDiagnostic: (_, _) {},
-        onClearDebugConsole: () {},
+        onClearConsole: () {},
       ),
     );
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -5,7 +5,7 @@
 @TestOn('browser')
 library;
 
-import 'package:dartpad_frontend/features/bottom_panel/models/debug_console_entry.dart';
+import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
 import 'package:dartpad_frontend/features/bottom_panel/views/bottom_panel.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:logging/logging.dart';
@@ -19,7 +19,7 @@ void main() {
         diagnostics: const [],
         hasMoreDiagnostics: false,
         activeFile: '',
-        logs: const [DebugConsoleEntry(message: 'Running pub get in /', level: Level.INFO)],
+        logs: const [ConsoleEntry(message: 'Running pub get in /', level: Level.INFO)],
         onOpenDiagnostic: (_, _) {},
         onClearDebugConsole: () => clearCalls++,
       ),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
@@ -55,6 +55,7 @@ class FakePreviewSandbox implements PreviewSandbox {
   int disposeCount = 0;
   int loadModuleCount = 0;
   int runAppCount = 0;
+  int runMainCount = 0;
   int hotReloadCount = 0;
 
   final consoleController = StreamController<ConsoleMessage>.broadcast();
@@ -68,6 +69,7 @@ class FakePreviewSandbox implements PreviewSandbox {
 
   Future<void> Function({required String code})? onLoadModule;
   Future<void> Function(Uri libraryUri)? onRunApp;
+  Future<void> Function(Uri libraryUri)? onRunMain;
   Future<void> Function({required String? code, required List<Uri> librariesToReload})? onHotReload;
 
   @override
@@ -93,6 +95,15 @@ class FakePreviewSandbox implements PreviewSandbox {
     runUri = libraryUri;
     if (onRunApp != null) {
       await onRunApp!(libraryUri);
+    }
+  }
+
+  @override
+  Future<void> runMain(Uri libraryUri) async {
+    runMainCount++;
+    runUri = libraryUri;
+    if (onRunMain != null) {
+      await onRunMain!(libraryUri);
     }
   }
 
@@ -126,6 +137,8 @@ class FakeWorkspaceRepository extends WorkspaceRepository {
 
   int startHotReloadCompilerCount = 0;
   int convertToPackageUriCount = 0;
+  int hasFlutterDependencyCount = 0;
+  bool flutterDependency = true;
 
   CompilerSession Function(Uri uri)? onStartHotReloadCompiler;
   Uri Function(String filePath)? onConvertToPackageUri;
@@ -146,6 +159,12 @@ class FakeWorkspaceRepository extends WorkspaceRepository {
       return onConvertToPackageUri!(filePath);
     }
     return Uri.parse('package:app/main.dart');
+  }
+
+  @override
+  Future<bool> hasFlutterDependency(String filePath) async {
+    hasFlutterDependencyCount++;
+    return flutterDependency;
   }
 }
 
@@ -234,6 +253,51 @@ void main() {
           'App is running.',
         ]),
       );
+
+      viewModel.dispose();
+      expect(fakeCompiler.closeCount, 1);
+      expect(fakeSandbox.disposeCount, 1);
+    });
+
+    test('runCode in pure-dart mode (no Flutter dependency) runs runMain successfully', () async {
+      final fakeSandbox = FakePreviewSandbox();
+      final fakeCompiler = FakeCompilerSession();
+
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+      repository.flutterDependency = false;
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      final stateChanges = <PreviewState>[];
+      viewModel.addListener(() {
+        stateChanges.add(viewModel.state);
+      });
+
+      await viewModel.runCode('lib/main.dart');
+      await pump();
+
+      expect(stateChanges, [
+        isA<PreviewStarting>(),
+        isA<PreviewRunning>(),
+      ]);
+
+      expect(viewModel.state, isA<PreviewRunning>());
+      expect(viewModel.canStart, isFalse);
+      expect(viewModel.canRestart, isTrue);
+      expect(viewModel.canHotReload, isTrue);
+      expect(viewModel.canStop, isTrue);
+      expect(viewModel.isRunning, isTrue);
+
+      expect(fakeCompiler.compileCount, 1);
+      expect(fakeSandbox.loadModuleCount, 1);
+      expect(fakeSandbox.loadedCode, 'compiled_code');
+      expect(fakeSandbox.runAppCount, 0);
+      expect(fakeSandbox.runMainCount, 1);
+      expect(fakeSandbox.runUri, Uri.parse('package:app/main.dart'));
 
       viewModel.dispose();
       expect(fakeCompiler.closeCount, 1);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
@@ -7,6 +7,7 @@ library;
 
 import 'dart:async';
 
+import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
@@ -136,4 +137,102 @@ void main() {
       expect(workspace.folders, containsAll({'build', '.dart_tool'}));
     },
   );
+
+  group('hasFlutterDependency', () {
+    test('returns true when flutter is a dependency in package_config.json', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        workspaceResourceApi: api,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      final packageConfigContent = '''
+      {
+        "configVersion": 2,
+        "packages": [
+          {
+            "name": "flutter",
+            "rootUri": "file:///path/to/flutter",
+            "packageUri": "lib/",
+            "languageVersion": "3.0"
+          }
+        ]
+      }
+      ''';
+
+      await api.root.getFile('.dart_tool/package_config.json').writeContent(packageConfigContent);
+
+      final hasFlutter = await repository.hasFlutterDependency('lib/main.dart');
+      expect(hasFlutter, isTrue);
+    });
+
+    test('returns false when package_config.json does not contain flutter dependency', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        workspaceResourceApi: api,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      final packageConfigContent = '''
+      {
+        "configVersion": 2,
+        "packages": [
+          {
+            "name": "path",
+            "rootUri": "file:///path/to/path",
+            "packageUri": "lib/",
+            "languageVersion": "3.0"
+          }
+        ]
+      }
+      ''';
+
+      await api.root.getFile('.dart_tool/package_config.json').writeContent(packageConfigContent);
+
+      final hasFlutter = await repository.hasFlutterDependency('lib/main.dart');
+      expect(hasFlutter, isFalse);
+    });
+
+    test('returns false when package_config.json is missing', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        workspaceResourceApi: api,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      final hasFlutter = await repository.hasFlutterDependency('lib/main.dart');
+      expect(hasFlutter, isFalse);
+    });
+
+    test('traverses up the directory tree to find package_config.json', () async {
+      final api = MemoryWorkspaceResourceApi();
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        workspaceResourceApi: api,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      final packageConfigContent = '''
+      {
+        "configVersion": 2,
+        "packages": [
+          {
+            "name": "flutter",
+            "rootUri": "file:///path/to/flutter",
+            "packageUri": "lib/",
+            "languageVersion": "3.0"
+          }
+        ]
+      }
+      ''';
+
+      await api.root.getFile('.dart_tool/package_config.json').writeContent(packageConfigContent);
+
+      final hasFlutter = await repository.hasFlutterDependency('subproject/lib/src/helpers/util.dart');
+      expect(hasFlutter, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Adds simple support for running pure-dart programs.

Pure-dart programs are detected by checking the package_config.json file if it contains flutter as a dependency or not. If not, the preview is started using `runMain` instead of `runApp`, the iframe is visually hidden and instead a console view is shown that displays the app logs normally shown in the editor console.

I've also fixed entrypoint uri resolution for entrypoints outside the lib directory, which need to be absolute file uris instead of package uris.

I've also renamed `DebugConsole` and others to be only `Console` since we just showing various logs and are not actually debugging.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
