### PR TITLE
add selection action extension to codemirror-dart

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -40143,6 +40143,117 @@ ${text}</tr>
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
     /**
+     * Creates a CodeMirror extension that displays a tooltip button above the
+     * selected text, allowing users to trigger a custom action.
+     *
+     * The action can also be triggered via the configured keyboard shortcut.
+     *
+     * @param config - The configuration options for the selection action.
+     * @param config.key - The keyboard shortcut key sequence (e.g., 'Mod-/').
+     * @param config.label - The text label to display on the tooltip button.
+     * @param config.run - A callback function executed when the action is triggered.
+     * Receives the 1-based start line, 1-based end line, and the selected text.
+     *
+     * @returns A list of CodeMirror extensions containing the tooltip StateField
+     * and the keymap configuration.
+     */
+    function selectionAction(config) {
+        /**
+         * Executes the custom run callback with details about the current selection
+         * and collapses the selection to the end of the selected range.
+         *
+         * @param view - The active editor view.
+         * @param from - The selection start character offset.
+         * @param to - The selection end character offset.
+         */
+        const runAction = (view, from, to) => {
+            const text = view.state.sliceDoc(from, to);
+            const lineFrom = view.state.doc.lineAt(from).number;
+            const lineTo = view.state.doc.lineAt(to).number;
+            config.run(lineFrom, lineTo, text);
+            view.dispatch({
+                selection: { anchor: to },
+            });
+        };
+        /**
+         * CodeMirror StateField that tracks the text selection and manages showing
+         * or hiding the custom tooltip action button.
+         */
+        const selectionTooltipField = StateField.define({
+            create() {
+                return null;
+            },
+            update(value, tr) {
+                if (tr.docChanged || tr.selection) {
+                    const { main } = tr.state.selection;
+                    if (main.empty) {
+                        return null;
+                    }
+                    return {
+                        pos: main.from,
+                        end: main.to,
+                        above: true,
+                        strictSide: true,
+                        create(view) {
+                            const dom = document.createElement("div");
+                            dom.className = "cm-selection-action-tooltip";
+                            const button = document.createElement("button");
+                            button.className = "cm-selection-action-btn";
+                            button.type = "button";
+                            const labelEl = document.createElement("span");
+                            labelEl.className = "cm-selection-action-label";
+                            labelEl.textContent = config.label;
+                            const shortcutEl = document.createElement("span");
+                            shortcutEl.className = "cm-selection-action-shortcut";
+                            const userAgentData = navigator.userAgentData;
+                            const isMac = userAgentData
+                                ? /Mac|iPhone|iPad|iPod/i.test(userAgentData.platform)
+                                : /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+                            let keyText = config.key;
+                            if (keyText.toLowerCase().startsWith("mod-")) {
+                                keyText =
+                                    (isMac ? "⌘" : "Ctrl+") + keyText.slice(4).toUpperCase();
+                            }
+                            else {
+                                keyText = keyText.replace(/Mod/gi, isMac ? "⌘" : "Ctrl");
+                            }
+                            shortcutEl.textContent = keyText;
+                            button.appendChild(labelEl);
+                            button.appendChild(shortcutEl);
+                            button.addEventListener("click", () => {
+                                runAction(view, main.from, main.to);
+                            });
+                            dom.appendChild(button);
+                            return { dom };
+                        },
+                    };
+                }
+                return value;
+            },
+            provide: (f) => showTooltip.from(f),
+        });
+        return [
+            selectionTooltipField,
+            keymap.of([
+                {
+                    key: config.key,
+                    run: (view) => {
+                        const { main } = view.state.selection;
+                        if (main.empty) {
+                            return false;
+                        }
+                        runAction(view, main.from, main.to);
+                        return true;
+                    },
+                },
+            ]),
+        ];
+    }
+
+    // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
+    /**
      * Main global interface exporting CodeMirror dependencies to Dart JS-Interop bindings.
      */
     window._codemirror = {
@@ -40178,6 +40289,7 @@ ${text}</tr>
         sql,
         createLspClient,
         gotoDefinitionOnClick,
+        selectionAction,
         diagnosticHoverToolbar,
         forceSemanticTokensRefresh,
     };

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
@@ -59,6 +59,23 @@ external JSPromise<JSBoolean> formatDocumentAsync(EditorView view);
 @JS()
 external JSAny gotoDefinitionOnClick();
 
+@JS()
+external JSAny selectionAction(SelectionActionConfig config);
+
+extension type SelectionActionConfig._(JSObject _) implements JSObject {
+  external factory SelectionActionConfig.js({
+    JSString key,
+    JSString label,
+    JSFunction run,
+  });
+
+  factory SelectionActionConfig({
+    required String key,
+    required String label,
+    required void Function(int from, int to, String text) run,
+  }) => SelectionActionConfig.js(key: key.toJS, label: label.toJS, run: run.toJS);
+}
+
 // =============================================================================
 // Linting & Diagnostics
 // =============================================================================

--- a/pkgs/dartpad_preview/codemirror-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/index.ts
@@ -34,6 +34,7 @@ import { gotoDefinitionOnClick } from "./gotoDefinition";
 import { diagnosticHoverToolbar } from "./diagnosticHoverToolbar";
 import { forceSemanticTokensRefresh } from "./semanticHighlighting";
 import { formatDocument, formatDocumentAsync } from "./formatting";
+import { selectionAction } from "./selectionAction";
 
 declare global {
   interface Window {
@@ -72,6 +73,7 @@ declare global {
       sql: typeof sql;
       createLspClient: typeof createLspClient;
       gotoDefinitionOnClick: typeof gotoDefinitionOnClick;
+      selectionAction: typeof selectionAction;
       diagnosticHoverToolbar: typeof diagnosticHoverToolbar;
       forceSemanticTokensRefresh: typeof forceSemanticTokensRefresh;
     };
@@ -116,6 +118,7 @@ window._codemirror = {
   sql,
   createLspClient,
   gotoDefinitionOnClick,
+  selectionAction,
   diagnosticHoverToolbar,
   forceSemanticTokensRefresh,
 };

--- a/pkgs/dartpad_preview/codemirror-dart/src/selectionAction.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/selectionAction.ts
@@ -1,0 +1,126 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import { showTooltip, Tooltip, EditorView, keymap } from "@codemirror/view";
+import { StateField } from "@codemirror/state";
+
+/**
+ * Creates a CodeMirror extension that displays a tooltip button above the
+ * selected text, allowing users to trigger a custom action.
+ *
+ * The action can also be triggered via the configured keyboard shortcut.
+ *
+ * @param config - The configuration options for the selection action.
+ * @param config.key - The keyboard shortcut key sequence (e.g., 'Mod-/').
+ * @param config.label - The text label to display on the tooltip button.
+ * @param config.run - A callback function executed when the action is triggered.
+ * Receives the 1-based start line, 1-based end line, and the selected text.
+ *
+ * @returns A list of CodeMirror extensions containing the tooltip StateField
+ * and the keymap configuration.
+ */
+export function selectionAction(config: {
+  key: string;
+  label: string;
+  run: (from: number, to: number, text: string) => void;
+}) {
+  /**
+   * Executes the custom run callback with details about the current selection
+   * and collapses the selection to the end of the selected range.
+   *
+   * @param view - The active editor view.
+   * @param from - The selection start character offset.
+   * @param to - The selection end character offset.
+   */
+  const runAction = (view: EditorView, from: number, to: number) => {
+    const text = view.state.sliceDoc(from, to);
+    const lineFrom = view.state.doc.lineAt(from).number;
+    const lineTo = view.state.doc.lineAt(to).number;
+    config.run(lineFrom, lineTo, text);
+    view.dispatch({
+      selection: { anchor: to },
+    });
+  };
+
+  /**
+   * CodeMirror StateField that tracks the text selection and manages showing
+   * or hiding the custom tooltip action button.
+   */
+  const selectionTooltipField = StateField.define<Tooltip | null>({
+    create() {
+      return null;
+    },
+    update(value, tr) {
+      if (tr.docChanged || tr.selection) {
+        const { main } = tr.state.selection;
+        if (main.empty) {
+          return null;
+        }
+        return {
+          pos: main.from,
+          end: main.to,
+          above: true,
+          strictSide: true,
+          create(view) {
+            const dom = document.createElement("div");
+            dom.className = "cm-selection-action-tooltip";
+
+            const button = document.createElement("button");
+            button.className = "cm-selection-action-btn";
+            button.type = "button";
+
+            const labelEl = document.createElement("span");
+            labelEl.className = "cm-selection-action-label";
+            labelEl.textContent = config.label;
+
+            const shortcutEl = document.createElement("span");
+            shortcutEl.className = "cm-selection-action-shortcut";
+
+            const userAgentData = (navigator as any).userAgentData;
+            const isMac = userAgentData
+              ? /Mac|iPhone|iPad|iPod/i.test(userAgentData.platform)
+              : /Mac|iPhone|iPad|iPod/i.test(navigator.userAgent);
+            let keyText = config.key;
+            if (keyText.toLowerCase().startsWith("mod-")) {
+              keyText =
+                (isMac ? "⌘" : "Ctrl+") + keyText.slice(4).toUpperCase();
+            } else {
+              keyText = keyText.replace(/Mod/gi, isMac ? "⌘" : "Ctrl");
+            }
+            shortcutEl.textContent = keyText;
+
+            button.appendChild(labelEl);
+            button.appendChild(shortcutEl);
+
+            button.addEventListener("click", () => {
+              runAction(view, main.from, main.to);
+            });
+
+            dom.appendChild(button);
+            return { dom };
+          },
+        };
+      }
+      return value;
+    },
+    provide: (f) => showTooltip.from(f),
+  });
+
+  return [
+    selectionTooltipField,
+    keymap.of([
+      {
+        key: config.key,
+        run: (view: EditorView) => {
+          const { main } = view.state.selection;
+          if (main.empty) {
+            return false;
+          }
+          runAction(view, main.from, main.to);
+          return true;
+        },
+      },
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/codemirror-dart/test/selectionAction.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/selectionAction.test.ts
@@ -1,0 +1,308 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EditorState, StateField } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import { selectionAction } from "../src/selectionAction";
+
+// Setup browser API mocks needed for tooltip testing
+class MockElement {
+  className = "";
+  type = "";
+  textContent = "";
+  children: MockElement[] = [];
+  listeners: Record<string, Function[]> = {};
+
+  appendChild(child: MockElement) {
+    this.children.push(child);
+  }
+
+  addEventListener(event: string, listener: Function) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event].push(listener);
+  }
+
+  click() {
+    if (this.listeners["click"]) {
+      for (const listener of this.listeners["click"]) {
+        listener();
+      }
+    }
+  }
+}
+
+function mockView(state: EditorState, dispatch: (tr: any) => void): EditorView {
+  return {
+    state,
+    dispatch,
+  } as unknown as EditorView;
+}
+
+// Helper to run code with mocked document and navigator
+function runWithMocks(
+  navigatorValue: { userAgent: string; userAgentData?: { platform: string } },
+  fn: () => void
+) {
+  const originalDocument = (globalThis as any).document;
+  const originalNavigator = (globalThis as any).navigator;
+
+  (globalThis as any).document = {
+    createElement(tag: string) {
+      return new MockElement();
+    }
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    value: navigatorValue,
+    configurable: true,
+  });
+
+  try {
+    fn();
+  } finally {
+    if (originalDocument === undefined) {
+      delete (globalThis as any).document;
+    } else {
+      (globalThis as any).document = originalDocument;
+    }
+
+    if (originalNavigator === undefined) {
+      delete (globalThis as any).navigator;
+    } else {
+      Object.defineProperty(globalThis, "navigator", {
+        value: originalNavigator,
+        configurable: true,
+      });
+    }
+  }
+}
+
+test("tooltip is null when selection is empty", () => {
+  const extensions = selectionAction({
+    key: "Mod-/",
+    label: "Test Action",
+    run: () => {},
+  });
+  const field = extensions[0] as StateField<any>;
+  const state = EditorState.create({
+    doc: "line one\nline two\nline three",
+    extensions,
+  });
+  
+  // Initial state is null
+  let tooltip = state.field(field);
+  assert.equal(tooltip, null);
+
+  // Empty selection (cursor)
+  const tr = state.update({ selection: { anchor: 5 } });
+  tooltip = tr.state.field(field);
+  assert.equal(tooltip, null);
+});
+
+test("tooltip is not null when selection is non-empty", () => {
+  const extensions = selectionAction({
+    key: "Mod-/",
+    label: "Test Action",
+    run: () => {},
+  });
+  const field = extensions[0] as StateField<any>;
+  const state = EditorState.create({
+    doc: "line one\nline two\nline three",
+    extensions,
+  });
+
+  const tr = state.update({ selection: { anchor: 0, head: 8 } });
+  const tooltip = tr.state.field(field);
+  assert.ok(tooltip);
+  assert.equal(tooltip.pos, 0);
+  assert.equal(tooltip.end, 8);
+  assert.equal(tooltip.above, true);
+  assert.equal(tooltip.strictSide, true);
+});
+
+test("keymap commands work on empty and non-empty selections", () => {
+  let runParams: { from: number; to: number; text: string } | null = null;
+  let dispatchedTr: any = null;
+
+  const extensions = selectionAction({
+    key: "Mod-/",
+    label: "Test Action",
+    run: (from, to, text) => {
+      runParams = { from, to, text };
+    },
+  });
+
+  const state = EditorState.create({
+    doc: "line one\nline two\nline three",
+    selection: { anchor: 9, head: 17 }, // "line two"
+    extensions,
+  });
+
+  const bindings = state.facet(keymap).flat();
+  const binding = bindings.find((b) => b.key === "Mod-/");
+  assert.ok(binding);
+  assert.ok(binding.run);
+
+  // Test empty selection returns false and does not run action
+  const stateEmpty = EditorState.create({
+    doc: "line one",
+    selection: { anchor: 3 },
+    extensions,
+  });
+  const viewEmpty = mockView(stateEmpty, () => {});
+  const emptyResult = binding.run(viewEmpty);
+  assert.equal(emptyResult, false);
+  assert.equal(runParams, null);
+
+  // Test non-empty selection runs action and dispatches selection collapse
+  const viewNonEmpty = mockView(state, (tr) => {
+    dispatchedTr = tr;
+  });
+  const nonEmptyResult = binding.run(viewNonEmpty);
+  assert.equal(nonEmptyResult, true);
+  // lineFrom and lineTo should be 1-based line numbers (line two is line 2)
+  assert.deepEqual(runParams, { from: 2, to: 2, text: "line two" });
+  assert.deepEqual(dispatchedTr, { selection: { anchor: 17 } });
+});
+
+test("tooltip DOM is created correctly for Mac shortcuts", () => {
+  runWithMocks({ userAgent: "Macintosh" }, () => {
+    const extensions = selectionAction({
+      key: "Mod-/",
+      label: "Test Action",
+      run: () => {},
+    });
+    const field = extensions[0] as StateField<any>;
+    let state = EditorState.create({
+      doc: "hello world",
+      extensions,
+    });
+    state = state.update({ selection: { anchor: 0, head: 5 } }).state;
+
+    const tooltip = state.field(field);
+    assert.ok(tooltip);
+
+    const view = mockView(state, () => {});
+    const { dom } = tooltip.create(view);
+
+    assert.equal((dom as any).className, "cm-selection-action-tooltip");
+    assert.equal((dom as any).children.length, 1);
+    const button = (dom as any).children[0];
+    assert.equal(button.className, "cm-selection-action-btn");
+    assert.equal(button.type, "button");
+    assert.equal(button.children.length, 2);
+
+    const labelEl = button.children[0];
+    assert.equal(labelEl.className, "cm-selection-action-label");
+    assert.equal(labelEl.textContent, "Test Action");
+
+    const shortcutEl = button.children[1];
+    assert.equal(shortcutEl.className, "cm-selection-action-shortcut");
+    assert.equal(shortcutEl.textContent, "⌘/");
+  });
+});
+
+test("tooltip DOM is created correctly for non-Mac shortcuts", () => {
+  runWithMocks({ userAgent: "Windows NT 10.0", userAgentData: { platform: "Windows" } }, () => {
+    const extensions = selectionAction({
+      key: "Mod-/",
+      label: "Test Action",
+      run: () => {},
+    });
+    const field = extensions[0] as StateField<any>;
+    let state = EditorState.create({
+      doc: "hello world",
+      extensions,
+    });
+    state = state.update({ selection: { anchor: 0, head: 5 } }).state;
+
+    const tooltip = state.field(field);
+    assert.ok(tooltip);
+
+    const view = mockView(state, () => {});
+    const { dom } = tooltip.create(view);
+
+    const button = (dom as any).children[0];
+    const shortcutEl = button.children[1];
+    assert.equal(shortcutEl.textContent, "Ctrl+/");
+  });
+});
+
+test("tooltip button click executes callback and collapses selection", () => {
+  runWithMocks({ userAgent: "Macintosh" }, () => {
+    let runParams: { from: number; to: number; text: string } | null = null;
+    let dispatchedTr: any = null;
+
+    const extensions = selectionAction({
+      key: "Mod-/",
+      label: "Test Action",
+      run: (from, to, text) => {
+        runParams = { from, to, text };
+      },
+    });
+    const field = extensions[0] as StateField<any>;
+    let state = EditorState.create({
+      doc: "hello world",
+      extensions,
+    });
+    state = state.update({ selection: { anchor: 0, head: 5 } }).state;
+
+    const tooltip = state.field(field);
+    assert.ok(tooltip);
+
+    const view = mockView(state, (tr) => {
+      dispatchedTr = tr;
+    });
+    const { dom } = tooltip.create(view);
+    const button = (dom as any).children[0];
+
+    button.click();
+
+    assert.deepEqual(runParams, { from: 1, to: 1, text: "hello" });
+    assert.deepEqual(dispatchedTr, { selection: { anchor: 5 } });
+  });
+});
+
+test("shortcut formatting when key is mixed or doesn't start with Mod-", () => {
+  // Test Mac platform
+  runWithMocks({ userAgent: "Macintosh" }, () => {
+    const extensionsMac = selectionAction({
+      key: "Shift-Mod-P",
+      label: "Test",
+      run: () => {},
+    });
+    let stateMac = EditorState.create({
+      doc: "hello",
+      extensions: extensionsMac,
+    });
+    stateMac = stateMac.update({ selection: { anchor: 0, head: 5 } }).state;
+    const tooltipMac = stateMac.field(extensionsMac[0] as StateField<any>);
+    const { dom: domMac } = tooltipMac.create(mockView(stateMac, () => {}));
+    const shortcutElMac = (domMac as any).children[0].children[1];
+    assert.equal(shortcutElMac.textContent, "Shift-⌘-P");
+  });
+
+  // Test non-Mac platform
+  runWithMocks({ userAgent: "Windows" }, () => {
+    const extensionsWin = selectionAction({
+      key: "Shift-Mod-P",
+      label: "Test",
+      run: () => {},
+    });
+    let stateWin = EditorState.create({
+      doc: "hello",
+      extensions: extensionsWin,
+    });
+    stateWin = stateWin.update({ selection: { anchor: 0, head: 5 } }).state;
+    const tooltipWin = stateWin.field(extensionsWin[0] as StateField<any>);
+    const { dom: domWin } = tooltipWin.create(mockView(stateWin, () => {}));
+    const shortcutElWin = (domWin as any).children[0].children[1];
+    assert.equal(shortcutElWin.textContent, "Shift-Ctrl-P");
+  });
+});

--- a/pkgs/dartpad_preview/codemirror-dart/test/selectionAction.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/selectionAction.test.ts
@@ -47,7 +47,7 @@ function mockView(state: EditorState, dispatch: (tr: any) => void): EditorView {
 // Helper to run code with mocked document and navigator
 function runWithMocks(
   navigatorValue: { userAgent: string; userAgentData?: { platform: string } },
-  fn: () => void
+  fn: () => void,
 ) {
   const originalDocument = (globalThis as any).document;
   const originalNavigator = (globalThis as any).navigator;
@@ -55,7 +55,7 @@ function runWithMocks(
   (globalThis as any).document = {
     createElement(tag: string) {
       return new MockElement();
-    }
+    },
   };
 
   Object.defineProperty(globalThis, "navigator", {
@@ -94,7 +94,7 @@ test("tooltip is null when selection is empty", () => {
     doc: "line one\nline two\nline three",
     extensions,
   });
-  
+
   // Initial state is null
   let tooltip = state.field(field);
   assert.equal(tooltip, null);
@@ -209,29 +209,32 @@ test("tooltip DOM is created correctly for Mac shortcuts", () => {
 });
 
 test("tooltip DOM is created correctly for non-Mac shortcuts", () => {
-  runWithMocks({ userAgent: "Windows NT 10.0", userAgentData: { platform: "Windows" } }, () => {
-    const extensions = selectionAction({
-      key: "Mod-/",
-      label: "Test Action",
-      run: () => {},
-    });
-    const field = extensions[0] as StateField<any>;
-    let state = EditorState.create({
-      doc: "hello world",
-      extensions,
-    });
-    state = state.update({ selection: { anchor: 0, head: 5 } }).state;
+  runWithMocks(
+    { userAgent: "Windows NT 10.0", userAgentData: { platform: "Windows" } },
+    () => {
+      const extensions = selectionAction({
+        key: "Mod-/",
+        label: "Test Action",
+        run: () => {},
+      });
+      const field = extensions[0] as StateField<any>;
+      let state = EditorState.create({
+        doc: "hello world",
+        extensions,
+      });
+      state = state.update({ selection: { anchor: 0, head: 5 } }).state;
 
-    const tooltip = state.field(field);
-    assert.ok(tooltip);
+      const tooltip = state.field(field);
+      assert.ok(tooltip);
 
-    const view = mockView(state, () => {});
-    const { dom } = tooltip.create(view);
+      const view = mockView(state, () => {});
+      const { dom } = tooltip.create(view);
 
-    const button = (dom as any).children[0];
-    const shortcutEl = button.children[1];
-    assert.equal(shortcutEl.textContent, "Ctrl+/");
-  });
+      const button = (dom as any).children[0];
+      const shortcutEl = button.children[1];
+      assert.equal(shortcutEl.textContent, "Ctrl+/");
+    },
+  );
 });
 
 test("tooltip button click executes callback and collapses selection", () => {

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -38,6 +38,7 @@ final class CodeMirrorEditor {
   /// - [onSave] is triggered on Cmd/Ctrl+S keypress.
   /// - [onCodeActionRequested] is triggered on Cmd/Ctrl+. keypress.
   /// - [onFixDiagnostic] is triggered when applying diagnostic fixes.
+  /// - [selectionActionConfig] is shown as a tooltip when selecting text in the editor.
   factory CodeMirrorEditor(
     web.HTMLElement element, {
     required String file,
@@ -46,6 +47,7 @@ final class CodeMirrorEditor {
     void Function()? onSave,
     void Function()? onCodeActionRequested,
     void Function(int from, int to, String message)? onFixDiagnostic,
+    cm.SelectionActionConfig? selectionActionConfig,
     LanguageServerClient? languageServerClient,
   }) {
     final langCompartment = cm.Compartment();
@@ -103,6 +105,7 @@ final class CodeMirrorEditor {
                 ),
               ].toJS,
             ),
+          if (selectionActionConfig != null) cm.selectionAction(selectionActionConfig),
           if (onFixDiagnostic != null)
             cm.diagnosticHoverToolbar(
               [


### PR DESCRIPTION
Adds the `selectionAction` codemirror extension for the dartpad prototype.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
