### PR TITLE
Update Flutter image tag from 'main' to 'stable'

### DIFF
--- a/.cloud_build/dart_pad.yaml
+++ b/.cloud_build/dart_pad.yaml
@@ -4,7 +4,7 @@
 
 steps:
   # Build dartpad_ui
-  - name: gcr.io/$PROJECT_ID/flutter:main
+  - name: gcr.io/$PROJECT_ID/flutter:stable
     args: ['build', 'web', '--wasm']
     dir: pkgs/dartpad_ui
 
@@ -14,7 +14,7 @@ steps:
     dir: pkgs/dartpad_ui
 
   # Build dartpad_preview
-  - name: gcr.io/$PROJECT_ID/flutter:main
+  - name: gcr.io/$PROJECT_ID/flutter:stable
     entrypoint: bash
     args:
       - -c


### PR DESCRIPTION
It seems like we are unable to compile dartpad_ui and dartpad_preview on the latest `main` channel of the Flutter SDK, due to dart:js_interop being apparently unavailable (see https://github.com/dart-lang/dart-pad/issues/3674) . This switches to the stable channel image.