### PR TITLE
Add dartpad preview editor quick fix

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -40097,7 +40097,7 @@ ${text}</tr>
                 create(view) {
                     const dom = document.createElement("div");
                     dom.className = "cm-diagnostic-hover-toolbar";
-                    dom.style.display = "flex";
+                    dom.style.display = "none";
                     dom.style.gap = "6px";
                     dom.style.padding = "4px 6px";
                     for (const action of actions) {
@@ -40110,7 +40110,26 @@ ${text}</tr>
                             e.stopPropagation();
                             action.run(view, from, to, activeDiagnostics.map((d) => d.diagnostic));
                         });
-                        dom.appendChild(button);
+                        const showButton = () => {
+                            if (button.parentElement === dom)
+                                return;
+                            dom.appendChild(button);
+                            dom.classList.add("cm-diagnostic-hover-toolbar-available");
+                            dom.style.display = "flex";
+                            if (dom.isConnected)
+                                view.requestMeasure();
+                        };
+                        if (!action.isAvailable) {
+                            showButton();
+                        }
+                        else {
+                            Promise.resolve(action.isAvailable(view, from, to, activeDiagnostics.map((d) => d.diagnostic)))
+                                .then((available) => {
+                                if (available)
+                                    showButton();
+                            })
+                                .catch(() => { });
+                        }
                     }
                     return { dom };
                 },

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
@@ -87,7 +87,7 @@ extension type SelectionActionConfig._(JSObject _) implements JSObject {
 external JSAny lintGutter();
 
 @JS()
-external JSAny linter(JSFunction? source);
+external JSAny linter(JSFunction? source, [JSObject? config]);
 
 @JS()
 external JSAny diagnosticHoverToolbar(JSArray<ToolbarAction> actions);
@@ -99,6 +99,7 @@ extension type ToolbarAction._(JSObject _) implements JSObject {
   external factory ToolbarAction({
     JSString label,
     JSFunction run,
+    JSFunction? isAvailable,
   });
 }
 

--- a/pkgs/dartpad_preview/codemirror-dart/src/diagnosticHoverToolbar.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/diagnosticHoverToolbar.ts
@@ -9,6 +9,12 @@ import { forEachDiagnostic, setDiagnosticsEffect } from "@codemirror/lint";
 export interface ToolbarAction {
   label: string;
   run: (view: EditorView, from: number, to: number, diagnostics: any[]) => void;
+  isAvailable?: (
+    view: EditorView,
+    from: number,
+    to: number,
+    diagnostics: any[],
+  ) => boolean | Promise<boolean>;
 }
 
 function hideTooltip(tr: any, tooltip: any) {
@@ -44,7 +50,7 @@ export function diagnosticHoverToolbar(actions: ToolbarAction[]): Extension {
         create(view) {
           const dom = document.createElement("div");
           dom.className = "cm-diagnostic-hover-toolbar";
-          dom.style.display = "flex";
+          dom.style.display = "none";
           dom.style.gap = "6px";
           dom.style.padding = "4px 6px";
 
@@ -64,7 +70,31 @@ export function diagnosticHoverToolbar(actions: ToolbarAction[]): Extension {
                 activeDiagnostics.map((d) => d.diagnostic),
               );
             });
-            dom.appendChild(button);
+
+            const showButton = () => {
+              if (button.parentElement === dom) return;
+              dom.appendChild(button);
+              dom.classList.add("cm-diagnostic-hover-toolbar-available");
+              dom.style.display = "flex";
+              if (dom.isConnected) view.requestMeasure();
+            };
+
+            if (!action.isAvailable) {
+              showButton();
+            } else {
+              Promise.resolve(
+                action.isAvailable(
+                  view,
+                  from,
+                  to,
+                  activeDiagnostics.map((d) => d.diagnostic),
+                ),
+              )
+                .then((available) => {
+                  if (available) showButton();
+                })
+                .catch(() => {});
+            }
           }
 
           return { dom };

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -129,6 +129,94 @@ void main() {
     expect(view.state.selection.main.anchor, 2);
   });
 
+  test('diagnostic hover renders Apply fix and reports its range', () async {
+    final parent = web.HTMLDivElement()
+      ..style.width = '320px'
+      ..style.height = '120px';
+    web.document.body!.append(parent);
+    int? requestedFrom;
+    int? requestedTo;
+
+    final lintSource = ((EditorView _) {
+      return [
+        {
+          'from': 1,
+          'to': 4,
+          'severity': 'warning',
+          'message': 'Use const',
+        },
+      ].jsify();
+    }).toJS;
+    final state = EditorState.create(
+      EditorStateConfig(
+        doc: 'test'.toJS,
+        extensions: [
+          linter(lintSource, {'delay': 0}.jsify() as JSObject),
+          diagnosticHoverToolbar(
+            <ToolbarAction>[
+              ToolbarAction(
+                label: 'Unavailable fix'.toJS,
+                isAvailable: ((EditorView _, int from, int to, JSArray<JSObject> diagnostics) {
+                  return Future.value(false.toJS).toJS;
+                }).toJS,
+                run: ((EditorView _, int from, int to, JSArray<JSObject> diagnostics) {
+                  expect(
+                    true,
+                    isFalse,
+                    reason: 'Unavailable toolbar actions must not be rendered.',
+                  );
+                }).toJS,
+              ),
+              ToolbarAction(
+                label: 'Apply fix'.toJS,
+                isAvailable: ((EditorView _, int from, int to, JSArray<JSObject> diagnostics) {
+                  return Future.value(true.toJS).toJS;
+                }).toJS,
+                run: ((EditorView _, int from, int to, JSArray<JSObject> diagnostics) {
+                  expect(diagnostics.toDart, hasLength(1));
+                  requestedFrom = from;
+                  requestedTo = to;
+                }).toJS,
+              ),
+            ].toJS,
+          ),
+        ].toJS,
+      ),
+    );
+    final view = EditorView(EditorViewConfig(parent: parent, state: state));
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    expect(view.dom.querySelector('.cm-lintRange'), isNotNull);
+    final rect = view.coordsAtPos(2)!;
+    final content = view.dom.querySelector('.cm-content')!;
+    content.dispatchEvent(
+      web.MouseEvent(
+        'mousemove',
+        web.MouseEventInit(
+          bubbles: true,
+          clientX: ((rect.left + rect.right) / 2).round(),
+          clientY: ((rect.top + rect.bottom) / 2).round(),
+        ),
+      ),
+    );
+    await Future<void>.delayed(const Duration(milliseconds: 1000));
+
+    final buttons = web.document.querySelectorAll('.cm-diagnostic-toolbar-btn');
+    expect(buttons.length, 1);
+    final button = buttons.item(0) as web.HTMLButtonElement?;
+    expect(button, isNotNull);
+    expect(button!.textContent, 'Apply fix');
+    button.click();
+
+    expect(requestedFrom, 1);
+    expect(requestedTo, 4);
+  });
+
   test('all language factories produce CodeMirror extensions', () {
     final extensions = <JSAny>[
       dart(),

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
@@ -37,9 +37,16 @@ class CodeActionsController {
   final _quickFixCache = _ActionsCacheSlot();
   final _allActionsCache = _ActionsCacheSlot();
 
-  /// Returns whether the LSP currently offers a quick fix for [from] and [to].
+  /// Returns whether the LSP currently offers a quick fix for the specified
+  /// range.
+  ///
   /// The result is cached for the matching document and range so activating the
   /// visible action does not issue the same request again.
+  ///
+  /// - [from]: The 0-based character offset at the start of the range in the
+  ///   document.
+  /// - [to]: The 0-based character offset at the end of the range in the
+  ///   document.
   Future<bool> hasQuickFixes({required int from, required int to}) async {
     if (_disposed) {
       return false;
@@ -66,11 +73,16 @@ class CodeActionsController {
     }
   }
 
-  /// Requests quick fixes from the LSP server for [from] and [to], or for the
-  /// current editor selection when no explicit range is provided.
+  /// Requests quick fixes from the LSP server for the specified range, or for
+  /// the current editor selection when no explicit range is provided.
   ///
   /// A single result is applied immediately. Multiple results are displayed in
   /// the floating panel so the user can choose one.
+  ///
+  /// - [from]: The optional 0-based character offset at the start of the range
+  ///   in the document.
+  /// - [to]: The optional 0-based character offset at the end of the range in
+  ///   the document.
   Future<void> triggerQuickFixes({int? from, int? to}) => _triggerActions(
     from: from,
     to: to,

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
@@ -32,10 +32,8 @@ class CodeActionsController {
   int _requestSerial = 0;
   int _loadSerial = 0;
   bool _disposed = false;
-  cm.Text? _cachedDocument;
-  int? _cachedFrom;
-  int? _cachedTo;
-  List<cm.LSPCodeAction>? _cachedQuickFixes;
+  final _quickFixCache = _ActionsCacheSlot();
+  final _allActionsCache = _ActionsCacheSlot();
 
   /// Returns whether the LSP currently offers a quick fix for [from] and [to].
   /// The result is cached for the matching document and range so activating the
@@ -51,7 +49,14 @@ class CodeActionsController {
     final rangeFrom = from.clamp(0, codeEditor.view.state.doc.length);
     final rangeTo = to.clamp(rangeFrom, codeEditor.view.state.doc.length);
     try {
-      final actions = await _loadQuickFixes(plugin, rangeFrom, rangeTo);
+      final actions = await _loadActions(
+        plugin,
+        rangeFrom,
+        rangeTo,
+        only: const ['quickfix'],
+        kindFilter: _quickFixKindFilter,
+        cache: _quickFixCache,
+      );
       return actions.isNotEmpty;
     } catch (e) {
       print('Error checking code actions: $e');
@@ -64,7 +69,38 @@ class CodeActionsController {
   ///
   /// A single result is applied immediately. Multiple results are displayed in
   /// the floating panel so the user can choose one.
-  Future<void> triggerQuickFixes({int? from, int? to}) async {
+  Future<void> triggerQuickFixes({int? from, int? to}) => _triggerActions(
+    from: from,
+    to: to,
+    loader: (plugin, rangeFrom, rangeTo) => _loadActions(
+      plugin,
+      rangeFrom,
+      rangeTo,
+      only: const ['quickfix'],
+      kindFilter: _quickFixKindFilter,
+      cache: _quickFixCache,
+    ),
+  );
+
+  /// Requests all code actions (quick fixes, refactorings, source actions, etc.)
+  /// from the LSP server for the current editor selection.
+  ///
+  /// Unlike [triggerQuickFixes], this does not filter by kind and is intended
+  /// for the Cmd/Ctrl+. shortcut.
+  Future<void> triggerCodeActions() => _triggerActions(
+    loader: (plugin, rangeFrom, rangeTo) => _loadActions(
+      plugin,
+      rangeFrom,
+      rangeTo,
+      cache: _allActionsCache,
+    ),
+  );
+
+  Future<void> _triggerActions({
+    int? from,
+    int? to,
+    required Future<List<cm.LSPCodeAction>> Function(cm.LSPPlugin, int, int) loader,
+  }) async {
     if (_disposed) {
       return;
     }
@@ -87,13 +123,8 @@ class CodeActionsController {
     onStateChanged();
 
     try {
-      final actions = await _loadQuickFixes(plugin, rangeFrom, rangeTo);
+      final actions = await loader(plugin, rangeFrom, rangeTo);
       if (_disposed || requestSerial != _requestSerial) {
-        return;
-      }
-
-      if (actions.length == 1) {
-        await applyCodeAction(actions.single);
         return;
       }
 
@@ -111,10 +142,17 @@ class CodeActionsController {
     }
   }
 
-  Future<List<cm.LSPCodeAction>> _loadQuickFixes(cm.LSPPlugin plugin, int from, int to) async {
+  Future<List<cm.LSPCodeAction>> _loadActions(
+    cm.LSPPlugin plugin,
+    int from,
+    int to, {
+    List<String>? only,
+    bool Function(cm.LSPCodeAction)? kindFilter,
+    required _ActionsCacheSlot cache,
+  }) async {
     final document = codeEditor.view.state.doc;
-    if (identical(document, _cachedDocument) && from == _cachedFrom && to == _cachedTo) {
-      return _cachedQuickFixes!;
+    if (identical(document, cache.document) && from == cache.from && to == cache.to) {
+      return cache.actions!;
     }
 
     plugin.client.sync();
@@ -135,17 +173,20 @@ class CodeActionsController {
       }
     }
 
+    final context = <String, Object?>{
+      'diagnostics': overlappingDiagnostics,
+      'triggerKind': 1,
+    };
+    if (only != null) {
+      context['only'] = only;
+    }
     final params = {
       'textDocument': {'uri': plugin.uri.toDart},
       'range': {
         'start': plugin.toPosition(from),
         'end': plugin.toPosition(to),
       },
-      'context': {
-        'diagnostics': overlappingDiagnostics,
-        'only': ['quickfix'],
-        'triggerKind': 1,
-      },
+      'context': context,
     };
     final result = await plugin.client.request('textDocument/codeAction'.toJS, params.jsify() as JSObject).toDart;
     if (_disposed || !identical(document, codeEditor.view.state.doc)) {
@@ -154,21 +195,22 @@ class CodeActionsController {
     final actions = <cm.LSPCodeAction>[];
     if (result != null) {
       final array = result as JSArray<JSObject>;
-      actions.addAll(
-        array.toDart.map(cm.LSPCodeAction.new).where((action) {
-          final kind = action.kind?.toDart;
-          return kind == null || kind.startsWith('quickfix');
-        }),
-      );
+      final mapped = array.toDart.map(cm.LSPCodeAction.new);
+      actions.addAll(kindFilter != null ? mapped.where(kindFilter) : mapped);
     }
 
     if (loadSerial == _loadSerial) {
-      _cachedDocument = document;
-      _cachedFrom = from;
-      _cachedTo = to;
-      _cachedQuickFixes = actions;
+      cache.document = document;
+      cache.from = from;
+      cache.to = to;
+      cache.actions = actions;
     }
     return actions;
+  }
+
+  static bool _quickFixKindFilter(cm.LSPCodeAction action) {
+    final kind = action.kind?.toDart;
+    return kind == null || kind.startsWith('quickfix');
   }
 
   /// Applies the selected LSP code action, which may include workspace edits or commands, and hides the panel.
@@ -190,7 +232,7 @@ class CodeActionsController {
       await codeEditor.languageServerClient?.executeCommand(commandStr, arguments);
     }
 
-    _clearQuickFixCache();
+    _clearCache();
 
     hideCodeActionPanel();
     codeEditor.focus();
@@ -214,14 +256,27 @@ class CodeActionsController {
     _loadSerial++;
     showFloatingPanel = false;
     codeActions = null;
-    _clearQuickFixCache();
+    _clearCache();
   }
 
-  void _clearQuickFixCache() {
+  void _clearCache() {
     _loadSerial++;
-    _cachedDocument = null;
-    _cachedFrom = null;
-    _cachedTo = null;
-    _cachedQuickFixes = null;
+    _quickFixCache.clear();
+    _allActionsCache.clear();
+  }
+}
+
+/// Holds the cached result of a single code-action LSP request.
+class _ActionsCacheSlot {
+  cm.Text? document;
+  int? from;
+  int? to;
+  List<cm.LSPCodeAction>? actions;
+
+  void clear() {
+    document = null;
+    from = null;
+    to = null;
+    actions = null;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
@@ -28,6 +28,8 @@ class CodeActionsController {
   bool showFloatingPanel = false;
   double panelLeft = 0;
   double panelTop = 0;
+  double anchorTop = 0;
+  double anchorBottom = 0;
   List<cm.LSPCodeAction>? codeActions;
   int _requestSerial = 0;
   int _loadSerial = 0;
@@ -118,6 +120,8 @@ class CodeActionsController {
     final rect = codeEditor.view.coordsAtPos(rangeFrom);
     panelLeft = rect?.left ?? 100;
     panelTop = rect?.bottom ?? 100;
+    anchorTop = rect?.top ?? 100;
+    anchorBottom = rect?.bottom ?? 100;
     showFloatingPanel = true;
     codeActions = null;
     onStateChanged();

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/code_actions_controller.dart
@@ -29,75 +29,153 @@ class CodeActionsController {
   double panelLeft = 0;
   double panelTop = 0;
   List<cm.LSPCodeAction>? codeActions;
+  int _requestSerial = 0;
+  int _loadSerial = 0;
+  bool _disposed = false;
+  cm.Text? _cachedDocument;
+  int? _cachedFrom;
+  int? _cachedTo;
+  List<cm.LSPCodeAction>? _cachedQuickFixes;
 
-  /// Requests the available code actions from the LSP server at the current cursor selection
-  /// and displays them in the floating panel.
+  /// Returns whether the LSP currently offers a quick fix for [from] and [to].
+  /// The result is cached for the matching document and range so activating the
+  /// visible action does not issue the same request again.
+  Future<bool> hasQuickFixes({required int from, required int to}) async {
+    if (_disposed) {
+      return false;
+    }
+    final plugin = cm.LSPPlugin.get(codeEditor.view);
+    if (plugin == null) {
+      return false;
+    }
+    final rangeFrom = from.clamp(0, codeEditor.view.state.doc.length);
+    final rangeTo = to.clamp(rangeFrom, codeEditor.view.state.doc.length);
+    try {
+      final actions = await _loadQuickFixes(plugin, rangeFrom, rangeTo);
+      return actions.isNotEmpty;
+    } catch (e) {
+      print('Error checking code actions: $e');
+      return false;
+    }
+  }
+
+  /// Requests quick fixes from the LSP server for [from] and [to], or for the
+  /// current editor selection when no explicit range is provided.
   ///
-  /// It filters diagnostics to find those overlapping with the selection and sends them as context.
-  Future<void> triggerCodeActions() async {
+  /// A single result is applied immediately. Multiple results are displayed in
+  /// the floating panel so the user can choose one.
+  Future<void> triggerQuickFixes({int? from, int? to}) async {
+    if (_disposed) {
+      return;
+    }
+    final requestSerial = ++_requestSerial;
     CodeMirrorEditor.hideAllTooltips();
     final plugin = cm.LSPPlugin.get(codeEditor.view);
     if (plugin == null) {
       return;
     }
 
-    plugin.client.sync();
-
     final selection = codeEditor.view.state.selection.main;
-    final startPos = plugin.toPosition(selection.from);
-    final endPos = plugin.toPosition(selection.to);
+    final rangeFrom = (from ?? selection.from).clamp(0, codeEditor.view.state.doc.length);
+    final rangeTo = (to ?? selection.to).clamp(rangeFrom, codeEditor.view.state.doc.length);
 
-    final fileDiagnostics = getDiagnostics()
-        .where((entry) => entry.fileName == file)
-        .map((entry) => entry.diagnostic)
-        .toList();
+    final rect = codeEditor.view.coordsAtPos(rangeFrom);
+    panelLeft = rect?.left ?? 100;
+    panelTop = rect?.bottom ?? 100;
+    showFloatingPanel = true;
+    codeActions = null;
+    onStateChanged();
 
+    try {
+      final actions = await _loadQuickFixes(plugin, rangeFrom, rangeTo);
+      if (_disposed || requestSerial != _requestSerial) {
+        return;
+      }
+
+      if (actions.length == 1) {
+        await applyCodeAction(actions.single);
+        return;
+      }
+
+      codeActions = actions;
+      showFloatingPanel = true;
+      onStateChanged();
+    } catch (e) {
+      if (_disposed || requestSerial != _requestSerial) {
+        return;
+      }
+      codeActions = [];
+      showFloatingPanel = true;
+      onStateChanged();
+      print('Error fetching code actions: $e');
+    }
+  }
+
+  Future<List<cm.LSPCodeAction>> _loadQuickFixes(cm.LSPPlugin plugin, int from, int to) async {
+    final document = codeEditor.view.state.doc;
+    if (identical(document, _cachedDocument) && from == _cachedFrom && to == _cachedTo) {
+      return _cachedQuickFixes!;
+    }
+
+    plugin.client.sync();
+    final loadSerial = ++_loadSerial;
     final overlappingDiagnostics = <Object?>[];
-    for (final diag in fileDiagnostics) {
-      final rawRange = diag.raw?['range'] as Map?;
-      if (rawRange != null) {
-        final start = rawRange['start'] as Map?;
-        final end = rawRange['end'] as Map?;
-        if (start != null && end != null) {
-          final startOffset = plugin.fromPosition(start.jsify() as JSObject);
-          final endOffset = plugin.fromPosition(end.jsify() as JSObject);
-          final intersects = startOffset <= selection.to && endOffset >= selection.from;
-          if (intersects && diag.raw != null) {
-            overlappingDiagnostics.add(diag.raw);
-          }
-        }
+    for (final diagnostic
+        in getDiagnostics().where((entry) => entry.fileName == file).map((entry) => entry.diagnostic)) {
+      final rawRange = diagnostic.raw?['range'] as Map?;
+      final start = rawRange?['start'] as Map?;
+      final end = rawRange?['end'] as Map?;
+      if (start == null || end == null) {
+        continue;
+      }
+      final startOffset = plugin.fromPosition(start.jsify() as JSObject);
+      final endOffset = plugin.fromPosition(end.jsify() as JSObject);
+      if (startOffset <= to && endOffset >= from && diagnostic.raw != null) {
+        overlappingDiagnostics.add(diagnostic.raw);
       }
     }
 
     final params = {
       'textDocument': {'uri': plugin.uri.toDart},
-      'range': {'start': startPos, 'end': endPos},
-      'context': {'diagnostics': overlappingDiagnostics},
+      'range': {
+        'start': plugin.toPosition(from),
+        'end': plugin.toPosition(to),
+      },
+      'context': {
+        'diagnostics': overlappingDiagnostics,
+        'only': ['quickfix'],
+        'triggerKind': 1,
+      },
     };
-
-    final rect = codeEditor.view.coordsAtPos(selection.from);
-    panelLeft = rect?.left ?? 100;
-    panelTop = rect?.bottom ?? 100;
-
-    try {
-      final promise = plugin.client.request('textDocument/codeAction'.toJS, params.jsify() as JSObject);
-      final result = await promise.toDart;
-      if (result == null) {
-        codeActions = [];
-      } else {
-        final arr = result as JSArray<JSObject>;
-        codeActions = arr.toDart.map(cm.LSPCodeAction.new).toList();
-      }
-
-      showFloatingPanel = true;
-      onStateChanged();
-    } catch (e) {
-      print('Error fetching code actions: $e');
+    final result = await plugin.client.request('textDocument/codeAction'.toJS, params.jsify() as JSObject).toDart;
+    if (_disposed || !identical(document, codeEditor.view.state.doc)) {
+      return [];
     }
+    final actions = <cm.LSPCodeAction>[];
+    if (result != null) {
+      final array = result as JSArray<JSObject>;
+      actions.addAll(
+        array.toDart.map(cm.LSPCodeAction.new).where((action) {
+          final kind = action.kind?.toDart;
+          return kind == null || kind.startsWith('quickfix');
+        }),
+      );
+    }
+
+    if (loadSerial == _loadSerial) {
+      _cachedDocument = document;
+      _cachedFrom = from;
+      _cachedTo = to;
+      _cachedQuickFixes = actions;
+    }
+    return actions;
   }
 
   /// Applies the selected LSP code action, which may include workspace edits or commands, and hides the panel.
   Future<void> applyCodeAction(cm.LSPCodeAction action) async {
+    if (_disposed) {
+      return;
+    }
     final edit = action.edit;
     if (edit != null) {
       final editMap = (edit.dartify() as Map).cast<String, Object?>();
@@ -112,14 +190,38 @@ class CodeActionsController {
       await codeEditor.languageServerClient?.executeCommand(commandStr, arguments);
     }
 
+    _clearQuickFixCache();
+
     hideCodeActionPanel();
     codeEditor.focus();
   }
 
   /// Hides the floating code action panel and clears the current code actions list.
   void hideCodeActionPanel() {
+    if (_disposed) {
+      return;
+    }
+    _requestSerial++;
     showFloatingPanel = false;
     codeActions = null;
     onStateChanged();
+  }
+
+  /// Cancels pending UI updates when the owning editor tab is destroyed.
+  void dispose() {
+    _disposed = true;
+    _requestSerial++;
+    _loadSerial++;
+    showFloatingPanel = false;
+    codeActions = null;
+    _clearQuickFixCache();
+  }
+
+  void _clearQuickFixCache() {
+    _loadSerial++;
+    _cachedDocument = null;
+    _cachedFrom = null;
+    _cachedTo = null;
+    _cachedQuickFixes = null;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -37,8 +37,8 @@ final class CodeMirrorEditor {
   /// - [onUpdate] is triggered when the document text changes.
   /// - [onSave] is triggered on Cmd/Ctrl+S keypress.
   /// - [onCodeActionRequested] is triggered on Cmd/Ctrl+. keypress.
-  /// - [onFixDiagnostic] is triggered when applying diagnostic fixes.
-  /// - [selectionActionConfig] is shown as a tooltip when selecting text in the editor.
+  /// - [onQuickFixRequested] is triggered from a diagnostic hover action.
+  /// - [onQuickFixAvailabilityRequested] controls whether that action is shown.
   factory CodeMirrorEditor(
     web.HTMLElement element, {
     required String file,
@@ -46,8 +46,8 @@ final class CodeMirrorEditor {
     void Function(String text)? onUpdate,
     void Function()? onSave,
     void Function()? onCodeActionRequested,
-    void Function(int from, int to, String message)? onFixDiagnostic,
-    cm.SelectionActionConfig? selectionActionConfig,
+    void Function(int from, int to)? onQuickFixRequested,
+    Future<bool> Function(int from, int to)? onQuickFixAvailabilityRequested,
     LanguageServerClient? languageServerClient,
   }) {
     final langCompartment = cm.Compartment();
@@ -106,18 +106,18 @@ final class CodeMirrorEditor {
                 ),
               ].toJS,
             ),
-          if (selectionActionConfig != null) cm.selectionAction(selectionActionConfig),
-          if (onFixDiagnostic != null)
+          if (onQuickFixRequested != null)
             cm.diagnosticHoverToolbar(
               [
                 cm.ToolbarAction(
-                  label: 'Fix with Agent'.toJS,
-                  run: ((cm.EditorView view, int from, int to, JSArray<JSObject> diagnostics) {
-                    final list = diagnostics.toDart;
-                    if (list.isNotEmpty) {
-                      final diag = cm.CMDiagnostic(list.first);
-                      onFixDiagnostic(from, to, diag.message.toDart);
-                    }
+                  label: 'Apply fix'.toJS,
+                  isAvailable: onQuickFixAvailabilityRequested == null
+                      ? null
+                      : ((cm.EditorView view, int from, int to, JSArray<JSObject> _) {
+                          return onQuickFixAvailabilityRequested(from, to).then((available) => available.toJS).toJS;
+                        }).toJS,
+                  run: ((cm.EditorView view, int from, int to, JSArray<JSObject> _) {
+                    onQuickFixRequested(from, to);
                   }).toJS,
                 ),
               ].toJS,

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -110,7 +110,7 @@ final class CodeMirrorEditor {
             cm.diagnosticHoverToolbar(
               [
                 cm.ToolbarAction(
-                  label: 'Apply fix'.toJS,
+                  label: 'Show Quick Fix'.toJS,
                   isAvailable: onQuickFixAvailabilityRequested == null
                       ? null
                       : ((cm.EditorView view, int from, int to, JSArray<JSObject> _) {

--- a/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
@@ -1,0 +1,291 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:codemirror_dart/codemirror_dart.dart' as cm;
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+final class _FakeLanguageServerClient implements LanguageServerClient {
+  final List<Map<String, Object?>> appliedEdits = [];
+  final List<(String, List<Object?>?)> executedCommands = [];
+
+  @override
+  JSObject createCodeMirrorExtension(String file) => JSArray();
+
+  @override
+  Future<void> applyWorkspaceEdit(Map<String, Object?> edit) async {
+    appliedEdits.add(edit);
+  }
+
+  @override
+  Future<void> executeCommand(String command, List<Object?>? arguments) async {
+    executedCommands.add((command, arguments));
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late JSObject lspPluginConstructor;
+  late JSFunction originalPluginGet;
+  late web.HTMLDivElement parent;
+  late CodeMirrorEditor editor;
+  late _FakeLanguageServerClient languageServerClient;
+  late CodeActionsController controller;
+  late List<Map<String, Object?>> responseActions;
+  late Future<List<Map<String, Object?>>> Function() responseProvider;
+  late String requestedMethod;
+  late Map<String, Object?> requestedParams;
+  late int requestCount;
+
+  setUpAll(() async {
+    final script = web.document.createElement('script') as web.HTMLScriptElement;
+    final loaded = web.EventStreamProviders.loadEvent.forTarget(script).first;
+    script.src = 'packages/codemirror_dart/assets/codemirror-dart.bundle.js';
+    web.document.head!.appendChild(script);
+    await loaded;
+
+    final namespace = web.window.getProperty<JSObject>('_codemirror'.toJS);
+    lspPluginConstructor = namespace.getProperty<JSObject>('LSPPlugin'.toJS);
+    originalPluginGet = lspPluginConstructor.getProperty<JSFunction>('get'.toJS);
+  });
+
+  setUp(() {
+    responseActions = [];
+    responseProvider = () async => responseActions;
+    requestedMethod = '';
+    requestedParams = {};
+    requestCount = 0;
+    languageServerClient = _FakeLanguageServerClient();
+    parent = web.HTMLDivElement();
+    web.document.body!.appendChild(parent);
+    editor = CodeMirrorEditor(
+      parent,
+      file: 'lib/main.dart',
+      initialDoc: 'final value = Widget();',
+      onCodeActionRequested: () {
+        unawaited(controller.triggerQuickFixes());
+      },
+      languageServerClient: languageServerClient,
+    );
+    controller = CodeActionsController(
+      codeEditor: editor,
+      file: 'lib/main.dart',
+      getDiagnostics: () => [
+        const DiagnosticEntry(
+          'lib/main.dart',
+          Diagnostic(
+            line: 0,
+            character: 14,
+            message: 'Use const',
+            severity: DiagnosticSeverity.info,
+            raw: {
+              'range': {
+                'start': {'line': 0, 'character': 14},
+                'end': {'line': 0, 'character': 22},
+              },
+              'message': 'Use const',
+            },
+          ),
+        ),
+      ],
+      onStateChanged: () {},
+    );
+
+    final fakeClient = JSObject()
+      ..setProperty('sync'.toJS, (() {}).toJS)
+      ..setProperty(
+        'request'.toJS,
+        ((JSString method, JSObject params) {
+          requestCount++;
+          requestedMethod = method.toDart;
+          requestedParams = (params.dartify() as Map).cast<String, Object?>();
+          return responseProvider().then((actions) => actions.jsify()).toJS;
+        }).toJS,
+      );
+    final fakePlugin = JSObject()
+      ..setProperty('client'.toJS, fakeClient)
+      ..setProperty('uri'.toJS, 'file:///workspace/lib/main.dart'.toJS)
+      ..setProperty(
+        'toPosition'.toJS,
+        ((int offset) => {'line': 0, 'character': offset}.jsify()).toJS,
+      )
+      ..setProperty(
+        'fromPosition'.toJS,
+        ((JSObject position) {
+          final map = (position.dartify() as Map).cast<String, Object?>();
+          return map['character']! as int;
+        }).toJS,
+      );
+    lspPluginConstructor.setProperty(
+      'get'.toJS,
+      ((cm.EditorView _) => fakePlugin).toJS,
+    );
+  });
+
+  tearDown(() {
+    controller.dispose();
+    editor.destroy();
+    parent.remove();
+    lspPluginConstructor.setProperty('get'.toJS, originalPluginGet);
+  });
+
+  test('requests only quick fixes with overlapping diagnostics', () async {
+    await controller.triggerQuickFixes(from: 14, to: 22);
+
+    expect(requestedMethod, 'textDocument/codeAction');
+    expect(requestedParams['range'], {
+      'start': {'line': 0, 'character': 14},
+      'end': {'line': 0, 'character': 22},
+    });
+    expect(requestedParams['context'], {
+      'diagnostics': [
+        {
+          'range': {
+            'start': {'line': 0, 'character': 14},
+            'end': {'line': 0, 'character': 22},
+          },
+          'message': 'Use const',
+        },
+      ],
+      'only': ['quickfix'],
+      'triggerKind': 1,
+    });
+    expect(controller.showFloatingPanel, isTrue);
+    expect(controller.codeActions, isEmpty);
+  });
+
+  test('reports unavailable quick fixes without opening the panel', () async {
+    expect(await controller.hasQuickFixes(from: 14, to: 22), isFalse);
+
+    expect(requestCount, 1);
+    expect(controller.showFloatingPanel, isFalse);
+    expect(controller.codeActions, isNull);
+  });
+
+  test('reuses the availability response when the action is triggered', () async {
+    responseActions = [
+      {'title': 'Use const', 'kind': 'quickfix'},
+      {'title': 'Suppress lint', 'kind': 'quickfix'},
+    ];
+
+    expect(await controller.hasQuickFixes(from: 14, to: 22), isTrue);
+    await controller.triggerQuickFixes(from: 14, to: 22);
+
+    expect(requestCount, 1);
+    expect(controller.codeActions, hasLength(2));
+  });
+
+  test('Ctrl+. requests quick fixes at the cursor', () async {
+    editor.view.dom
+        .querySelector('.cm-content')!
+        .dispatchEvent(
+          web.KeyboardEvent(
+            'keydown',
+            web.KeyboardEventInit(
+              bubbles: true,
+              cancelable: true,
+              key: '.',
+              code: 'Period',
+              ctrlKey: true,
+            ),
+          ),
+        );
+    await pumpEventQueue();
+
+    expect(requestedMethod, 'textDocument/codeAction');
+    expect(requestedParams['range'], {
+      'start': {'line': 0, 'character': 0},
+      'end': {'line': 0, 'character': 0},
+    });
+  });
+
+  test('applies a single quick fix edit and command immediately', () async {
+    responseActions = [
+      {
+        'title': 'Use const',
+        'kind': 'quickfix',
+        'edit': {
+          'changes': {
+            'file:///workspace/lib/main.dart': [
+              {
+                'range': {
+                  'start': {'line': 0, 'character': 14},
+                  'end': {'line': 0, 'character': 14},
+                },
+                'newText': 'const ',
+              },
+            ],
+          },
+        },
+        'command': {
+          'command': 'dart.logAction',
+          'arguments': ['useConst'],
+        },
+      },
+    ];
+
+    await controller.triggerQuickFixes(from: 14, to: 22);
+
+    expect(languageServerClient.appliedEdits, hasLength(1));
+    expect(languageServerClient.executedCommands, hasLength(1));
+    expect(languageServerClient.executedCommands.single.$1, 'dart.logAction');
+    expect(languageServerClient.executedCommands.single.$2, ['useConst']);
+    expect(controller.showFloatingPanel, isFalse);
+    expect(controller.codeActions, isNull);
+  });
+
+  test('shows multiple quick fixes without applying one', () async {
+    responseActions = [
+      {'title': 'Use const', 'kind': 'quickfix'},
+      {'title': 'Suppress lint', 'kind': 'quickfix'},
+      {'title': 'Extract method', 'kind': 'refactor.extract'},
+    ];
+
+    await controller.triggerQuickFixes(from: 14, to: 22);
+
+    expect(controller.showFloatingPanel, isTrue);
+    expect(
+      controller.codeActions!.map((action) => action.title.toDart),
+      ['Use const', 'Suppress lint'],
+    );
+    expect(languageServerClient.appliedEdits, isEmpty);
+    expect(languageServerClient.executedCommands, isEmpty);
+  });
+
+  test('ignores a stale code-action response', () async {
+    final firstResponse = Completer<List<Map<String, Object?>>>();
+    responseProvider = () {
+      if (requestCount == 1) {
+        return firstResponse.future;
+      }
+      return Future.value([
+        {'title': 'Current fix A', 'kind': 'quickfix'},
+        {'title': 'Current fix B', 'kind': 'quickfix'},
+      ]);
+    };
+
+    final firstRequest = controller.triggerQuickFixes(from: 14, to: 22);
+    await controller.triggerQuickFixes(from: 0, to: 0);
+    firstResponse.complete([
+      {'title': 'Stale fix A', 'kind': 'quickfix'},
+      {'title': 'Stale fix B', 'kind': 'quickfix'},
+    ]);
+    await firstRequest;
+
+    expect(
+      controller.codeActions!.map((action) => action.title.toDart),
+      ['Current fix A', 'Current fix B'],
+    );
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
@@ -300,6 +300,8 @@ void main() {
     await controller.triggerCodeActions();
 
     expect(controller.showFloatingPanel, isTrue);
+    expect(controller.anchorTop, isPositive);
+    expect(controller.anchorBottom, isPositive);
     expect(
       controller.codeActions!.map((action) => action.title.toDart),
       ['Use const', 'Extract method', 'Sort members'],

--- a/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/editor/code_actions_controller_test.dart
@@ -74,7 +74,7 @@ void main() {
       file: 'lib/main.dart',
       initialDoc: 'final value = Widget();',
       onCodeActionRequested: () {
-        unawaited(controller.triggerQuickFixes());
+        unawaited(controller.triggerCodeActions());
       },
       languageServerClient: languageServerClient,
     );
@@ -186,7 +186,7 @@ void main() {
     expect(controller.codeActions, hasLength(2));
   });
 
-  test('Ctrl+. requests quick fixes at the cursor', () async {
+  test('Ctrl+. requests all code actions at the cursor', () async {
     editor.view.dom
         .querySelector('.cm-content')!
         .dispatchEvent(
@@ -208,9 +208,11 @@ void main() {
       'start': {'line': 0, 'character': 0},
       'end': {'line': 0, 'character': 0},
     });
+    final context = requestedParams['context'] as Map;
+    expect(context.containsKey('only'), isFalse);
   });
 
-  test('applies a single quick fix edit and command immediately', () async {
+  test('shows a single quick fix in the panel without auto-applying', () async {
     responseActions = [
       {
         'title': 'Use const',
@@ -237,12 +239,11 @@ void main() {
 
     await controller.triggerQuickFixes(from: 14, to: 22);
 
-    expect(languageServerClient.appliedEdits, hasLength(1));
-    expect(languageServerClient.executedCommands, hasLength(1));
-    expect(languageServerClient.executedCommands.single.$1, 'dart.logAction');
-    expect(languageServerClient.executedCommands.single.$2, ['useConst']);
-    expect(controller.showFloatingPanel, isFalse);
-    expect(controller.codeActions, isNull);
+    expect(controller.showFloatingPanel, isTrue);
+    expect(controller.codeActions, hasLength(1));
+    expect(controller.codeActions!.single.title.toDart, 'Use const');
+    expect(languageServerClient.appliedEdits, isEmpty);
+    expect(languageServerClient.executedCommands, isEmpty);
   });
 
   test('shows multiple quick fixes without applying one', () async {
@@ -287,5 +288,23 @@ void main() {
       controller.codeActions!.map((action) => action.title.toDart),
       ['Current fix A', 'Current fix B'],
     );
+  });
+
+  test('triggerCodeActions returns all action kinds without filtering', () async {
+    responseActions = [
+      {'title': 'Use const', 'kind': 'quickfix'},
+      {'title': 'Extract method', 'kind': 'refactor.extract'},
+      {'title': 'Sort members', 'kind': 'source.sortMembers'},
+    ];
+
+    await controller.triggerCodeActions();
+
+    expect(controller.showFloatingPanel, isTrue);
+    expect(
+      controller.codeActions!.map((action) => action.title.toDart),
+      ['Use const', 'Extract method', 'Sort members'],
+    );
+    final context = requestedParams['context'] as Map;
+    expect(context.containsKey('only'), isFalse);
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -62,9 +62,11 @@ http://localhost:8080/?package=material_ui
 
 To load a GitHub gist, provide its ID using the following parameter:
 
-* `gist`: The ID from the GitHub Gist URL. The gist's flat file list is
-preserved at the workspace root. `main.dart`, then the sole Dart file, or
-finally `README.md` is opened automatically when present.
+* `gist`: The ID from the GitHub Gist URL. Dart files from the gist's flat
+file list are placed under `lib/`, so `main.dart` becomes `lib/main.dart`;
+non-Dart files such as `pubspec.yaml` remain at the workspace root. The
+resulting `lib/main.dart`, then the sole Dart file, or finally `README.md` is
+opened automatically when present.
 
 Example:
 ```url

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -62,11 +62,9 @@ http://localhost:8080/?package=material_ui
 
 To load a GitHub gist, provide its ID using the following parameter:
 
-* `gist`: The ID from the GitHub Gist URL. Dart files from the gist's flat
-file list are placed under `lib/`, so `main.dart` becomes `lib/main.dart`;
-non-Dart files such as `pubspec.yaml` remain at the workspace root. The
-resulting `lib/main.dart`, then the sole Dart file, or finally `README.md` is
-opened automatically when present.
+* `gist`: The ID from the GitHub Gist URL. The gist's flat file list is
+preserved at the workspace root. `main.dart`, then the sole Dart file, or
+finally `README.md` is opened automatically when present.
 
 Example:
 ```url

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
@@ -32,7 +32,7 @@ final class CodeMirrorTab extends EditorTab<Component> {
       onUpdate: _handleEditorUpdate,
       onSave: onSaveAll,
       onCodeActionRequested: () {
-        unawaited(codeActionsController.triggerQuickFixes());
+        unawaited(codeActionsController.triggerCodeActions());
       },
       onQuickFixRequested: (from, to) {
         unawaited(codeActionsController.triggerQuickFixes(from: from, to: to));

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
@@ -9,6 +9,7 @@ import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
 import '../../shared/node_container.dart';
+import '../components/code_action_panel.dart';
 
 /// A workspace-backed text editor tab that preserves its editor state while
 /// switching between files.
@@ -30,7 +31,22 @@ final class CodeMirrorTab extends EditorTab<Component> {
       initialDoc: content,
       onUpdate: _handleEditorUpdate,
       onSave: onSaveAll,
+      onCodeActionRequested: () {
+        unawaited(codeActionsController.triggerQuickFixes());
+      },
+      onQuickFixRequested: (from, to) {
+        unawaited(codeActionsController.triggerQuickFixes(from: from, to: to));
+      },
+      onQuickFixAvailabilityRequested: (from, to) {
+        return codeActionsController.hasQuickFixes(from: from, to: to);
+      },
       languageServerClient: languageServerClient,
+    );
+    codeActionsController = CodeActionsController(
+      codeEditor: editor,
+      file: path,
+      getDiagnostics: () => editor.languageServerClient?.allDiagnostics ?? const [],
+      onStateChanged: _notifyUpdate,
     );
   }
 
@@ -44,6 +60,9 @@ final class CodeMirrorTab extends EditorTab<Component> {
 
   /// The CodeMirror editor managed by this tab.
   late final CodeMirrorEditor editor;
+
+  /// Coordinates LSP quick-fix requests and the optional action chooser.
+  late final CodeActionsController codeActionsController;
 
   final StreamController<void> _updates = StreamController<void>.broadcast();
   EditorViewState? _savedViewState;
@@ -138,21 +157,16 @@ final class CodeMirrorTab extends EditorTab<Component> {
     _notifyUpdate();
   }
 
-  /// Applies LSP edits and persists them when the document was previously
-  /// clean. Dirty documents keep the combined user and LSP edits in memory.
+  /// Applies LSP edits in memory. The editor update listener marks the tab as
+  /// dirty, and the changes are persisted through the normal save flow.
   Future<void> applyEdits(List<dynamic> edits) async {
-    final wasDirty = _isDirty;
     editor.applyEdits(edits);
-    if (!wasDirty) {
-      await _persistCurrentContent();
-    } else {
-      _notifyUpdate();
-    }
   }
 
   @override
   void rename(String newPath) {
     super.rename(newPath);
+    codeActionsController.file = newPath;
     editor.applyRename(newPath);
   }
 
@@ -168,10 +182,13 @@ final class CodeMirrorTab extends EditorTab<Component> {
   }
 
   @override
-  Component build() => NodeContainer(
-    container,
-    onAttached: _scheduleMeasureAndRestore,
-  );
+  Component build() => Component.fragment([
+    NodeContainer(
+      container,
+      onAttached: _scheduleMeasureAndRestore,
+    ),
+    if (codeActionsController.showFloatingPanel) CodeActionPanel(controller: codeActionsController),
+  ]);
 
   @override
   void dispose() {
@@ -182,6 +199,7 @@ final class CodeMirrorTab extends EditorTab<Component> {
     _active = false;
     _measureTimer?.cancel();
     _measureTimer = null;
+    codeActionsController.dispose();
     editor.destroy();
     unawaited(_updates.close());
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
@@ -329,44 +329,50 @@ List<StyleRule> get codemirrorStyles => [
     fontSize: 10.px,
     backgroundColor: const Color.rgba(255, 255, 255, 0.15),
   ),
+  css(
+    '.editor-container:has(.cm-diagnostic-hover-toolbar-available) .cm-tooltip-lint',
+  ).styles(
+    raw: {
+      'border-radius': '6px 6px 0 0 !important',
+    },
+  ),
   css('.editor-container .cm-diagnostic-hover-toolbar').styles(
     display: .flex,
     padding: .symmetric(vertical: 4.px, horizontal: 6.px),
-    radius: .circular(6.px),
     gap: .all(6.px),
-    backgroundColor: colorContainer,
+    backgroundColor: colorSurface,
+    raw: {
+      'border-radius': '0 0 6px 6px !important',
+      'border-top': '1px solid rgba(255, 255, 255, 0.85) !important',
+      'margin-top': '-1px',
+    },
   ),
   css('.editor-container .cm-diagnostic-toolbar-btn').styles(
     display: .inlineFlex,
-    padding: .symmetric(vertical: 4.px, horizontal: 10.px),
-    border: .all(color: colorBorder, width: 1.px),
-    radius: .circular(4.px),
+    padding: .symmetric(vertical: 2.px, horizontal: 4.px),
+    border: .none,
     cursor: .pointer,
-    transition: .combine([
-      Transition('background-color', duration: 150.ms, curve: .ease),
-      Transition('border-color', duration: 150.ms, curve: .ease),
-      Transition('color', duration: 150.ms, curve: .ease),
-      Transition('opacity', duration: 150.ms, curve: .ease),
-    ]),
+    transition: Transition('color', duration: 150.ms, curve: .ease),
     alignItems: .center,
     color: colorPrimary,
     fontSize: 12.px,
     fontWeight: .w500,
-    backgroundColor: colorContainer,
+    backgroundColor: Colors.transparent,
     raw: {
       'background-image': 'none',
     },
   ),
-  css('.editor-container .cm-diagnostic-toolbar-btn:not(:disabled):hover').styles(
-    border: .all(color: colorPrimary, width: 1.px),
-    color: colorOnPrimary,
-    backgroundColor: colorPrimary,
+  css(
+    '.editor-container .cm-diagnostic-toolbar-btn:not(:disabled):hover, '
+    '.editor-container .cm-diagnostic-toolbar-btn:not(:disabled):focus-visible',
+  ).styles(
+    outline: const Outline(style: .none),
+    textDecoration: const TextDecoration(line: .underline),
   ),
   css('.editor-container .cm-diagnostic-toolbar-btn:disabled').styles(
-    border: .all(color: colorBorder, width: 1.px),
     opacity: .5,
     cursor: .notAllowed,
     color: colorOnContainer,
-    backgroundColor: colorContainer,
+    backgroundColor: Colors.transparent,
   ),
 ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
@@ -207,8 +207,8 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
       (groups[group] ??= []).add(action);
     }
 
-    // Stable display order: Quick Fix first, then Refactor, Source, Other.
-    const order = ['Quick Fix', 'Refactor', 'Source', 'Other'];
+    // Stable display order: Quick Fix first, then Flutter, Extract, Refactor, Source, Other.
+    const order = ['Quick Fix', 'Flutter', 'Extract', 'Refactor', 'Source', 'Other'];
     final sortedKeys = groups.keys.toList()
       ..sort((groupA, groupB) {
         final indexA = order.indexOf(groupA);
@@ -239,6 +239,12 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
   static String _kindGroup(String? kind) {
     if (kind == null || kind.startsWith('quickfix')) {
       return 'Quick Fix';
+    }
+    if (kind.startsWith('refactor.extract')) {
+      return 'Extract';
+    }
+    if (kind.startsWith('refactor.flutter')) {
+      return 'Flutter';
     }
     if (kind.startsWith('refactor')) {
       return 'Refactor';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
@@ -1,0 +1,221 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:codemirror_dart/codemirror_dart.dart' show LSPCodeAction;
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+
+/// Displays the quick fixes returned for the current diagnostic or selection.
+final class CodeActionPanel extends StatefulComponent {
+  const CodeActionPanel({required this.controller, super.key});
+
+  final CodeActionsController controller;
+
+  @override
+  State<CodeActionPanel> createState() => _CodeActionPanelState();
+
+  @css
+  static List<StyleRule> get styles => _CodeActionPanelState.styles;
+}
+
+final class _CodeActionPanelState extends State<CodeActionPanel> {
+  final GlobalNodeKey _panelKey = GlobalNodeKey();
+  StreamSubscription<web.MouseEvent>? _clickSubscription;
+  List<LSPCodeAction>? _focusedActions;
+
+  @override
+  void initState() {
+    super.initState();
+    Timer.run(() {
+      if (!mounted) {
+        return;
+      }
+      _clickSubscription = web.EventStreamProviders.mouseDownEvent.forTarget(web.document).listen((event) {
+        final panel = _panelKey.currentNode;
+        final target = event.target as web.Node?;
+        if (panel != null && target != null && !panel.contains(target)) {
+          component.controller.hideCodeActionPanel();
+        }
+      });
+      _focusFirstAction();
+    });
+  }
+
+  @override
+  void didUpdateComponent(CodeActionPanel oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    Timer.run(_focusFirstAction);
+  }
+
+  @override
+  void dispose() {
+    unawaited(_clickSubscription?.cancel());
+    super.dispose();
+  }
+
+  void _focusFirstAction() {
+    if (!mounted) {
+      return;
+    }
+    final actions = component.controller.codeActions;
+    if (actions == null || actions.isEmpty || identical(actions, _focusedActions)) {
+      return;
+    }
+    _focusedActions = actions;
+    final panel = _panelKey.currentNode as web.Element?;
+    (panel?.querySelector('.code-action-btn') as web.HTMLButtonElement?)?.focus();
+  }
+
+  void _handleKeyDown(web.Event event) {
+    final keyboardEvent = event as web.KeyboardEvent;
+    final panel = _panelKey.currentNode as web.Element?;
+    final buttons = panel?.querySelectorAll('.code-action-btn');
+    if (buttons == null || buttons.length == 0) {
+      return;
+    }
+
+    final activeElement = web.document.activeElement;
+    var activeIndex = 0;
+    for (var i = 0; i < buttons.length; i++) {
+      if (identical(buttons.item(i), activeElement)) {
+        activeIndex = i;
+        break;
+      }
+    }
+
+    int? nextIndex;
+    switch (keyboardEvent.key) {
+      case 'ArrowDown':
+        nextIndex = (activeIndex + 1) % buttons.length;
+      case 'ArrowUp':
+        nextIndex = (activeIndex - 1 + buttons.length) % buttons.length;
+      case 'Home':
+        nextIndex = 0;
+      case 'End':
+        nextIndex = buttons.length - 1;
+      case 'Enter' || ' ':
+        keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
+        (buttons.item(activeIndex) as web.HTMLButtonElement).click();
+        return;
+      case 'Escape':
+        keyboardEvent.preventDefault();
+        keyboardEvent.stopPropagation();
+        component.controller.hideCodeActionPanel();
+        component.controller.codeEditor.focus();
+        return;
+    }
+
+    if (nextIndex != null) {
+      keyboardEvent.preventDefault();
+      keyboardEvent.stopPropagation();
+      (buttons.item(nextIndex) as web.HTMLButtonElement).focus();
+    }
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final actions = component.controller.codeActions;
+    final children = switch (actions) {
+      null => const <Component>[
+        div(classes: 'code-action-empty-item', [.text('Loading quick fixes...')]),
+      ],
+      [] => const <Component>[
+        div(classes: 'code-action-empty-item', [.text('No quick fixes available')]),
+      ],
+      _ => <Component>[
+        const div(classes: 'code-action-group-header', [.text('Quick Fix')]),
+        div(
+          classes: 'code-action-group-list',
+          events: {'keydown': _handleKeyDown},
+          [
+            for (final action in actions)
+              button(
+                classes: 'code-action-btn',
+                type: .button,
+                onClick: () => unawaited(component.controller.applyCodeAction(action)),
+                [.text(action.title.toDart)],
+              ),
+          ],
+        ),
+      ],
+    };
+
+    return div(
+      key: _panelKey,
+      classes: 'code-action-floating-panel',
+      styles: Styles(
+        raw: {
+          'left': '${component.controller.panelLeft}px',
+          'top': '${component.controller.panelTop}px',
+        },
+      ),
+      children,
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css('.code-action-floating-panel').styles(
+      display: .flex,
+      position: const .fixed(),
+      zIndex: const ZIndex(100),
+      minWidth: 180.px,
+      maxWidth: 320.px,
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(8.px),
+      shadow: BoxShadow(
+        offsetX: .zero,
+        offsetY: 8.px,
+        blur: 24.px,
+        color: const .rgba(0, 0, 0, 0.5),
+      ),
+      flexDirection: .column,
+      color: colorOnSurface,
+      fontFamily: const .list([FontFamily('Inter'), FontFamilies.sansSerif]),
+      fontSize: 12.px,
+      backgroundColor: colorSurface,
+    ),
+    css('.code-action-group-header').styles(
+      padding: .only(top: 8.px, right: 12.px, bottom: 4.px, left: 12.px),
+      color: colorOnContainer,
+      fontSize: 10.px,
+      fontWeight: .w700,
+      raw: {
+        'text-transform': 'uppercase',
+        'letter-spacing': '0.5px',
+      },
+    ),
+    css('.code-action-group-list').styles(
+      display: .flex,
+      padding: .only(bottom: 4.px),
+      flexDirection: .column,
+    ),
+    css('.code-action-btn').styles(
+      padding: .symmetric(vertical: 7.px, horizontal: 12.px),
+      border: .none,
+      cursor: .pointer,
+      transition: Transition('background-color', duration: 100.ms),
+      color: colorOnSurface,
+      textAlign: .left,
+      fontSize: 12.px,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.code-action-btn:hover, .code-action-btn:focus-visible').styles(
+      outline: const Outline(style: .none),
+      backgroundColor: const .rgba(255, 255, 255, 0.08),
+    ),
+    css('.code-action-empty-item').styles(
+      padding: .symmetric(vertical: 12.px, horizontal: 16.px),
+      color: colorOnContainer,
+      textAlign: .center,
+    ),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
@@ -46,19 +46,72 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
         }
       });
       _focusFirstAction();
+      _adjustPosition();
     });
   }
 
   @override
   void didUpdateComponent(CodeActionPanel oldComponent) {
     super.didUpdateComponent(oldComponent);
-    Timer.run(_focusFirstAction);
+    Timer.run(() {
+      _focusFirstAction();
+      _adjustPosition();
+    });
   }
 
   @override
   void dispose() {
     unawaited(_clickSubscription?.cancel());
     super.dispose();
+  }
+
+  void _adjustPosition() {
+    if (!mounted) {
+      return;
+    }
+    final panel = _panelKey.currentNode as web.HTMLElement?;
+    if (panel == null) {
+      return;
+    }
+
+    final rect = panel.getBoundingClientRect();
+    final panelHeight = rect.height;
+    final panelWidth = rect.width;
+    final viewportHeight = web.window.innerHeight;
+    final viewportWidth = web.window.innerWidth;
+
+    final anchorTop = component.controller.anchorTop != 0
+        ? component.controller.anchorTop
+        : component.controller.panelTop;
+    final anchorBottom = component.controller.anchorBottom != 0
+        ? component.controller.anchorBottom
+        : component.controller.panelTop;
+    final anchorLeft = component.controller.panelLeft;
+
+    const margin = 8.0;
+    final spaceBelow = viewportHeight - anchorBottom - margin;
+    final spaceAbove = anchorTop - margin;
+
+    double top;
+    if (anchorBottom + panelHeight > viewportHeight - margin && spaceAbove > spaceBelow) {
+      top = (anchorTop - panelHeight).clamp(
+        margin,
+        (viewportHeight - panelHeight - margin).clamp(margin, viewportHeight.toDouble()),
+      );
+    } else {
+      top = anchorBottom.clamp(
+        margin,
+        (viewportHeight - panelHeight - margin).clamp(margin, viewportHeight.toDouble()),
+      );
+    }
+
+    final left = anchorLeft.clamp(
+      margin,
+      (viewportWidth - panelWidth - margin).clamp(margin, viewportWidth.toDouble()),
+    );
+
+    panel.style.top = '${top}px';
+    panel.style.left = '${left}px';
   }
 
   void _focusFirstAction() {
@@ -203,6 +256,7 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
       zIndex: const ZIndex(100),
       minWidth: 180.px,
       maxWidth: 320.px,
+      maxHeight: const Unit.expression('min(360px, calc(100vh - 32px))'),
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(8.px),
       shadow: BoxShadow(
@@ -216,6 +270,9 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
       fontFamily: const .list([FontFamily('Inter'), FontFamilies.sansSerif]),
       fontSize: 12.px,
       backgroundColor: colorSurface,
+      raw: {
+        'overflow-y': 'auto',
+      },
     ),
     css('.code-action-group-header').styles(
       padding: .only(top: 8.px, right: 12.px, bottom: 4.px, left: 12.px),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
@@ -126,27 +126,12 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
     final actions = component.controller.codeActions;
     final children = switch (actions) {
       null => const <Component>[
-        div(classes: 'code-action-empty-item', [.text('Loading quick fixes...')]),
+        div(classes: 'code-action-empty-item', [.text('Loading code actions...')]),
       ],
       [] => const <Component>[
-        div(classes: 'code-action-empty-item', [.text('No quick fixes available')]),
+        div(classes: 'code-action-empty-item', [.text('No code actions available')]),
       ],
-      _ => <Component>[
-        const div(classes: 'code-action-group-header', [.text('Quick Fix')]),
-        div(
-          classes: 'code-action-group-list',
-          events: {'keydown': _handleKeyDown},
-          [
-            for (final action in actions)
-              button(
-                classes: 'code-action-btn',
-                type: .button,
-                onClick: () => unawaited(component.controller.applyCodeAction(action)),
-                [.text(action.title.toDart)],
-              ),
-          ],
-        ),
-      ],
+      _ => _buildGroupedActions(actions),
     };
 
     return div(
@@ -160,6 +145,54 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
       ),
       children,
     );
+  }
+
+  List<Component> _buildGroupedActions(List<LSPCodeAction> actions) {
+    final groups = <String, List<LSPCodeAction>>{};
+    for (final action in actions) {
+      final group = _kindGroup(action.kind?.toDart);
+      (groups[group] ??= []).add(action);
+    }
+
+    // Stable display order: Quick Fix first, then Refactor, Source, Other.
+    const order = ['Quick Fix', 'Refactor', 'Source', 'Other'];
+    final sortedKeys = groups.keys.toList()..sort((groupA, groupB) {
+      final indexA = order.indexOf(groupA);
+      final indexB = order.indexOf(groupB);
+      return (indexA == -1 ? order.length : indexA).compareTo(indexB == -1 ? order.length : indexB);
+      });
+
+    return <Component>[
+      for (final group in sortedKeys) ...[
+        div(classes: 'code-action-group-header', [.text(group)]),
+        div(
+          classes: 'code-action-group-list',
+          events: {'keydown': _handleKeyDown},
+          [
+            for (final action in groups[group]!)
+              button(
+                classes: 'code-action-btn',
+                type: .button,
+                onClick: () => unawaited(component.controller.applyCodeAction(action)),
+                [.text(action.title.toDart)],
+              ),
+          ],
+        ),
+      ],
+    ];
+  }
+
+  static String _kindGroup(String? kind) {
+    if (kind == null || kind.startsWith('quickfix')) {
+      return 'Quick Fix';
+    }
+    if (kind.startsWith('refactor')) {
+      return 'Refactor';
+    }
+    if (kind.startsWith('source')) {
+      return 'Source';
+    }
+    return 'Other';
   }
 
   static List<StyleRule> get styles => [

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/code_action_panel.dart
@@ -156,10 +156,11 @@ final class _CodeActionPanelState extends State<CodeActionPanel> {
 
     // Stable display order: Quick Fix first, then Refactor, Source, Other.
     const order = ['Quick Fix', 'Refactor', 'Source', 'Other'];
-    final sortedKeys = groups.keys.toList()..sort((groupA, groupB) {
-      final indexA = order.indexOf(groupA);
-      final indexB = order.indexOf(groupB);
-      return (indexA == -1 ? order.length : indexA).compareTo(indexB == -1 ? order.length : indexB);
+    final sortedKeys = groups.keys.toList()
+      ..sort((groupA, groupB) {
+        final indexA = order.indexOf(groupA);
+        final indexB = order.indexOf(groupB);
+        return (indexA == -1 ? order.length : indexA).compareTo(indexB == -1 ? order.length : indexB);
       });
 
     return <Component>[

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -180,6 +180,7 @@ class _FooterState extends State<Footer> {
         div(classes: 'app-footer-shortcuts-list', [
           _shortcutRow('Save files', 'Ctrl/Cmd + S'),
           _shortcutRow('Format Dart files', 'Shift + Alt + F'),
+          _shortcutRow('Quick fix', 'Ctrl/Cmd + .'),
           _shortcutRow('Toggle line comment', 'Ctrl/Cmd + /'),
           _shortcutRow('Indent', 'Tab'),
         ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -359,7 +359,7 @@ void main() {
     tester.pumpComponent(CodeActionPanel(controller: controller));
     await pumpEventQueue();
 
-    expect(web.document.querySelector('.code-action-empty-item')!.textContent, 'No quick fixes available');
+    expect(web.document.querySelector('.code-action-empty-item')!.textContent, 'No code actions available');
 
     web.document.body!.dispatchEvent(
       web.MouseEvent('mousedown', web.MouseEventInit(bubbles: true)),
@@ -367,5 +367,28 @@ void main() {
     await pumpEventQueue();
 
     expect(controller.showFloatingPanel, isFalse);
+  });
+
+  testClient('quick-fix panel adjusts position above when near screen bottom', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    final controller = mainTab.codeActionsController
+      ..showFloatingPanel = true
+      ..panelLeft = 50
+      ..panelTop = (web.window.innerHeight - 20).toDouble()
+      ..anchorTop = (web.window.innerHeight - 40).toDouble()
+      ..anchorBottom = (web.window.innerHeight - 20).toDouble()
+      ..codeActions = [
+        LSPCodeAction({'title': 'Wrap with Center', 'kind': 'refactor'}.jsify() as JSObject),
+        LSPCodeAction({'title': 'Wrap with Container', 'kind': 'refactor'}.jsify() as JSObject),
+      ];
+
+    tester.pumpComponent(CodeActionPanel(controller: controller));
+    await pumpEventQueue();
+
+    final panel = web.document.querySelector('.code-action-floating-panel') as web.HTMLElement;
+    final topStyle = panel.style.top;
+    expect(topStyle, isNotEmpty);
+    final topValue = double.parse(topStyle.replaceAll('px', ''));
+    expect(topValue, lessThan(controller.anchorTop));
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -6,12 +6,15 @@
 library;
 
 import 'dart:async';
+import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:codemirror_dart/codemirror_dart.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/bottom_panel/view_models/diagnostics_view_model.dart';
 import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab.dart';
 import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab_adapter.dart';
+import 'package:dartpad_frontend/features/editor/components/code_action_panel.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_stack.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_tabs.dart';
 import 'package:dartpad_frontend/features/editor/view_models/tabs_view_model.dart';
@@ -260,5 +263,109 @@ void main() {
     );
 
     expect(web.document.querySelectorAll('.editor-tab-slot').length, 0);
+  });
+
+  testClient('quick-fix panel renders choices and applies the selected action', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    final controller = mainTab.codeActionsController
+      ..showFloatingPanel = true
+      ..codeActions = [
+        LSPCodeAction({'title': 'Use const', 'kind': 'quickfix'}.jsify() as JSObject),
+        LSPCodeAction({'title': 'Suppress lint', 'kind': 'quickfix'}.jsify() as JSObject),
+      ];
+
+    tester.pumpComponent(mainTab.build());
+    await pumpEventQueue();
+
+    final buttons = web.document.querySelectorAll('.code-action-btn');
+    expect(buttons.length, 2);
+    expect(buttons.item(0)!.textContent, 'Use const');
+    expect(buttons.item(1)!.textContent, 'Suppress lint');
+    expect(web.document.activeElement, same(buttons.item(0)));
+
+    buttons
+        .item(0)!
+        .dispatchEvent(
+          web.KeyboardEvent(
+            'keydown',
+            web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true),
+          ),
+        );
+    expect(web.document.activeElement, same(buttons.item(1)));
+
+    buttons
+        .item(1)!
+        .dispatchEvent(
+          web.KeyboardEvent(
+            'keydown',
+            web.KeyboardEventInit(key: 'ArrowUp', bubbles: true, cancelable: true),
+          ),
+        );
+    expect(web.document.activeElement, same(buttons.item(0)));
+
+    buttons
+        .item(0)!
+        .dispatchEvent(
+          web.KeyboardEvent(
+            'keydown',
+            web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true),
+          ),
+        );
+
+    buttons
+        .item(1)!
+        .dispatchEvent(
+          web.KeyboardEvent(
+            'keydown',
+            web.KeyboardEventInit(key: 'Enter', bubbles: true, cancelable: true),
+          ),
+        );
+    await pumpEventQueue();
+
+    expect(controller.showFloatingPanel, isFalse);
+    expect(controller.codeActions, isNull);
+  });
+
+  testClient('Escape closes the quick-fix panel and restores editor focus', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    final controller = mainTab.codeActionsController
+      ..showFloatingPanel = true
+      ..codeActions = [
+        LSPCodeAction({'title': 'Use const', 'kind': 'quickfix'}.jsify() as JSObject),
+        LSPCodeAction({'title': 'Suppress lint', 'kind': 'quickfix'}.jsify() as JSObject),
+      ];
+
+    tester.pumpComponent(mainTab.build());
+    await pumpEventQueue();
+
+    web.document.activeElement!.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(key: 'Escape', bubbles: true, cancelable: true),
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(controller.showFloatingPanel, isFalse);
+    expect(web.document.activeElement, same(mainTab.editor.view.dom.querySelector('.cm-content')));
+  });
+
+  testClient('quick-fix panel reports no results and closes on outside click', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    final controller = mainTab.codeActionsController
+      ..showFloatingPanel = true
+      ..codeActions = [];
+
+    tester.pumpComponent(CodeActionPanel(controller: controller));
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.code-action-empty-item')!.textContent, 'No quick fixes available');
+
+    web.document.body!.dispatchEvent(
+      web.MouseEvent('mousedown', web.MouseEventInit(bubbles: true)),
+    );
+    await pumpEventQueue();
+
+    expect(controller.showFloatingPanel, isFalse);
   });
 }


### PR DESCRIPTION
- Add LSP-powered Quick Fix support to the DartPad Preview editor.
- Show an Apply fix action in diagnostic tooltips only when the language server provides a matching Quick Fix.
- Add Cmd+. on macOS and Ctrl+. on Windows/Linux to request Quick Fixes at the cursor.
- Apply a single available fix immediately and show a keyboard-accessible selection panel when multiple fixes are available.
- Support keyboard navigation with arrow keys, Enter, Space, Home, End, and Escape.
- Apply LSP workspace edits in memory so modified files are marked as dirty instead of being persisted immediately.
