### PR TITLE
fix dartpad preview deployment

### DIFF
--- a/.cloud_build/dart_pad.yaml
+++ b/.cloud_build/dart_pad.yaml
@@ -21,9 +21,8 @@ steps:
       - |
         export PATH="/opt/flutter/bin:$$PATH"
         export PATH="$$PATH":"$$HOME/.pub-cache/bin"
-        dart pub global activate jaspr_cli
         dart pub get
-        dart pub global run jaspr_cli:jaspr build
+        dart run jaspr_cli:jaspr build -v
     dir: pkgs/dartpad_preview/dartpad_frontend
 
   # Deploy dartpad_preview to Firebase Hosting (site: sketch-pad-1cebb)


### PR DESCRIPTION
Fixes the Jaspr build for the dartpad preview deployment.

Fixes #3674

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
