### PR TITLE
Add device mode toggle to dartpad preview

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
@@ -179,8 +179,8 @@ class _DeviceModeDropdownState extends State<DeviceModeDropdown> {
         backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
       ),
       css('.device-dropdown-item.active').styles(
-        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
         fontWeight: .w500,
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
       ),
     ]),
   ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
@@ -1,0 +1,187 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import '../../shared/icons.dart';
+import '../models/device_mode.dart';
+
+class DeviceModeDropdown extends StatefulComponent {
+  const DeviceModeDropdown({
+    required this.mode,
+    required this.onModeSelected,
+    this.disabled = false,
+    super.key,
+  });
+
+  final DeviceMode mode;
+  final ValueChanged<DeviceMode> onModeSelected;
+  final bool disabled;
+
+  @override
+  State<DeviceModeDropdown> createState() => _DeviceModeDropdownState();
+
+  @css
+  static List<StyleRule> get styles => _DeviceModeDropdownState.styles;
+}
+
+class _DeviceModeDropdownState extends State<DeviceModeDropdown> {
+  bool _isOpen = false;
+  StreamSubscription<web.MouseEvent>? _clickOutsideSubscription;
+
+  void _toggleDropdown(web.Event event) {
+    event.stopPropagation(); // prevent immediate close from clicking the trigger itself
+    setState(() {
+      _isOpen = !_isOpen;
+    });
+
+    if (_isOpen) {
+      _listenForClickOutside();
+    } else {
+      _cancelListenForClickOutside();
+    }
+  }
+
+  void _listenForClickOutside() {
+    _clickOutsideSubscription?.cancel();
+    _clickOutsideSubscription = web.EventStreamProviders.clickEvent.forTarget(web.document).listen((e) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isOpen = false;
+      });
+      _cancelListenForClickOutside();
+    });
+  }
+
+  void _cancelListenForClickOutside() {
+    _clickOutsideSubscription?.cancel();
+    _clickOutsideSubscription = null;
+  }
+
+  @override
+  void dispose() {
+    _cancelListenForClickOutside();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final currentMode = component.mode;
+    final disabled = component.disabled;
+
+    return div(classes: 'device-dropdown-container', [
+      button(
+        classes: 'device-dropdown-trigger${disabled ? ' disabled' : ''}',
+        attributes: disabled ? {'disabled': 'true'} : {},
+        events: disabled ? {} : {'click': _toggleDropdown},
+        [
+          Icon(currentMode.icon, size: 18.0),
+          span(classes: 'device-dropdown-label', [.text(currentMode.title)]),
+          const Icon('keyboard_arrow_down', size: 16.0),
+        ],
+      ),
+      if (_isOpen)
+        div(classes: 'device-dropdown-menu', [
+          for (final mode in DeviceMode.values)
+            div(
+              classes: 'device-dropdown-item${mode == currentMode ? ' active' : ''}',
+              events: {
+                'click': (e) {
+                  component.onModeSelected(mode);
+                  setState(() {
+                    _isOpen = false;
+                  });
+                  _cancelListenForClickOutside();
+                },
+              },
+              [
+                Icon(mode.icon, size: 18.0),
+                span([.text(mode.title)]),
+              ],
+            ),
+        ]),
+    ]);
+  }
+
+  static List<StyleRule> get styles => [
+    css('.device-dropdown-container', [
+      css('&').styles(
+        display: .inlineFlex,
+        position: const .relative(),
+      ),
+      css('.device-dropdown-trigger').styles(
+        display: .flex,
+        height: 28.px,
+        padding: .symmetric(horizontal: 8.px),
+        border: .none,
+        radius: .circular(4.px),
+        cursor: .pointer,
+        transition: Transition('background-color', duration: 150.ms, curve: .ease),
+        justifyContent: .center,
+        alignItems: .center,
+        gap: Gap.all(6.px),
+        color: colorOnSurface,
+        whiteSpace: .noWrap,
+        backgroundColor: Colors.transparent,
+      ),
+      css('.device-dropdown-trigger:not(.disabled):hover').styles(
+        backgroundColor: colorContainer,
+      ),
+      css('.device-dropdown-trigger.disabled').styles(
+        opacity: 0.5,
+        cursor: .notAllowed,
+      ),
+      css('.device-dropdown-label').styles(
+        color: colorOnSurface,
+        fontSize: 13.px,
+        fontWeight: .w500,
+      ),
+      css('.device-dropdown-menu').styles(
+        display: .flex,
+        position: .absolute(top: 34.px, left: 0.px),
+        zIndex: const ZIndex(100),
+        minWidth: 180.px,
+        padding: .symmetric(vertical: 4.px),
+        border: .all(color: colorBorder, width: 1.px),
+        radius: .circular(8.px),
+        shadow: BoxShadow(
+          offsetX: 0.px,
+          offsetY: 8.px,
+          blur: 24.px,
+          color: Colors.black.withOpacity(0.5),
+        ),
+        backdropFilter: .blur(8.px),
+        flexDirection: .column,
+        backgroundColor: colorContainer,
+      ),
+      css('.device-dropdown-item').styles(
+        display: .flex,
+        padding: .symmetric(vertical: 8.px, horizontal: 12.px),
+        cursor: .pointer,
+        transition: .combine([
+          Transition('background-color', duration: 100.ms, curve: .ease),
+          Transition('color', duration: 100.ms, curve: .ease),
+        ]),
+        alignItems: .center,
+        gap: .all(10.px),
+        color: colorOnContainer,
+        fontSize: 13.px,
+        fontWeight: .w400,
+      ),
+      css('.device-dropdown-item:hover').styles(
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
+      ),
+      css('.device-dropdown-item.active').styles(
+        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
+        fontWeight: .w500,
+      ),
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
@@ -2,16 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
-import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
+import '../../shared/components/dropdown_menu.dart';
 import '../../shared/icons.dart';
 import '../models/device_mode.dart';
 
-class DeviceModeDropdown extends StatefulComponent {
+class DeviceModeDropdown extends StatelessComponent {
   const DeviceModeDropdown({
     required this.mode,
     required this.onModeSelected,
@@ -24,164 +23,59 @@ class DeviceModeDropdown extends StatefulComponent {
   final bool disabled;
 
   @override
-  State<DeviceModeDropdown> createState() => _DeviceModeDropdownState();
-
-  @css
-  static List<StyleRule> get styles => _DeviceModeDropdownState.styles;
-}
-
-class _DeviceModeDropdownState extends State<DeviceModeDropdown> {
-  bool _isOpen = false;
-  StreamSubscription<web.MouseEvent>? _clickOutsideSubscription;
-
-  void _toggleDropdown(web.Event event) {
-    event.stopPropagation(); // prevent immediate close from clicking the trigger itself
-    setState(() {
-      _isOpen = !_isOpen;
-    });
-
-    if (_isOpen) {
-      _listenForClickOutside();
-    } else {
-      _cancelListenForClickOutside();
-    }
-  }
-
-  void _listenForClickOutside() {
-    _clickOutsideSubscription?.cancel();
-    _clickOutsideSubscription = web.EventStreamProviders.clickEvent.forTarget(web.document).listen((e) {
-      if (!mounted) {
-        return;
-      }
-      setState(() {
-        _isOpen = false;
-      });
-      _cancelListenForClickOutside();
-    });
-  }
-
-  void _cancelListenForClickOutside() {
-    _clickOutsideSubscription?.cancel();
-    _clickOutsideSubscription = null;
-  }
-
-  @override
-  void dispose() {
-    _cancelListenForClickOutside();
-    super.dispose();
-  }
-
-  @override
   Component build(BuildContext context) {
-    final currentMode = component.mode;
-    final disabled = component.disabled;
-
-    return div(classes: 'device-dropdown-container', [
-      button(
+    return DropdownMenu(
+      alignLeft: true,
+      disabled: disabled,
+      trigger: button(
         classes: 'device-dropdown-trigger${disabled ? ' disabled' : ''}',
         attributes: disabled ? {'disabled': 'true'} : {},
-        events: disabled ? {} : {'click': _toggleDropdown},
         [
-          Icon(currentMode.icon, size: 18.0),
-          span(classes: 'device-dropdown-label', [.text(currentMode.title)]),
+          Icon(mode.icon, size: 18.0),
+          span(classes: 'device-dropdown-label', [.text(mode.title)]),
           const Icon('keyboard_arrow_down', size: 16.0),
         ],
       ),
-      if (_isOpen)
-        div(classes: 'device-dropdown-menu', [
-          for (final mode in DeviceMode.values)
-            div(
-              classes: 'device-dropdown-item${mode == currentMode ? ' active' : ''}',
-              events: {
-                'click': (e) {
-                  component.onModeSelected(mode);
-                  setState(() {
-                    _isOpen = false;
-                  });
-                  _cancelListenForClickOutside();
-                },
-              },
-              [
-                Icon(mode.icon, size: 18.0),
-                span([.text(mode.title)]),
-              ],
-            ),
-        ]),
-    ]);
+      items: [
+        for (final m in DeviceMode.values)
+          DropdownMenuItem(
+            label: m.title,
+            leadingIcon: m.icon,
+            isSelected: m == mode,
+            onPressed: () => onModeSelected(m),
+          ),
+      ],
+    );
   }
 
+  @css
   static List<StyleRule> get styles => [
-    css('.device-dropdown-container', [
-      css('&').styles(
-        display: .inlineFlex,
-        position: const .relative(),
-      ),
-      css('.device-dropdown-trigger').styles(
-        display: .flex,
-        height: 28.px,
-        padding: .symmetric(horizontal: 8.px),
-        border: .none,
-        radius: .circular(4.px),
-        cursor: .pointer,
-        transition: Transition('background-color', duration: 150.ms, curve: .ease),
-        justifyContent: .center,
-        alignItems: .center,
-        gap: Gap.all(6.px),
-        color: colorOnSurface,
-        whiteSpace: .noWrap,
-        backgroundColor: Colors.transparent,
-      ),
-      css('.device-dropdown-trigger:not(.disabled):hover').styles(
-        backgroundColor: colorContainer,
-      ),
-      css('.device-dropdown-trigger.disabled').styles(
-        opacity: 0.5,
-        cursor: .notAllowed,
-      ),
-      css('.device-dropdown-label').styles(
-        color: colorOnSurface,
-        fontSize: 13.px,
-        fontWeight: .w500,
-      ),
-      css('.device-dropdown-menu').styles(
-        display: .flex,
-        position: .absolute(top: 34.px, left: 0.px),
-        zIndex: const ZIndex(100),
-        minWidth: 180.px,
-        padding: .symmetric(vertical: 4.px),
-        border: .all(color: colorBorder, width: 1.px),
-        radius: .circular(8.px),
-        shadow: BoxShadow(
-          offsetX: 0.px,
-          offsetY: 8.px,
-          blur: 24.px,
-          color: Colors.black.withOpacity(0.5),
-        ),
-        backdropFilter: .blur(8.px),
-        flexDirection: .column,
-        backgroundColor: colorContainer,
-      ),
-      css('.device-dropdown-item').styles(
-        display: .flex,
-        padding: .symmetric(vertical: 8.px, horizontal: 12.px),
-        cursor: .pointer,
-        transition: .combine([
-          Transition('background-color', duration: 100.ms, curve: .ease),
-          Transition('color', duration: 100.ms, curve: .ease),
-        ]),
-        alignItems: .center,
-        gap: .all(10.px),
-        color: colorOnContainer,
-        fontSize: 13.px,
-        fontWeight: .w400,
-      ),
-      css('.device-dropdown-item:hover').styles(
-        backgroundColor: colorContainer.highlight(colorOnContainer, 0.1),
-      ),
-      css('.device-dropdown-item.active').styles(
-        fontWeight: .w500,
-        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
-      ),
-    ]),
+    css('.device-dropdown-trigger').styles(
+      display: .flex,
+      height: 28.px,
+      padding: .symmetric(horizontal: 8.px),
+      border: .none,
+      radius: .circular(4.px),
+      cursor: .pointer,
+      transition: Transition('background-color', duration: 150.ms, curve: .ease),
+      justifyContent: .center,
+      alignItems: .center,
+      gap: Gap.all(6.px),
+      color: colorOnSurface,
+      whiteSpace: .noWrap,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.device-dropdown-trigger:not(.disabled):hover').styles(
+      backgroundColor: colorContainer,
+    ),
+    css('.device-dropdown-trigger.disabled').styles(
+      opacity: 0.5,
+      cursor: .notAllowed,
+    ),
+    css('.device-dropdown-label').styles(
+      color: colorOnSurface,
+      fontSize: 13.px,
+      fontWeight: .w500,
+    ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/device_mode.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/device_mode.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// The preset viewport and device modes for the preview panel.
+enum DeviceMode {
+  /// Responsive mode using the available preview container dimensions.
+  current,
+
+  /// Mobile device viewport preset (390 x 846).
+  mobile((390, 846)),
+
+  /// Tablet device viewport preset (760 x 576).
+  tablet((760, 576));
+
+  const DeviceMode([this.size]);
+
+  /// The width and height dimensions in pixels, or `null` for responsive sizing.
+  final (int, int)? size;
+
+  String get title => switch (this) {
+    DeviceMode.current => 'Current screen size',
+    DeviceMode.mobile => 'Mobile',
+    DeviceMode.tablet => 'Tablet',
+  };
+
+  String get icon => switch (this) {
+    DeviceMode.current => 'devices',
+    DeviceMode.mobile => 'smartphone',
+    DeviceMode.tablet => 'tablet',
+  };
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -169,31 +169,32 @@ class _PreviewContainerState extends State<PreviewContainer> {
               ],
             ),
           ),
-          ButtonGroup(
-            children: [
-              DeviceModeDropdown(
-                mode: mode,
-                disabled: !isRunning,
-                onModeSelected: (m) {
-                  setState(() {
-                    mode = m;
-                    isRotated = false;
-                  });
-                  context.binding.addPostFrameCallback(_updateScale);
-                },
-              ),
-              if (mode.size != null)
-                IconButton(
-                  icon: 'screen_rotation',
-                  tooltip: 'Rotate orientation',
+          if (viewModel.isFlutter)
+            ButtonGroup(
+              children: [
+                DeviceModeDropdown(
+                  mode: mode,
                   disabled: !isRunning,
-                  onClick: (_) {
-                    setState(() => isRotated = !isRotated);
+                  onModeSelected: (m) {
+                    setState(() {
+                      mode = m;
+                      isRotated = false;
+                    });
                     context.binding.addPostFrameCallback(_updateScale);
                   },
                 ),
-            ],
-          ),
+                if (mode.size != null)
+                  IconButton(
+                    icon: 'screen_rotation',
+                    tooltip: 'Rotate orientation',
+                    disabled: !isRunning,
+                    onClick: (_) {
+                      setState(() => isRotated = !isRotated);
+                      context.binding.addPostFrameCallback(_updateScale);
+                    },
+                  ),
+              ],
+            ),
         ]),
       ]),
       div(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -2,16 +2,23 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:js_interop';
+import 'dart:math';
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
 import '../../bottom_panel/views/console_panel.dart';
 import '../../shared/components/button_group.dart';
+import '../../shared/components/icon_button.dart';
 import '../../shared/components/task_status_indicator.dart';
 import '../../shared/node_container.dart';
 import '../../shared/task_status.dart';
+import '../components/device_mode_dropdown.dart';
 import '../components/runtime_button.dart';
+import '../models/device_mode.dart';
 import '../models/preview_state.dart';
 import '../view_models/preview_view_model.dart';
 
@@ -50,8 +57,81 @@ class PreviewContainer extends StatefulComponent {
 }
 
 class _PreviewContainerState extends State<PreviewContainer> {
+  final GlobalNodeKey<web.HTMLElement> _contentKey = GlobalNodeKey();
+  web.ResizeObserver? _resizeObserver;
+
+  DeviceMode mode = .mobile;
+  bool isRotated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    context.binding.addPostFrameCallback(_setupObserver);
+  }
+
+  void _setupObserver() {
+    if (!mounted || _resizeObserver != null) {
+      return;
+    }
+    final element = _contentKey.currentNode;
+    if (element != null) {
+      _resizeObserver = web.ResizeObserver(
+        (JSArray<web.ResizeObserverEntry> entries, web.ResizeObserver observer) {
+          _updateScale();
+        }.toJS,
+      );
+      _resizeObserver!.observe(element);
+      _updateScale();
+    }
+  }
+
+  void _updateScale() {
+    final element = _contentKey.currentNode;
+    if (element == null) {
+      return;
+    }
+
+    final size = mode.size;
+
+    if (size == null) {
+      element.style.removeProperty('--device-width');
+      element.style.removeProperty('--device-height');
+      element.style.removeProperty('--device-scale');
+      return;
+    }
+
+    final baseW = size.$1;
+    final baseH = size.$2;
+    final deviceW = isRotated ? baseH : baseW;
+    final deviceH = isRotated ? baseW : baseH;
+
+    final parentRect = element.getBoundingClientRect();
+    final availableW = parentRect.width - 32;
+    final availableH = parentRect.height - 32;
+
+    if (availableW <= 0 || availableH <= 0) {
+      return;
+    }
+
+    final scaleW = availableW / deviceW;
+    final scaleH = availableH / deviceH;
+    final newScale = min(1.0, scaleW < scaleH ? scaleW : scaleH);
+
+    element.style.setProperty('--device-width', '${deviceW}px');
+    element.style.setProperty('--device-height', '${deviceH}px');
+    element.style.setProperty('--device-scale', newScale.toStringAsFixed(4));
+  }
+
+  @override
+  void dispose() {
+    _resizeObserver?.disconnect();
+    super.dispose();
+  }
+
   @override
   Component build(BuildContext context) {
+    context.binding.addPostFrameCallback(_updateScale);
+
     final viewModel = component.preview;
     final state = viewModel.state;
     final isRunning = viewModel.isRunning;
@@ -89,10 +169,41 @@ class _PreviewContainerState extends State<PreviewContainer> {
               ],
             ),
           ),
+          ButtonGroup(
+            children: [
+              DeviceModeDropdown(
+                mode: mode,
+                disabled: !isRunning,
+                onModeSelected: (m) {
+                  setState(() {
+                    mode = m;
+                    isRotated = false;
+                  });
+                  context.binding.addPostFrameCallback(_updateScale);
+                },
+              ),
+              if (mode.size != null)
+                IconButton(
+                  icon: 'screen_rotation',
+                  tooltip: 'Rotate orientation',
+                  disabled: !isRunning,
+                  onClick: (_) {
+                    setState(() => isRotated = !isRotated);
+                    context.binding.addPostFrameCallback(_updateScale);
+                  },
+                ),
+            ],
+          ),
         ]),
       ]),
       div(
-        classes: 'preview-content ${!isRunning ? 'status-stopped' : ''} ${!viewModel.isFlutter ? 'is-dart' : ''}',
+        key: _contentKey,
+        classes: [
+          'preview-content',
+          'mode-${mode.name}',
+          if (!isRunning) 'status-stopped',
+          if (!viewModel.isFlutter) 'is-dart',
+        ].join(' '),
         [
           NodeContainer(viewModel.containerElement),
           if (taskStatusMode != null)
@@ -142,6 +253,8 @@ class _PreviewContainerState extends State<PreviewContainer> {
         css('.preview-controls').styles(
           display: .flex,
           alignItems: .center,
+          justifyContent: .center,
+          flexWrap: .wrap,
           flex: const .grow(1),
           raw: {'flex-basis': '0%'},
         ),
@@ -155,6 +268,9 @@ class _PreviewContainerState extends State<PreviewContainer> {
           justifyContent: .center,
           alignItems: .center,
           flex: const .grow(1),
+        ),
+        css('&.mode-mobile, &.mode-tablet').styles(
+          padding: Padding.all(16.px),
         ),
         css('& .preview, & iframe').styles(
           width: 100.percent,
@@ -174,12 +290,50 @@ class _PreviewContainerState extends State<PreviewContainer> {
           width: 100.percent,
           height: 100.percent,
         ),
-        css('& > .preview').styles(
+        css('&.mode-current > .preview').styles(
           width: 100.percent,
           height: 100.percent,
           border: .none,
           radius: .circular(0.px),
           shadow: .none,
+        ),
+        css('&.mode-mobile > .preview').styles(
+          position: .absolute(top: 50.percent, left: 50.percent),
+          border: .all(color: colorBorder, width: 1.px),
+          radius: .circular(12.px),
+          overflow: .hidden,
+          shadow: BoxShadow(
+            offsetX: 0.px,
+            offsetY: 8.px,
+            blur: 24.px,
+            color: Colors.black.withOpacity(0.4),
+          ),
+          backgroundColor: Colors.white,
+          raw: {
+            'width': 'var(--device-width, 390px)',
+            'height': 'var(--device-height, 846px)',
+            'transform': 'translate(-50%, -50%) scale(var(--device-scale, 1))',
+            'transform-origin': 'center center',
+          },
+        ),
+        css('&.mode-tablet > .preview').styles(
+          position: .absolute(top: 50.percent, left: 50.percent),
+          border: .all(color: colorBorder, width: 1.px),
+          radius: .circular(12.px),
+          overflow: .hidden,
+          shadow: BoxShadow(
+            offsetX: 0.px,
+            offsetY: 8.px,
+            blur: 24.px,
+            color: Colors.black.withOpacity(0.4),
+          ),
+          backgroundColor: Colors.white,
+          raw: {
+            'width': 'var(--device-width, 760px)',
+            'height': 'var(--device-height, 576px)',
+            'transform': 'translate(-50%, -50%) scale(var(--device-scale, 1))',
+            'transform-origin': 'center center',
+          },
         ),
       ]),
     ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -252,9 +252,9 @@ class _PreviewContainerState extends State<PreviewContainer> {
         ),
         css('.preview-controls').styles(
           display: .flex,
-          alignItems: .center,
-          justifyContent: .center,
           flexWrap: .wrap,
+          justifyContent: .center,
+          alignItems: .center,
           flex: const .grow(1),
           raw: {'flex-basis': '0%'},
         ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
@@ -198,8 +198,7 @@ class _DropdownMenuState extends State<DropdownMenu> {
                         alt: '',
                         classes: 'dropdown-menu-item-image',
                       ),
-                    if (entry.leadingIcon != null)
-                      Icon(entry.leadingIcon!, size: entry.leadingIconSize),
+                    if (entry.leadingIcon != null) Icon(entry.leadingIcon!, size: entry.leadingIconSize),
                     span([.text(entry.label)]),
                     if (entry.trailingIcon != null) Icon(entry.trailingIcon!, size: entry.trailingIconSize),
                   ],

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
@@ -30,8 +30,11 @@ class DropdownMenuItem extends DropdownMenuEntry {
     required this.label,
     required this.onPressed,
     this.leadingImage,
+    this.leadingIcon,
+    this.leadingIconSize = 18,
     this.trailingIcon,
     this.trailingIconSize = 16,
+    this.isSelected = false,
   });
 
   /// The text label displayed for this menu item.
@@ -43,11 +46,20 @@ class DropdownMenuItem extends DropdownMenuEntry {
   /// Optional leading image URL (e.g. a logo).
   final String? leadingImage;
 
+  /// Optional leading icon name (Material Symbol).
+  final String? leadingIcon;
+
+  /// Size of the leading icon.
+  final double leadingIconSize;
+
   /// Optional trailing icon name (Material Symbol).
   final String? trailingIcon;
 
   /// Size of the trailing icon.
   final double trailingIconSize;
+
+  /// Whether this item represents the currently selected value.
+  final bool isSelected;
 }
 
 /// A reusable dropdown menu component.
@@ -171,7 +183,10 @@ class _DropdownMenuState extends State<DropdownMenu> {
                   ],
                 ),
                 DropdownMenuItem() => button(
-                  classes: 'dropdown-menu-item',
+                  classes: [
+                    'dropdown-menu-item',
+                    if (entry.isSelected) 'active',
+                  ].join(' '),
                   onClick: () {
                     _closeMenu();
                     entry.onPressed();
@@ -183,6 +198,8 @@ class _DropdownMenuState extends State<DropdownMenu> {
                         alt: '',
                         classes: 'dropdown-menu-item-image',
                       ),
+                    if (entry.leadingIcon != null)
+                      Icon(entry.leadingIcon!, size: entry.leadingIconSize),
                     span([.text(entry.label)]),
                     if (entry.trailingIcon != null) Icon(entry.trailingIcon!, size: entry.trailingIconSize),
                   ],
@@ -195,6 +212,7 @@ class _DropdownMenuState extends State<DropdownMenu> {
 
   static List<StyleRule> get styles => [
     css('.dropdown-menu-anchor').styles(
+      display: .inlineFlex,
       position: const .relative(),
     ),
     css('.dropdown-menu-panel').styles(
@@ -236,14 +254,22 @@ class _DropdownMenuState extends State<DropdownMenu> {
       border: .none,
       cursor: .pointer,
       alignItems: .center,
-      gap: Gap.all(6.px),
+      gap: Gap.all(8.px),
       color: colorOnContainer,
       textAlign: .left,
       fontSize: 14.px,
+      whiteSpace: .noWrap,
       backgroundColor: Colors.transparent,
     ),
     css('.dropdown-menu-item:hover').styles(
       backgroundColor: colorBorder,
+    ),
+    css('.dropdown-menu-item.active').styles(
+      fontWeight: .w500,
+      backgroundColor: colorContainer.highlight(colorOnContainer, 0.15),
+    ),
+    css('.dropdown-menu-item.active:hover').styles(
+      backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
     ),
     css('.dropdown-menu-item-image').styles(
       width: 20.px,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -1,0 +1,289 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
+import 'package:dartpad_frontend/features/preview/models/preview_state.dart';
+import 'package:dartpad_frontend/features/preview/view/preview_container.dart';
+import 'package:dartpad_frontend/features/preview/view_models/preview_view_model.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+class FakePreviewViewModel extends ChangeNotifier implements PreviewViewModel {
+  @override
+  final web.Element containerElement = web.document.createElement('div')..className = 'preview';
+
+  @override
+  PreviewState state = PreviewRunning('lib/main.dart');
+
+  @override
+  bool isRunning = true;
+
+  @override
+  bool isFlutter = true;
+
+  @override
+  bool canStart = false;
+
+  @override
+  bool canRestart = true;
+
+  @override
+  bool canHotReload = true;
+
+  @override
+  bool canStop = true;
+
+  @override
+  List<ConsoleEntry> appLogs = const [];
+
+  void setRunning(bool value) {
+    isRunning = value;
+    state = value ? PreviewRunning('lib/main.dart') : PreviewInitial();
+    canStart = !value;
+    canRestart = value;
+    canHotReload = value;
+    canStop = value;
+    notifyListeners();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late FakePreviewViewModel preview;
+  late TaskStatusController taskStatus;
+
+  setUp(() {
+    preview = FakePreviewViewModel();
+    taskStatus = TaskStatusController();
+
+    final style = web.document.createElement('style') as web.HTMLStyleElement;
+    style.id = 'test-preview-style';
+    style.textContent = '''
+      .preview-container {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        height: 100%;
+      }
+      .preview-content {
+        flex: 1;
+        width: 100%;
+        height: 100%;
+      }
+    ''';
+    web.document.head!.appendChild(style);
+  });
+
+  tearDown(() {
+    web.document.getElementById('test-preview-style')?.remove();
+    taskStatus.dispose();
+    preview.dispose();
+  });
+
+  Component buildContainer({
+    FakePreviewViewModel? customPreview,
+    String width = '1000px',
+    String height = '1000px',
+  }) {
+    return div(
+      attributes: {
+        'style': 'display: flex; flex-direction: column; width: $width; height: $height;',
+      },
+      [
+        PreviewContainer(
+          preview: customPreview ?? preview,
+          taskStatus: taskStatus,
+          activeFile: 'lib/main.dart',
+          onOpenConsole: () {},
+        ),
+      ],
+    );
+  }
+
+  web.HTMLButtonElement? findRotateButton() {
+    final buttons = web.document.querySelectorAll('.preview-controls .icon-button');
+    for (var i = 0; i < buttons.length; i++) {
+      final btn = buttons.item(i) as web.HTMLButtonElement;
+      if (btn.textContent?.contains('screen_rotation') ?? false) {
+        return btn;
+      }
+    }
+    return null;
+  }
+
+  web.HTMLButtonElement findDropdownTrigger() {
+    return web.document.querySelector('.device-dropdown-trigger')! as web.HTMLButtonElement;
+  }
+
+  Future<void> selectDropdownOption(String title) async {
+    final trigger = findDropdownTrigger();
+    trigger.click();
+    await pumpEventQueue();
+
+    final items = web.document.querySelectorAll('.device-dropdown-item');
+    for (var i = 0; i < items.length; i++) {
+      final item = items.item(i) as web.HTMLElement;
+      if (item.textContent?.contains(title) ?? false) {
+        item.click();
+        await pumpEventQueue();
+        return;
+      }
+    }
+    throw StateError('Option "$title" not found in dropdown');
+  }
+
+  testClient('defaults to mobile mode with rotation button visible', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final trigger = findDropdownTrigger();
+    expect(trigger.textContent, contains('Mobile'));
+    expect(trigger.textContent, contains('smartphone'));
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    expect(content.className, contains('mode-mobile'));
+
+    final rotateBtn = findRotateButton();
+    expect(rotateBtn, isNotNull);
+    expect(rotateBtn!.disabled, isFalse);
+  });
+
+  testClient('switches mode to tablet and updates CSS classes', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    await selectDropdownOption('Tablet');
+
+    final trigger = findDropdownTrigger();
+    expect(trigger.textContent, contains('Tablet'));
+    expect(trigger.textContent, contains('tablet'));
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    expect(content.className, contains('mode-tablet'));
+
+    final rotateBtn = findRotateButton();
+    expect(rotateBtn, isNotNull);
+    expect(rotateBtn!.disabled, isFalse);
+  });
+
+  testClient('switches mode to current screen size and removes rotation button', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    expect(findRotateButton(), isNotNull);
+
+    await selectDropdownOption('Current screen size');
+
+    final trigger = findDropdownTrigger();
+    expect(trigger.textContent, contains('Current screen size'));
+    expect(trigger.textContent, contains('devices'));
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    expect(content.className, contains('mode-current'));
+
+    expect(findRotateButton(), isNull);
+  });
+
+  testClient('toggles orientation and resets rotation when switching mode', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    final rotateBtn = findRotateButton()!;
+
+    // Initial mobile dimensions
+    expect(content.style.getPropertyValue('--device-width'), '390px');
+    expect(content.style.getPropertyValue('--device-height'), '846px');
+
+    // Rotate to landscape
+    rotateBtn.click();
+    await pumpEventQueue();
+
+    expect(content.style.getPropertyValue('--device-width'), '846px');
+    expect(content.style.getPropertyValue('--device-height'), '390px');
+
+    // Switching to tablet resets orientation back to default (portrait for tablet: 760x576)
+    await selectDropdownOption('Tablet');
+
+    expect(content.style.getPropertyValue('--device-width'), '760px');
+    expect(content.style.getPropertyValue('--device-height'), '576px');
+  });
+
+  testClient('removes device CSS variables in current screen size mode', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    expect(content.style.getPropertyValue('--device-width'), '390px');
+
+    await selectDropdownOption('Current screen size');
+
+    expect(content.style.getPropertyValue('--device-width'), isEmpty);
+    expect(content.style.getPropertyValue('--device-height'), isEmpty);
+    expect(content.style.getPropertyValue('--device-scale'), isEmpty);
+  });
+
+  testClient('calculates downscaling when container is smaller than device dimensions', (tester) async {
+    // 390px width device in a 200px wide container
+    tester.pumpComponent(buildContainer(width: '200px', height: '500px'));
+    await pumpEventQueue();
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    final scaleStr = content.style.getPropertyValue('--device-scale');
+    expect(scaleStr, isNotEmpty);
+
+    final scale = double.parse(scaleStr);
+    expect(scale, lessThan(1.0));
+    expect(scale, greaterThan(0.0));
+  });
+
+  testClient('disables dropdown and rotate button when preview is stopped', (tester) async {
+    preview.setRunning(false);
+
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final trigger = findDropdownTrigger();
+    expect(trigger.className, contains('disabled'));
+    expect(trigger.getAttribute('disabled'), 'true');
+
+    // Clicking trigger does not open menu
+    trigger.click();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.device-dropdown-menu'), isNull);
+
+    final rotateBtn = findRotateButton()!;
+    expect(rotateBtn.disabled, isTrue);
+
+    final content = web.document.querySelector('.preview-content') as web.HTMLElement;
+    expect(content.className, contains('status-stopped'));
+  });
+
+  testClient('mounts and unmounts cleanly without errors', (tester) async {
+    final showContainer = ValueNotifier(true);
+
+    tester.pumpComponent(
+      ListenableBuilder(
+        listenable: showContainer,
+        builder: (context) => showContainer.value ? buildContainer() : const Component.fragment([]),
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.preview-container'), isNotNull);
+
+    showContainer.value = false;
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.preview-container'), isNull);
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -43,7 +43,7 @@ class FakePreviewViewModel extends ChangeNotifier implements PreviewViewModel {
   @override
   List<ConsoleEntry> appLogs = const [];
 
-  void setRunning(bool value) {
+  void setRunning({required bool value}) {
     isRunning = value;
     state = value ? PreviewRunning('lib/main.dart') : PreviewInitial();
     canStart = !value;
@@ -129,7 +129,7 @@ void main() {
     trigger.click();
     await pumpEventQueue();
 
-    final items = web.document.querySelectorAll('.device-dropdown-item');
+    final items = web.document.querySelectorAll('.dropdown-menu-item');
     for (var i = 0; i < items.length; i++) {
       final item = items.item(i) as web.HTMLElement;
       if (item.textContent?.contains(title) ?? false) {
@@ -247,7 +247,7 @@ void main() {
   });
 
   testClient('disables dropdown and rotate button when preview is stopped', (tester) async {
-    preview.setRunning(false);
+    preview.setRunning(value: false);
 
     tester.pumpComponent(buildContainer());
     await pumpEventQueue();
@@ -259,7 +259,7 @@ void main() {
     // Clicking trigger does not open menu
     trigger.click();
     await pumpEventQueue();
-    expect(web.document.querySelector('.device-dropdown-menu'), isNull);
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNull);
 
     final rotateBtn = findRotateButton()!;
     expect(rotateBtn.disabled, isTrue);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/dropdown_menu_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/dropdown_menu_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/dropdown_menu.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  testClient('opens and closes dropdown menu on trigger click', (tester) async {
+    tester.pumpComponent(
+      DropdownMenu(
+        items: [
+          DropdownMenuItem(label: 'Item 1', onPressed: () {}),
+          DropdownMenuItem(label: 'Item 2', onPressed: () {}),
+        ],
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNull);
+
+    final trigger = web.document.querySelector('.dropdown-menu-default-trigger') as web.HTMLButtonElement;
+    trigger.click();
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNotNull);
+    final items = web.document.querySelectorAll('.dropdown-menu-item');
+    expect(items.length, 2);
+
+    trigger.click();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNull);
+  });
+
+  testClient('renders leadingIcon, trailingIcon, and active state for selected items', (tester) async {
+    tester.pumpComponent(
+      DropdownMenu(
+        items: [
+          DropdownMenuItem(
+            label: 'Selected Item',
+            leadingIcon: 'check_circle',
+            trailingIcon: 'chevron_right',
+            isSelected: true,
+            onPressed: () {},
+          ),
+          DropdownMenuItem(
+            label: 'Normal Item',
+            onPressed: () {},
+          ),
+        ],
+      ),
+    );
+    await pumpEventQueue();
+
+    final trigger = web.document.querySelector('.dropdown-menu-default-trigger') as web.HTMLButtonElement;
+    trigger.click();
+    await pumpEventQueue();
+
+    final items = web.document.querySelectorAll('.dropdown-menu-item');
+    expect(items.length, 2);
+
+    final firstItem = items.item(0) as web.HTMLElement;
+    expect(firstItem.className, contains('active'));
+    expect(firstItem.textContent, contains('check_circle'));
+    expect(firstItem.textContent, contains('Selected Item'));
+    expect(firstItem.textContent, contains('chevron_right'));
+
+    final secondItem = items.item(1) as web.HTMLElement;
+    expect(secondItem.className, isNot(contains('active')));
+  });
+
+  testClient('invokes onPressed and closes menu on item click', (tester) async {
+    var itemClicked = false;
+    tester.pumpComponent(
+      DropdownMenu(
+        items: [
+          DropdownMenuItem(
+            label: 'Click Me',
+            onPressed: () => itemClicked = true,
+          ),
+        ],
+      ),
+    );
+    await pumpEventQueue();
+
+    (web.document.querySelector('.dropdown-menu-default-trigger') as web.HTMLButtonElement).click();
+    await pumpEventQueue();
+
+    final item = web.document.querySelector('.dropdown-menu-item') as web.HTMLButtonElement;
+    item.click();
+    await pumpEventQueue();
+
+    expect(itemClicked, isTrue);
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNull);
+  });
+
+  testClient('does not open menu when disabled is true', (tester) async {
+    tester.pumpComponent(
+      DropdownMenu(
+        disabled: true,
+        items: [
+          DropdownMenuItem(label: 'Disabled Option', onPressed: () {}),
+        ],
+      ),
+    );
+    await pumpEventQueue();
+
+    final trigger = web.document.querySelector('.dropdown-menu-default-trigger') as web.HTMLButtonElement;
+    trigger.click();
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('.dropdown-menu-panel'), isNull);
+  });
+}


### PR DESCRIPTION
Adds the device mode switcher to the preview toolbar. This allows to select from predefined mobile and tablet dimensions for the preview, which will be scaled accordingly.

<img width="515" height="827" alt="Bildschirmfoto 2026-08-17 um 14 22 24" src="https://github.com/user-attachments/assets/0c984332-dd9b-41fa-864a-9b670c95f5ae" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
