### PR TITLE
feat(dartpad-preview) add error dialog when loading/init fails

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -342,7 +342,7 @@ class AppState extends State<App> {
       } else {
         userErrorMessage = 'The default project could not be loaded.';
         _updateLoadingStatus(session, 'Initializing Workspace...', clearError: true);
-        project = await loadExampleProject(
+        project = await loadSampleProject(
           session.repository.root,
         );
       }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -19,6 +19,7 @@ import 'features/filetree/file_tree_view.dart';
 import 'features/preview/view/preview_container.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
+import 'features/shared/components/error_dialog.dart';
 import 'features/shared/components/footer.dart';
 import 'features/shared/components/split_panel.dart';
 import 'features/shared/events/log_event.dart';
@@ -138,7 +139,7 @@ class AppState extends State<App> {
       }
       setState(() {
         _isInitializingWorkspace = false;
-        _errorMessage = 'Failed to initialize workspace: $error';
+        _errorMessage = 'The workspace could not be initialized.';
       });
     }
   }
@@ -300,6 +301,7 @@ class AppState extends State<App> {
     required ProjectSource source,
   }) async {
     final params = source.queryParameters;
+    var userErrorMessage = 'The project could not be loaded.';
 
     try {
       final LoadedProject project;
@@ -307,32 +309,41 @@ class AppState extends State<App> {
         'archive': final String archiveUrlParam,
         'path': final String filePathParam,
       }) {
+        userErrorMessage =
+            'The project archive could not be downloaded. '
+            'Please check that the URL is correct and accessible.';
         _updateLoadingStatus(session, 'Downloading Archive...', clearError: true);
         final archiveUrl = Uri.decodeComponent(archiveUrlParam);
         final filePath = Uri.decodeComponent(filePathParam);
         final loader = ArchiveLoader(archiveUrl: archiveUrl, filePath: filePath);
         project = await loader.loadArchive(session.repository.root);
       } else if (params case {'package': final String packageName}) {
+        userErrorMessage =
+            'The package "$packageName" could not be resolved from pub.dev. '
+            'Please verify the package name in the URL.';
         _updateLoadingStatus(session, 'Resolving Package...', clearError: true);
         final loader = await ArchiveLoader.forPackage(packageName);
         _updateLoadingStatus(session, 'Downloading Package...');
         project = await loader.loadArchive(session.repository.root);
       } else if (params['gist'] case final String gistId) {
+        userErrorMessage =
+            'The GitHub Gist could not be loaded. '
+            'Please check that the Gist ID "$gistId" in the URL is correct.';
         _updateLoadingStatus(session, 'Downloading Gist...', clearError: true);
         final loader = GistLoader(gistId: gistId);
         project = await loader.loadGist(session.repository.root);
       } else if (params['sample'] case final String sampleId) {
-        _updateLoadingStatus(session, 'Loading Example...', clearError: true);
-        project = await loadExampleProject(
+        userErrorMessage = 'The requested sample "$sampleId" could not be loaded.';
+        _updateLoadingStatus(session, 'Loading Sample...', clearError: true);
+        project = await loadSampleProject(
           session.repository.root,
           sampleId: sampleId,
-          onFailure: (failure) => _reportExampleLoadFailure(session, failure),
         );
       } else {
+        userErrorMessage = 'The default project could not be loaded.';
         _updateLoadingStatus(session, 'Initializing Workspace...', clearError: true);
         project = await loadExampleProject(
           session.repository.root,
-          onFailure: (failure) => _reportExampleLoadFailure(session, failure),
         );
       }
 
@@ -352,32 +363,11 @@ class AppState extends State<App> {
     } catch (error) {
       if (_isCurrent(session)) {
         setState(() {
-          _errorMessage = 'Failed to load project: $error';
+          _errorMessage = userErrorMessage;
         });
       }
       return null;
     }
-  }
-
-  void _reportExampleLoadFailure(
-    WorkspaceSession session,
-    ExampleLoadFailure failure,
-  ) {
-    if (!_isCurrent(session)) {
-      return;
-    }
-
-    session.events.dispatch(
-      LogEvent(
-        failure.message,
-        level: Level.WARNING,
-        error: failure.error,
-        stackTrace: failure.stackTrace,
-      ),
-    );
-    setState(() {
-      _errorMessage = failure.message;
-    });
   }
 
   void _updateLoadingStatus(
@@ -446,10 +436,11 @@ class AppState extends State<App> {
             ),
           ]),
           Footer(
-            statusLabel: _errorMessage ?? session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
+            statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
           ),
         ]),
       ),
+      if (_errorMessage case final String message) ErrorDialog(errorMessage: message),
     ]);
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/error_dialog.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/error_dialog.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import '../icons.dart';
+
+/// A non-dismissible modal overlay that displays a descriptive error message
+/// when a critical failure occurs during project loading or workspace
+/// initialization.
+///
+/// The overlay cannot be dismissed. The only action available is the
+/// "Reload Page" button which reloads the browser window.
+class ErrorDialog extends StatelessComponent {
+  const ErrorDialog({required this.errorMessage, super.key});
+
+  /// A user-facing description of what went wrong.
+  final String errorMessage;
+
+  @override
+  Component build(BuildContext context) {
+    return div(
+      classes: 'error-dialog-backdrop',
+      attributes: const {
+        'role': 'alertdialog',
+        'aria-modal': 'true',
+        'aria-labelledby': 'error-dialog-title',
+        'aria-describedby': 'error-dialog-message',
+      },
+      [
+        div(classes: 'error-dialog', [
+          div(classes: 'error-dialog-content', [
+            const Icon('error', size: 48, classes: 'error-dialog-icon'),
+            const h2(
+              id: 'error-dialog-title',
+              classes: 'error-dialog-title',
+              [.text('Oops, something went wrong!')],
+            ),
+            div(
+              id: 'error-dialog-message',
+              classes: 'error-dialog-message',
+              [.text(errorMessage)],
+            ),
+            const div(
+              classes: 'error-dialog-hint',
+              [.text('Please reload the page to try again.')],
+            ),
+            button(
+              classes: 'error-dialog-reload-button',
+              attributes: const {
+                'title': 'Reload Page',
+                'aria-label': 'Reload Page',
+              },
+              events: {
+                'click': (_) => web.window.location.reload(),
+              },
+              [
+                const Icon('refresh', size: 18),
+                const .text('Reload Page'),
+              ],
+            ),
+          ]),
+        ]),
+      ],
+    );
+  }
+
+  @css
+  static List<StyleRule> get styles => [
+    css('.error-dialog-backdrop').styles(
+      display: .flex,
+      position: .fixed(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
+      zIndex: const ZIndex(9999),
+      justifyContent: .center,
+      alignItems: .center,
+      backgroundColor: const Color('rgba(0, 0, 0, 0.55)'),
+    ),
+    css('.error-dialog').styles(
+      minWidth: 360.px,
+      maxWidth: 460.px,
+      padding: .zero,
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(10.px),
+      color: colorOnSurface,
+      backgroundColor: colorContainer,
+    ),
+    css('.error-dialog-content').styles(
+      display: .flex,
+      padding: .symmetric(vertical: 32.px, horizontal: 28.px),
+      flexDirection: .column,
+      alignItems: .center,
+      gap: Gap.all(16.px),
+    ),
+    css('.error-dialog-icon').styles(
+      color: colorError,
+    ),
+    css('.error-dialog-title').styles(
+      margin: .zero,
+      color: colorOnContainer,
+      textAlign: .center,
+      fontSize: 18.px,
+      fontWeight: .w600,
+    ),
+    css('.error-dialog-message').styles(
+      padding: .symmetric(vertical: 8.px, horizontal: 16.px),
+      border: .all(color: colorError.highlight(colorBorder, 0.5), width: 1.px),
+      radius: .circular(6.px),
+      color: colorOnContainer,
+      textAlign: .center,
+      fontSize: 13.px,
+      lineHeight: 1.5.em,
+      backgroundColor: colorErrorSurface,
+    ),
+    css('.error-dialog-hint').styles(
+      color: colorOnSurface,
+      textAlign: .center,
+      fontSize: 13.px,
+    ),
+    css('.error-dialog-reload-button', [
+      css('&').styles(
+        display: .inlineFlex,
+        padding: .symmetric(vertical: 10.px, horizontal: 20.px),
+        border: .none,
+        radius: .circular(6.px),
+        outline: const Outline(style: .none),
+        cursor: .pointer,
+        justifyContent: .center,
+        alignItems: .center,
+        gap: Gap.all(6.px),
+        color: colorOnPrimary,
+        fontSize: 14.px,
+        fontWeight: FontWeight.w500,
+        backgroundColor: colorPrimary,
+      ),
+      css('&:hover').styles(
+        backgroundColor: colorPrimary.highlight(colorOnPrimary, 0.1),
+      ),
+    ]),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
@@ -8,40 +8,17 @@ import 'archive_loader.dart';
 import 'examples.g.dart';
 import 'project_loader.dart';
 
-final class ExampleLoadFailure {
-  const ExampleLoadFailure({
-    required this.message,
-    required this.error,
-    required this.stackTrace,
-  });
-
-  final String message;
-  final Object error;
-  final StackTrace stackTrace;
-}
-
-typedef ExampleLoadFailureHandler = void Function(ExampleLoadFailure failure);
-
-/// Loads an example project from its packaged archive into [root].
-Future<LoadedProject> loadExampleProject(
+/// Loads a sample project from its packaged archive into [root].
+///
+/// Throws an [ArgumentError] when [sampleId] does not match any known sample.
+/// Archive download errors propagate to the caller.
+Future<LoadedProject> loadSampleProject(
   WorkspaceFolder root, {
   String? sampleId,
-  ExampleLoadFailureHandler? onFailure,
 }) async {
-  if (sampleId == null) {
-    return _loadExample(root, Examples.defaultExample, onFailure: onFailure);
-  }
-
-  final example = Examples.getById(sampleId);
-  if (example == null) {
-    onFailure?.call(
-      ExampleLoadFailure(
-        message: 'Error while loading $sampleId example, falling back to counter example.',
-        error: ArgumentError.value(sampleId, 'sampleId', 'Unknown example ID'),
-        stackTrace: StackTrace.current,
-      ),
-    );
-    return _loadExample(root, Examples.defaultExample, onFailure: onFailure);
+  final requestedSample = Samples.getById(sampleId);
+  if (sampleId != null && requestedSample == null) {
+    throw ArgumentError.value(sampleId, 'sampleId', 'Unknown sample ID');
   }
 
   return _loadExample(root, example, onFailure: onFailure);
@@ -57,23 +34,7 @@ Future<LoadedProject> _loadExample(
     filePath: example.entryPath,
   );
 
-  try {
-    return await loader.loadArchive(root);
-  } catch (error, stackTrace) {
-    onFailure?.call(
-      ExampleLoadFailure(
-        message: 'Error while loading ${example.id} example, falling back to counter example.',
-        error: error,
-        stackTrace: stackTrace,
-      ),
-    );
-    await createFallbackExampleProject(root);
-    return const LoadedProject(
-      projectDir: '',
-      entryPath: exampleProjectEntryPath,
-      packageRoot: '',
-    );
-  }
+  return loader.loadArchive(root);
 }
 
 /// The default entry path for example projects.
@@ -83,122 +44,3 @@ const String exampleProjectEntryPath = 'lib/main.dart';
 Future<void> openExampleProject(Future<void> Function(String path) openFile) {
   return openFile(exampleProjectEntryPath);
 }
-
-/// Creates the files for the default DartPad example project (fallback).
-Future<void> createFallbackExampleProject(WorkspaceFolder root) async {
-  await root.getFolder('lib').create();
-  await root.getFile(_fallbackPubspecPath).writeContent(fallbackPubspec.trimLeft());
-  await root.getFile(_fallbackAnalysisOptionsPath).writeContent(fallbackAnalysisOptions.trimLeft());
-  await root.getFile(exampleProjectEntryPath).writeContent(fallbackMainDart.trimLeft());
-}
-
-const String _fallbackAnalysisOptionsPath = 'analysis_options.yaml';
-const String _fallbackPubspecPath = 'pubspec.yaml';
-
-/// The initial Dart source for the default example project fallback.
-const String fallbackMainDart = r'''
-import 'package:flutter/material.dart';
-
-void main() {
-  runApp(const CounterApp());
-}
-
-class CounterApp extends StatelessWidget {
-  const CounterApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Counter',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
-      home: const CounterPage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class CounterPage extends StatefulWidget {
-  const CounterPage({super.key, required this.title});
-
-  final String title;
-
-  @override
-  State<CounterPage> createState() => _CounterPageState();
-}
-
-class _CounterPageState extends State<CounterPage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
-    );
-  }
-}
-''';
-
-/// The initial pubspec for the default example project fallback.
-const String fallbackPubspec = '''
-name: counter_app
-description: A simple counter app.
-publish_to: none
-version: 1.0.0+1
-
-environment:
-    sdk: ^3.12.0
-
-dependencies:
-  flutter:
-    sdk: flutter
-
-dev_dependencies:
-  flutter_lints: ^6.0.0
-
-flutter:
-  uses-material-design: true
-''';
-
-const String fallbackAnalysisOptions = '''
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI.
-#
-# For more information, see: https://dart.dev/guides/language/analysis-options
-
-include: package:flutter_lints/flutter.yaml
-
-# linter:
-#   rules:
-#     # avoid_print: false # Uncomment to disable the `avoid_print` rule
-#     # prefer_single_quotes: true # Uncomment to enable the `prefer_single_quotes` rule
-''';

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
@@ -16,8 +16,7 @@ Future<LoadedProject> loadSampleProject(
   WorkspaceFolder root, {
   String? sampleId,
 }) async {
-  final requestedExample =
-      sampleId != null ? Examples.getById(sampleId) : null;
+  final requestedExample = sampleId != null ? Examples.getById(sampleId) : null;
   if (sampleId != null && requestedExample == null) {
     throw ArgumentError.value(sampleId, 'sampleId', 'Unknown example ID');
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
@@ -16,9 +16,10 @@ Future<LoadedProject> loadSampleProject(
   WorkspaceFolder root, {
   String? sampleId,
 }) async {
-  final requestedSample = Samples.getById(sampleId);
-  if (sampleId != null && requestedSample == null) {
-    throw ArgumentError.value(sampleId, 'sampleId', 'Unknown sample ID');
+  final requestedExample =
+      sampleId != null ? Examples.getById(sampleId) : null;
+  if (sampleId != null && requestedExample == null) {
+    throw ArgumentError.value(sampleId, 'sampleId', 'Unknown example ID');
   }
 
   return _loadExample(root, example, onFailure: onFailure);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/example_project.dart
@@ -22,14 +22,7 @@ Future<LoadedProject> loadSampleProject(
     throw ArgumentError.value(sampleId, 'sampleId', 'Unknown example ID');
   }
 
-  return _loadExample(root, example, onFailure: onFailure);
-}
-
-Future<LoadedProject> _loadExample(
-  WorkspaceFolder root,
-  Example example, {
-  ExampleLoadFailureHandler? onFailure,
-}) async {
+  final example = requestedExample ?? Examples.defaultExample;
   final loader = ArchiveLoader(
     archiveUrl: example.archivePath,
     filePath: example.entryPath,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/example_project_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/example_project_test.dart
@@ -24,38 +24,41 @@ void main() {
     return Uint8List.fromList(const GZipEncoder().encode(TarEncoder().encode(archive)));
   }
 
-  test('reports an unknown example ID before loading the counter example', () async {
+  test('throws ArgumentError for an unknown sample ID', () async {
     final api = MemoryWorkspaceResourceApi();
-    final failures = <ExampleLoadFailure>[];
+
+    await expectLater(
+      http.runWithClient(
+        () => loadSampleProject(
+          api.root,
+          sampleId: 'unknown-sample',
+        ),
+        () => MockClient((_) async => http.Response.bytes(counterArchive(), 200)),
+      ),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+
+  test('throws when the sample archive is unavailable', () async {
+    final api = MemoryWorkspaceResourceApi();
+
+    await expectLater(
+      http.runWithClient(
+        () => loadSampleProject(api.root, sampleId: 'dart'),
+        () => MockClient((_) async => http.Response('Not Found', 404)),
+      ),
+      throwsA(isA<Exception>()),
+    );
+  });
+
+  test('loads a valid sample successfully', () async {
+    final api = MemoryWorkspaceResourceApi();
 
     final project = await http.runWithClient(
-      () => loadExampleProject(
-        api.root,
-        sampleId: 'unknown-sample',
-        onFailure: failures.add,
-      ),
+      () => loadSampleProject(api.root),
       () => MockClient((_) async => http.Response.bytes(counterArchive(), 200)),
     );
 
     expect(project.entryPath, 'lib/main.dart');
-    expect(failures.map((failure) => failure.message), [
-      'Error while loading unknown-sample example, falling back to counter example.',
-    ]);
-  });
-
-  test('reports an unavailable snippet and creates the built-in counter fallback', () async {
-    final api = MemoryWorkspaceResourceApi();
-    final failures = <ExampleLoadFailure>[];
-
-    final project = await http.runWithClient(
-      () => loadExampleProject(api.root, sampleId: 'dart', onFailure: failures.add),
-      () => MockClient((_) async => http.Response('Not Found', 404)),
-    );
-
-    expect(project.entryPath, 'lib/main.dart');
-    expect(await api.fileExist('lib/main.dart'), isTrue);
-    expect(failures.map((failure) => failure.message), [
-      'Error while loading dart example, falling back to counter example.',
-    ]);
   });
 }


### PR DESCRIPTION
Show a non-dismissible error dialog for project loading failures

Errors during project loading (invalid URLs, missing gists/packages/samples, workspace init failures) were only shown as truncated text in the footer status bar. They are now displayed in a full-screen error dialog with a descriptive message and a Reload Page button.

- New ErrorDialog component 
- Descriptive error messages per source type (archive, package, gist, sample, workspace init)
- Removed sample fallback — loadSampleProject no longer silently falls back to a hardcoded counter sample; errors propagate to the caller. 