### PR TITLE
Add embed mode (?embed=true) to DartPad Preview

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -31,6 +31,12 @@ import 'features/workspace/data/workspace_repository.dart';
 import 'features/workspace/workspace_lifecycle.dart';
 import 'features/workspace/workspace_session.dart';
 
+/// Whether the application is running in embed mode (`?embed=true`).
+///
+/// When `true`, the app bar and footer are hidden and the file tree starts
+/// collapsed into a narrow rail with a toggle button.
+final bool isEmbedMode = Uri.base.queryParameters['embed'] == 'true';
+
 /// The deliberately small first production slice of DartPad.
 class App extends StatefulComponent {
   const App({super.key});
@@ -408,14 +414,15 @@ class AppState extends State<App> {
   Component build(BuildContext context) {
     final session = _session;
     return div(classes: 'app-shell', [
-      AppBar(
-        onCreateNewSnippet: _isInitializingWorkspace || session.repository.dartpad == null
-            ? null
-            : (example) => resetWorkspace(ProjectSource.example(example.id)),
-        onLoadSample: _isInitializingWorkspace || session.repository.dartpad == null
-            ? null
-            : (example) => resetWorkspace(ProjectSource.example(example.id)),
-      ),
+      if (!isEmbedMode)
+        AppBar(
+          onCreateNewSnippet: _isInitializingWorkspace || session.repository.dartpad == null
+              ? null
+              : (example) => resetWorkspace(ProjectSource.example(example.id)),
+          onLoadSample: _isInitializingWorkspace || session.repository.dartpad == null
+              ? null
+              : (example) => resetWorkspace(ProjectSource.example(example.id)),
+        ),
       ListenableBuilder(
         key: ValueKey(_workspaceGeneration),
         listenable: session.tabs,
@@ -431,13 +438,15 @@ class AppState extends State<App> {
                 onSwitchFile: session.tabs.switchFile,
                 onCloseFile: session.tabs.closeFile,
                 bottomPanel: _buildBottomPanel(session),
+                isEmbedMode: isEmbedMode,
               ),
               right: _buildPreviewPanel(session),
             ),
           ]),
-          Footer(
-            statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
-          ),
+          if (!isEmbedMode)
+            Footer(
+              statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
+            ),
         ]),
       ),
       if (_errorMessage case final String message) ErrorDialog(errorMessage: message),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -8,11 +8,12 @@ import 'package:jaspr/jaspr.dart';
 
 import '../../../app_styles.dart';
 import '../../shared/components/split_panel.dart';
+import '../../shared/icons.dart';
 import 'editor_stack.dart';
 import 'editor_tabs.dart';
 
 /// Top-level layout shell that hosts the CodeMirror editor.
-class EditorShell extends StatelessComponent {
+class EditorShell extends StatefulComponent {
   /// Creates the top-level editor layout.
   const EditorShell({
     required this.openTabs,
@@ -22,6 +23,7 @@ class EditorShell extends StatelessComponent {
     required this.onSwitchFile,
     required this.onCloseFile,
     required this.bottomPanel,
+    this.isEmbedMode = false,
     super.key,
   }) : assert(
          openTabs == null || (onSwitchFile != null && onCloseFile != null),
@@ -49,46 +51,124 @@ class EditorShell extends StatelessComponent {
   /// Bottom panel (e.g. problems view) rendered below the editor.
   final Component bottomPanel;
 
+  /// Whether the app is running in embed mode (`?embed=true`).
+  ///
+  /// When `true`, the file tree starts collapsed into a narrow rail with a
+  /// toggle button.
+  final bool isEmbedMode;
+
+  @override
+  State<EditorShell> createState() => _EditorShellState();
+
+  @css
+  static List<StyleRule> get styles => _EditorShellState.styles;
+}
+
+class _EditorShellState extends State<EditorShell> {
+  late bool _fileTreeCollapsed;
+
+  @override
+  void initState() {
+    super.initState();
+    _fileTreeCollapsed = component.isEmbedMode;
+  }
+
+  void _toggleFileTree() {
+    setState(() {
+      _fileTreeCollapsed = !_fileTreeCollapsed;
+    });
+  }
+
   @override
   Component build(BuildContext context) {
-    final openTabs = this.openTabs;
+    final openTabs = component.openTabs;
+
+    final editorContent = main_(classes: 'editor-host', [
+      SplitPanel(
+        isVertical: true,
+        useRatio: true,
+        initialValue: 0.75,
+        minValue: 0.3,
+        maxValue: 0.9,
+        left: div(classes: 'editor-area', [
+          if (openTabs != null) ...[
+            EditorTabs(
+              openTabs: openTabs,
+              activeFile: component.activeFile,
+              onSwitchFile: component.onSwitchFile!,
+              onCloseFile: component.onCloseFile!,
+            ),
+            EditorStack(
+              openTabs: openTabs,
+              activeFile: component.activeFile,
+              overlay: component.editorOverlay,
+            ),
+          ],
+        ]),
+        right: component.bottomPanel,
+      ),
+    ]);
+
+    // In embed mode with collapsed file tree, show a narrow rail instead of
+    // the full SplitPanel with file tree.
+    if (component.isEmbedMode && _fileTreeCollapsed) {
+      return div(classes: 'editor-shell', [
+        aside(classes: 'file-tree-rail', [
+          button(
+            classes: 'file-tree-rail-button',
+            attributes: {
+              'title': 'Show file tree',
+              'aria-label': 'Show file tree',
+            },
+            onClick: _toggleFileTree,
+            [const Icon('folder_open', size: 18)],
+          ),
+        ]),
+        editorContent,
+      ]);
+    }
+
+    // In embed mode with expanded file tree, show the file tree with a
+    // collapse button in its header area.
+    if (component.isEmbedMode) {
+      return div(classes: 'editor-shell', [
+        SplitPanel(
+          initialValue: 200,
+          useRatio: false,
+          minValue: 150,
+          maxValue: 300,
+          left: aside(classes: 'file-tree-pane', [
+            div(classes: 'file-tree-collapse-bar', [
+              button(
+                classes: 'file-tree-rail-button',
+                attributes: {
+                  'title': 'Hide file tree',
+                  'aria-label': 'Hide file tree',
+                },
+                onClick: _toggleFileTree,
+                [const Icon('chevron_left', size: 18)],
+              ),
+            ]),
+            component.fileTree,
+          ]),
+          right: editorContent,
+        ),
+      ]);
+    }
+
+    // Standard (non-embed) layout.
     return div(classes: 'editor-shell', [
       SplitPanel(
         initialValue: 200,
         useRatio: false,
         minValue: 150,
         maxValue: 300,
-        left: aside(classes: 'file-tree-pane', [fileTree]),
-        right: main_(classes: 'editor-host', [
-          SplitPanel(
-            isVertical: true,
-            useRatio: true,
-            initialValue: 0.75,
-            minValue: 0.3,
-            maxValue: 0.9,
-            left: div(classes: 'editor-area', [
-              if (openTabs != null) ...[
-                EditorTabs(
-                  openTabs: openTabs,
-                  activeFile: activeFile,
-                  onSwitchFile: onSwitchFile!,
-                  onCloseFile: onCloseFile!,
-                ),
-                EditorStack(
-                  openTabs: openTabs,
-                  activeFile: activeFile,
-                  overlay: editorOverlay,
-                ),
-              ],
-            ]),
-            right: bottomPanel,
-          ),
-        ]),
+        left: aside(classes: 'file-tree-pane', [component.fileTree]),
+        right: editorContent,
       ),
     ]);
   }
 
-  @css
   static List<StyleRule> get styles => [
     css('.editor-shell').styles(
       display: .flex,
@@ -121,6 +201,52 @@ class EditorShell extends StatelessComponent {
       overflow: .hidden,
       flexDirection: .column,
       flex: const Flex(grow: 1, basis: .zero),
+    ),
+
+    // -- Embed mode: collapsed file-tree rail --
+    css('.file-tree-rail').styles(
+      display: .flex,
+      width: 36.px,
+      minWidth: 36.px,
+      padding: .only(top: 8.px),
+      border: .only(
+        right: .solid(color: colorBorder, width: 1.px),
+      ),
+      flexDirection: .column,
+      alignItems: .center,
+      flex: const .shrink(0),
+      backgroundColor: colorSurface,
+    ),
+    css('.file-tree-rail-button').styles(
+      display: .flex,
+      width: 28.px,
+      height: 28.px,
+      padding: .zero,
+      border: .none,
+      radius: .circular(6.px),
+      cursor: .pointer,
+      justifyContent: .center,
+      alignItems: .center,
+      color: colorOnSurface,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.file-tree-rail-button:hover').styles(
+      backgroundColor: colorBorder,
+    ),
+
+    // -- Embed mode: collapse bar above file tree when expanded --
+    css('.file-tree-collapse-bar').styles(
+      display: .flex,
+      height: 32.px,
+      minHeight: 32.px,
+      padding: .symmetric(horizontal: 4.px),
+      border: .only(
+        bottom: .solid(color: colorBorder, width: 1.px),
+      ),
+      justifyContent: .end,
+      alignItems: .center,
+      flex: const .shrink(0),
+      backgroundColor: colorSurface,
     ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
@@ -1,0 +1,232 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/editor/components/editor_shell.dart';
+import 'package:jaspr/dom.dart' hide path;
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+/// Minimal [EditorTab] implementation for testing [EditorShell] rendering.
+final class _FakeTab extends EditorTab<Component> {
+  _FakeTab(super.path);
+
+  @override
+  Component build() => div(id: 'editor-$path', [Component.text(path)]);
+}
+
+/// Helper that creates an [EditorShell] with sensible defaults.
+EditorShell _createShell({
+  List<EditorTab<Component>>? openTabs,
+  String activeFile = 'main.dart',
+  bool isEmbedMode = false,
+}) {
+  final tabs = openTabs ?? [_FakeTab('main.dart')];
+  return EditorShell(
+    openTabs: tabs,
+    activeFile: activeFile,
+    fileTree: const div(id: 'file-tree', [Component.text('tree')]),
+    editorOverlay: const div(id: 'editor-overlay', []),
+    onSwitchFile: (_) {},
+    onCloseFile: (_, {bool discardChanges = false}) => true,
+    bottomPanel: const div(id: 'bottom', [Component.text('bottom')]),
+    isEmbedMode: isEmbedMode,
+  );
+}
+
+void main() {
+  group('EditorShell – standard mode', () {
+    testClient('renders file tree pane and editor host', (tester) {
+      tester.pumpComponent(_createShell());
+
+      expect(web.document.querySelector('.editor-shell'), isNotNull);
+      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+      expect(web.document.querySelector('#file-tree'), isNotNull);
+    });
+
+    testClient('does not render embed-mode elements', (tester) {
+      tester.pumpComponent(_createShell());
+
+      expect(web.document.querySelector('.file-tree-rail'), isNull);
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNull);
+    });
+
+    testClient('renders without open tabs', (tester) {
+      tester.pumpComponent(_createShell(openTabs: null));
+
+      expect(web.document.querySelector('.editor-shell'), isNotNull);
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+    });
+
+    testClient('renders editor overlay', (tester) {
+      tester.pumpComponent(_createShell());
+
+      expect(web.document.querySelector('#editor-overlay'), isNotNull);
+    });
+
+    testClient('renders bottom panel', (tester) {
+      tester.pumpComponent(_createShell());
+
+      expect(web.document.querySelector('#bottom'), isNotNull);
+    });
+  });
+
+  group('EditorShell – embed mode', () {
+    testClient('starts with collapsed file tree rail', (tester) {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Collapsed: rail is visible, full file-tree pane is not.
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNull);
+    });
+
+    testClient('collapsed rail has expand button with correct aria-label', (
+      tester,
+    ) {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      final button = web.document.querySelector('.file-tree-rail .file-tree-rail-button');
+      expect(button, isNotNull);
+      expect(button!.getAttribute('aria-label'), 'Show file tree');
+      expect(button.getAttribute('title'), 'Show file tree');
+    });
+
+    testClient('editor host is still rendered when collapsed', (tester) {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+    });
+
+    testClient('clicking expand button shows file tree with collapse bar', (
+      tester,
+    ) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Initially collapsed – rail visible, pane not.
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+      expect(web.document.querySelector('.file-tree-pane'), isNull);
+
+      // Click expand button.
+      final expandButton =
+          web.document.querySelector('.file-tree-rail .file-tree-rail-button')! as web.HTMLButtonElement;
+      expandButton.click();
+      await pumpEventQueue();
+
+      // Now expanded – pane and collapse bar visible, rail gone.
+      expect(web.document.querySelector('.file-tree-rail'), isNull);
+      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNotNull);
+      expect(web.document.querySelector('#file-tree'), isNotNull);
+    });
+
+    testClient('expanded view has collapse button with correct aria-label', (
+      tester,
+    ) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Expand first.
+      (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+
+      final collapseButton = web.document.querySelector('.file-tree-collapse-bar .file-tree-rail-button');
+      expect(collapseButton, isNotNull);
+      expect(collapseButton!.getAttribute('aria-label'), 'Hide file tree');
+      expect(collapseButton.getAttribute('title'), 'Hide file tree');
+    });
+
+    testClient('clicking collapse button returns to rail', (tester) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Expand.
+      (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+
+      // Collapse.
+      (web.document.querySelector('.file-tree-collapse-bar .file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+
+      // Back to collapsed state.
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNull);
+    });
+
+    testClient('toggle cycle: collapse → expand → collapse', (tester) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // State 1: collapsed (initial).
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+
+      // Expand.
+      (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+
+      // State 2: expanded.
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNotNull);
+      expect(web.document.querySelector('.file-tree-rail'), isNull);
+
+      // Collapse.
+      (web.document.querySelector('.file-tree-collapse-bar .file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+
+      // State 3: collapsed again.
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNull);
+    });
+
+    testClient('file tree content is visible when expanded', (tester) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Collapsed: file tree is not rendered in the pane.
+      expect(web.document.querySelector('.file-tree-pane #file-tree'), isNull);
+
+      // Expand.
+      (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+
+      // File tree content is now visible inside the pane.
+      expect(web.document.querySelector('.file-tree-pane #file-tree'), isNotNull);
+    });
+
+    testClient('editor host remains through toggle cycles', (tester) async {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      // Collapsed.
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+
+      // Expand.
+      (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+
+      // Collapse again.
+      (web.document.querySelector('.file-tree-collapse-bar .file-tree-rail-button')! as web.HTMLButtonElement).click();
+      await pumpEventQueue();
+      expect(web.document.querySelector('.editor-host'), isNotNull);
+    });
+  });
+
+  group('EditorShell – isEmbedMode=false vs true comparison', () {
+    testClient('standard mode shows file tree pane directly', (tester) {
+      tester.pumpComponent(_createShell(isEmbedMode: false));
+
+      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree-rail'), isNull);
+    });
+
+    testClient('embed mode does not show file tree pane initially', (tester) {
+      tester.pumpComponent(_createShell(isEmbedMode: true));
+
+      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree-rail'), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Adds support for an embed mode optimized for iframe embedding, matching the behavior of the existing DartPad UI.

When the page is loaded with ?embed=true:

Header (AppBar) and Footer are hidden
File tree starts collapsed into a narrow 36px rail with a toggle button to expand/collapse it