### PR TITLE
Add responsive UI layout 

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -497,9 +497,7 @@ class AppState extends State<App> {
                 bottomPanel: _buildBottomPanel(session),
                 isEmbedMode: isEmbedMode,
                 mobileTabBar: isEmbedMode ? null : _buildMobileTabBar(),
-                mobilePreviewPanel: _mobileTabIndex == 1
-                    ? _buildPreviewPanel(session)
-                    : null,
+                mobilePreviewPanel: _mobileTabIndex == 1 ? _buildPreviewPanel(session) : null,
               ),
           ]),
           if (!isEmbedMode)

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -17,6 +17,7 @@ import 'features/editor/components/editor_shell.dart';
 import 'features/editor/components/error_toast.dart';
 import 'features/editor/components/pubspec_editor_actions.dart';
 import 'features/filetree/file_tree_view.dart';
+import 'features/preview/models/preview_state.dart';
 import 'features/preview/view/preview_container.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
@@ -37,6 +38,9 @@ import 'features/workspace/workspace_session.dart';
 /// When `true`, the app bar and footer are hidden and the file tree starts
 /// collapsed into a narrow rail with a toggle button.
 final bool isEmbedMode = Uri.base.queryParameters['embed'] == 'true';
+
+/// Smallest screen width when the screen is considered to be a large screen.
+const minLargeScreenWidth = 866.0;
 
 /// The deliberately small first production slice of DartPad.
 class App extends StatefulComponent {
@@ -100,19 +104,51 @@ class AppState extends State<App> {
   String _projectDir = '';
   String? _errorMessage;
 
+  bool _isLargeScreen = true;
+  int _mobileTabIndex = 0;
+  StreamSubscription<web.Event>? _resizeSubscription;
+
   @override
   void initState() {
     super.initState();
+    _isLargeScreen = web.window.innerWidth >= minLargeScreenWidth;
+    _resizeSubscription = web.EventStreamProviders.resizeEvent.forTarget(web.window).listen((_) {
+      _updateScreenSize();
+    });
+
     final events = AppEventBus();
     _session = WorkspaceSession.create(
       WorkspaceRepository.create(events: events),
     );
+    _session.preview.addListener(_onPreviewStateChanged);
     unawaited(
       _initializeWorkspace(
         _session,
         source: ProjectSource.fromUri(Uri.base),
       ),
     );
+  }
+
+  void _updateScreenSize() {
+    final isLarge = web.window.innerWidth >= minLargeScreenWidth;
+    if (_isLargeScreen != isLarge) {
+      setState(() {
+        _isLargeScreen = isLarge;
+      });
+    }
+  }
+
+  void _onPreviewStateChanged() {
+    if (!_isLargeScreen) {
+      final state = _session.preview.state;
+      if (state is PreviewStarting || state is PreviewRestarting || state is PreviewRunning) {
+        if (_mobileTabIndex != 1) {
+          setState(() {
+            _mobileTabIndex = 1;
+          });
+        }
+      }
+    }
   }
 
   bool _isCurrent(WorkspaceSession session) => mounted && identical(_session, session);
@@ -266,6 +302,8 @@ class AppState extends State<App> {
         previousWorkspaceDisposed: previousWorkspaceDisposed.future,
       ),
     );
+    oldSession.preview.removeListener(_onPreviewStateChanged);
+    nextSession.preview.addListener(_onPreviewStateChanged);
 
     final newSearch = source.search;
     if (web.window.location.search != newSearch) {
@@ -415,7 +453,7 @@ class AppState extends State<App> {
   Component build(BuildContext context) {
     final session = _session;
     return div(classes: 'app-shell', [
-      if (!isEmbedMode)
+      if (!isEmbedMode || !_isLargeScreen)
         AppBar(
           onCreateNewSnippet: _isInitializingWorkspace || session.repository.dartpad == null
               ? null
@@ -423,30 +461,59 @@ class AppState extends State<App> {
           onLoadSample: _isInitializingWorkspace || session.repository.dartpad == null
               ? null
               : (example) => resetWorkspace(ProjectSource.example(example.id)),
+          isMobile: !_isLargeScreen,
+          isEmbedMode: isEmbedMode,
+          selectedTab: _mobileTabIndex,
+          onTabSelected: (tab) => setState(() => _mobileTabIndex = tab),
         ),
       ListenableBuilder(
         key: ValueKey(_workspaceGeneration),
         listenable: session.tabs,
         builder: (context) => div(classes: 'app-workspace-container', [
           div(classes: 'app-workspace', [
-            SplitPanel(
-              initialValue: 0.7,
-              left: EditorShell(
-                openTabs: session.tabs.openTabs,
-                activeFile: session.tabs.activeFile,
-                fileTree: _buildFileTree(session),
-                editorOverlay: _buildEditorOverlay(session),
-                onSwitchFile: session.tabs.switchFile,
-                onCloseFile: session.tabs.closeFile,
-                bottomPanel: _buildBottomPanel(session),
-                isEmbedMode: isEmbedMode,
+            if (_isLargeScreen)
+              SplitPanel(
+                initialValue: 0.7,
+                left: EditorShell(
+                  openTabs: session.tabs.openTabs,
+                  activeFile: session.tabs.activeFile,
+                  fileTree: _buildFileTree(session),
+                  editorOverlay: _buildEditorOverlay(session),
+                  onSwitchFile: session.tabs.switchFile,
+                  onCloseFile: session.tabs.closeFile,
+                  bottomPanel: _buildBottomPanel(session),
+                  isEmbedMode: isEmbedMode,
+                ),
+                right: _buildPreviewPanel(session),
+              )
+            else ...[
+              div(
+                classes: 'app-workspace-mobile-pane ${_mobileTabIndex == 0 ? 'active' : 'hidden'}',
+                [
+                  EditorShell(
+                    openTabs: session.tabs.openTabs,
+                    activeFile: session.tabs.activeFile,
+                    fileTree: _buildFileTree(session),
+                    editorOverlay: _buildEditorOverlay(session),
+                    onSwitchFile: session.tabs.switchFile,
+                    onCloseFile: session.tabs.closeFile,
+                    bottomPanel: _buildBottomPanel(session),
+                    isEmbedMode: isEmbedMode,
+                  ),
+                ],
               ),
-              right: _buildPreviewPanel(session),
-            ),
+              div(
+                classes: 'app-workspace-mobile-pane ${_mobileTabIndex == 1 ? 'active' : 'hidden'}',
+                [
+                  _buildPreviewPanel(session),
+                ],
+              ),
+            ],
           ]),
           if (!isEmbedMode)
             Footer(
               statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
+              isMobile: !_isLargeScreen,
             ),
         ]),
       ),
@@ -511,6 +578,8 @@ class AppState extends State<App> {
 
   @override
   void dispose() {
+    _resizeSubscription?.cancel();
+    _session.preview.removeListener(_onPreviewStateChanged);
     unawaited(_session.dispose(closeWorker: true));
     super.dispose();
   }
@@ -536,6 +605,18 @@ class AppState extends State<App> {
       minWidth: .zero,
       minHeight: .zero,
       flex: const Flex(grow: 1, basis: .zero),
+    ),
+    css('.app-workspace-mobile-pane').styles(
+      display: .flex,
+      width: 100.percent,
+      height: 100.percent,
+      minWidth: .zero,
+      minHeight: .zero,
+      flexDirection: .column,
+      flex: const Flex(grow: 1, basis: .zero),
+    ),
+    css('.app-workspace-mobile-pane.hidden').styles(
+      display: .none,
     ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -16,6 +16,7 @@ import 'features/editor/codemirror/code_mirror_tab.dart';
 import 'features/editor/components/editor_shell.dart';
 import 'features/editor/components/error_toast.dart';
 import 'features/editor/components/pubspec_editor_actions.dart';
+import 'features/editor/components/small_screen_tab_bar.dart';
 import 'features/filetree/file_tree_view.dart';
 import 'features/preview/models/preview_state.dart';
 import 'features/preview/view/preview_container.dart';
@@ -35,7 +36,7 @@ import 'features/workspace/workspace_session.dart';
 
 /// Whether the application is running in embed mode (`?embed=true`).
 ///
-/// When `true`, the app bar and footer are hidden and the file tree starts
+/// When `true`, the [AppBar] and footer are hidden and the file tree starts
 /// collapsed into a narrow rail with a toggle button.
 final bool isEmbedMode = Uri.base.queryParameters['embed'] == 'true';
 
@@ -105,7 +106,7 @@ class AppState extends State<App> {
   String? _errorMessage;
 
   bool _isLargeScreen = true;
-  int _mobileTabIndex = 0;
+  SmallScreenTab _selectedSmallScreenTab = .code;
   StreamSubscription<web.Event>? _resizeSubscription;
 
   @override
@@ -142,9 +143,9 @@ class AppState extends State<App> {
     if (!_isLargeScreen) {
       final state = _session.preview.state;
       if (state is PreviewStarting || state is PreviewRestarting || state is PreviewRunning) {
-        if (_mobileTabIndex != 1) {
+        if (_selectedSmallScreenTab != .output) {
           setState(() {
-            _mobileTabIndex = 1;
+            _selectedSmallScreenTab = .output;
           });
         }
       }
@@ -461,10 +462,14 @@ class AppState extends State<App> {
           onLoadSample: _isInitializingWorkspace || session.repository.dartpad == null
               ? null
               : (example) => resetWorkspace(ProjectSource.example(example.id)),
-          isMobile: !_isLargeScreen,
+          isSmallScreen: !_isLargeScreen,
           isEmbedMode: isEmbedMode,
-          selectedTab: _mobileTabIndex,
-          onTabSelected: isEmbedMode ? (tab) => setState(() => _mobileTabIndex = tab) : null,
+          smallScreenTabBar: !_isLargeScreen
+              ? SmallScreenTabBar(
+                  selectedTab: _selectedSmallScreenTab,
+                  onTabSelected: (tab) => setState(() => _selectedSmallScreenTab = tab),
+                )
+              : null,
         ),
       ListenableBuilder(
         key: ValueKey(_workspaceGeneration),
@@ -496,14 +501,13 @@ class AppState extends State<App> {
                 onCloseFile: session.tabs.closeFile,
                 bottomPanel: _buildBottomPanel(session),
                 isEmbedMode: isEmbedMode,
-                mobileTabBar: isEmbedMode ? null : _buildMobileTabBar(),
-                mobilePreviewPanel: _mobileTabIndex == 1 ? _buildPreviewPanel(session) : null,
+                smallScreenPreviewPanel: _selectedSmallScreenTab == .output ? _buildPreviewPanel(session) : null,
               ),
           ]),
           if (!isEmbedMode)
             Footer(
               statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
-              isMobile: !_isLargeScreen,
+              isSmallScreen: !_isLargeScreen,
             ),
         ]),
       ),
@@ -554,27 +558,6 @@ class AppState extends State<App> {
         actions: session.fileTree.actions,
       ),
     );
-  }
-
-  Component _buildMobileTabBar() {
-    return div(classes: 'app-bar-tab-bar', [
-      button(
-        classes: 'app-bar-tab ${_mobileTabIndex == 0 ? 'active' : ''}',
-        events: {'click': (_) => setState(() => _mobileTabIndex = 0)},
-        attributes: const {'type': 'button'},
-        const [
-          span(classes: 'app-bar-tab-label', [Component.text('Code')]),
-        ],
-      ),
-      button(
-        classes: 'app-bar-tab ${_mobileTabIndex == 1 ? 'active' : ''}',
-        events: {'click': (_) => setState(() => _mobileTabIndex = 1)},
-        attributes: const {'type': 'button'},
-        const [
-          span(classes: 'app-bar-tab-label', [Component.text('Output')]),
-        ],
-      ),
-    ]);
   }
 
   Component _buildPreviewPanel(WorkspaceSession session) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -462,7 +462,6 @@ class AppState extends State<App> {
           onLoadSample: _isInitializingWorkspace || session.repository.dartpad == null
               ? null
               : (example) => resetWorkspace(ProjectSource.example(example.id)),
-          isSmallScreen: !_isLargeScreen,
           isEmbedMode: isEmbedMode,
           smallScreenTabBar: !_isLargeScreen
               ? SmallScreenTabBar(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -464,7 +464,7 @@ class AppState extends State<App> {
           isMobile: !_isLargeScreen,
           isEmbedMode: isEmbedMode,
           selectedTab: _mobileTabIndex,
-          onTabSelected: (tab) => setState(() => _mobileTabIndex = tab),
+          onTabSelected: isEmbedMode ? (tab) => setState(() => _mobileTabIndex = tab) : null,
         ),
       ListenableBuilder(
         key: ValueKey(_workspaceGeneration),
@@ -486,29 +486,21 @@ class AppState extends State<App> {
                 ),
                 right: _buildPreviewPanel(session),
               )
-            else ...[
-              div(
-                classes: 'app-workspace-mobile-pane ${_mobileTabIndex == 0 ? 'active' : 'hidden'}',
-                [
-                  EditorShell(
-                    openTabs: session.tabs.openTabs,
-                    activeFile: session.tabs.activeFile,
-                    fileTree: _buildFileTree(session),
-                    editorOverlay: _buildEditorOverlay(session),
-                    onSwitchFile: session.tabs.switchFile,
-                    onCloseFile: session.tabs.closeFile,
-                    bottomPanel: _buildBottomPanel(session),
-                    isEmbedMode: isEmbedMode,
-                  ),
-                ],
+            else
+              EditorShell(
+                openTabs: session.tabs.openTabs,
+                activeFile: session.tabs.activeFile,
+                fileTree: _buildFileTree(session),
+                editorOverlay: _buildEditorOverlay(session),
+                onSwitchFile: session.tabs.switchFile,
+                onCloseFile: session.tabs.closeFile,
+                bottomPanel: _buildBottomPanel(session),
+                isEmbedMode: isEmbedMode,
+                mobileTabBar: isEmbedMode ? null : _buildMobileTabBar(),
+                mobilePreviewPanel: _mobileTabIndex == 1
+                    ? _buildPreviewPanel(session)
+                    : null,
               ),
-              div(
-                classes: 'app-workspace-mobile-pane ${_mobileTabIndex == 1 ? 'active' : 'hidden'}',
-                [
-                  _buildPreviewPanel(session),
-                ],
-              ),
-            ],
           ]),
           if (!isEmbedMode)
             Footer(
@@ -566,6 +558,27 @@ class AppState extends State<App> {
     );
   }
 
+  Component _buildMobileTabBar() {
+    return div(classes: 'app-bar-tab-bar', [
+      button(
+        classes: 'app-bar-tab ${_mobileTabIndex == 0 ? 'active' : ''}',
+        events: {'click': (_) => setState(() => _mobileTabIndex = 0)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'app-bar-tab-label', [Component.text('Code')]),
+        ],
+      ),
+      button(
+        classes: 'app-bar-tab ${_mobileTabIndex == 1 ? 'active' : ''}',
+        events: {'click': (_) => setState(() => _mobileTabIndex = 1)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'app-bar-tab-label', [Component.text('Output')]),
+        ],
+      ),
+    ]);
+  }
+
   Component _buildPreviewPanel(WorkspaceSession session) {
     return ListenableBuilder(
       listenable: session.preview,
@@ -605,18 +618,6 @@ class AppState extends State<App> {
       minWidth: .zero,
       minHeight: .zero,
       flex: const Flex(grow: 1, basis: .zero),
-    ),
-    css('.app-workspace-mobile-pane').styles(
-      display: .flex,
-      width: 100.percent,
-      height: 100.percent,
-      minWidth: .zero,
-      minHeight: .zero,
-      flexDirection: .column,
-      flex: const Flex(grow: 1, basis: .zero),
-    ),
-    css('.app-workspace-mobile-pane.hidden').styles(
-      display: .none,
     ),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -81,7 +81,7 @@ class _EditorShellState extends State<EditorShell> {
   @override
   void initState() {
     super.initState();
-    _fileTreeCollapsed = component.isEmbedMode;
+    _fileTreeCollapsed = component.isEmbedMode || component.mobileTabBar != null;
   }
 
   void _toggleFileTree() {
@@ -119,10 +119,25 @@ class _EditorShellState extends State<EditorShell> {
         right: component.bottomPanel,
       ),
     ]);
+    // Determine the right-hand content: in mobile mode wrap with the tab bar,
+    // otherwise just the editor.
+    final Component rightContent;
+    if (component.mobileTabBar != null) {
+      rightContent = div(classes: 'editor-shell-mobile-content', [
+        component.mobileTabBar!,
+        if (component.mobilePreviewPanel != null)
+          component.mobilePreviewPanel!
+        else
+          editorContent,
+      ]);
+    } else if (component.mobilePreviewPanel != null) {
+      rightContent = component.mobilePreviewPanel!;
+    } else {
+      rightContent = editorContent;
+    }
 
-    // In embed mode with collapsed file tree, show a narrow rail instead of
-    // the full SplitPanel with file tree.
-    if (component.isEmbedMode && _fileTreeCollapsed) {
+    // Collapsed file tree: show a narrow rail with a toggle button.
+    if (_fileTreeCollapsed) {
       return div(classes: 'editor-shell', [
         aside(classes: 'file-tree-rail', [
           button(
@@ -135,65 +150,31 @@ class _EditorShellState extends State<EditorShell> {
             [const Icon('folder_open', size: 18)],
           ),
         ]),
-        editorContent,
+        rightContent,
       ]);
     }
 
-    // In embed mode with expanded file tree, show the file tree with a
-    // collapse button in its header area.
-    if (component.isEmbedMode) {
-      return div(classes: 'editor-shell', [
-        SplitPanel(
-          initialValue: 200,
-          useRatio: false,
-          minValue: 150,
-          maxValue: 300,
-          left: aside(classes: 'file-tree-pane', [
-            div(classes: 'file-tree-collapse-bar', [
-              button(
-                classes: 'file-tree-rail-button',
-                attributes: {
-                  'title': 'Hide file tree',
-                  'aria-label': 'Hide file tree',
-                },
-                onClick: _toggleFileTree,
-                [const Icon('chevron_left', size: 18)],
-              ),
-            ]),
-            component.fileTree,
-          ]),
-          right: editorContent,
-        ),
-      ]);
-    }
-
-    // Standard (non-embed) layout.
-    // When a mobile tab bar is provided, wrap the right-hand content in a
-    // column so the tab bar sits above the editor/preview area – but only
-    // spans the editor width, not the file tree.
-    final Component rightContent;
-    if (component.mobileTabBar != null) {
-      rightContent = div(classes: 'editor-shell-mobile-content', [
-        component.mobileTabBar!,
-        if (component.mobilePreviewPanel != null)
-          component.mobilePreviewPanel!
-        else
-          editorContent,
-      ]);
-    } else if (component.mobilePreviewPanel != null) {
-      // Embed mode: no tab bar, but preview replaces the editor when selected.
-      rightContent = component.mobilePreviewPanel!;
-    } else {
-      rightContent = editorContent;
-    }
-
+    // Expanded file tree with collapse button.
     return div(classes: 'editor-shell', [
       SplitPanel(
         initialValue: 200,
         useRatio: false,
         minValue: 150,
         maxValue: 300,
-        left: aside(classes: 'file-tree-pane', [component.fileTree]),
+        left: aside(classes: 'file-tree-pane', [
+          div(classes: 'file-tree-collapse-bar', [
+            button(
+              classes: 'file-tree-rail-button',
+              attributes: {
+                'title': 'Hide file tree',
+                'aria-label': 'Hide file tree',
+              },
+              onClick: _toggleFileTree,
+              [const Icon('chevron_left', size: 18)],
+            ),
+          ]),
+          component.fileTree,
+        ]),
         right: rightContent,
       ),
     ]);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -10,7 +10,7 @@ import '../../../app_styles.dart';
 import '../../shared/components/split_panel.dart';
 import '../../shared/icons.dart';
 import 'editor_stack.dart';
-import 'editor_tabs.dart';
+import 'editor_tab_bar.dart';
 
 /// Top-level layout shell that hosts the CodeMirror editor.
 class EditorShell extends StatefulComponent {
@@ -24,8 +24,7 @@ class EditorShell extends StatefulComponent {
     required this.onCloseFile,
     required this.bottomPanel,
     this.isEmbedMode = false,
-    this.mobileTabBar,
-    this.mobilePreviewPanel,
+    this.smallScreenPreviewPanel,
     super.key,
   }) : assert(
          openTabs == null || (onSwitchFile != null && onCloseFile != null),
@@ -59,14 +58,9 @@ class EditorShell extends StatefulComponent {
   /// toggle button.
   final bool isEmbedMode;
 
-  /// Optional tab bar (Code / Output) rendered above the editor in mobile
-  /// layout. When provided, the tab bar is placed to the right of the file
-  /// tree so it does not span the full screen width.
-  final Component? mobileTabBar;
-
-  /// The preview panel to show when the Output tab is active in mobile layout.
+  /// The preview panel to show when the Output tab is active in a small-screen layout.
   /// When non-null, the preview panel replaces the editor content.
-  final Component? mobilePreviewPanel;
+  final Component? smallScreenPreviewPanel;
 
   @override
   State<EditorShell> createState() => _EditorShellState();
@@ -81,7 +75,7 @@ class _EditorShellState extends State<EditorShell> {
   @override
   void initState() {
     super.initState();
-    _fileTreeCollapsed = component.isEmbedMode || component.mobileTabBar != null;
+    _fileTreeCollapsed = component.isEmbedMode;
   }
 
   void _toggleFileTree() {
@@ -103,7 +97,7 @@ class _EditorShellState extends State<EditorShell> {
         maxValue: 0.9,
         left: div(classes: 'editor-area', [
           if (openTabs != null) ...[
-            EditorTabs(
+            EditorTabBar(
               openTabs: openTabs,
               activeFile: component.activeFile,
               onSwitchFile: component.onSwitchFile!,
@@ -119,16 +113,9 @@ class _EditorShellState extends State<EditorShell> {
         right: component.bottomPanel,
       ),
     ]);
-    // Determine the right-hand content: in mobile mode wrap with the tab bar,
-    // otherwise just the editor.
     final Component rightContent;
-    if (component.mobileTabBar != null) {
-      rightContent = div(classes: 'editor-shell-mobile-content', [
-        component.mobileTabBar!,
-        if (component.mobilePreviewPanel != null) component.mobilePreviewPanel! else editorContent,
-      ]);
-    } else if (component.mobilePreviewPanel != null) {
-      rightContent = component.mobilePreviewPanel!;
+    if (component.smallScreenPreviewPanel != null) {
+      rightContent = component.smallScreenPreviewPanel!;
     } else {
       rightContent = editorContent;
     }
@@ -210,16 +197,6 @@ class _EditorShellState extends State<EditorShell> {
       flexDirection: .column,
       flex: const Flex(grow: 1, basis: .zero),
     ),
-
-    // -- Mobile layout: content column to the right of the file tree --
-    css('.editor-shell-mobile-content').styles(
-      display: .flex,
-      minWidth: .zero,
-      minHeight: .zero,
-      flexDirection: .column,
-      flex: const Flex(grow: 1, basis: .zero),
-    ),
-
     // -- Embed mode: collapsed file-tree rail --
     css('.file-tree-rail').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -113,12 +113,7 @@ class _EditorShellState extends State<EditorShell> {
         right: component.bottomPanel,
       ),
     ]);
-    final Component rightContent;
-    if (component.smallScreenPreviewPanel != null) {
-      rightContent = component.smallScreenPreviewPanel!;
-    } else {
-      rightContent = editorContent;
-    }
+    final Component rightContent = component.smallScreenPreviewPanel ?? editorContent;
 
     // Collapsed file tree: show a narrow rail with a toggle button.
     if (_fileTreeCollapsed) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -125,10 +125,7 @@ class _EditorShellState extends State<EditorShell> {
     if (component.mobileTabBar != null) {
       rightContent = div(classes: 'editor-shell-mobile-content', [
         component.mobileTabBar!,
-        if (component.mobilePreviewPanel != null)
-          component.mobilePreviewPanel!
-        else
-          editorContent,
+        if (component.mobilePreviewPanel != null) component.mobilePreviewPanel! else editorContent,
       ]);
     } else if (component.mobilePreviewPanel != null) {
       rightContent = component.mobilePreviewPanel!;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -24,6 +24,8 @@ class EditorShell extends StatefulComponent {
     required this.onCloseFile,
     required this.bottomPanel,
     this.isEmbedMode = false,
+    this.mobileTabBar,
+    this.mobilePreviewPanel,
     super.key,
   }) : assert(
          openTabs == null || (onSwitchFile != null && onCloseFile != null),
@@ -56,6 +58,15 @@ class EditorShell extends StatefulComponent {
   /// When `true`, the file tree starts collapsed into a narrow rail with a
   /// toggle button.
   final bool isEmbedMode;
+
+  /// Optional tab bar (Code / Output) rendered above the editor in mobile
+  /// layout. When provided, the tab bar is placed to the right of the file
+  /// tree so it does not span the full screen width.
+  final Component? mobileTabBar;
+
+  /// The preview panel to show when the Output tab is active in mobile layout.
+  /// When non-null, the preview panel replaces the editor content.
+  final Component? mobilePreviewPanel;
 
   @override
   State<EditorShell> createState() => _EditorShellState();
@@ -157,6 +168,25 @@ class _EditorShellState extends State<EditorShell> {
     }
 
     // Standard (non-embed) layout.
+    // When a mobile tab bar is provided, wrap the right-hand content in a
+    // column so the tab bar sits above the editor/preview area – but only
+    // spans the editor width, not the file tree.
+    final Component rightContent;
+    if (component.mobileTabBar != null) {
+      rightContent = div(classes: 'editor-shell-mobile-content', [
+        component.mobileTabBar!,
+        if (component.mobilePreviewPanel != null)
+          component.mobilePreviewPanel!
+        else
+          editorContent,
+      ]);
+    } else if (component.mobilePreviewPanel != null) {
+      // Embed mode: no tab bar, but preview replaces the editor when selected.
+      rightContent = component.mobilePreviewPanel!;
+    } else {
+      rightContent = editorContent;
+    }
+
     return div(classes: 'editor-shell', [
       SplitPanel(
         initialValue: 200,
@@ -164,7 +194,7 @@ class _EditorShellState extends State<EditorShell> {
         minValue: 150,
         maxValue: 300,
         left: aside(classes: 'file-tree-pane', [component.fileTree]),
-        right: editorContent,
+        right: rightContent,
       ),
     ]);
   }
@@ -199,6 +229,15 @@ class _EditorShellState extends State<EditorShell> {
       minWidth: .zero,
       minHeight: .zero,
       overflow: .hidden,
+      flexDirection: .column,
+      flex: const Flex(grow: 1, basis: .zero),
+    ),
+
+    // -- Mobile layout: content column to the right of the file tree --
+    css('.editor-shell-mobile-content').styles(
+      display: .flex,
+      minWidth: .zero,
+      minHeight: .zero,
       flexDirection: .column,
       flex: const Flex(grow: 1, basis: .zero),
     ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tab_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tab_bar.dart
@@ -10,13 +10,13 @@ import 'package:web/web.dart' as web;
 import '../../../app_styles.dart';
 import '../../shared/icons.dart';
 
-/// Renders a tab bar for switching between and closing open editor files.
-final class EditorTabs extends StatelessComponent {
-  /// Creates a tab strip for [openTabs].
+/// Displays open editor files and lets users switch between or close them.
+final class EditorTabBar extends StatelessComponent {
+  /// Creates an [EditorTabBar] for [openTabs].
   ///
   /// [confirmDiscard] can override the browser confirmation dialog, for
   /// example in tests.
-  const EditorTabs({
+  const EditorTabBar({
     required this.openTabs,
     required this.activeFile,
     required this.onSwitchFile,
@@ -42,7 +42,7 @@ final class EditorTabs extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'editor-tabs', [
+    return div(classes: 'editor-tab-bar', [
       for (final tab in openTabs)
         div(
           key: ValueKey('tab-${tab.path}'),
@@ -101,7 +101,7 @@ final class EditorTabs extends StatelessComponent {
 
   @css
   static List<StyleRule> get styles => [
-    css('.editor-tabs', [
+    css('.editor-tab-bar', [
       css('&').styles(
         display: .flex,
         minHeight: 38.px,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tabs.dart
@@ -129,9 +129,6 @@ final class EditorTabs extends StatelessComponent {
           backgroundColor: colorContainer.highlight(colorOnContainer, 0.15),
         ),
         css('&.active').styles(
-          border: .only(
-            top: .solid(color: colorPrimary, width: 2.px),
-          ),
           color: colorOnContainer,
           backgroundColor: colorContainer,
         ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/small_screen_tab_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/small_screen_tab_bar.dart
@@ -1,0 +1,97 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+
+import '../../../app_styles.dart';
+
+/// A tab displayed in [SmallScreenTabBar].
+enum SmallScreenTab {
+  code,
+  output,
+}
+
+/// The Code / Output [SmallScreenTabBar] displayed on small screens.
+final class SmallScreenTabBar extends StatelessComponent {
+  const SmallScreenTabBar({
+    this.selectedTab = .code,
+    required this.onTabSelected,
+    super.key,
+  });
+
+  /// The tab currently displayed in the editor area.
+  final SmallScreenTab selectedTab;
+
+  /// Called when the displayed tab changes.
+  final void Function(SmallScreenTab tab) onTabSelected;
+
+  @override
+  Component build(BuildContext context) {
+    return div(classes: 'small-screen-tab-bar', [
+      button(
+        classes: 'small-screen-tab-bar-tab ${selectedTab == .code ? 'active' : ''}',
+        events: {'click': (_) => onTabSelected(.code)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'small-screen-tab-bar-label', [Component.text('Code')]),
+        ],
+      ),
+      button(
+        classes: 'small-screen-tab-bar-tab ${selectedTab == .output ? 'active' : ''}',
+        events: {'click': (_) => onTabSelected(.output)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'small-screen-tab-bar-label', [Component.text('Output')]),
+        ],
+      ),
+    ]);
+  }
+
+  @css
+  static List<StyleRule> get styles => [
+    css('.small-screen-tab-bar').styles(
+      display: .flex,
+      height: 40.px,
+      minHeight: 40.px,
+      padding: .only(bottom: 4.px),
+      alignItems: .center,
+      backgroundColor: colorSurface,
+    ),
+    css('.small-screen-tab-bar-tab').styles(
+      display: .flex,
+      position: const .relative(),
+      height: 100.percent,
+      padding: .zero,
+      border: .none,
+      cursor: .pointer,
+      justifyContent: .center,
+      alignItems: .center,
+      flex: const Flex(grow: 1, basis: .zero),
+      color: colorOnSurface,
+      fontSize: 14.px,
+      fontWeight: .w500,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.small-screen-tab-bar-tab:hover').styles(
+      backgroundColor: colorSurface.highlight(colorOnSurface, 0.04),
+    ),
+    css('.small-screen-tab-bar-tab.active').styles(
+      color: colorPrimary,
+      fontWeight: .w600,
+    ),
+    css('.small-screen-tab-bar-tab.active::after').styles(
+      content: '',
+      position: .absolute(bottom: 0.px, left: 50.percent),
+      width: 48.px,
+      height: 3.px,
+      radius: .circular(2.px),
+      backgroundColor: colorPrimary,
+      raw: {'transform': 'translateX(-50%)'},
+    ),
+    css('.small-screen-tab-bar-label').styles(
+      whiteSpace: .noWrap,
+    ),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
@@ -191,8 +191,6 @@ class _AppBarState extends State<AppBar> {
           ),
         ]),
       ]),
-      // Mobile Tab bar placed under header bar.
-      if (isMobile) tabBar,
     ]);
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
@@ -19,6 +19,10 @@ class AppBar extends StatefulComponent {
   const AppBar({
     this.onCreateNewSnippet,
     this.onLoadSample,
+    this.isMobile = false,
+    this.isEmbedMode = false,
+    this.selectedTab = 0,
+    this.onTabSelected,
     super.key,
   });
 
@@ -27,6 +31,18 @@ class AppBar extends StatefulComponent {
 
   /// Called when the user selects a sample from the sample menu.
   final void Function(Example example)? onLoadSample;
+
+  /// Whether the app bar is being rendered in mobile (compact) layout mode.
+  final bool isMobile;
+
+  /// Whether the application is running in embed mode.
+  final bool isEmbedMode;
+
+  /// The active mobile tab index (0 = Code, 1 = Output).
+  final int selectedTab;
+
+  /// Called when the active mobile tab is switched.
+  final void Function(int tab)? onTabSelected;
 
   @override
   State<AppBar> createState() => _AppBarState();
@@ -65,102 +81,138 @@ class _AppBarState extends State<AppBar> {
   Component build(BuildContext context) {
     final isCreateDisabled = component.onCreateNewSnippet == null;
     final isSamplesDisabled = component.onLoadSample == null;
+    final isMobile = component.isMobile;
 
-    return div(classes: 'app-bar', [
-      // Left section: logo + title + create + samples.
-      div(classes: 'app-bar-left', [
-        const img(
-          src: 'images/dart_logo_192.png',
-          alt: 'Dart',
-          classes: 'app-bar-logo',
-        ),
-        const span(classes: 'app-bar-title', [.text('DartPad')]),
-        const div(classes: 'app-bar-divider', []),
-        DropdownMenu(
-          alignLeft: true,
-          disabled: isCreateDisabled,
-          trigger: button(
-            classes: 'app-bar-text-button',
+    if (component.isEmbedMode && !isMobile) {
+      return const Component.fragment([]);
+    }
+
+    final tabBar = div(classes: 'app-bar-tab-bar', [
+      button(
+        classes: 'app-bar-tab ${component.selectedTab == 0 ? 'active' : ''}',
+        events: {'click': (_) => component.onTabSelected?.call(0)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'app-bar-tab-label', [Component.text('Code')]),
+        ],
+      ),
+      button(
+        classes: 'app-bar-tab ${component.selectedTab == 1 ? 'active' : ''}',
+        events: {'click': (_) => component.onTabSelected?.call(1)},
+        attributes: const {'type': 'button'},
+        const [
+          span(classes: 'app-bar-tab-label', [Component.text('Output')]),
+        ],
+      ),
+    ]);
+
+    if (component.isEmbedMode) {
+      return tabBar;
+    }
+
+    return div(classes: 'app-bar-container', [
+      div(classes: 'app-bar', [
+        // Left section: logo + title + create + samples.
+        div(classes: 'app-bar-left', [
+          const img(
+            src: 'images/dart_logo_192.png',
+            alt: 'Dart',
+            classes: 'app-bar-logo',
+          ),
+          const span(classes: 'app-bar-title', [.text('DartPad')]),
+          const div(classes: 'app-bar-divider', []),
+          DropdownMenu(
+            alignLeft: true,
             disabled: isCreateDisabled,
-            attributes: {
-              'aria-label': 'Create a new snippet',
-              'title': 'Create a new snippet',
-            },
-            [
-              const Icon('add_circle', size: 18),
-              const span(classes: 'app-bar-button-label', [.text('Create')]),
+            trigger: button(
+              classes: 'app-bar-text-button',
+              disabled: isCreateDisabled,
+              attributes: {
+                'aria-label': 'Create a new snippet',
+                'title': 'Create a new snippet',
+              },
+              [
+                const Icon('add_circle', size: 18),
+                if (!isMobile) const span(classes: 'app-bar-button-label', [.text('Create')]),
+              ],
+            ),
+            items: [
+              for (final example in Examples.snippets)
+                DropdownMenuItem(
+                  label: example.name,
+                  leadingImage: example.icon,
+                  onPressed: () => component.onCreateNewSnippet?.call(example),
+                ),
             ],
           ),
-          items: [
-            for (final example in Examples.snippets)
-              DropdownMenuItem(
-                label: example.name,
-                leadingImage: example.icon,
-                onPressed: () => component.onCreateNewSnippet?.call(example),
-              ),
-          ],
-        ),
-        DropdownMenu(
-          alignLeft: true,
-          disabled: isSamplesDisabled,
-          trigger: button(
-            classes: 'app-bar-text-button',
+          DropdownMenu(
+            alignLeft: true,
             disabled: isSamplesDisabled,
-            attributes: {
-              'aria-label': 'Samples',
-              'title': 'Try a sample',
-            },
-            [
-              const Icon('playlist_add', size: 18),
-              const span(classes: 'app-bar-button-label', [.text('Samples')]),
+            trigger: button(
+              classes: 'app-bar-text-button',
+              disabled: isSamplesDisabled,
+              attributes: {
+                'aria-label': 'Samples',
+                'title': 'Try a sample',
+              },
+              [
+                const Icon('playlist_add', size: 18),
+                if (!isMobile) const span(classes: 'app-bar-button-label', [.text('Samples')]),
+              ],
+            ),
+            items: _buildExampleItems(),
+          ),
+        ]),
+        // Spacer.
+        const div(classes: 'app-bar-spacer', []),
+        // Right section: theme toggle + overflow menu.
+        div(classes: 'app-bar-right', [
+          const ThemeToggle(),
+          DropdownMenu(
+            trigger: const dp.IconButton(
+              icon: 'more_vert',
+              tooltip: 'More options',
+              label: 'More options',
+            ),
+            items: [
+              DropdownMenuItem(
+                label: 'Install SDK',
+                trailingIcon: 'launch',
+                onPressed: () => _openLink('https://flutter.dev/get-started'),
+              ),
+              DropdownMenuItem(
+                label: 'Sharing guide',
+                trailingIcon: 'launch',
+                onPressed: () => _openLink(
+                  'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
+                ),
+              ),
             ],
           ),
-          items: _buildExampleItems(),
-        ),
+        ]),
       ]),
-      // Spacer.
-      const div(classes: 'app-bar-spacer', []),
-      // Right section: theme toggle + overflow menu.
-      div(classes: 'app-bar-right', [
-        const ThemeToggle(),
-        DropdownMenu(
-          trigger: const dp.IconButton(
-            icon: 'more_vert',
-            tooltip: 'More options',
-            label: 'More options',
-          ),
-          items: [
-            DropdownMenuItem(
-              label: 'Install SDK',
-              trailingIcon: 'launch',
-              onPressed: () => _openLink('https://flutter.dev/get-started'),
-            ),
-            DropdownMenuItem(
-              label: 'Sharing guide',
-              trailingIcon: 'launch',
-              onPressed: () => _openLink(
-                'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
-              ),
-            ),
-          ],
-        ),
-      ]),
+      // Mobile Tab bar placed under header bar.
+      if (isMobile) tabBar,
     ]);
   }
 
   static List<StyleRule> get styles => [
+    css('.app-bar-container').styles(
+      display: .flex,
+      position: const .relative(),
+      zIndex: const ZIndex(200),
+      flexDirection: .column,
+      flex: const .shrink(0),
+    ),
     css('.app-bar').styles(
       display: .flex,
       position: const .relative(),
-      // File-tree folder rows are sticky and use z-indices up to 100. Keep
-      // the whole app bar above that stacking context so dropdowns are never
-      // painted behind the workspace.
       zIndex: const ZIndex(200),
       height: 48.px,
       minHeight: 48.px,
       padding: .symmetric(horizontal: 12.px),
       border: .only(
-        bottom: .solid(color: colorBorder, width: 2.px),
+        bottom: .solid(color: colorBorder, width: 1.px),
       ),
       alignItems: .center,
       gap: Gap.all(8.px),
@@ -176,6 +228,50 @@ class _AppBarState extends State<AppBar> {
     ),
     css('.app-bar-spacer').styles(
       flex: const Flex(grow: 1),
+    ),
+    css('.app-bar-tab-bar').styles(
+      display: .flex,
+      height: 40.px,
+      minHeight: 40.px,
+      border: .only(
+        bottom: .solid(color: colorBorder, width: 2.px),
+      ),
+      alignItems: .center,
+      backgroundColor: colorSurface,
+    ),
+    css('.app-bar-tab').styles(
+      display: .flex,
+      position: const .relative(),
+      height: 100.percent,
+      padding: .zero,
+      border: .none,
+      cursor: .pointer,
+      justifyContent: .center,
+      alignItems: .center,
+      flex: const Flex(grow: 1, basis: .zero),
+      color: colorOnSurface,
+      fontSize: 14.px,
+      fontWeight: .w500,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.app-bar-tab:hover').styles(
+      backgroundColor: colorSurface.highlight(colorOnSurface, 0.04),
+    ),
+    css('.app-bar-tab.active').styles(
+      color: colorPrimary,
+      fontWeight: .w600,
+    ),
+    css('.app-bar-tab.active::after').styles(
+      content: '',
+      position: .absolute(bottom: 0.px, left: 50.percent),
+      width: 48.px,
+      height: 3.px,
+      radius: .circular(2.px),
+      backgroundColor: colorPrimary,
+      raw: {'transform': 'translateX(-50%)'},
+    ),
+    css('.app-bar-tab-label').styles(
+      whiteSpace: .noWrap,
     ),
     css('.app-bar-right').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
@@ -7,24 +7,27 @@ import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
+import '../../editor/components/small_screen_tab_bar.dart';
 import '../../startup/examples.g.dart';
 import '../icons.dart';
 import 'dropdown_menu.dart';
 import 'icon_button.dart' as dp;
 import 'theme_toggle.dart';
 
-/// The main application bar with the DartPad logo, title, theme toggle, and
+/// The main [AppBar] with the DartPad logo, title, theme toggle, and
 /// overflow menu.
 class AppBar extends StatefulComponent {
   const AppBar({
     this.onCreateNewSnippet,
     this.onLoadSample,
-    this.isMobile = false,
+    this.isSmallScreen = false,
     this.isEmbedMode = false,
-    this.selectedTab = 0,
-    this.onTabSelected,
+    this.smallScreenTabBar,
     super.key,
-  });
+  }) : assert(
+         smallScreenTabBar == null || isSmallScreen,
+         'A SmallScreenTabBar requires a small-screen layout.',
+       );
 
   /// Called when the user selects a snippet from the Create menu.
   final void Function(Example example)? onCreateNewSnippet;
@@ -32,17 +35,14 @@ class AppBar extends StatefulComponent {
   /// Called when the user selects a sample from the sample menu.
   final void Function(Example example)? onLoadSample;
 
-  /// Whether the app bar is being rendered in mobile (compact) layout mode.
-  final bool isMobile;
+  /// Whether this [AppBar] is being rendered in a small-screen layout.
+  final bool isSmallScreen;
 
   /// Whether the application is running in embed mode.
   final bool isEmbedMode;
 
-  /// The active mobile tab index (0 = Code, 1 = Output).
-  final int selectedTab;
-
-  /// Called when the active mobile tab is switched.
-  final void Function(int tab)? onTabSelected;
+  /// Code / Output [SmallScreenTabBar] displayed in small-screen layouts.
+  final SmallScreenTabBar? smallScreenTabBar;
 
   @override
   State<AppBar> createState() => _AppBarState();
@@ -79,118 +79,107 @@ class _AppBarState extends State<AppBar> {
 
   @override
   Component build(BuildContext context) {
+    return switch ((component.isEmbedMode, component.isSmallScreen)) {
+      // Large embedded layouts show neither AppBar nor SmallScreenTabBar.
+      (true, false) => const Component.fragment([]),
+      // Small embedded layouts show only SmallScreenTabBar.
+      (true, true) => component.smallScreenTabBar ?? const Component.fragment([]),
+      // Large standalone layouts show AppBar.
+      (false, false) => _buildAppBar(),
+      // Small standalone layouts show AppBar and SmallScreenTabBar.
+      (false, true) => _buildAppBar(component.smallScreenTabBar),
+    };
+  }
+
+  Component _buildAppBar([SmallScreenTabBar? smallScreenTabBar]) {
     final isCreateDisabled = component.onCreateNewSnippet == null;
     final isSamplesDisabled = component.onLoadSample == null;
-    final isMobile = component.isMobile;
+    final isSmallScreen = component.isSmallScreen;
 
-    if (component.isEmbedMode && !isMobile) {
-      return const Component.fragment([]);
-    }
-
-    final tabBar = div(classes: 'app-bar-tab-bar', [
-      button(
-        classes: 'app-bar-tab ${component.selectedTab == 0 ? 'active' : ''}',
-        events: {'click': (_) => component.onTabSelected?.call(0)},
-        attributes: const {'type': 'button'},
-        const [
-          span(classes: 'app-bar-tab-label', [Component.text('Code')]),
-        ],
-      ),
-      button(
-        classes: 'app-bar-tab ${component.selectedTab == 1 ? 'active' : ''}',
-        events: {'click': (_) => component.onTabSelected?.call(1)},
-        attributes: const {'type': 'button'},
-        const [
-          span(classes: 'app-bar-tab-label', [Component.text('Output')]),
-        ],
-      ),
+    final appBar = div(classes: 'app-bar', [
+      // Left section: logo + title + create + samples.
+      div(classes: 'app-bar-left', [
+        const img(
+          src: 'images/dart_logo_192.png',
+          alt: 'Dart',
+          classes: 'app-bar-logo',
+        ),
+        const span(classes: 'app-bar-title', [.text('DartPad')]),
+        const div(classes: 'app-bar-divider', []),
+        DropdownMenu(
+          alignLeft: true,
+          disabled: isCreateDisabled,
+          trigger: button(
+            classes: 'app-bar-text-button',
+            disabled: isCreateDisabled,
+            attributes: {
+              'aria-label': 'Create a new snippet',
+              'title': 'Create a new snippet',
+            },
+            [
+              const Icon('add_circle', size: 18),
+              if (!isSmallScreen) const span(classes: 'app-bar-button-label', [.text('Create')]),
+            ],
+          ),
+          items: [
+            for (final example in Examples.snippets)
+              DropdownMenuItem(
+                label: example.name,
+                leadingImage: example.icon,
+                onPressed: () => component.onCreateNewSnippet?.call(example),
+              ),
+          ],
+        ),
+        DropdownMenu(
+          alignLeft: true,
+          disabled: isSamplesDisabled,
+          trigger: button(
+            classes: 'app-bar-text-button',
+            disabled: isSamplesDisabled,
+            attributes: {
+              'aria-label': 'Samples',
+              'title': 'Try a sample',
+            },
+            [
+              const Icon('playlist_add', size: 18),
+              if (!isSmallScreen) const span(classes: 'app-bar-button-label', [.text('Samples')]),
+            ],
+          ),
+          items: _buildExampleItems(),
+        ),
+      ]),
+      // Spacer.
+      const div(classes: 'app-bar-spacer', []),
+      // Right section: theme toggle + overflow menu.
+      div(classes: 'app-bar-right', [
+        const ThemeToggle(),
+        DropdownMenu(
+          trigger: const dp.IconButton(
+            icon: 'more_vert',
+            tooltip: 'More options',
+            label: 'More options',
+          ),
+          items: [
+            DropdownMenuItem(
+              label: 'Install SDK',
+              trailingIcon: 'launch',
+              onPressed: () => _openLink('https://flutter.dev/get-started'),
+            ),
+            DropdownMenuItem(
+              label: 'Sharing guide',
+              trailingIcon: 'launch',
+              onPressed: () => _openLink(
+                'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
+              ),
+            ),
+          ],
+        ),
+      ]),
     ]);
 
-    if (component.isEmbedMode) {
-      return tabBar;
-    }
-
     return div(classes: 'app-bar-container', [
-      div(classes: 'app-bar', [
-        // Left section: logo + title + create + samples.
-        div(classes: 'app-bar-left', [
-          const img(
-            src: 'images/dart_logo_192.png',
-            alt: 'Dart',
-            classes: 'app-bar-logo',
-          ),
-          const span(classes: 'app-bar-title', [.text('DartPad')]),
-          const div(classes: 'app-bar-divider', []),
-          DropdownMenu(
-            alignLeft: true,
-            disabled: isCreateDisabled,
-            trigger: button(
-              classes: 'app-bar-text-button',
-              disabled: isCreateDisabled,
-              attributes: {
-                'aria-label': 'Create a new snippet',
-                'title': 'Create a new snippet',
-              },
-              [
-                const Icon('add_circle', size: 18),
-                if (!isMobile) const span(classes: 'app-bar-button-label', [.text('Create')]),
-              ],
-            ),
-            items: [
-              for (final example in Examples.snippets)
-                DropdownMenuItem(
-                  label: example.name,
-                  leadingImage: example.icon,
-                  onPressed: () => component.onCreateNewSnippet?.call(example),
-                ),
-            ],
-          ),
-          DropdownMenu(
-            alignLeft: true,
-            disabled: isSamplesDisabled,
-            trigger: button(
-              classes: 'app-bar-text-button',
-              disabled: isSamplesDisabled,
-              attributes: {
-                'aria-label': 'Samples',
-                'title': 'Try a sample',
-              },
-              [
-                const Icon('playlist_add', size: 18),
-                if (!isMobile) const span(classes: 'app-bar-button-label', [.text('Samples')]),
-              ],
-            ),
-            items: _buildExampleItems(),
-          ),
-        ]),
-        // Spacer.
-        const div(classes: 'app-bar-spacer', []),
-        // Right section: theme toggle + overflow menu.
-        div(classes: 'app-bar-right', [
-          const ThemeToggle(),
-          DropdownMenu(
-            trigger: const dp.IconButton(
-              icon: 'more_vert',
-              tooltip: 'More options',
-              label: 'More options',
-            ),
-            items: [
-              DropdownMenuItem(
-                label: 'Install SDK',
-                trailingIcon: 'launch',
-                onPressed: () => _openLink('https://flutter.dev/get-started'),
-              ),
-              DropdownMenuItem(
-                label: 'Sharing guide',
-                trailingIcon: 'launch',
-                onPressed: () => _openLink(
-                  'https://github.com/dart-lang/dart-pad/wiki/Sharing-Guide',
-                ),
-              ),
-            ],
-          ),
-        ]),
-      ]),
+      appBar,
+      ?smallScreenTabBar,
     ]);
   }
 
@@ -226,48 +215,6 @@ class _AppBarState extends State<AppBar> {
     ),
     css('.app-bar-spacer').styles(
       flex: const Flex(grow: 1),
-    ),
-    css('.app-bar-tab-bar').styles(
-      display: .flex,
-      height: 40.px,
-      minHeight: 40.px,
-      padding: .only(bottom: 4.px),
-      alignItems: .center,
-      backgroundColor: colorSurface,
-    ),
-    css('.app-bar-tab').styles(
-      display: .flex,
-      position: const .relative(),
-      height: 100.percent,
-      padding: .zero,
-      border: .none,
-      cursor: .pointer,
-      justifyContent: .center,
-      alignItems: .center,
-      flex: const Flex(grow: 1, basis: .zero),
-      color: colorOnSurface,
-      fontSize: 14.px,
-      fontWeight: .w500,
-      backgroundColor: Colors.transparent,
-    ),
-    css('.app-bar-tab:hover').styles(
-      backgroundColor: colorSurface.highlight(colorOnSurface, 0.04),
-    ),
-    css('.app-bar-tab.active').styles(
-      color: colorPrimary,
-      fontWeight: .w600,
-    ),
-    css('.app-bar-tab.active::after').styles(
-      content: '',
-      position: .absolute(bottom: 0.px, left: 50.percent),
-      width: 48.px,
-      height: 3.px,
-      radius: .circular(2.px),
-      backgroundColor: colorPrimary,
-      raw: {'transform': 'translateX(-50%)'},
-    ),
-    css('.app-bar-tab-label').styles(
-      whiteSpace: .noWrap,
     ),
     css('.app-bar-right').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
@@ -231,9 +231,7 @@ class _AppBarState extends State<AppBar> {
       display: .flex,
       height: 40.px,
       minHeight: 40.px,
-      border: .only(
-        bottom: .solid(color: colorBorder, width: 2.px),
-      ),
+      padding: .only(bottom: 4.px),
       alignItems: .center,
       backgroundColor: colorSurface,
     ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/app_bar.dart
@@ -20,14 +20,10 @@ class AppBar extends StatefulComponent {
   const AppBar({
     this.onCreateNewSnippet,
     this.onLoadSample,
-    this.isSmallScreen = false,
     this.isEmbedMode = false,
     this.smallScreenTabBar,
     super.key,
-  }) : assert(
-         smallScreenTabBar == null || isSmallScreen,
-         'A SmallScreenTabBar requires a small-screen layout.',
-       );
+  });
 
   /// Called when the user selects a snippet from the Create menu.
   final void Function(Example example)? onCreateNewSnippet;
@@ -35,14 +31,14 @@ class AppBar extends StatefulComponent {
   /// Called when the user selects a sample from the sample menu.
   final void Function(Example example)? onLoadSample;
 
-  /// Whether this [AppBar] is being rendered in a small-screen layout.
-  final bool isSmallScreen;
-
   /// Whether the application is running in embed mode.
   final bool isEmbedMode;
 
   /// Code / Output [SmallScreenTabBar] displayed in small-screen layouts.
   final SmallScreenTabBar? smallScreenTabBar;
+
+  /// Whether this [AppBar] is being rendered in a small-screen layout.
+  bool get isSmallScreen => smallScreenTabBar != null;
 
   @override
   State<AppBar> createState() => _AppBarState();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -18,15 +18,15 @@ final class Footer extends StatefulComponent {
   /// Creates the application footer.
   const Footer({
     required this.statusLabel,
-    this.isMobile = false,
+    this.isSmallScreen = false,
     super.key,
   });
 
   /// Human-readable label for the current application status.
   final String statusLabel;
 
-  /// Whether the footer is rendered in mobile layout mode.
-  final bool isMobile;
+  /// Whether the footer is rendered in a small-screen layout.
+  final bool isSmallScreen;
 
   @override
   State<Footer> createState() => _FooterState();
@@ -107,7 +107,7 @@ class _FooterState extends State<Footer> {
             tooltip: 'Keyboard shortcuts',
             onClick: (_) => _openShortcuts(),
           ),
-          if (!component.isMobile) ...[
+          if (!component.isSmallScreen) ...[
             _buildPrivacyNoticeLink(),
             _buildFeedbackLink(),
           ],

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -18,11 +18,15 @@ final class Footer extends StatefulComponent {
   /// Creates the application footer.
   const Footer({
     required this.statusLabel,
+    this.isMobile = false,
     super.key,
   });
 
   /// Human-readable label for the current application status.
   final String statusLabel;
+
+  /// Whether the footer is rendered in mobile layout mode.
+  final bool isMobile;
 
   @override
   State<Footer> createState() => _FooterState();
@@ -103,8 +107,10 @@ class _FooterState extends State<Footer> {
             tooltip: 'Keyboard shortcuts',
             onClick: (_) => _openShortcuts(),
           ),
-          _buildPrivacyNoticeLink(),
-          _buildFeedbackLink(),
+          if (!component.isMobile) ...[
+            _buildPrivacyNoticeLink(),
+            _buildFeedbackLink(),
+          ],
         ]),
         div(
           classes: 'app-footer-runtime-versions',

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
@@ -50,11 +50,12 @@ void main() {
       expect(web.document.querySelector('#file-tree'), isNotNull);
     });
 
-    testClient('does not render embed-mode elements', (tester) {
+    testClient('does not render collapsed rail in standard mode', (tester) {
       tester.pumpComponent(_createShell());
 
       expect(web.document.querySelector('.file-tree-rail'), isNull);
-      expect(web.document.querySelector('.file-tree-collapse-bar'), isNull);
+      // Collapse bar is always shown when the file tree is expanded.
+      expect(web.document.querySelector('.file-tree-collapse-bar'), isNotNull);
     });
 
     testClient('renders without open tabs', (tester) {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -16,7 +16,7 @@ import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab.dart
 import 'package:dartpad_frontend/features/editor/codemirror/code_mirror_tab_adapter.dart';
 import 'package:dartpad_frontend/features/editor/components/code_action_panel.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_stack.dart';
-import 'package:dartpad_frontend/features/editor/components/editor_tabs.dart';
+import 'package:dartpad_frontend/features/editor/components/editor_tab_bar.dart';
 import 'package:dartpad_frontend/features/editor/view_models/tabs_view_model.dart';
 import 'package:dartpad_frontend/features/startup/example_project.dart';
 import 'package:jaspr/jaspr.dart';
@@ -208,7 +208,7 @@ void main() {
     mainTab.editor.text = '${mainTab.content}\n// dirty';
 
     tester.pumpComponent(
-      EditorTabs(
+      EditorTabBar(
         openTabs: tabs!.openTabs,
         activeFile: tabs!.activeFile,
         onSwitchFile: tabs!.switchFile,
@@ -227,7 +227,7 @@ void main() {
     var shouldDiscard = false;
 
     tester.pumpComponent(
-      EditorTabs(
+      EditorTabBar(
         openTabs: tabs!.openTabs,
         activeFile: tabs!.activeFile,
         onSwitchFile: tabs!.switchFile,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
@@ -69,4 +69,63 @@ void main() {
     expect(selectedExampleId, 'fibonacci');
     expect(web.document.querySelector('.dropdown-menu-panel-left'), isNull);
   });
+
+  testClient('renders desktop layout with button labels and without mobile tabs', (tester) {
+    tester.pumpComponent(const AppBar(isMobile: false));
+
+    final labels = web.document.querySelectorAll('.app-bar-button-label');
+    expect(labels.length, 2);
+    expect((labels.item(0)! as web.HTMLElement).textContent, 'Create');
+    expect((labels.item(1)! as web.HTMLElement).textContent, 'Examples');
+
+    final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
+    expect(mobileTabs, isNull);
+  });
+
+  testClient('renders mobile layout without button labels and with mobile tabs', (tester) async {
+    int? activeTab;
+    tester.pumpComponent(
+      AppBar(
+        isMobile: true,
+        selectedTab: 0,
+        onTabSelected: (tab) => activeTab = tab,
+      ),
+    );
+
+    final labels = web.document.querySelectorAll('.app-bar-button-label');
+    expect(labels.length, 0);
+
+    final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
+    expect(mobileTabs, isNotNull);
+
+    final tabs = web.document.querySelectorAll('.app-bar-tab');
+    expect(tabs.length, 2);
+    expect((tabs.item(0)! as web.HTMLButtonElement).textContent, 'Code');
+    expect((tabs.item(0)! as web.HTMLButtonElement).classList.contains('active'), isTrue);
+    expect((tabs.item(1)! as web.HTMLButtonElement).textContent, 'Output');
+    expect((tabs.item(1)! as web.HTMLButtonElement).classList.contains('active'), isFalse);
+
+    (tabs.item(1)! as web.HTMLButtonElement).click();
+    await pumpEventQueue();
+    expect(activeTab, 1);
+  });
+
+  testClient('renders nothing in desktop embed mode', (tester) {
+    tester.pumpComponent(const AppBar(isMobile: false, isEmbedMode: true));
+
+    expect(web.document.querySelector('.app-bar'), isNull);
+    expect(web.document.querySelector('.app-bar-tab-bar'), isNull);
+  });
+
+  testClient('renders only tab bar in mobile embed mode', (tester) {
+    tester.pumpComponent(const AppBar(isMobile: true, isEmbedMode: true));
+
+    expect(web.document.querySelector('.app-bar'), isNull);
+    expect(web.document.querySelector('.app-bar-tab-bar'), isNotNull);
+
+    final tabs = web.document.querySelectorAll('.app-bar-tab');
+    expect(tabs.length, 2);
+  });
 }
+
+

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
@@ -5,6 +5,7 @@
 @TestOn('browser')
 library;
 
+import 'package:dartpad_frontend/features/editor/components/small_screen_tab_bar.dart';
 import 'package:dartpad_frontend/features/shared/components/app_bar.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
@@ -70,46 +71,58 @@ void main() {
     expect(web.document.querySelector('.dropdown-menu-panel-left'), isNull);
   });
 
-  testClient('renders desktop layout with button labels and without mobile tabs', (tester) {
-    tester.pumpComponent(const AppBar(isMobile: false));
+  testClient('renders AppBar with button labels and without SmallScreenTabBar on large screens', (tester) {
+    tester.pumpComponent(const AppBar(isSmallScreen: false));
 
     final labels = web.document.querySelectorAll('.app-bar-button-label');
     expect(labels.length, 2);
     expect((labels.item(0)! as web.HTMLElement).textContent, 'Create');
     expect((labels.item(1)! as web.HTMLElement).textContent, 'Samples');
 
-    final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
-    expect(mobileTabs, isNull);
+    final smallScreenTabBar = web.document.querySelector('.small-screen-tab-bar');
+    expect(smallScreenTabBar, isNull);
   });
 
-  testClient('renders mobile layout without button labels and without mobile tabs', (tester) {
+  testClient('renders AppBar and SmallScreenTabBar on small screens', (tester) {
     tester.pumpComponent(
-      const AppBar(isMobile: true),
+      AppBar(
+        isSmallScreen: true,
+        smallScreenTabBar: SmallScreenTabBar(onTabSelected: (_) {}),
+      ),
     );
 
     final labels = web.document.querySelectorAll('.app-bar-button-label');
     expect(labels.length, 0);
 
-    // Mobile tab bar is no longer rendered inside AppBar; it is handled
-    // by EditorShell so it only spans the editor/preview width.
-    final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
-    expect(mobileTabs, isNull);
+    final smallScreenTabBar = web.document.querySelector('.small-screen-tab-bar');
+    expect(smallScreenTabBar, isNotNull);
   });
 
-  testClient('renders nothing in desktop embed mode', (tester) {
-    tester.pumpComponent(const AppBar(isMobile: false, isEmbedMode: true));
+  testClient('renders nothing in large-screen embed mode', (tester) {
+    tester.pumpComponent(const AppBar(isSmallScreen: false, isEmbedMode: true));
 
     expect(web.document.querySelector('.app-bar'), isNull);
-    expect(web.document.querySelector('.app-bar-tab-bar'), isNull);
+    expect(web.document.querySelector('.small-screen-tab-bar'), isNull);
   });
 
-  testClient('renders only tab bar in mobile embed mode', (tester) {
-    tester.pumpComponent(const AppBar(isMobile: true, isEmbedMode: true));
+  testClient('renders only SmallScreenTabBar in small-screen embed mode', (tester) {
+    var selectedTab = SmallScreenTab.code;
+    tester.pumpComponent(
+      AppBar(
+        isSmallScreen: true,
+        isEmbedMode: true,
+        smallScreenTabBar: SmallScreenTabBar(
+          onTabSelected: (tab) => selectedTab = tab,
+        ),
+      ),
+    );
 
     expect(web.document.querySelector('.app-bar'), isNull);
-    expect(web.document.querySelector('.app-bar-tab-bar'), isNotNull);
+    expect(web.document.querySelector('.small-screen-tab-bar'), isNotNull);
 
-    final tabs = web.document.querySelectorAll('.app-bar-tab');
+    final tabs = web.document.querySelectorAll('.small-screen-tab-bar-tab');
     expect(tabs.length, 2);
+    (tabs.item(1)! as web.HTMLButtonElement).click();
+    expect(selectedTab, SmallScreenTab.output);
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
@@ -127,5 +127,3 @@ void main() {
     expect(tabs.length, 2);
   });
 }
-
-

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
@@ -72,7 +72,7 @@ void main() {
   });
 
   testClient('renders AppBar with button labels and without SmallScreenTabBar on large screens', (tester) {
-    tester.pumpComponent(const AppBar(isSmallScreen: false));
+    tester.pumpComponent(const AppBar());
 
     final labels = web.document.querySelectorAll('.app-bar-button-label');
     expect(labels.length, 2);
@@ -86,7 +86,6 @@ void main() {
   testClient('renders AppBar and SmallScreenTabBar on small screens', (tester) {
     tester.pumpComponent(
       AppBar(
-        isSmallScreen: true,
         smallScreenTabBar: SmallScreenTabBar(onTabSelected: (_) {}),
       ),
     );
@@ -99,7 +98,7 @@ void main() {
   });
 
   testClient('renders nothing in large-screen embed mode', (tester) {
-    tester.pumpComponent(const AppBar(isSmallScreen: false, isEmbedMode: true));
+    tester.pumpComponent(const AppBar(isEmbedMode: true));
 
     expect(web.document.querySelector('.app-bar'), isNull);
     expect(web.document.querySelector('.small-screen-tab-bar'), isNull);
@@ -109,7 +108,6 @@ void main() {
     var selectedTab = SmallScreenTab.code;
     tester.pumpComponent(
       AppBar(
-        isSmallScreen: true,
         isEmbedMode: true,
         smallScreenTabBar: SmallScreenTabBar(
           onTabSelected: (tab) => selectedTab = tab,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/app_bar_test.dart
@@ -76,38 +76,24 @@ void main() {
     final labels = web.document.querySelectorAll('.app-bar-button-label');
     expect(labels.length, 2);
     expect((labels.item(0)! as web.HTMLElement).textContent, 'Create');
-    expect((labels.item(1)! as web.HTMLElement).textContent, 'Examples');
+    expect((labels.item(1)! as web.HTMLElement).textContent, 'Samples');
 
     final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
     expect(mobileTabs, isNull);
   });
 
-  testClient('renders mobile layout without button labels and with mobile tabs', (tester) async {
-    int? activeTab;
+  testClient('renders mobile layout without button labels and without mobile tabs', (tester) {
     tester.pumpComponent(
-      AppBar(
-        isMobile: true,
-        selectedTab: 0,
-        onTabSelected: (tab) => activeTab = tab,
-      ),
+      const AppBar(isMobile: true),
     );
 
     final labels = web.document.querySelectorAll('.app-bar-button-label');
     expect(labels.length, 0);
 
+    // Mobile tab bar is no longer rendered inside AppBar; it is handled
+    // by EditorShell so it only spans the editor/preview width.
     final mobileTabs = web.document.querySelector('.app-bar-tab-bar');
-    expect(mobileTabs, isNotNull);
-
-    final tabs = web.document.querySelectorAll('.app-bar-tab');
-    expect(tabs.length, 2);
-    expect((tabs.item(0)! as web.HTMLButtonElement).textContent, 'Code');
-    expect((tabs.item(0)! as web.HTMLButtonElement).classList.contains('active'), isTrue);
-    expect((tabs.item(1)! as web.HTMLButtonElement).textContent, 'Output');
-    expect((tabs.item(1)! as web.HTMLButtonElement).classList.contains('active'), isFalse);
-
-    (tabs.item(1)! as web.HTMLButtonElement).click();
-    await pumpEventQueue();
-    expect(activeTab, 1);
+    expect(mobileTabs, isNull);
   });
 
   testClient('renders nothing in desktop embed mode', (tester) {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
@@ -11,7 +11,7 @@ import 'package:web/web.dart' as web;
 
 void main() {
   testClient('renders desktop footer with privacy and feedback links', (tester) {
-    tester.pumpComponent(const Footer(statusLabel: 'Ready', isMobile: false));
+    tester.pumpComponent(const Footer(statusLabel: 'Ready', isSmallScreen: false));
 
     final links = web.document.querySelectorAll('.app-footer-link');
     expect(links.length, 2);
@@ -20,8 +20,8 @@ void main() {
     expect(status?.textContent, 'Ready');
   });
 
-  testClient('renders mobile footer without privacy and feedback links', (tester) {
-    tester.pumpComponent(const Footer(statusLabel: 'Ready', isMobile: true));
+  testClient('renders small-screen footer without privacy and feedback links', (tester) {
+    tester.pumpComponent(const Footer(statusLabel: 'Ready', isSmallScreen: true));
 
     final links = web.document.querySelectorAll('.app-footer-link');
     expect(links.length, 0);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/footer.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  testClient('renders desktop footer with privacy and feedback links', (tester) {
+    tester.pumpComponent(const Footer(statusLabel: 'Ready', isMobile: false));
+
+    final links = web.document.querySelectorAll('.app-footer-link');
+    expect(links.length, 2);
+
+    final status = web.document.querySelector('.app-footer-status');
+    expect(status?.textContent, 'Ready');
+  });
+
+  testClient('renders mobile footer without privacy and feedback links', (tester) {
+    tester.pumpComponent(const Footer(statusLabel: 'Ready', isMobile: true));
+
+    final links = web.document.querySelectorAll('.app-footer-link');
+    expect(links.length, 0);
+
+    final status = web.document.querySelector('.app-footer-status');
+    expect(status?.textContent, 'Ready');
+  });
+}


### PR DESCRIPTION
**- Responsive Layout:** Adds minLargeScreenWidth = 866.0 breakpoint and reactive window resize tracking. Switches between desktop SplitPanel and mobile Code / Output panes 
**- AppBar & TabBar:** Renders a dedicated full-width tab bar (Code / Output) under the header on mobile and collapses action button labels to icons.
**- Footer**: Hides feedback/privacy links on mobile to fit smaller screens.

<img width="823" height="1297" alt="grafik" src="https://github.com/user-attachments/assets/95ebf722-572d-4a89-91ee-136ec332b7b4" />
