### PR TITLE
feat(dartpad-preview): add dart lsp highlting to tooltips

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -21159,7 +21159,8 @@
         const dartLanguage = new Language(dataFacet, customParser, [
             indentUnit.of("  "),
             indentService.of(dartIndent),
-        ]);
+        ], // extensions
+        "dart");
         return new LanguageSupport(dartLanguage, [
             indentUnit.of("  "),
         ]);

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/languages.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/languages.dart
@@ -39,6 +39,13 @@ external JSAny sass();
 @JS()
 external JSAny sql();
 
+/// Returns the full Dart editor extension bundle as a jsified array:
+/// `[LanguageSupport, languageData (commentTokens), keymap (toggle comment)]`.
+///
+/// **Not to be confused with [dartLanguage]**, which returns a single
+/// `LanguageSupport` object. Use [dartLanguage] when only the language
+/// definition is needed (e.g. for the LSP client's `highlightLanguage`
+/// callback). Use [dart] when setting up a full editor instance.
 JSObject dart() {
   final language = dartLanguage();
 

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/lsp_client.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/lsp_client.dart
@@ -72,7 +72,9 @@ class CodeMirrorLspClient {
     void Function(String) sendToServer,
     String rootUri, {
     required Future<void> Function(String) onDisplayFile,
-    required JSAny language,
+    // Expects a JS LanguageSupport object (from dartLanguage()), not the
+    // bundled array returned by dart().
+    required JSObject language,
   }) {
     late final CodeMirrorLspClient instance;
 

--- a/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
@@ -9,8 +9,9 @@ import { Text } from "@codemirror/state";
 import type { EditorView } from "@codemirror/view";
 import { LSPPlugin } from "@codemirror/lsp-client";
 
-import { CMWorkspace } from "../src/lspClient";
+import { CMWorkspace, createLspClient } from "../src/lspClient";
 import { formatDocument, formatDocumentAsync } from "../src/formatting";
+import { dartLanguage } from "codemirror-lang-dart";
 
 function fakeView(contents: string): EditorView {
   return {
@@ -254,3 +255,39 @@ test("formatDocument remains a synchronous CodeMirror command", () => {
     LSPPlugin.get = originalGet;
   }
 });
+
+test("dartLanguage produces a Language with name 'dart'", () => {
+  const stubParse = () => new Int32Array(0);
+  const support = dartLanguage(stubParse);
+
+  assert.ok(support.language, "language property should exist");
+  assert.equal(support.language.name, "dart");
+  assert.ok(support.language.parser, "language should have a parser");
+});
+
+test("createLspClient accepts dartLanguage() and language.name is 'dart'", () => {
+  const stubParse = () => new Int32Array(0);
+  const support = dartLanguage(stubParse);
+
+  const bindings = createLspClient(
+    () => {},
+    "file:///workspace",
+    () => {},
+    () => {},
+    [],
+    support,
+  );
+
+  // This is a smoke test: the highlightLanguage callback inside
+  // createLspClient matches on `language.language.name === "dart"`, but
+  // that callback is not exposed outside createLspClient, so we cannot
+  // call it directly. Instead we verify the precondition it depends on:
+  // that language.name is set to "dart". The first test above asserts
+  // this property, and together they ensure the callback will match.
+  assert.ok(bindings);
+  assert.ok(support.language, "language property should exist");
+  assert.equal(support.language.name, "dart");
+
+  bindings.dispose();
+});
+

--- a/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
@@ -290,4 +290,3 @@ test("createLspClient accepts dartLanguage() and language.name is 'dart'", () =>
 
   bindings.dispose();
 });
-

--- a/pkgs/dartpad_preview/codemirror-lang-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-lang-dart/src/index.ts
@@ -267,6 +267,7 @@ export function dartLanguage(parseCallback: ParseCallback) {
       indentUnit.of("  "),
       indentService.of(dartIndent),
     ], // extensions
+    "dart",
   );
 
   return new LanguageSupport(dartLanguage, [

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
@@ -95,7 +95,11 @@ class LanguageServerClient {
             await handler(relativePath);
           }
         },
-        language: dart(),
+        // Use dartLanguage() (single LanguageSupport object), NOT dart()
+        // (bundled array of extensions). The LSP client's highlightLanguage
+        // callback accesses language.language to get the Language instance
+        // whose .name must equal "dart" for hover syntax highlighting.
+        language: dartLanguage(),
       );
     }
     _languageServerSubscription = (languageServerMessages ?? languageServer!.languageServerChannel.stream).listen(


### PR DESCRIPTION
Adds syntax highliting for Dart Code in tooltips:

<img width="455" height="257" alt="grafik" src="https://github.com/user-attachments/assets/a4e3624c-0dc8-4868-bd09-c145231dc596" />
