### PR TITLE
feat(dartpad-preview): add context menu

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/types.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/types.dart
@@ -179,8 +179,7 @@ extension type EditorView._(JSObject _) implements JSObject {
   @JS('posAtCoords')
   external int? _posAtCoords(EditorCoords coords, [JSBoolean? precise]);
 
-  int? posAtCoords(EditorCoords coords, {bool? precise}) =>
-      _posAtCoords(coords, precise?.toJS);
+  int? posAtCoords(EditorCoords coords, {bool? precise}) => _posAtCoords(coords, precise?.toJS);
 
   external static UpdateListener get updateListener;
 

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/types.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/types.dart
@@ -46,6 +46,7 @@ extension type EditorSelection(JSObject _) implements JSObject {
   external static SelectionRange range(int anchor, int head);
   external static EditorSelection single(int anchor, [int? head]);
 
+  external int get mainIndex;
   external JSArray<SelectionRange> get ranges;
   external SelectionRange get main;
 }
@@ -64,6 +65,8 @@ extension type EditorState(JSObject _) implements JSObject {
 
   external Text get doc;
   external EditorSelection get selection;
+
+  external JSString sliceDoc([int? from, int? to]);
 }
 
 /// Options passed when creating an editor state.
@@ -97,6 +100,7 @@ extension type Text(JSObject _) implements JSObject {
   external int get length;
   external int get lines;
   external Line line(int line);
+  external Line lineAt(int pos);
 
   @JS('toString')
   external JSString toJsString();
@@ -170,11 +174,25 @@ extension type EditorView._(JSObject _) implements JSObject {
   external void focus();
   external web.HTMLElement get scrollDOM;
   external web.HTMLElement get dom;
+  external web.HTMLElement get contentDOM;
   external Rect? coordsAtPos(int pos, [int? side]);
+  @JS('posAtCoords')
+  external int? _posAtCoords(EditorCoords coords, [JSBoolean? precise]);
+
+  int? posAtCoords(EditorCoords coords, {bool? precise}) =>
+      _posAtCoords(coords, precise?.toJS);
 
   external static UpdateListener get updateListener;
 
   external static JSAny scrollIntoView(int pos, [ScrollIntoViewOptions? options]);
+}
+
+/// A point with x and y coordinates used by [EditorView.posAtCoords].
+extension type EditorCoords._(JSObject _) implements JSObject {
+  external factory EditorCoords({double x, double y});
+
+  external double get x;
+  external double get y;
 }
 
 /// The type of object given to the [EditorView] constructor.

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -132,6 +132,30 @@ void main() {
 
     expect(view.state.doc.toJsString().toDart, 'hio');
     expect(view.state.selection.main.anchor, 2);
+    expect(view.contentDOM, isNotNull);
+    expect(view.contentDOM.classList.contains('cm-content'), isTrue);
+  });
+
+  test('EditorView posAtCoords resolves coordinate position', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(EditorStateConfig(doc: 'hello world'.toJS)),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    final coords = view.coordsAtPos(2);
+    if (coords != null) {
+      final pos = view.posAtCoords(EditorCoords(x: coords.left + 2, y: coords.top + 2));
+      expect(pos, isNotNull);
+    }
   });
 
   test('diagnostic hover renders Apply fix and reports its range', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -22,6 +22,7 @@ import 'features/preview/models/preview_state.dart';
 import 'features/preview/view/preview_container.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
+import 'features/shared/components/context_menu.dart';
 import 'features/shared/components/error_dialog.dart';
 import 'features/shared/components/footer.dart';
 import 'features/shared/components/split_panel.dart';
@@ -520,6 +521,9 @@ class AppState extends State<App> {
     if (!_isCurrent(session)) {
       return;
     }
+    if (loadingStatus == status && (!clearError || _errorMessage == null)) {
+      return;
+    }
     setState(() {
       loadingStatus = status;
       if (clearError) {
@@ -582,6 +586,7 @@ class AppState extends State<App> {
                   onSwitchFile: session.tabs.switchFile,
                   onCloseFile: session.tabs.closeFile,
                   bottomPanel: _buildBottomPanel(session),
+                  contextMenu: session.contextMenu,
                   isEmbedMode: isEmbedMode,
                 ),
                 right: _buildPreviewPanel(session),
@@ -595,6 +600,7 @@ class AppState extends State<App> {
                 onSwitchFile: session.tabs.switchFile,
                 onCloseFile: session.tabs.closeFile,
                 bottomPanel: _buildBottomPanel(session),
+                contextMenu: session.contextMenu,
                 isEmbedMode: isEmbedMode,
                 smallScreenPreviewPanel: _selectedSmallScreenTab == .output ? _buildPreviewPanel(session) : null,
               ),
@@ -609,6 +615,17 @@ class AppState extends State<App> {
         ]),
       ),
       if (_errorMessage case final String message) ErrorDialog(errorMessage: message),
+      ListenableBuilder(
+        listenable: session.contextMenu,
+        builder: (context) => ContextMenu(
+          key: const ValueKey('active-context-menu'),
+          x: session.contextMenu.x,
+          y: session.contextMenu.y,
+          items: session.contextMenu.items,
+          isOpen: session.contextMenu.isOpen,
+          onClose: session.contextMenu.hide,
+        ),
+      ),
     ]);
   }
 
@@ -623,6 +640,7 @@ class AppState extends State<App> {
           activeFile: session.tabs.activeFile,
           logs: session.console.logs,
           onClearConsole: session.console.clear,
+          contextMenu: session.contextMenu,
           onOpenDiagnostic: (fileName, diagnostic) {
             unawaited(session.diagnostics.openDiagnostic(fileName, diagnostic));
           },
@@ -643,7 +661,10 @@ class AppState extends State<App> {
         ),
         onPubClean: (workspacePath) => session.repository.pubClean(path: workspacePath),
       ),
-      ErrorToast(events: session.events),
+      ErrorToast(
+        key: const ValueKey('editor-error-toast'),
+        events: session.events,
+      ),
     ]);
   }
 
@@ -653,6 +674,7 @@ class AppState extends State<App> {
       builder: (context) => FileTreeView(
         state: session.fileTree.state,
         actions: session.fileTree.actions,
+        contextMenu: session.contextMenu,
       ),
     );
   }
@@ -676,6 +698,7 @@ class AppState extends State<App> {
   }
 
   static List<StyleRule> get styles => [
+    ...ContextMenu.styles,
     css('.app-shell').styles(
       display: .flex,
       width: 100.percent,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -6,6 +6,7 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
+import '../../shared/components/context_menu.dart';
 import '../models/console_entry.dart';
 import 'bottom_panel_tabs.dart';
 import 'console_panel.dart';
@@ -29,6 +30,7 @@ class BottomPanel extends StatefulComponent {
     required this.onOpenDiagnostic,
     required this.logs,
     required this.onClearConsole,
+    this.contextMenu,
     super.key,
   });
 
@@ -49,6 +51,9 @@ class BottomPanel extends StatefulComponent {
 
   /// Clears the debug output.
   final void Function() onClearConsole;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
 
   @override
   State<BottomPanel> createState() => _BottomPanelState();
@@ -88,7 +93,11 @@ class _BottomPanelState extends State<BottomPanel> {
           activeFile: component.activeFile,
           onOpenDiagnostic: component.onOpenDiagnostic,
         ),
-        BottomPanelTab.console => ConsolePanel(logs: component.logs),
+        BottomPanelTab.console => ConsolePanel(
+          logs: component.logs,
+          onClear: component.onClearConsole,
+          contextMenu: component.contextMenu,
+        ),
       },
     ]);
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/console_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/console_panel.dart
@@ -2,19 +2,30 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:js_interop';
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
+import '../../shared/components/context_menu.dart';
 import '../models/console_entry.dart';
 
 /// Displays the application's structured log events.
 class ConsolePanel extends StatefulComponent {
-  const ConsolePanel({required this.logs, super.key});
+  const ConsolePanel({
+    required this.logs,
+    this.onClear,
+    this.contextMenu,
+    super.key,
+  });
 
   final List<ConsoleEntry> logs;
+  final VoidCallback? onClear;
+  final ContextMenuController? contextMenu;
 
   @override
   State<ConsolePanel> createState() => _DebugConsolePanelState();
@@ -54,21 +65,65 @@ class _DebugConsolePanelState extends State<ConsolePanel> {
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'console-panel', [
-      div(
-        key: _listKey,
-        classes: 'console-list',
-        [
-          if (component.logs.isEmpty)
-            const div(classes: 'console-empty', [.text('No output yet')])
-          else
-            for (final log in component.logs)
-              div(classes: 'log-row ${log.level.consoleCssClass}', [
-                pre(classes: 'log-message', [.text(log.message)]),
-              ]),
-        ],
+    return div(
+      classes: 'console-panel',
+      events: {
+        'contextmenu': _handleContextMenu,
+      },
+      [
+        div(
+          key: _listKey,
+          classes: 'console-list',
+          [
+            if (component.logs.isEmpty)
+              const div(classes: 'console-empty', [.text('No output yet')])
+            else
+              for (final log in component.logs)
+                div(classes: 'log-row ${log.level.consoleCssClass}', [
+                  pre(classes: 'log-message', [.text(log.message)]),
+                ]),
+          ],
+        ),
+      ],
+    );
+  }
+
+  void _handleContextMenu(web.Event event) {
+    final menu = component.contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    event.preventDefault();
+    event.stopPropagation();
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildContextMenuItems(),
+    );
+  }
+
+  List<ContextMenuEntry> _buildContextMenuItems() {
+    return [
+      ContextMenuItem(
+        label: 'Clear console',
+        disabled: component.logs.isEmpty,
+        onPressed: () => component.onClear?.call(),
       ),
-    ]);
+      ContextMenuItem(
+        label: 'Copy output',
+        disabled: component.logs.isEmpty,
+        onPressed: () {
+          final text = component.logs.map((l) => l.message).join('\n');
+          unawaited(
+            web.window.navigator.clipboard.writeText(text).toDart.catchError((Object e) {
+              web.console.warn('Clipboard write failed: $e'.toJS);
+              return null;
+            }),
+          );
+        },
+      ),
+    ];
   }
 
   static List<StyleRule> get styles => [

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
@@ -3,13 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 
+import 'package:codemirror_dart/codemirror_dart.dart' as cm;
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
+import '../../shared/app_event_bus.dart';
+import '../../shared/components/context_menu.dart';
 import '../../shared/node_container.dart';
 import '../components/code_action_panel.dart';
+import 'editor_context_menu.dart';
 
 /// A workspace-backed text editor tab that preserves its editor state while
 /// switching between files.
@@ -20,6 +25,8 @@ final class CodeMirrorTab extends EditorTab<Component> {
     required String content,
     required this.onSaveAll,
     required this.workspaceResourceApi,
+    this.contextMenu,
+    this.events,
     LanguageServerClient? languageServerClient,
   }) : _savedContent = content,
        container = web.document.createElement('div') as web.HTMLElement,
@@ -48,12 +55,27 @@ final class CodeMirrorTab extends EditorTab<Component> {
       getDiagnostics: () => editor.languageServerClient?.allDiagnostics ?? const [],
       onStateChanged: _notifyUpdate,
     );
+
+    _contextMenuHandler = (web.MouseEvent event) {
+      event.preventDefault();
+      event.stopPropagation();
+      _showContextMenu(event.clientX.toDouble(), event.clientY.toDouble());
+    }.toJS;
+    container.addEventListener('contextmenu', _contextMenuHandler);
   }
+
+  late final JSFunction _contextMenuHandler;
 
   /// Saves all dirty tabs when CodeMirror receives its save command.
   final void Function() onSaveAll;
 
   final WorkspaceResourceApi workspaceResourceApi;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
+
+  /// The event bus for system notifications and error toasts.
+  final AppEventBus? events;
 
   /// The DOM element that hosts the CodeMirror editor.
   final web.HTMLElement container;
@@ -181,6 +203,32 @@ final class CodeMirrorTab extends EditorTab<Component> {
     }
   }
 
+  void _showContextMenu(double clientX, double clientY) {
+    final menu = contextMenu;
+    if (menu == null) {
+      return;
+    }
+
+    final pos = editor.view.posAtCoords(cm.EditorCoords(x: clientX, y: clientY));
+    if (pos != null) {
+      final selection = editor.view.state.selection;
+      final insideSelection = selection.ranges.toDart.any((r) => pos >= r.from && pos <= r.to);
+      if (!insideSelection) {
+        editor.view.dispatch(cm.TransactionSpec(selection: cm.EditorSelection.single(pos)));
+      }
+    }
+
+    menu.show(
+      clientX,
+      clientY,
+      buildEditorContextMenu(
+        editor: editor,
+        path: path,
+        events: events,
+      ),
+    );
+  }
+
   @override
   Component build() => Component.fragment([
     NodeContainer(
@@ -199,6 +247,7 @@ final class CodeMirrorTab extends EditorTab<Component> {
     _active = false;
     _measureTimer?.cancel();
     _measureTimer = null;
+    container.removeEventListener('contextmenu', _contextMenuHandler);
     codeActionsController.dispose();
     editor.destroy();
     unawaited(_updates.close());

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab_adapter.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab_adapter.dart
@@ -9,13 +9,21 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
+import '../../shared/app_event_bus.dart';
+import '../../shared/components/context_menu.dart';
 import '../../shared/editable_text_file.dart';
 import 'code_mirror_tab.dart';
 
 /// Creates text tabs and synchronizes them with workspace and LSP changes.
 final class CodeMirrorTabAdapter extends EditorTabAdapter<Component> {
   /// Creates an adapter for files using the codemirror editor.
-  CodeMirrorTabAdapter();
+  CodeMirrorTabAdapter({
+    this.contextMenu,
+    this.events,
+  });
+
+  final ContextMenuController? contextMenu;
+  final AppEventBus? events;
 
   TabsController<Component>? _tabs;
   LanguageServerClient? _languageServerClient;
@@ -54,6 +62,8 @@ final class CodeMirrorTabAdapter extends EditorTabAdapter<Component> {
       onSaveAll: _saveAll,
       workspaceResourceApi: tabs.workspaceResourceApi,
       languageServerClient: _languageServerClient,
+      contextMenu: contextMenu,
+      events: events,
     );
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/editor_context_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/editor_context_menu.dart
@@ -1,0 +1,272 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:codemirror_dart/codemirror_dart.dart' as cm;
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:web/web.dart' as web;
+
+import '../../shared/app_event_bus.dart';
+import '../../shared/components/context_menu.dart';
+import '../../shared/components/shortcut_definitions.dart';
+import '../../shared/events/error_toast_event.dart';
+
+/// Builds the context menu items for a [CodeMirrorEditor].
+List<ContextMenuEntry> buildEditorContextMenu({
+  required CodeMirrorEditor editor,
+  required String path,
+  AppEventBus? events,
+}) {
+  if (!path.endsWith('.dart')) {
+    return [
+      ContextMenuItem.fromShortcut(
+        shortcut: ShortcutDefinition.cut,
+        onPressed: () => handleEditorCut(editor),
+      ),
+      ContextMenuItem.fromShortcut(
+        shortcut: ShortcutDefinition.copy,
+        onPressed: () => handleEditorCopy(editor),
+      ),
+      ContextMenuItem.fromShortcut(
+        shortcut: ShortcutDefinition.paste,
+        onPressed: () {
+          unawaited(
+            handleEditorPaste(
+              editor,
+              mod: resolveDisplayKey('Mod'),
+              onPasteError: (message) => events?.dispatch(ErrorToastEvent(message)),
+            ),
+          );
+        },
+      ),
+    ];
+  }
+
+  return [
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.goToDefinition,
+      onPressed: () => dispatchEditorKey(editor, key: 'F12', code: 'F12'),
+    ),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.findReferences,
+      onPressed: () => dispatchEditorKey(editor, key: 'F12', code: 'F12', shiftKey: true),
+    ),
+    const ContextMenuDivider(),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.renameSymbol,
+      onPressed: () => dispatchEditorKey(editor, key: 'F2', code: 'F2'),
+    ),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.formatDocument,
+      onPressed: () => unawaited(editor.format()),
+    ),
+    const ContextMenuDivider(),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.cut,
+      onPressed: () => handleEditorCut(editor),
+    ),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.copy,
+      onPressed: () => handleEditorCopy(editor),
+    ),
+    ContextMenuItem.fromShortcut(
+      shortcut: ShortcutDefinition.paste,
+      onPressed: () {
+        unawaited(
+          handleEditorPaste(
+            editor,
+            mod: resolveDisplayKey('Mod'),
+            onPasteError: (message) => events?.dispatch(ErrorToastEvent(message)),
+          ),
+        );
+      },
+    ),
+  ];
+}
+
+/// Dispatches a synthetic keyboard event to CodeMirror's DOM element.
+void dispatchEditorKey(
+  CodeMirrorEditor editor, {
+  required String key,
+  required String code,
+  bool ctrlKey = false,
+  bool altKey = false,
+  bool shiftKey = false,
+  bool metaKey = false,
+}) {
+  editor.focus();
+  final target = editor.view.contentDOM;
+  final event = web.KeyboardEvent(
+    'keydown',
+    web.KeyboardEventInit(
+      key: key,
+      code: code,
+      ctrlKey: ctrlKey,
+      altKey: altKey,
+      shiftKey: shiftKey,
+      metaKey: metaKey,
+      bubbles: true,
+      cancelable: true,
+    ),
+  );
+  target.dispatchEvent(event);
+}
+
+/// Copies selected text (or the active line) to clipboard.
+///
+/// [writeClipboard] exists to make the copy logic independently testable.
+void handleEditorCopy(
+  CodeMirrorEditor editor, {
+  Future<void> Function(String text)? writeClipboard,
+}) {
+  final state = editor.view.state;
+  final ranges = state.selection.ranges.toDart;
+  final String text;
+  final hasNonEmpty = ranges.any((r) => !r.empty);
+  if (hasNonEmpty) {
+    text = ranges.where((r) => !r.empty).map((r) => state.sliceDoc(r.from, r.to).toDart).join('\n');
+  } else {
+    final buffer = StringBuffer();
+    final seenLines = <int>{};
+    for (final range in ranges) {
+      // Copy the entire line when there is no selection (VS Code behavior).
+      final line = state.doc.lineAt(range.from);
+      if (seenLines.add(line.from)) {
+        buffer.writeln(state.sliceDoc(line.from, line.to).toDart);
+      }
+    }
+    text = buffer.toString();
+  }
+  if (text.isNotEmpty) {
+    unawaited(
+      (writeClipboard ?? _writeClipboardText)(text).catchError((Object e) {
+        web.console.warn('Clipboard write failed: $e'.toJS);
+      }),
+    );
+  }
+  editor.focus();
+}
+
+/// Cuts selected text (or the active line) to clipboard and removes it from the editor.
+///
+/// [writeClipboard] exists to make the cut logic independently testable.
+void handleEditorCut(
+  CodeMirrorEditor editor, {
+  Future<void> Function(String text)? writeClipboard,
+}) {
+  final state = editor.view.state;
+  final ranges = state.selection.ranges.toDart;
+  final changes = <cm.ChangeSpec>[];
+  final String text;
+  final hasNonEmpty = ranges.any((r) => !r.empty);
+  if (hasNonEmpty) {
+    final pieces = <String>[];
+    for (final range in ranges) {
+      if (!range.empty) {
+        pieces.add(state.sliceDoc(range.from, range.to).toDart);
+        changes.add(cm.ChangeSpec(from: range.from, to: range.to, insert: ''.toJS));
+      }
+    }
+    text = pieces.join('\n');
+  } else {
+    final buffer = StringBuffer();
+    final seenLines = <int>{};
+    for (final range in ranges) {
+      // Cut the entire line when there is no selection (VS Code behavior).
+      final line = state.doc.lineAt(range.from);
+      if (!seenLines.add(line.from)) {
+        continue;
+      }
+      final int from;
+      final int to;
+      if (line.to < state.doc.length) {
+        // Include the newline character so the line is fully removed.
+        from = line.from;
+        to = line.to + 1;
+      } else if (line.from > 0) {
+        // On the last line, include the preceding newline character so no
+        // empty ghost line remains.
+        from = line.from - 1;
+        to = line.to;
+      } else {
+        from = line.from;
+        to = line.to;
+      }
+      buffer.writeln(state.sliceDoc(line.from, line.to).toDart);
+      changes.add(cm.ChangeSpec(from: from, to: to, insert: ''.toJS));
+    }
+    text = buffer.toString();
+  }
+  if (text.isNotEmpty) {
+    unawaited(
+      (writeClipboard ?? _writeClipboardText)(text).catchError((Object e) {
+        web.console.warn('Clipboard write failed: $e'.toJS);
+      }),
+    );
+  }
+  if (changes.isNotEmpty) {
+    editor.view.dispatch(
+      cm.TransactionSpec(changes: changes.toJS),
+    );
+  }
+  editor.focus();
+}
+
+/// Pastes text from the system clipboard into the editor.
+///
+/// [readClipboard] exists to make the editor update independently testable.
+/// The production path calls the Clipboard API immediately, while the menu
+/// item's click still has a transient browser user activation.
+Future<void> handleEditorPaste(
+  CodeMirrorEditor editor, {
+  void Function(String message)? onPasteError,
+  String mod = 'Ctrl',
+  Future<String> Function()? readClipboard,
+}) async {
+  try {
+    // Invoke the privileged browser API before doing anything else so this
+    // call stays inside the menu click's transient user activation.
+    final pasteText = await (readClipboard ?? _readClipboardText)();
+    if (pasteText.isEmpty) {
+      return;
+    }
+
+    final selection = editor.view.state.selection;
+    final changes = <cm.ChangeSpec>[];
+    final pastedRanges = <cm.SelectionRange>[];
+    var offset = 0;
+    for (final range in selection.ranges.toDart) {
+      changes.add(
+        cm.ChangeSpec(
+          from: range.from,
+          to: range.to,
+          insert: pasteText.toJS,
+        ),
+      );
+      pastedRanges.add(
+        cm.EditorSelection.cursor(range.from + offset + pasteText.length),
+      );
+      offset += pasteText.length - (range.to - range.from);
+    }
+    editor.view.dispatch(
+      cm.TransactionSpec(
+        changes: changes.toJS,
+        selection: cm.EditorSelection.create(pastedRanges.toJS, selection.mainIndex),
+      ),
+    );
+  } catch (_) {
+    onPasteError?.call(
+      'Paste failed. The browser may not have clipboard permission. '
+      'Allow clipboard access for this site, or use $mod + V.',
+    );
+  } finally {
+    editor.focus();
+  }
+}
+
+Future<String> _readClipboardText() async => (await web.window.navigator.clipboard.readText().toDart).toDart;
+
+Future<void> _writeClipboardText(String text) async => web.window.navigator.clipboard.writeText(text).toDart;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -7,6 +7,7 @@ import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
 import '../../../app_styles.dart';
+import '../../shared/components/context_menu.dart';
 import '../../shared/components/split_panel.dart';
 import '../../shared/icons.dart';
 import 'editor_stack.dart';
@@ -23,6 +24,7 @@ class EditorShell extends StatefulComponent {
     required this.onSwitchFile,
     required this.onCloseFile,
     required this.bottomPanel,
+    this.contextMenu,
     this.isEmbedMode = false,
     this.smallScreenPreviewPanel,
     super.key,
@@ -51,6 +53,9 @@ class EditorShell extends StatefulComponent {
 
   /// Bottom panel (e.g. problems view) rendered below the editor.
   final Component bottomPanel;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
 
   /// Whether the app is running in embed mode (`?embed=true`).
   ///
@@ -102,6 +107,7 @@ class _EditorShellState extends State<EditorShell> {
               activeFile: component.activeFile,
               onSwitchFile: component.onSwitchFile!,
               onCloseFile: component.onCloseFile!,
+              contextMenu: component.contextMenu,
             ),
             EditorStack(
               openTabs: openTabs,
@@ -115,9 +121,10 @@ class _EditorShellState extends State<EditorShell> {
     ]);
     final Component rightContent = component.smallScreenPreviewPanel ?? editorContent;
 
+    final Component shellContent;
     // Collapsed file tree: show a narrow rail with a toggle button.
     if (_fileTreeCollapsed) {
-      return div(classes: 'editor-shell', [
+      shellContent = div(classes: 'editor-shell', [
         aside(classes: 'file-tree-rail', [
           button(
             classes: 'file-tree-rail-button',
@@ -131,32 +138,34 @@ class _EditorShellState extends State<EditorShell> {
         ]),
         rightContent,
       ]);
+    } else {
+      // Expanded file tree with collapse button.
+      shellContent = div(classes: 'editor-shell', [
+        SplitPanel(
+          initialValue: 200,
+          useRatio: false,
+          minValue: 150,
+          maxValue: 300,
+          left: aside(classes: 'file-tree-pane', [
+            div(classes: 'file-tree-collapse-bar', [
+              button(
+                classes: 'file-tree-rail-button',
+                attributes: {
+                  'title': 'Hide file tree',
+                  'aria-label': 'Hide file tree',
+                },
+                onClick: _toggleFileTree,
+                [const Icon('chevron_left', size: 18)],
+              ),
+            ]),
+            component.fileTree,
+          ]),
+          right: rightContent,
+        ),
+      ]);
     }
 
-    // Expanded file tree with collapse button.
-    return div(classes: 'editor-shell', [
-      SplitPanel(
-        initialValue: 200,
-        useRatio: false,
-        minValue: 150,
-        maxValue: 300,
-        left: aside(classes: 'file-tree-pane', [
-          div(classes: 'file-tree-collapse-bar', [
-            button(
-              classes: 'file-tree-rail-button',
-              attributes: {
-                'title': 'Hide file tree',
-                'aria-label': 'Hide file tree',
-              },
-              onClick: _toggleFileTree,
-              [const Icon('chevron_left', size: 18)],
-            ),
-          ]),
-          component.fileTree,
-        ]),
-        right: rightContent,
-      ),
-    ]);
+    return shellContent;
   }
 
   static List<StyleRule> get styles => [

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tab_bar.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_tab_bar.dart
@@ -2,12 +2,16 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:js_interop';
+
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
+import '../../shared/components/context_menu.dart';
 import '../../shared/icons.dart';
 
 /// Displays open editor files and lets users switch between or close them.
@@ -22,6 +26,7 @@ final class EditorTabBar extends StatelessComponent {
     required this.onSwitchFile,
     required this.onCloseFile,
     this.confirmDiscard,
+    this.contextMenu,
     super.key,
   });
 
@@ -40,63 +45,166 @@ final class EditorTabBar extends StatelessComponent {
   /// Requests confirmation before discarding changes in the file at [path].
   final bool Function(String path)? confirmDiscard;
 
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
+
+  bool _closeSingleTab(EditorTab<Component> tabToClose) {
+    final discardChanges =
+        tabToClose.hasUnsavedChanges &&
+        (confirmDiscard?.call(tabToClose.path) ??
+            web.window.confirm(
+              'Discard unsaved changes in ${tabToClose.name}?',
+            ));
+    if (tabToClose.hasUnsavedChanges && !discardChanges) {
+      return false;
+    }
+    return onCloseFile(
+      tabToClose.path,
+      discardChanges: discardChanges,
+    );
+  }
+
+  void _closeOtherTabs(EditorTab<Component> keepTab) {
+    final tabsToClose = openTabs.where((t) => t.path != keepTab.path).toList();
+    for (final t in tabsToClose) {
+      if (!_closeSingleTab(t)) {
+        break;
+      }
+    }
+  }
+
+  void _closeAllTabs() {
+    for (final t in List.of(openTabs)) {
+      if (!_closeSingleTab(t)) {
+        break;
+      }
+    }
+  }
+
   @override
   Component build(BuildContext context) {
-    return div(classes: 'editor-tab-bar', [
-      for (final tab in openTabs)
-        div(
-          key: ValueKey('tab-${tab.path}'),
-          classes: [
-            'editor-tab',
-            if (tab.path == activeFile) 'active',
-            if (tab.hasUnsavedChanges) 'dirty',
-          ].join(' '),
-          attributes: {
-            'title': tab.path,
-            'tabindex': '0',
-            'role': 'tab',
-            'aria-selected': tab.path == activeFile ? 'true' : 'false',
-          },
-          events: {
-            'click': (_) => onSwitchFile(tab.path),
-            'keydown': (event) {
-              final keyboardEvent = event as web.KeyboardEvent;
-              if (keyboardEvent.key == 'Enter' || keyboardEvent.key == ' ') {
-                onSwitchFile(tab.path);
-              }
+    return div(
+      classes: 'editor-tab-bar',
+      events: {
+        'contextmenu': _handleTabBarContextMenu,
+      },
+      [
+        for (final tab in openTabs)
+          div(
+            key: ValueKey('tab-${tab.path}'),
+            classes: [
+              'editor-tab',
+              if (tab.path == activeFile) 'active',
+              if (tab.hasUnsavedChanges) 'dirty',
+            ].join(' '),
+            attributes: {
+              'title': tab.path,
+              'tabindex': '0',
+              'role': 'tab',
+              'aria-selected': tab.path == activeFile ? 'true' : 'false',
             },
-          },
-          [
-            span(classes: 'editor-tab-name', [.text(tab.name)]),
-            if (tab.hasUnsavedChanges) const span(classes: 'editor-tab-dirty-dot', []),
-            button(
-              classes: 'editor-tab-action close',
-              attributes: {
-                'title': 'Close tab',
-                'aria-label': 'Close ${tab.name}',
+            events: {
+              'click': (_) => onSwitchFile(tab.path),
+              'keydown': (event) {
+                final keyboardEvent = event as web.KeyboardEvent;
+                if (keyboardEvent.key == 'Enter' || keyboardEvent.key == ' ') {
+                  onSwitchFile(tab.path);
+                }
               },
-              events: {
-                'click': (event) {
-                  event.stopPropagation();
-                  final discardChanges =
-                      tab.hasUnsavedChanges &&
-                      (confirmDiscard?.call(tab.path) ??
-                          web.window.confirm(
-                            'Discard unsaved changes in ${tab.name}?',
-                          ));
-                  if (!tab.hasUnsavedChanges || discardChanges) {
-                    onCloseFile(
-                      tab.path,
-                      discardChanges: discardChanges,
-                    );
-                  }
+              'contextmenu': (event) => _handleTabContextMenu(event, tab),
+            },
+            [
+              span(classes: 'editor-tab-name', [.text(tab.name)]),
+              if (tab.hasUnsavedChanges) const span(classes: 'editor-tab-dirty-dot', []),
+              button(
+                classes: 'editor-tab-action close',
+                attributes: {
+                  'title': 'Close tab',
+                  'aria-label': 'Close ${tab.name}',
                 },
-              },
-              [const Icon('close', size: 12)],
-            ),
-          ],
-        ),
-    ]);
+                events: {
+                  'click': (event) {
+                    event.stopPropagation();
+                    _closeSingleTab(tab);
+                  },
+                },
+                [const Icon('close', size: 12)],
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+
+  void _handleTabBarContextMenu(web.Event event) {
+    final menu = contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    final target = mouseEvent.target as web.Element?;
+    if (target?.closest('.editor-tab') != null) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildTabBarContextMenuItems(),
+    );
+  }
+
+  List<ContextMenuEntry> _buildTabBarContextMenuItems() {
+    return [
+      ContextMenuItem(
+        label: 'Close all tabs',
+        disabled: openTabs.isEmpty,
+        onPressed: _closeAllTabs,
+      ),
+    ];
+  }
+
+  void _handleTabContextMenu(web.Event event, EditorTab<Component> tab) {
+    final menu = contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    event.preventDefault();
+    event.stopPropagation();
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildTabContextMenuItems(tab),
+    );
+  }
+
+  List<ContextMenuEntry> _buildTabContextMenuItems(EditorTab<Component> tab) {
+    final hasOthers = openTabs.length > 1;
+
+    return [
+      ContextMenuItem(
+        label: 'Close',
+        onPressed: () => _closeSingleTab(tab),
+      ),
+      ContextMenuItem(
+        label: 'Close others',
+        disabled: !hasOthers,
+        onPressed: () => _closeOtherTabs(tab),
+      ),
+      ContextMenuItem(
+        label: 'Close all',
+        onPressed: _closeAllTabs,
+      ),
+      const ContextMenuDivider(),
+      ContextMenuItem(
+        label: 'Copy path',
+        onPressed: () {
+          unawaited(web.window.navigator.clipboard.writeText(tab.path).toDart.catchError((Object? _) => null));
+        },
+      ),
+    ];
   }
 
   @css

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/error_toast.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/error_toast.dart
@@ -56,6 +56,9 @@ final class _ErrorToastState extends State<ErrorToast> {
   }
 
   void _show(ErrorToastEvent event) {
+    if (!mounted) {
+      return;
+    }
     _dismissTimer?.cancel();
     setState(() {
       _message = event.message;
@@ -78,22 +81,25 @@ final class _ErrorToastState extends State<ErrorToast> {
   @override
   Component build(BuildContext context) {
     final message = _message;
-    if (message == null) {
-      return const .empty();
-    }
-    return div(
-      key: ValueKey(_toastId),
-      classes: 'editor-error-toast',
-      attributes: const {
-        'role': 'alert',
-        'aria-live': 'assertive',
-        'aria-atomic': 'true',
-      },
-      [
-        const Icon('error', size: 18, classes: 'editor-error-toast-icon'),
-        span([.text(message)]),
-      ],
-    );
+    // Keep the stateful component's root render object stable. Replacing an
+    // empty component with a keyed element while the context menu closes can
+    // otherwise make Jaspr detach the old fragment from the wrong parent.
+    return div(classes: 'editor-error-toast-host', [
+      if (message != null)
+        div(
+          key: ValueKey(_toastId),
+          classes: 'editor-error-toast',
+          attributes: const {
+            'role': 'alert',
+            'aria-live': 'assertive',
+            'aria-atomic': 'true',
+          },
+          [
+            const Icon('error', size: 18, classes: 'editor-error-toast-icon'),
+            span([.text(message)]),
+          ],
+        ),
+    ]);
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
@@ -3,12 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/components/file_icon.dart';
 import 'package:web/web.dart' as web;
 
+import '../../shared/components/context_menu.dart';
 import '../file_tree_models.dart';
 import 'file_tree_input_item.dart';
 import 'file_tree_row.dart';
@@ -24,6 +26,7 @@ class FileTreeFileItem extends StatefulComponent {
     required this.selectedPath,
     required this.onSelect,
     this.confirmDelete,
+    this.contextMenu,
     super.key,
   });
 
@@ -47,6 +50,9 @@ class FileTreeFileItem extends StatefulComponent {
 
   /// Optional callback to confirm deletion of this file.
   final bool Function(String message)? confirmDelete;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
 
   @override
   State<FileTreeFileItem> createState() => _FileTreeFileItemState();
@@ -169,6 +175,12 @@ class _FileTreeFileItemState extends State<FileTreeFileItem> {
             unawaited(Future<void>.sync(() => component.actions.openFile(path)));
           }
         },
+        'contextmenu': (web.Event event) => _handleContextMenu(
+          event,
+          path,
+          openable: openable,
+          protected: protected,
+        ),
       },
       children: [
         const span(classes: 'file-tree-disclosure spacer', []),
@@ -186,6 +198,66 @@ class _FileTreeFileItemState extends State<FileTreeFileItem> {
           ),
       ],
     );
+  }
+
+  void _handleContextMenu(
+    web.Event event,
+    String path, {
+    required bool openable,
+    required bool protected,
+  }) {
+    final menu = component.contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    event.preventDefault();
+    event.stopPropagation();
+    component.actions.clearOperationError();
+    component.onSelect(path);
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildContextMenuItems(path, openable: openable, protected: protected),
+    );
+  }
+
+  List<ContextMenuEntry> _buildContextMenuItems(
+    String path, {
+    required bool openable,
+    required bool protected,
+  }) {
+    return [
+      if (openable)
+        ContextMenuItem(
+          label: 'Open',
+          onPressed: () {
+            unawaited(Future<void>.sync(() => component.actions.openFile(path)));
+          },
+        ),
+      if (!protected) ...[
+        ContextMenuItem(
+          label: 'Rename',
+          onPressed: () {
+            setState(() {
+              _isRenaming = true;
+            });
+          },
+        ),
+        ContextMenuItem(
+          label: 'Delete',
+          destructive: true,
+          onPressed: () => _confirmDeleteFile(path),
+        ),
+        const ContextMenuDivider(),
+      ],
+      ContextMenuItem(
+        label: 'Copy path',
+        onPressed: () {
+          unawaited(web.window.navigator.clipboard.writeText(path).toDart.catchError((Object? _) => null));
+        },
+      ),
+    ];
   }
 
   Component _fileIcon(String fileName) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:js_interop';
 
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
@@ -10,6 +11,7 @@ import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/components/file_icon.dart';
 import 'package:web/web.dart' as web;
 
+import '../../shared/components/context_menu.dart';
 import '../../shared/icons.dart';
 import '../file_tree_models.dart';
 import 'file_tree_file_item.dart';
@@ -32,6 +34,8 @@ class FileTreeFolderItem extends StatefulComponent {
     required this.onCancelCreate,
     this.confirmDelete,
     this.collapseAllCount = 0,
+    this.contextMenu,
+    this.onStartCreate,
     super.key,
   });
 
@@ -70,6 +74,12 @@ class FileTreeFolderItem extends StatefulComponent {
 
   /// Trigger generation counter to collapse all folders recursively.
   final int collapseAllCount;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
+
+  /// Callback to initiate entry creation inside this folder.
+  final void Function(String folderPath, FileTreeEntryKind kind)? onStartCreate;
 
   @override
   State<FileTreeFolderItem> createState() => _FileTreeFolderItemState();
@@ -216,6 +226,11 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
             });
           }
         },
+        'contextmenu': (web.Event event) => _handleContextMenu(
+          event,
+          path,
+          protected: protected,
+        ),
       },
       children: [
         button(
@@ -303,6 +318,8 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
                 onCancelCreate: component.onCancelCreate,
                 confirmDelete: component.confirmDelete,
                 collapseAllCount: component.collapseAllCount,
+                contextMenu: component.contextMenu,
+                onStartCreate: component.onStartCreate,
               );
             }),
             if (component.creatingEntry == FileTreeEntryKind.file && component.creatingInFolder == path)
@@ -334,11 +351,77 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
                 selectedPath: component.selectedPath,
                 onSelect: component.onSelect,
                 confirmDelete: component.confirmDelete,
+                contextMenu: component.contextMenu,
               );
             }),
           ]),
       ],
     );
+  }
+
+  void _handleContextMenu(
+    web.Event event,
+    String path, {
+    required bool protected,
+  }) {
+    final menu = component.contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    event.preventDefault();
+    event.stopPropagation();
+    component.onSelect(path);
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildContextMenuItems(path, protected: protected),
+    );
+  }
+
+  List<ContextMenuEntry> _buildContextMenuItems(
+    String path, {
+    required bool protected,
+  }) {
+    return [
+      ContextMenuItem(
+        label: 'New file',
+        disabled: component.state.busy,
+        onPressed: () {
+          component.onStartCreate?.call(path, FileTreeEntryKind.file);
+        },
+      ),
+      ContextMenuItem(
+        label: 'New folder',
+        disabled: component.state.busy,
+        onPressed: () {
+          component.onStartCreate?.call(path, FileTreeEntryKind.folder);
+        },
+      ),
+      if (!protected) ...[
+        const ContextMenuDivider(),
+        ContextMenuItem(
+          label: 'Rename',
+          onPressed: () {
+            setState(() {
+              _isRenaming = true;
+            });
+          },
+        ),
+        ContextMenuItem(
+          label: 'Delete',
+          destructive: true,
+          onPressed: () => _confirmDeleteFolder(path),
+        ),
+      ],
+      const ContextMenuDivider(),
+      ContextMenuItem(
+        label: 'Copy path',
+        onPressed: () {
+          unawaited(web.window.navigator.clipboard.writeText(path).toDart.catchError((Object? _) => null));
+        },
+      ),
+    ];
   }
 
   void _confirmDeleteFolder(String path) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -10,6 +10,7 @@ import 'package:jaspr_content/components/file_icon.dart';
 import 'package:web/web.dart' as web;
 
 import '../../app_styles.dart';
+import '../shared/components/context_menu.dart';
 import '../shared/icons.dart';
 import 'components/file_tree_file_item.dart';
 import 'components/file_tree_folder_item.dart';
@@ -26,6 +27,7 @@ final class FileTreeView extends StatefulComponent {
     required this.state,
     required this.actions,
     this.confirmDelete,
+    this.contextMenu,
     super.key,
   });
 
@@ -37,6 +39,9 @@ final class FileTreeView extends StatefulComponent {
 
   /// An optional callback used to confirm destructive operations.
   final bool Function(String message)? confirmDelete;
+
+  /// The context menu controller used to show right-click menus.
+  final ContextMenuController? contextMenu;
 
   @override
   State<FileTreeView> createState() => _FileTreeViewInternalState();
@@ -181,6 +186,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
               unawaited(actions.moveEntry(sourcePath, state.focusedPath));
             }
           },
+          'contextmenu': _handleContextMenu,
         },
         [
           if (_creatingEntry != null && _creatingInFolder == state.focusedPath)
@@ -244,6 +250,14 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
                 creatingInFolder: _creatingInFolder,
                 creatingEntry: _creatingEntry,
                 collapseAllCount: _collapseAllCount,
+                contextMenu: component.contextMenu,
+                onStartCreate: (folderPath, kind) {
+                  setState(() {
+                    _creatingEntry = kind;
+                    _creatingInFolder = folderPath;
+                    _selectedPath = null;
+                  });
+                },
                 onConfirmCreate: (name) async {
                   final parentPath = _creatingInFolder!;
                   final kind = _creatingEntry!;
@@ -280,6 +294,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
                     _selectedPath = selectedPath;
                   });
                 },
+                contextMenu: component.contextMenu,
                 confirmDelete: component.confirmDelete,
               );
             }
@@ -287,6 +302,53 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
         ],
       ),
     ]);
+  }
+
+  void _handleContextMenu(web.Event event) {
+    final menu = component.contextMenu;
+    if (menu == null) {
+      return;
+    }
+    final mouseEvent = event as web.MouseEvent;
+    final target = mouseEvent.target as web.Element?;
+    if (target?.closest('.file-tree-item') != null) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    menu.show(
+      mouseEvent.clientX.toDouble(),
+      mouseEvent.clientY.toDouble(),
+      _buildContextMenuItems(),
+    );
+  }
+
+  List<ContextMenuEntry> _buildContextMenuItems() {
+    final state = component.state;
+    return [
+      ContextMenuItem(
+        label: 'New file',
+        disabled: state.busy,
+        onPressed: () {
+          setState(() {
+            _creatingEntry = FileTreeEntryKind.file;
+            _creatingInFolder = state.focusedPath;
+            _selectedPath = null;
+          });
+        },
+      ),
+      ContextMenuItem(
+        label: 'New folder',
+        disabled: state.busy,
+        onPressed: () {
+          setState(() {
+            _creatingEntry = FileTreeEntryKind.folder;
+            _creatingInFolder = state.focusedPath;
+            _selectedPath = null;
+          });
+        },
+      ),
+    ];
   }
 
   Component _toolbarButton({

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
@@ -1,0 +1,471 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import 'shortcut_definitions.dart';
+
+/// Base entry for items inside a [ContextMenu].
+sealed class ContextMenuEntry {
+  const ContextMenuEntry();
+}
+
+/// A non-interactive separator line.
+class ContextMenuDivider extends ContextMenuEntry {
+  const ContextMenuDivider();
+}
+
+/// An interactive item in a [ContextMenu].
+class ContextMenuItem extends ContextMenuEntry {
+  const ContextMenuItem({
+    required this.label,
+    required this.onPressed,
+    this.shortcut,
+    this.disabled = false,
+    this.destructive = false,
+  });
+
+  /// Creates a context menu item from a [ShortcutDefinition].
+  ///
+  /// The [shortcut] definition provides the default [label] and [shortcut] string
+  /// (resolved via [resolveDisplayKey]).
+  factory ContextMenuItem.fromShortcut({
+    required ShortcutDefinition shortcut,
+    required VoidCallback onPressed,
+  }) => ContextMenuItem(
+    label: shortcut.label,
+    onPressed: onPressed,
+    shortcut: resolveDisplayKey(shortcut.displayKey),
+  );
+
+  /// The text label displayed for this menu item.
+  final String label;
+
+  /// Called when the item is activated.
+  final VoidCallback onPressed;
+
+  /// Optional keyboard shortcut label (e.g. "Ctrl+.", "F2", "Shift+Alt+F").
+  final String? shortcut;
+
+  /// Whether the item is disabled and non-clickable.
+  final bool disabled;
+
+  /// Whether this is a destructive action (rendered with error styling).
+  final bool destructive;
+}
+
+/// Controller that manages displaying and dismissing a floating context menu.
+class ContextMenuController extends ChangeNotifier {
+  bool _isDisposed = false;
+  bool _isOpen = false;
+  double _x = 0;
+  double _y = 0;
+  List<ContextMenuEntry> _items = const [];
+
+  bool get isOpen => _isOpen;
+  double get x => _x;
+  double get y => _y;
+  List<ContextMenuEntry> get items => _items;
+
+  /// Opens the context menu at viewport coordinates ([x], [y]) with [items].
+  void show(double x, double y, List<ContextMenuEntry> items) {
+    if (_isDisposed) {
+      return;
+    }
+    if (items.isEmpty) {
+      hide();
+      return;
+    }
+    _x = x;
+    _y = y;
+    _items = items;
+    _isOpen = true;
+    notifyListeners();
+  }
+
+  /// Closes the currently active context menu.
+  void hide() {
+    if (_isDisposed) {
+      return;
+    }
+    if (!_isOpen) {
+      return;
+    }
+    _isOpen = false;
+    _items = const [];
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}
+
+/// A floating context menu rendered at a given (x, y) coordinate.
+class ContextMenu extends StatefulComponent {
+  const ContextMenu({
+    required this.x,
+    required this.y,
+    required this.items,
+    required this.onClose,
+    this.isOpen = true,
+    super.key,
+  });
+
+  final double x;
+  final double y;
+  final List<ContextMenuEntry> items;
+  final VoidCallback onClose;
+
+  /// Whether the menu is visible and responds to global interactions.
+  ///
+  /// Keeping the component mounted while hidden avoids replacing a component
+  /// subtree during a document-level event callback.
+  final bool isOpen;
+
+  @override
+  State<ContextMenu> createState() => _ContextMenuState();
+
+  @css
+  static List<StyleRule> get styles => _ContextMenuState.styles;
+}
+
+class _ContextMenuState extends State<ContextMenu> {
+  final GlobalNodeKey _menuKey = GlobalNodeKey();
+  StreamSubscription<web.MouseEvent>? _dismissSubscription;
+  StreamSubscription<web.KeyboardEvent>? _keySubscription;
+  StreamSubscription<web.Event>? _resizeSubscription;
+  double? _adjustedX;
+  double? _adjustedY;
+  bool _isPositioned = false;
+
+  @override
+  void initState() {
+    super.initState();
+    Timer.run(() {
+      if (!mounted) {
+        return;
+      }
+      _dismissSubscription = web.EventStreamProviders.mouseDownEvent.forTarget(web.document).listen((event) {
+        final menu = _menuKey.currentNode;
+        final target = event.target as web.Node?;
+        if (component.isOpen && menu != null && target != null && !menu.contains(target)) {
+          component.onClose();
+        }
+      });
+      _keySubscription = web.EventStreamProviders.keyDownEvent.forTarget(web.document).listen(_handleGlobalKeyDown);
+      _resizeSubscription = web.EventStreamProviders.resizeEvent.forTarget(web.window).listen((_) {
+        component.onClose();
+      });
+      if (component.isOpen) {
+        _adjustPosition();
+        _focusFirstItem();
+      }
+    });
+  }
+
+  @override
+  void didUpdateComponent(ContextMenu oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (!component.isOpen) {
+      _isPositioned = false;
+      return;
+    }
+    if (oldComponent.x != component.x || oldComponent.y != component.y) {
+      _adjustedX = component.x;
+      _adjustedY = component.y;
+      _isPositioned = false;
+    }
+    Timer.run(() {
+      if (mounted) {
+        _adjustPosition();
+        if (!oldComponent.isOpen) {
+          _focusFirstItem();
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _dismissSubscription?.cancel();
+    _dismissSubscription = null;
+    _keySubscription?.cancel();
+    _keySubscription = null;
+    _resizeSubscription?.cancel();
+    _resizeSubscription = null;
+    super.dispose();
+  }
+
+  List<web.HTMLButtonElement> _getEnabledItems() {
+    final menu = _menuKey.currentNode as web.HTMLElement?;
+    if (menu == null) {
+      return const [];
+    }
+    final nodeList = menu.querySelectorAll('.context-menu-item:not(:disabled)');
+    final items = <web.HTMLButtonElement>[];
+    for (var i = 0; i < nodeList.length; i++) {
+      final node = nodeList.item(i);
+      if (node != null) {
+        final btn = node as web.HTMLButtonElement;
+        if (!btn.disabled) {
+          items.add(btn);
+        }
+      }
+    }
+    return items;
+  }
+
+  int _findFocusedIndex(List<web.HTMLButtonElement> items) {
+    final active = web.document.activeElement;
+    if (active == null) {
+      return -1;
+    }
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      if (identical(item, active) || item.contains(active)) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  void _focusFirstItem() {
+    final items = _getEnabledItems();
+    if (items.isNotEmpty) {
+      items.first.focus();
+    }
+  }
+
+  void _adjustPosition() {
+    final menu = _menuKey.currentNode as web.HTMLElement?;
+    if (menu == null) {
+      return;
+    }
+
+    final rect = menu.getBoundingClientRect();
+    final vpW = web.window.innerWidth;
+    final vpH = web.window.innerHeight;
+
+    double x = component.x;
+    double y = component.y;
+
+    final maxW = vpW.toDouble();
+    final maxH = vpH.toDouble();
+
+    const margin = 8.0;
+    if (maxW > margin && x + rect.width > maxW - margin) {
+      x = (maxW - rect.width - margin).clamp(margin, maxW);
+    }
+    if (maxH > margin && y + rect.height > maxH - margin) {
+      y = (maxH - rect.height - margin).clamp(margin, maxH);
+    }
+
+    _adjustedX = x;
+    _adjustedY = y;
+    _isPositioned = true;
+
+    menu.style.left = '${x}px';
+    menu.style.top = '${y}px';
+    menu.style.opacity = '1';
+  }
+
+  void _handleGlobalKeyDown(web.KeyboardEvent event) {
+    if (!component.isOpen) {
+      return;
+    }
+    switch (event.key) {
+      case 'Escape':
+        event.preventDefault();
+        event.stopPropagation();
+        component.onClose();
+      case 'ArrowDown':
+        final items = _getEnabledItems();
+        if (items.isNotEmpty) {
+          event.preventDefault();
+          event.stopPropagation();
+          final index = _findFocusedIndex(items);
+          if (index == -1 || index >= items.length - 1) {
+            items.first.focus();
+          } else {
+            items[index + 1].focus();
+          }
+        }
+      case 'ArrowUp':
+        final items = _getEnabledItems();
+        if (items.isNotEmpty) {
+          event.preventDefault();
+          event.stopPropagation();
+          final index = _findFocusedIndex(items);
+          if (index == -1 || index <= 0) {
+            items.last.focus();
+          } else {
+            items[index - 1].focus();
+          }
+        }
+      case 'Home':
+        final items = _getEnabledItems();
+        if (items.isNotEmpty) {
+          event.preventDefault();
+          event.stopPropagation();
+          items.first.focus();
+        }
+      case 'End':
+        final items = _getEnabledItems();
+        if (items.isNotEmpty) {
+          event.preventDefault();
+          event.stopPropagation();
+          items.last.focus();
+        }
+      case 'Enter':
+      case ' ':
+      case 'Spacebar':
+        final items = _getEnabledItems();
+        final index = _findFocusedIndex(items);
+        if (index != -1) {
+          event.preventDefault();
+          event.stopPropagation();
+          items[index].click();
+        }
+    }
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return div(
+      key: _menuKey,
+      classes: 'context-menu',
+      attributes: const {
+        'role': 'menu',
+        'tabindex': '-1',
+      },
+      styles: Styles(
+        raw: {
+          'opacity': _isPositioned ? '1' : '0',
+          'left': '${_adjustedX ?? component.x}px',
+          'top': '${_adjustedY ?? component.y}px',
+          'display': component.isOpen ? 'flex' : 'none',
+        },
+      ),
+      [
+        for (final entry in component.items)
+          switch (entry) {
+            ContextMenuDivider() => const div(classes: 'context-menu-divider', []),
+            ContextMenuItem() => button(
+              classes: [
+                'context-menu-item',
+                if (entry.destructive) 'destructive',
+              ].join(' '),
+              attributes: {
+                'type': 'button',
+                'role': 'menuitem',
+                if (entry.disabled) 'disabled': '',
+                if (entry.disabled) 'aria-disabled': 'true',
+              },
+              onClick: entry.disabled
+                  ? null
+                  : () {
+                      try {
+                        entry.onPressed();
+                      } finally {
+                        Timer.run(component.onClose);
+                      }
+                    },
+              [
+                span(classes: 'context-menu-item-label', [.text(entry.label)]),
+                if (entry.shortcut != null) span(classes: 'context-menu-item-shortcut', [.text(entry.shortcut!)]),
+              ],
+            ),
+          },
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css('.context-menu').styles(
+      display: .flex,
+      position: const .fixed(),
+      zIndex: const ZIndex(9999),
+      minWidth: 200.px,
+      maxWidth: 340.px,
+      maxHeight: const Unit.expression('min(480px, calc(100vh - 24px))'),
+      padding: .symmetric(vertical: 4.px),
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(5.px),
+      shadow: BoxShadow(
+        offsetX: .zero,
+        offsetY: 4.px,
+        blur: 16.px,
+        color: const .rgba(0, 0, 0, 0.2),
+      ),
+      flexDirection: .column,
+      color: colorOnContainer,
+      fontFamily: const .list([FontFamily('Inter'), FontFamily('Segoe UI'), FontFamilies.sansSerif]),
+      fontSize: 12.px,
+      backgroundColor: colorContainer,
+      raw: {
+        'overflow-y': 'auto',
+      },
+    ),
+    css('.context-menu-divider').styles(
+      height: 1.px,
+      margin: .symmetric(vertical: 3.px),
+      backgroundColor: colorBorder,
+    ),
+    css('.context-menu-item', [
+      css('&').styles(
+        display: .flex,
+        width: 100.percent,
+        padding: .symmetric(vertical: 5.px, horizontal: 14.px),
+        border: .none,
+        outline: const Outline(style: .none),
+        cursor: .pointer,
+        transition: Transition('background-color', duration: 80.ms),
+        alignItems: .center,
+        gap: Gap.all(12.px),
+        color: colorOnContainer,
+        textAlign: .left,
+        fontSize: 12.px,
+        backgroundColor: Colors.transparent,
+      ),
+      css('&:hover:not(:disabled), &:focus-visible:not(:disabled)').styles(
+        color: colorOnContainer,
+        backgroundColor: colorContainer.highlight(colorOnSurface, 0.1),
+      ),
+      css('&:disabled').styles(
+        opacity: 0.45,
+        cursor: .defaultCursor,
+      ),
+      css('&.destructive').styles(
+        color: colorError,
+      ),
+      css('&.destructive:hover:not(:disabled), &.destructive:focus-visible:not(:disabled)').styles(
+        color: colorError,
+        backgroundColor: colorErrorSurface,
+      ),
+    ]),
+    css('.context-menu-item-label').styles(
+      overflow: .hidden,
+      flex: const Flex(grow: 1, basis: .zero),
+      textOverflow: .ellipsis,
+      whiteSpace: .noWrap,
+    ),
+    css('.context-menu-item-shortcut').styles(
+      padding: .only(left: 16.px),
+      opacity: 0.6,
+      flex: const .shrink(0),
+      color: colorOnContainer,
+      fontFamily: const .list([FontFamily('Inter'), FontFamily('Segoe UI'), FontFamilies.sansSerif]),
+      fontSize: 11.px,
+      whiteSpace: .noWrap,
+    ),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -5,12 +5,13 @@
 import 'package:web/web.dart' as web;
 
 /// Whether the current platform is macOS.
-final _isMac = web.window.navigator.platform.toLowerCase().contains('mac');
+final isMac = web.window.navigator.platform.toLowerCase().contains('mac') ||
+    web.window.navigator.userAgent.toLowerCase().contains('mac');
 
 /// Resolves platform-agnostic modifier placeholders in a display key string.
 ///
 /// - `Mod` → `⌘` on macOS, `Ctrl` on other platforms.
-String resolveDisplayKey(String key) => key.replaceAll('Mod', _isMac ? '⌘' : 'Ctrl');
+String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'Ctrl');
 
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
@@ -25,23 +26,27 @@ enum ShortcutCategory {
   final String label;
 }
 
-/// A keyboard shortcut shown in the shortcuts dialog.
+/// A keyboard shortcut shown in the shortcuts dialog or context menus.
 ///
 /// Each definition provides both the display text for the UI and the
 /// corresponding CodeMirror key notation(s) used for automated testing.
+///
+/// Shortcuts without a [category] (such as native clipboard actions) are not
+/// listed in the general shortcuts dialog and are only used for menus or
+/// toolbars.
 class ShortcutDefinition {
   const ShortcutDefinition({
     required this.label,
     required this.displayKey,
-    required this.codemirrorKeys,
-    required this.category,
+    this.codemirrorKeys = const [],
+    this.category,
     this.isPrimary = true,
   });
 
   /// Human-readable command name, e.g. `'Quick fix'`.
   final String label;
 
-  /// Display string shown in the dialog.
+  /// Display string shown in the dialog or context menus.
   ///
   /// May contain the placeholder `Mod` which is resolved at render time
   /// via [resolveDisplayKey] to `⌘` on macOS or `Ctrl` on other platforms.
@@ -56,13 +61,234 @@ class ShortcutDefinition {
   final List<String> codemirrorKeys;
 
   /// The category this shortcut belongs to.
-  final ShortcutCategory category;
+  ///
+  /// Shortcuts with a `null` category (such as native clipboard actions) are
+  /// not listed in the general shortcuts dialog, but are used in menus and
+  /// toolbars.
+  final ShortcutCategory? category;
 
   /// Whether this shortcut is shown in the collapsed (primary) view.
   ///
   /// When `false`, the shortcut is only visible after expanding the
   /// "Show more shortcuts" section.
   final bool isPrimary;
+
+  // ── Refactoring & code intelligence ──────────────────────────────────────
+  static const quickFix = ShortcutDefinition(
+    label: 'Quick fix',
+    displayKey: 'Mod + .',
+    codemirrorKeys: ['Mod-.'],
+    category: ShortcutCategory.refactoring,
+  );
+
+  static const renameSymbol = ShortcutDefinition(
+    label: 'Rename symbol',
+    displayKey: 'F2',
+    codemirrorKeys: ['F2'],
+    category: ShortcutCategory.refactoring,
+  );
+
+  static const goToDefinition = ShortcutDefinition(
+    label: 'Go to definition',
+    displayKey: 'F12',
+    codemirrorKeys: ['F12'],
+    category: ShortcutCategory.refactoring,
+  );
+
+  static const findReferences = ShortcutDefinition(
+    label: 'Find references',
+    displayKey: 'Shift + F12',
+    codemirrorKeys: ['Shift-F12'],
+    category: ShortcutCategory.refactoring,
+  );
+
+  static const formatDocument = ShortcutDefinition(
+    label: 'Format document',
+    displayKey: 'Shift + Alt + F',
+    codemirrorKeys: ['Shift-Alt-f', 'Shift-Alt-F'],
+    category: ShortcutCategory.refactoring,
+  );
+
+  static const nextProblem = ShortcutDefinition(
+    label: 'Next problem',
+    displayKey: 'F8',
+    codemirrorKeys: ['F8'],
+    category: ShortcutCategory.refactoring,
+    isPrimary: false,
+  );
+
+  // ── Editing ──────────────────────────────────────────────────────────────
+  static const toggleLineComment = ShortcutDefinition(
+    label: 'Toggle line comment',
+    displayKey: 'Mod + /',
+    codemirrorKeys: ['Mod-/'],
+    category: ShortcutCategory.editing,
+  );
+
+  static const toggleBlockComment = ShortcutDefinition(
+    label: 'Toggle block comment',
+    displayKey: 'Shift + Alt + A',
+    codemirrorKeys: ['Alt-A'],
+    category: ShortcutCategory.editing,
+  );
+
+  static const moveLine = ShortcutDefinition(
+    label: 'Move line up / down',
+    displayKey: 'Alt + ↑ / ↓',
+    codemirrorKeys: ['Alt-ArrowUp', 'Alt-ArrowDown'],
+    category: ShortcutCategory.editing,
+  );
+
+  static const deleteLine = ShortcutDefinition(
+    label: 'Delete line',
+    displayKey: 'Mod + Shift + K',
+    codemirrorKeys: ['Shift-Mod-k'],
+    category: ShortcutCategory.editing,
+  );
+
+  static const indent = ShortcutDefinition(
+    label: 'Indent',
+    displayKey: 'Tab',
+    codemirrorKeys: ['Tab'],
+    category: ShortcutCategory.editing,
+    isPrimary: false,
+  );
+
+  static const outdent = ShortcutDefinition(
+    label: 'Outdent',
+    displayKey: 'Shift + Tab',
+    codemirrorKeys: ['Shift-Tab'],
+    category: ShortcutCategory.editing,
+    isPrimary: false,
+  );
+
+  static const copyLine = ShortcutDefinition(
+    label: 'Copy line up / down',
+    displayKey: 'Shift + Alt + ↑ / ↓',
+    codemirrorKeys: ['Shift-Alt-ArrowUp', 'Shift-Alt-ArrowDown'],
+    category: ShortcutCategory.editing,
+    isPrimary: false,
+  );
+
+  static const insertBlankLine = ShortcutDefinition(
+    label: 'Insert blank line',
+    displayKey: 'Mod + Enter',
+    codemirrorKeys: ['Mod-Enter'],
+    category: ShortcutCategory.editing,
+    isPrimary: false,
+  );
+
+  static const jumpToMatchingBracket = ShortcutDefinition(
+    label: 'Jump to matching bracket',
+    displayKey: r'Mod + Shift + \',
+    codemirrorKeys: [r'Shift-Mod-\'],
+    category: ShortcutCategory.editing,
+    isPrimary: false,
+  );
+
+  // ── Search ───────────────────────────────────────────────────────────────
+  static const find = ShortcutDefinition(
+    label: 'Find',
+    displayKey: 'Mod + F',
+    codemirrorKeys: ['Mod-f'],
+    category: ShortcutCategory.search,
+  );
+
+  static const selectNextOccurrence = ShortcutDefinition(
+    label: 'Select next occurrence',
+    displayKey: 'Mod + D',
+    codemirrorKeys: ['Mod-d'],
+    category: ShortcutCategory.search,
+  );
+
+  static const findNext = ShortcutDefinition(
+    label: 'Find next',
+    displayKey: 'F3 / Mod + G',
+    codemirrorKeys: ['F3', 'Mod-g'],
+    category: ShortcutCategory.search,
+    isPrimary: false,
+  );
+
+  static const findPrevious = ShortcutDefinition(
+    label: 'Find previous',
+    displayKey: 'Shift + F3 / Mod + Shift + G',
+    codemirrorKeys: ['Shift-F3', 'Mod-Shift-g'],
+    category: ShortcutCategory.search,
+    isPrimary: false,
+  );
+
+  static const selectAllOccurrences = ShortcutDefinition(
+    label: 'Select all occurrences',
+    displayKey: 'Mod + Shift + L',
+    codemirrorKeys: ['Mod-Shift-l'],
+    category: ShortcutCategory.search,
+    isPrimary: false,
+  );
+
+  static const goToLine = ShortcutDefinition(
+    label: 'Go to line',
+    displayKey: 'Mod + Alt + G',
+    codemirrorKeys: ['Mod-Alt-g'],
+    category: ShortcutCategory.search,
+    isPrimary: false,
+  );
+
+  // ── Autocomplete & folding ───────────────────────────────────────────────
+  static const triggerAutocomplete = ShortcutDefinition(
+    label: 'Trigger autocomplete',
+    displayKey: 'Ctrl + Space',
+    codemirrorKeys: ['Ctrl-Space'],
+    category: ShortcutCategory.autocompleteFolding,
+    isPrimary: false,
+  );
+
+  static const foldCode = ShortcutDefinition(
+    label: 'Fold code',
+    displayKey: 'Ctrl + Shift + [',
+    codemirrorKeys: ['Ctrl-Shift-['],
+    category: ShortcutCategory.autocompleteFolding,
+    isPrimary: false,
+  );
+
+  static const unfoldCode = ShortcutDefinition(
+    label: 'Unfold code',
+    displayKey: 'Ctrl + Shift + ]',
+    codemirrorKeys: ['Ctrl-Shift-]'],
+    category: ShortcutCategory.autocompleteFolding,
+    isPrimary: false,
+  );
+
+  static const foldAll = ShortcutDefinition(
+    label: 'Fold all',
+    displayKey: 'Ctrl + Alt + [',
+    codemirrorKeys: ['Ctrl-Alt-['],
+    category: ShortcutCategory.autocompleteFolding,
+    isPrimary: false,
+  );
+
+  static const unfoldAll = ShortcutDefinition(
+    label: 'Unfold all',
+    displayKey: 'Ctrl + Alt + ]',
+    codemirrorKeys: ['Ctrl-Alt-]'],
+    category: ShortcutCategory.autocompleteFolding,
+    isPrimary: false,
+  );
+
+  // ── Native clipboard actions ─────────────────────────────────────────────
+  static const cut = ShortcutDefinition(
+    label: 'Cut',
+    displayKey: 'Mod + X',
+  );
+
+  static const copy = ShortcutDefinition(
+    label: 'Copy',
+    displayKey: 'Mod + C',
+  );
+
+  static const paste = ShortcutDefinition(
+    label: 'Paste',
+    displayKey: 'Mod + V',
+  );
 }
 
 /// The complete list of keyboard shortcuts displayed in the shortcuts dialog.
@@ -74,183 +300,38 @@ class ShortcutDefinition {
 /// modifier key. Call [resolveDisplayKey] to get the platform-specific string.
 const shortcutDefinitions = <ShortcutDefinition>[
   // ── Refactoring & code intelligence ──────────────────────────────────────
-  ShortcutDefinition(
-    label: 'Quick fix',
-    displayKey: 'Mod + .',
-    codemirrorKeys: ['Mod-.'],
-    category: ShortcutCategory.refactoring,
-  ),
-  ShortcutDefinition(
-    label: 'Rename symbol',
-    displayKey: 'F2',
-    codemirrorKeys: ['F2'],
-    category: ShortcutCategory.refactoring,
-  ),
-  ShortcutDefinition(
-    label: 'Go to definition',
-    displayKey: 'F12',
-    codemirrorKeys: ['F12'],
-    category: ShortcutCategory.refactoring,
-  ),
-  ShortcutDefinition(
-    label: 'Find references',
-    displayKey: 'Shift + F12',
-    codemirrorKeys: ['Shift-F12'],
-    category: ShortcutCategory.refactoring,
-  ),
-  ShortcutDefinition(
-    label: 'Format Dart files',
-    displayKey: 'Shift + Alt + F',
-    codemirrorKeys: ['Shift-Alt-f', 'Shift-Alt-F'],
-    category: ShortcutCategory.refactoring,
-  ),
-  ShortcutDefinition(
-    label: 'Next problem',
-    displayKey: 'F8',
-    codemirrorKeys: ['F8'],
-    category: ShortcutCategory.refactoring,
-    isPrimary: false,
-  ),
+  ShortcutDefinition.quickFix,
+  ShortcutDefinition.renameSymbol,
+  ShortcutDefinition.goToDefinition,
+  ShortcutDefinition.findReferences,
+  ShortcutDefinition.formatDocument,
+  ShortcutDefinition.nextProblem,
 
   // ── Editing ──────────────────────────────────────────────────────────────
-  ShortcutDefinition(
-    label: 'Toggle line comment',
-    displayKey: 'Mod + /',
-    codemirrorKeys: ['Mod-/'],
-    category: ShortcutCategory.editing,
-  ),
-  ShortcutDefinition(
-    label: 'Toggle block comment',
-    displayKey: 'Shift + Alt + A',
-    codemirrorKeys: ['Alt-A'],
-    category: ShortcutCategory.editing,
-  ),
-  ShortcutDefinition(
-    label: 'Move line up / down',
-    displayKey: 'Alt + ↑ / ↓',
-    codemirrorKeys: ['Alt-ArrowUp', 'Alt-ArrowDown'],
-    category: ShortcutCategory.editing,
-  ),
-  ShortcutDefinition(
-    label: 'Delete line',
-    displayKey: 'Mod + Shift + K',
-    codemirrorKeys: ['Shift-Mod-k'],
-    category: ShortcutCategory.editing,
-  ),
-  ShortcutDefinition(
-    label: 'Indent',
-    displayKey: 'Tab',
-    codemirrorKeys: ['Tab'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Outdent',
-    displayKey: 'Shift + Tab',
-    codemirrorKeys: ['Shift-Tab'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Copy line up / down',
-    displayKey: 'Shift + Alt + ↑ / ↓',
-    codemirrorKeys: ['Shift-Alt-ArrowUp', 'Shift-Alt-ArrowDown'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Insert blank line',
-    displayKey: 'Mod + Enter',
-    codemirrorKeys: ['Mod-Enter'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Jump to matching bracket',
-    displayKey: r'Mod + Shift + \',
-    codemirrorKeys: [r'Shift-Mod-\'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  ),
+  ShortcutDefinition.toggleLineComment,
+  ShortcutDefinition.toggleBlockComment,
+  ShortcutDefinition.moveLine,
+  ShortcutDefinition.deleteLine,
+  ShortcutDefinition.indent,
+  ShortcutDefinition.outdent,
+  ShortcutDefinition.copyLine,
+  ShortcutDefinition.insertBlankLine,
+  ShortcutDefinition.jumpToMatchingBracket,
 
   // ── Search ───────────────────────────────────────────────────────────────
-  ShortcutDefinition(
-    label: 'Find',
-    displayKey: 'Mod + F',
-    codemirrorKeys: ['Mod-f'],
-    category: ShortcutCategory.search,
-  ),
-  ShortcutDefinition(
-    label: 'Select next occurrence',
-    displayKey: 'Mod + D',
-    codemirrorKeys: ['Mod-d'],
-    category: ShortcutCategory.search,
-  ),
-  ShortcutDefinition(
-    label: 'Find next',
-    displayKey: 'F3 / Mod + G',
-    codemirrorKeys: ['F3', 'Mod-g'],
-    category: ShortcutCategory.search,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Find previous',
-    displayKey: 'Shift + F3 / Mod + Shift + G',
-    codemirrorKeys: ['Shift-F3', 'Mod-Shift-g'],
-    category: ShortcutCategory.search,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Select all occurrences',
-    displayKey: 'Mod + Shift + L',
-    codemirrorKeys: ['Mod-Shift-l'],
-    category: ShortcutCategory.search,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Go to line',
-    displayKey: 'Mod + Alt + G',
-    codemirrorKeys: ['Mod-Alt-g'],
-    category: ShortcutCategory.search,
-    isPrimary: false,
-  ),
+  ShortcutDefinition.find,
+  ShortcutDefinition.selectNextOccurrence,
+  ShortcutDefinition.findNext,
+  ShortcutDefinition.findPrevious,
+  ShortcutDefinition.selectAllOccurrences,
+  ShortcutDefinition.goToLine,
 
   // ── Autocomplete & folding ───────────────────────────────────────────────
-  ShortcutDefinition(
-    label: 'Trigger autocomplete',
-    displayKey: 'Ctrl + Space',
-    codemirrorKeys: ['Ctrl-Space'],
-    category: ShortcutCategory.autocompleteFolding,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Fold code',
-    displayKey: 'Ctrl + Shift + [',
-    codemirrorKeys: ['Ctrl-Shift-['],
-    category: ShortcutCategory.autocompleteFolding,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Unfold code',
-    displayKey: 'Ctrl + Shift + ]',
-    codemirrorKeys: ['Ctrl-Shift-]'],
-    category: ShortcutCategory.autocompleteFolding,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Fold all',
-    displayKey: 'Ctrl + Alt + [',
-    codemirrorKeys: ['Ctrl-Alt-['],
-    category: ShortcutCategory.autocompleteFolding,
-    isPrimary: false,
-  ),
-  ShortcutDefinition(
-    label: 'Unfold all',
-    displayKey: 'Ctrl + Alt + ]',
-    codemirrorKeys: ['Ctrl-Alt-]'],
-    category: ShortcutCategory.autocompleteFolding,
-    isPrimary: false,
-  ),
+  ShortcutDefinition.triggerAutocomplete,
+  ShortcutDefinition.foldCode,
+  ShortcutDefinition.unfoldCode,
+  ShortcutDefinition.foldAll,
+  ShortcutDefinition.unfoldAll,
 ];
 
 /// The number of shortcut rows visible when the dialog is collapsed.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -5,7 +5,8 @@
 import 'package:web/web.dart' as web;
 
 /// Whether the current platform is macOS.
-final isMac = web.window.navigator.platform.toLowerCase().contains('mac') ||
+final isMac =
+    web.window.navigator.platform.toLowerCase().contains('mac') ||
     web.window.navigator.userAgent.toLowerCase().contains('mac');
 
 /// Resolves platform-agnostic modifier placeholders in a display key string.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
@@ -104,7 +104,9 @@ class _ShortcutsDialogState extends State<ShortcutsDialog> {
     // Group shortcuts by category, preserving the order of first appearance.
     final categories = <ShortcutCategory, List<ShortcutDefinition>>{};
     for (final shortcut in shortcutDefinitions) {
-      categories.putIfAbsent(shortcut.category, () => []).add(shortcut);
+      if (shortcut.category case final category?) {
+        categories.putIfAbsent(category, () => []).add(shortcut);
+      }
     }
 
     final shortcutRows = <Component>[];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
@@ -17,6 +17,7 @@ import '../filetree/file_tree_tabs_adapter.dart';
 import '../filetree/file_tree_view_model.dart';
 import '../preview/view_models/preview_view_model.dart';
 import '../shared/app_event_bus.dart';
+import '../shared/components/context_menu.dart';
 import 'data/workspace_repository.dart';
 
 /// Owns every resource whose lifetime is tied to one worker workspace.
@@ -29,11 +30,16 @@ final class WorkspaceSession {
     required this.fileTree,
     required this.diagnostics,
     required this.preview,
+    required this.contextMenu,
     required this._codemirrorAdapter,
   });
 
   factory WorkspaceSession.create(WorkspaceRepository repository) {
-    final codemirrorAdapter = CodeMirrorTabAdapter();
+    final contextMenu = ContextMenuController();
+    final codemirrorAdapter = CodeMirrorTabAdapter(
+      contextMenu: contextMenu,
+      events: repository.events,
+    );
     final tabs = TabsViewModel(
       workspaceResourceApi: repository.workspaceResourceApi,
       adapters: [
@@ -59,6 +65,7 @@ final class WorkspaceSession {
         workspaceRepository: repository,
         eventBus: repository.events,
       ),
+      contextMenu: contextMenu,
       codemirrorAdapter: codemirrorAdapter,
     );
   }
@@ -70,6 +77,7 @@ final class WorkspaceSession {
   final FileTreeViewModel fileTree;
   final DiagnosticsViewModel diagnostics;
   final PreviewViewModel preview;
+  final ContextMenuController contextMenu;
   final CodeMirrorTabAdapter _codemirrorAdapter;
 
   LanguageServer? _languageServer;
@@ -124,6 +132,8 @@ final class WorkspaceSession {
     await _safeAwait(_languageServer?.stop());
     _languageServer = null;
 
+    contextMenu.hide();
+    contextMenu.dispose();
     await _safeAwait(
       closeWorker ? repository.close() : repository.closeWorkspaceOnly(),
     );

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/codemirror/editor_context_menu_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/codemirror/editor_context_menu_test.dart
@@ -1,0 +1,320 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+
+import 'package:codemirror_dart/codemirror_dart.dart' as cm;
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/editor/codemirror/editor_context_menu.dart';
+import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  setUpAll(() async {
+    final script = web.document.createElement('script') as web.HTMLScriptElement;
+    final loaded = web.EventStreamProviders.loadEvent.forTarget(script).first;
+    script.src = 'packages/codemirror_dart/assets/codemirror-dart.bundle.js';
+    web.document.head!.appendChild(script);
+    await loaded;
+  });
+
+  group('EditorContextMenu', () {
+    late web.HTMLElement container;
+    late CodeMirrorEditor editor;
+
+    setUp(() {
+      container = web.document.createElement('div') as web.HTMLElement;
+      web.document.body?.appendChild(container);
+      editor = CodeMirrorEditor(
+        container,
+        file: 'main.dart',
+        initialDoc: 'void main() {}',
+      );
+    });
+
+    tearDown(() {
+      editor.destroy();
+      container.remove();
+    });
+
+    test('builds menu items in the exact required order', () {
+      final items = buildEditorContextMenu(
+        editor: editor,
+        path: 'main.dart',
+      );
+
+      // Verify total items (7 actions + 2 dividers = 9 entries)
+      expect(items.length, 9);
+
+      // 1. Go to Definition
+      expect(items[0], isA<ContextMenuItem>());
+      final item1 = items[0] as ContextMenuItem;
+      expect(item1.label, 'Go to definition');
+      expect(item1.shortcut, 'F12');
+
+      // 2. Find References
+      expect(items[1], isA<ContextMenuItem>());
+      final item2 = items[1] as ContextMenuItem;
+      expect(item2.label, 'Find references');
+      expect(item2.shortcut, 'Shift + F12');
+
+      // Divider
+      expect(items[2], isA<ContextMenuDivider>());
+
+      // 3. Rename Symbol
+      expect(items[3], isA<ContextMenuItem>());
+      final item3 = items[3] as ContextMenuItem;
+      expect(item3.label, 'Rename symbol');
+      expect(item3.shortcut, 'F2');
+
+      // 4. Format Document
+      expect(items[4], isA<ContextMenuItem>());
+      final item4 = items[4] as ContextMenuItem;
+      expect(item4.label, 'Format document');
+      expect(item4.shortcut, 'Shift + Alt + F');
+
+      // Divider
+      expect(items[5], isA<ContextMenuDivider>());
+
+      // 5. Cut
+      expect(items[6], isA<ContextMenuItem>());
+      final item5 = items[6] as ContextMenuItem;
+      expect(item5.label, 'Cut');
+
+      // 6. Copy
+      expect(items[7], isA<ContextMenuItem>());
+      final item6 = items[7] as ContextMenuItem;
+      expect(item6.label, 'Copy');
+
+      // 7. Paste
+      expect(items[8], isA<ContextMenuItem>());
+      final item7 = items[8] as ContextMenuItem;
+      expect(item7.label, 'Paste');
+    });
+
+    test('builds only edit items for non-Dart files without dividers', () {
+      final items = buildEditorContextMenu(
+        editor: editor,
+        path: 'pubspec.yaml',
+      );
+
+      expect(items.length, 3);
+
+      expect(items[0], isA<ContextMenuItem>());
+      final item0 = items[0] as ContextMenuItem;
+      expect(item0.label, 'Cut');
+
+      expect(items[1], isA<ContextMenuItem>());
+      final item1 = items[1] as ContextMenuItem;
+      expect(item1.label, 'Copy');
+
+      expect(items[2], isA<ContextMenuItem>());
+      final item2 = items[2] as ContextMenuItem;
+      expect(item2.label, 'Paste');
+
+      for (final item in items) {
+        expect(item, isNot(isA<ContextMenuDivider>()));
+      }
+    });
+
+    test('pastes clipboard text over the current selection', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          selection: cm.EditorSelection.single(5, 9),
+        ),
+      );
+
+      await handleEditorPaste(
+        editor,
+        readClipboard: () async => 'runApp',
+      );
+
+      expect(editor.text, 'void runApp() {}');
+      expect(editor.view.state.selection.main.head, 11);
+    });
+
+    test('pastes into every selection and preserves the main selection', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'aa bb cc'.toJS),
+          selection: cm.EditorSelection.create(
+            [
+              cm.EditorSelection.range(0, 2),
+              cm.EditorSelection.range(6, 8),
+            ].toJS,
+            1,
+          ),
+        ),
+      );
+
+      await handleEditorPaste(
+        editor,
+        readClipboard: () async => 'X',
+      );
+
+      expect(editor.text, 'X bb X');
+      final selection = editor.view.state.selection;
+      expect(selection.ranges.toDart.map((range) => range.head), [1, 6]);
+      expect(selection.mainIndex, 1);
+      expect(selection.main.head, 6);
+    });
+
+    test('reports a clipboard read failure without editing', () async {
+      String? pasteError;
+
+      await handleEditorPaste(
+        editor,
+        readClipboard: () => Future<String>.error(StateError('read denied')),
+        onPasteError: (message) => pasteError = message,
+      );
+
+      expect(editor.text, 'void main() {}');
+      expect(pasteError, contains('browser may not have clipboard permission'));
+    });
+
+    test('copies multiple non-empty selections joined with newlines', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'first line\nsecond line\nthird line'.toJS),
+          selection: cm.EditorSelection.create(
+            [
+              cm.EditorSelection.range(0, 5), // 'first'
+              cm.EditorSelection.range(11, 17), // 'second'
+              cm.EditorSelection.range(23, 28), // 'third'
+            ].toJS,
+          ),
+        ),
+      );
+
+      String? copiedText;
+      handleEditorCopy(editor, writeClipboard: (text) async => copiedText = text);
+
+      expect(copiedText, 'first\nsecond\nthird');
+    });
+
+    test('copies single selection without trailing newline', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          selection: cm.EditorSelection.single(0, 4), // 'void'
+        ),
+      );
+
+      String? copiedText;
+      handleEditorCopy(editor, writeClipboard: (text) async => copiedText = text);
+
+      expect(copiedText, 'void');
+    });
+
+    test('cuts last line without leaving a ghost empty line at end of document', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'line 1\nline 2\nline 3'.toJS),
+          selection: cm.EditorSelection.single(15), // cursor on 'line 3'
+        ),
+      );
+
+      String? cutText;
+      handleEditorCut(editor, writeClipboard: (text) async => cutText = text);
+
+      expect(cutText, 'line 3\n');
+      expect(editor.text, 'line 1\nline 2');
+    });
+
+    test('cuts middle line cleanly', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'line 1\nline 2\nline 3'.toJS),
+          selection: cm.EditorSelection.single(8), // cursor on 'line 2'
+        ),
+      );
+
+      String? cutText;
+      handleEditorCut(editor, writeClipboard: (text) async => cutText = text);
+
+      expect(cutText, 'line 2\n');
+      expect(editor.text, 'line 1\nline 3');
+    });
+
+    test('cuts multiple non-empty selections joined with newlines', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'aaa bbb ccc'.toJS),
+          selection: cm.EditorSelection.create(
+            [
+              cm.EditorSelection.range(0, 3), // 'aaa'
+              cm.EditorSelection.range(8, 11), // 'ccc'
+            ].toJS,
+          ),
+        ),
+      );
+
+      String? cutText;
+      handleEditorCut(editor, writeClipboard: (text) async => cutText = text);
+
+      expect(cutText, 'aaa\nccc');
+      expect(editor.text, ' bbb ');
+    });
+
+    test('cuts line with multiple cursors on the same line without duplicate changes', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'line 1\nline 2\nline 3'.toJS),
+          selection: cm.EditorSelection.create(
+            [
+              cm.EditorSelection.cursor(7), // start of line 2
+              cm.EditorSelection.cursor(10), // middle of line 2
+            ].toJS,
+          ),
+        ),
+      );
+
+      String? cutText;
+      handleEditorCut(editor, writeClipboard: (text) async => cutText = text);
+
+      expect(cutText, 'line 2\n');
+      expect(editor.text, 'line 1\nline 3');
+    });
+
+    test('copies line with multiple cursors on the same line without duplicating text', () async {
+      editor.view.dispatch(
+        cm.TransactionSpec(
+          changes: cm.ChangeSpec(from: 0, to: editor.text.length, insert: 'line 1\nline 2\nline 3'.toJS),
+          selection: cm.EditorSelection.create(
+            [
+              cm.EditorSelection.cursor(7), // start of line 2
+              cm.EditorSelection.cursor(10), // middle of line 2
+            ].toJS,
+          ),
+        ),
+      );
+
+      String? copiedText;
+      handleEditorCopy(editor, writeClipboard: (text) async => copiedText = text);
+
+      expect(copiedText, 'line 2\n');
+    });
+
+    test('dispatchEditorKey dispatches keydown event to contentDOM', () {
+      web.Event? receivedEvent;
+      final listener = ((web.Event e) {
+        receivedEvent = e;
+      }).toJS;
+
+      editor.view.contentDOM.addEventListener('keydown', listener);
+      addTearDown(() => editor.view.contentDOM.removeEventListener('keydown', listener));
+
+      dispatchEditorKey(editor, key: 'F12', code: 'F12');
+
+      expect(receivedEvent, isNotNull);
+      final keyEvent = receivedEvent as web.KeyboardEvent;
+      expect(keyEvent.key, 'F12');
+      expect(keyEvent.code, 'F12');
+      expect(keyEvent.target, equals(editor.view.contentDOM));
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_tab_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_tab_bar_test.dart
@@ -90,9 +90,11 @@ void main() {
       await pumpEventQueue();
 
       expect(contextMenu.isOpen, isTrue);
-      final closeAllItem = contextMenu.items.firstWhere(
-        (item) => item is ContextMenuItem && item.label == 'Close all tabs',
-      ) as ContextMenuItem;
+      final closeAllItem =
+          contextMenu.items.firstWhere(
+                (item) => item is ContextMenuItem && item.label == 'Close all tabs',
+              )
+              as ContextMenuItem;
 
       closeAllItem.onPressed();
 
@@ -136,16 +138,17 @@ void main() {
       );
       await pumpEventQueue();
 
-      final closeOthersItem = contextMenu.items.firstWhere(
-        (item) => item is ContextMenuItem && item.label == 'Close others',
-      ) as ContextMenuItem;
+      final closeOthersItem =
+          contextMenu.items.firstWhere(
+                (item) => item is ContextMenuItem && item.label == 'Close others',
+              )
+              as ContextMenuItem;
 
       closeOthersItem.onPressed();
 
       expect(promptedPaths, ['lib/dirty1.dart']);
       expect(closedPaths, isEmpty);
     });
-
 
     testClient('closeAllTabs continues closing all tabs if user confirms each discard', (tester) async {
       final contextMenu = ContextMenuController();
@@ -182,9 +185,11 @@ void main() {
       );
       await pumpEventQueue();
 
-      final closeAllItem = contextMenu.items.firstWhere(
-        (item) => item is ContextMenuItem && item.label == 'Close all',
-      ) as ContextMenuItem;
+      final closeAllItem =
+          contextMenu.items.firstWhere(
+                (item) => item is ContextMenuItem && item.label == 'Close all',
+              )
+              as ContextMenuItem;
 
       closeAllItem.onPressed();
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_tab_bar_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_tab_bar_test.dart
@@ -1,0 +1,195 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/editor/components/editor_tab_bar.dart';
+import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
+import 'package:jaspr/dom.dart' hide path;
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+final class _TestEditorTab extends EditorTab<Component> {
+  _TestEditorTab(super.path, {this.unsaved = false});
+
+  final bool unsaved;
+
+  @override
+  Component build() => const Component.fragment([]);
+
+  @override
+  void discardUnsavedChanges() {}
+
+  @override
+  bool get hasUnsavedChanges => unsaved;
+
+  @override
+  bool get keepAlive => false;
+
+  @override
+  Stream<void> get onUpdate => const Stream.empty();
+
+  @override
+  Future<void> save() async {}
+}
+
+void main() {
+  group('EditorTabBar – batch close cancellation', () {
+    testClient('closeAllTabs aborts immediately when user cancels discard on a dirty tab', (tester) async {
+      final contextMenu = ContextMenuController();
+      final tab1 = _TestEditorTab('lib/a.dart', unsaved: true);
+      final tab2 = _TestEditorTab('lib/b.dart', unsaved: true);
+      final tab3 = _TestEditorTab('lib/c.dart', unsaved: false);
+
+      final closedPaths = <String>[];
+      final promptedPaths = <String>[];
+
+      tester.pumpComponent(
+        div([
+          EditorTabBar(
+            openTabs: [tab1, tab2, tab3],
+            activeFile: 'lib/a.dart',
+            onSwitchFile: (_) {},
+            onCloseFile: (path, {discardChanges = false}) {
+              closedPaths.add(path);
+              return true;
+            },
+            confirmDiscard: (path) {
+              promptedPaths.add(path);
+              return false; // User cancels confirmation dialog
+            },
+            contextMenu: contextMenu,
+          ),
+          ListenableBuilder(
+            listenable: contextMenu,
+            builder: (context) => contextMenu.isOpen
+                ? ContextMenu(
+                    x: contextMenu.x,
+                    y: contextMenu.y,
+                    items: contextMenu.items,
+                    onClose: contextMenu.hide,
+                  )
+                : const Component.fragment([]),
+          ),
+        ]),
+      );
+
+      final tabBar = web.document.querySelector('.editor-tab-bar') as web.HTMLElement;
+      tabBar.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(clientX: 10, clientY: 10, bubbles: true, cancelable: true),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(contextMenu.isOpen, isTrue);
+      final closeAllItem = contextMenu.items.firstWhere(
+        (item) => item is ContextMenuItem && item.label == 'Close all tabs',
+      ) as ContextMenuItem;
+
+      closeAllItem.onPressed();
+
+      // Only tab1 was prompted, then the batch aborted because user clicked cancel
+      expect(promptedPaths, ['lib/a.dart']);
+      expect(closedPaths, isEmpty);
+    });
+
+    testClient('closeOtherTabs aborts when user cancels discard on dirty tab', (tester) async {
+      final contextMenu = ContextMenuController();
+      final tab1 = _TestEditorTab('lib/keep.dart', unsaved: false);
+      final tab2 = _TestEditorTab('lib/dirty1.dart', unsaved: true);
+      final tab3 = _TestEditorTab('lib/dirty2.dart', unsaved: true);
+
+      final closedPaths = <String>[];
+      final promptedPaths = <String>[];
+
+      tester.pumpComponent(
+        EditorTabBar(
+          openTabs: [tab1, tab2, tab3],
+          activeFile: 'lib/keep.dart',
+          onSwitchFile: (_) {},
+          onCloseFile: (path, {discardChanges = false}) {
+            closedPaths.add(path);
+            return true;
+          },
+          confirmDiscard: (path) {
+            promptedPaths.add(path);
+            return false;
+          },
+          contextMenu: contextMenu,
+        ),
+      );
+
+      final firstTab = web.document.querySelector('.editor-tab') as web.HTMLElement;
+      firstTab.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(clientX: 10, clientY: 10, bubbles: true, cancelable: true),
+        ),
+      );
+      await pumpEventQueue();
+
+      final closeOthersItem = contextMenu.items.firstWhere(
+        (item) => item is ContextMenuItem && item.label == 'Close others',
+      ) as ContextMenuItem;
+
+      closeOthersItem.onPressed();
+
+      expect(promptedPaths, ['lib/dirty1.dart']);
+      expect(closedPaths, isEmpty);
+    });
+
+
+    testClient('closeAllTabs continues closing all tabs if user confirms each discard', (tester) async {
+      final contextMenu = ContextMenuController();
+      final tab1 = _TestEditorTab('lib/a.dart', unsaved: true);
+      final tab2 = _TestEditorTab('lib/b.dart', unsaved: false);
+      final tab3 = _TestEditorTab('lib/c.dart', unsaved: true);
+
+      final closedPaths = <String>[];
+      final promptedPaths = <String>[];
+
+      tester.pumpComponent(
+        EditorTabBar(
+          openTabs: [tab1, tab2, tab3],
+          activeFile: 'lib/a.dart',
+          onSwitchFile: (_) {},
+          onCloseFile: (path, {discardChanges = false}) {
+            closedPaths.add(path);
+            return true;
+          },
+          confirmDiscard: (path) {
+            promptedPaths.add(path);
+            return true; // User confirms discard
+          },
+          contextMenu: contextMenu,
+        ),
+      );
+
+      final firstTab = web.document.querySelector('.editor-tab') as web.HTMLElement;
+      firstTab.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(clientX: 10, clientY: 10, bubbles: true, cancelable: true),
+        ),
+      );
+      await pumpEventQueue();
+
+      final closeAllItem = contextMenu.items.firstWhere(
+        (item) => item is ContextMenuItem && item.label == 'Close all',
+      ) as ContextMenuItem;
+
+      closeAllItem.onPressed();
+
+      expect(promptedPaths, ['lib/a.dart', 'lib/c.dart']);
+      expect(closedPaths, ['lib/a.dart', 'lib/b.dart', 'lib/c.dart']);
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/error_toast_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/error_toast_test.dart
@@ -115,7 +115,6 @@ void main() {
     expect(contextMenu.isOpen, isFalse);
     expect(web.document.querySelector('.editor-error-toast')?.textContent, contains('Clipboard access denied'));
 
-    contextMenu.dispose();
     await events.dispose();
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/error_toast_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/error_toast_test.dart
@@ -9,7 +9,10 @@ import 'dart:async';
 
 import 'package:dartpad_frontend/features/editor/components/error_toast.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
 import 'package:dartpad_frontend/features/shared/events/error_toast_event.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
 
@@ -24,6 +27,8 @@ void main() {
     );
     await pumpEventQueue();
 
+    expect(web.document.querySelector('.editor-error-toast'), isNull);
+
     events.dispatch(const ErrorToastEvent('Saving failed, try again'));
     await pumpEventQueue();
 
@@ -36,6 +41,81 @@ void main() {
     await pumpEventQueue();
 
     expect(web.document.querySelector('.editor-error-toast'), isNull);
+    await events.dispose();
+  });
+
+  testClient('remounts toast on consecutive errors to restart animation', (tester) async {
+    final events = AppEventBus();
+    tester.pumpComponent(
+      ErrorToast(
+        events: events,
+        displayDuration: const Duration(seconds: 1),
+      ),
+    );
+    await pumpEventQueue();
+
+    events.dispatch(const ErrorToastEvent('First error'));
+    await pumpEventQueue();
+    final firstToast = web.document.querySelector('.editor-error-toast');
+    expect(firstToast, isNotNull);
+    expect(firstToast!.textContent, contains('First error'));
+
+    await Future<void>.delayed(const Duration(milliseconds: 600));
+    events.dispatch(const ErrorToastEvent('Second error'));
+    await pumpEventQueue();
+
+    final secondToast = web.document.querySelector('.editor-error-toast');
+    expect(secondToast, isNotNull);
+    expect(firstToast.isConnected, isFalse);
+    expect(secondToast!.textContent, contains('Second error'));
+
+    await Future<void>.delayed(const Duration(milliseconds: 600));
+    await pumpEventQueue();
+    expect(web.document.querySelector('.editor-error-toast'), isNotNull);
+
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+    await pumpEventQueue();
+    expect(web.document.querySelector('.editor-error-toast'), isNull);
+    await events.dispose();
+  });
+
+  testClient('shows an error while a context menu closes without corrupting the render tree', (tester) async {
+    final events = AppEventBus();
+    final contextMenu = ContextMenuController();
+
+    tester.pumpComponent(
+      div([
+        ErrorToast(events: events),
+        ListenableBuilder(
+          listenable: contextMenu,
+          builder: (context) => ContextMenu(
+            x: contextMenu.x,
+            y: contextMenu.y,
+            items: contextMenu.items,
+            isOpen: contextMenu.isOpen,
+            onClose: contextMenu.hide,
+          ),
+        ),
+      ]),
+    );
+    await pumpEventQueue();
+
+    contextMenu.show(10, 10, [
+      ContextMenuItem(
+        label: 'Paste',
+        onPressed: () => events.dispatch(const ErrorToastEvent('Clipboard access denied')),
+      ),
+    ]);
+    await pumpEventQueue();
+
+    final paste = web.document.querySelector('.context-menu-item') as web.HTMLButtonElement;
+    paste.click();
+    await pumpEventQueue();
+
+    expect(contextMenu.isOpen, isFalse);
+    expect(web.document.querySelector('.editor-error-toast')?.textContent, contains('Clipboard access denied'));
+
+    contextMenu.dispose();
     await events.dispose();
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/tabs_view_model_test.dart
@@ -391,4 +391,61 @@ void main() {
     final topValue = double.parse(topStyle.replaceAll('px', ''));
     expect(topValue, lessThan(controller.anchorTop));
   });
+
+  testClient('right-click contextmenu positions cursor when outside selection', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    mainTab.editor.text = 'void main() {\n  print("hello");\n}';
+    // Set selection initially at position 0
+    mainTab.editor.view.dispatch(
+      TransactionSpec(selection: EditorSelection.single(0)),
+    );
+
+    // Get coords for position 10
+    final coords = mainTab.editor.view.coordsAtPos(10);
+    if (coords != null) {
+      mainTab.container.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(
+            bubbles: true,
+            cancelable: true,
+            clientX: ((coords.left + coords.right) / 2).round(),
+            clientY: ((coords.top + coords.bottom) / 2).round(),
+          ),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(mainTab.editor.view.state.selection.main.anchor, 10);
+    }
+  });
+
+  testClient('right-click contextmenu preserves selection when inside existing selection', (tester) async {
+    final mainTab = tabs!.activeTab! as CodeMirrorTab;
+    mainTab.editor.text = 'void main() {\n  print("hello");\n}';
+    // Set selection from 5 to 15
+    mainTab.editor.view.dispatch(
+      TransactionSpec(selection: EditorSelection.single(5, 15)),
+    );
+
+    // Get coords for position 10 (inside range 5..15)
+    final coords = mainTab.editor.view.coordsAtPos(10);
+    if (coords != null) {
+      mainTab.container.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(
+            bubbles: true,
+            cancelable: true,
+            clientX: ((coords.left + coords.right) / 2).round(),
+            clientY: ((coords.top + coords.bottom) / 2).round(),
+          ),
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(mainTab.editor.view.state.selection.main.from, 5);
+      expect(mainTab.editor.view.state.selection.main.to, 15);
+    }
+  });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/context_menu_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/context_menu_test.dart
@@ -1,0 +1,625 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
+import 'package:dartpad_frontend/features/bottom_panel/views/console_panel.dart';
+import 'package:dartpad_frontend/features/editor/components/editor_tab_bar.dart';
+import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
+import 'package:jaspr/dom.dart' hide path;
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:logging/logging.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  group('ContextMenuController', () {
+    test('opens and closes correctly', () {
+      final controller = ContextMenuController();
+      expect(controller.isOpen, isFalse);
+
+      var notified = false;
+      controller.addListener(() => notified = true);
+
+      controller.show(100, 200, [
+        ContextMenuItem(label: 'Item 1', onPressed: () {}),
+      ]);
+
+      expect(controller.isOpen, isTrue);
+      expect(controller.x, 100);
+      expect(controller.y, 200);
+      expect(controller.items.length, 1);
+      expect(notified, isTrue);
+
+      notified = false;
+      controller.hide();
+      expect(controller.isOpen, isFalse);
+      expect(controller.items, isEmpty);
+      expect(notified, isTrue);
+    });
+
+    test('calling show with empty items closes the menu', () {
+      final controller = ContextMenuController();
+      controller.show(100, 200, [ContextMenuItem(label: 'A', onPressed: () {})]);
+      expect(controller.isOpen, isTrue);
+
+      controller.show(100, 200, []);
+      expect(controller.isOpen, isFalse);
+    });
+
+    test('calling show and hide on disposed controller does not throw', () {
+      final controller = ContextMenuController()..dispose();
+
+      expect(
+        () => controller.show(100, 200, [ContextMenuItem(label: 'A', onPressed: () {})]),
+        returnsNormally,
+      );
+      expect(controller.isOpen, isFalse);
+
+      expect(controller.hide, returnsNormally);
+      expect(controller.isOpen, isFalse);
+    });
+  });
+
+  group('ContextMenu Component', () {
+    testClient('renders menu items, shortcuts and dividers', (tester) async {
+      var item1Clicked = false;
+
+      tester.pumpComponent(
+        ContextMenu(
+          x: 50,
+          y: 50,
+          onClose: () {},
+          items: [
+            ContextMenuItem(
+              label: 'Cut',
+              shortcut: 'Ctrl+X',
+              onPressed: () => item1Clicked = true,
+            ),
+            const ContextMenuItem(
+              label: 'Disabled Item',
+              disabled: true,
+              onPressed: _noop,
+            ),
+            const ContextMenuDivider(),
+            ContextMenuItem(
+              label: 'Delete',
+              destructive: true,
+              onPressed: () {},
+            ),
+          ],
+        ),
+      );
+
+      final menu = web.document.querySelector('.context-menu');
+      expect(menu, isNotNull);
+
+      // Divider
+      final divider = menu?.querySelector('.context-menu-divider');
+      expect(divider, isNotNull);
+
+      // Menu items
+      final items = menu?.querySelectorAll('.context-menu-item');
+      expect(items?.length, 3);
+
+      final firstItem = items?.item(0) as web.HTMLButtonElement?;
+      expect(firstItem?.textContent, contains('Cut'));
+      expect(firstItem?.textContent, contains('Ctrl+X'));
+
+      final disabledItem = items?.item(1) as web.HTMLButtonElement?;
+      expect(disabledItem?.disabled, isTrue);
+
+      final destructiveItem = items?.item(2) as web.HTMLButtonElement?;
+      expect(destructiveItem?.className, contains('destructive'));
+
+      // Click item
+      firstItem?.click();
+      expect(item1Clicked, isTrue);
+    });
+
+    testClient('invokes onClose when clicking an item', (tester) async {
+      var closed = false;
+      var clicked = false;
+
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () => closed = true,
+          items: [
+            ContextMenuItem(
+              label: 'Option 1',
+              onPressed: () => clicked = true,
+            ),
+          ],
+        ),
+      );
+
+      final button = web.document.querySelector('.context-menu-item') as web.HTMLButtonElement?;
+      button?.click();
+      await pumpEventQueue();
+
+      expect(clicked, isTrue);
+      expect(closed, isTrue);
+    });
+
+    testClient('invokes onClose on Escape keydown', (tester) async {
+      var closed = false;
+
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () => closed = true,
+          items: [
+            ContextMenuItem(label: 'Action', onPressed: () {}),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      web.document.dispatchEvent(
+        web.KeyboardEvent(
+          'keydown',
+          web.KeyboardEventInit(key: 'Escape', bubbles: true, cancelable: true),
+        ),
+      );
+
+      expect(closed, isTrue);
+    });
+
+    testClient('invokes onClose on clicking outside the menu', (tester) async {
+      var closed = false;
+
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () => closed = true,
+          items: [
+            ContextMenuItem(label: 'Action', onPressed: () {}),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      // Click on the document outside the menu
+      web.document.body?.dispatchEvent(
+        web.MouseEvent(
+          'mousedown',
+          web.MouseEventInit(bubbles: true, cancelable: true),
+        ),
+      );
+
+      expect(closed, isTrue);
+    });
+
+    testClient('exception safety: invokes onClose even if onPressed throws synchronously', (tester) async {
+      var closed = false;
+      Object? caughtError;
+
+      await runZonedGuarded(
+        () async {
+          tester.pumpComponent(
+            ContextMenu(
+              x: 10,
+              y: 10,
+              onClose: () => closed = true,
+              items: [
+                ContextMenuItem(
+                  label: 'Throws Exception',
+                  onPressed: () => throw StateError('Deliberate test exception'),
+                ),
+              ],
+            ),
+          );
+
+          await pumpEventQueue();
+
+          final button = web.document.querySelector('.context-menu-item') as web.HTMLButtonElement?;
+          button?.click();
+          await pumpEventQueue();
+        },
+        (error, stack) {
+          caughtError = error;
+        },
+      );
+
+      expect(caughtError, isA<StateError>());
+      expect(closed, isTrue);
+    });
+  });
+
+  group('ContextMenu Keyboard Navigation & WAI-ARIA', () {
+    testClient('focuses first enabled item on open and skips disabled items', (tester) async {
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () {},
+          items: [
+            const ContextMenuItem(label: 'Disabled Item', disabled: true, onPressed: _noop),
+            ContextMenuItem(label: 'First Enabled Item', onPressed: () {}),
+            ContextMenuItem(label: 'Second Enabled Item', onPressed: () {}),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      final buttons = web.document.querySelectorAll('.context-menu-item');
+      final firstEnabledButton = buttons.item(1) as web.HTMLButtonElement;
+
+      expect(web.document.activeElement, equals(firstEnabledButton));
+    });
+
+    testClient('navigates with ArrowDown, ArrowUp, Home, and End keys, skipping disabled items', (tester) async {
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () {},
+          items: [
+            ContextMenuItem(label: 'Item 1', onPressed: () {}),
+            const ContextMenuItem(label: 'Item 2 (Disabled)', disabled: true, onPressed: _noop),
+            ContextMenuItem(label: 'Item 3', onPressed: () {}),
+            ContextMenuItem(label: 'Item 4', onPressed: () {}),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      final buttons = web.document.querySelectorAll('.context-menu-item');
+      final item1 = buttons.item(0) as web.HTMLButtonElement;
+      final item3 = buttons.item(2) as web.HTMLButtonElement;
+      final item4 = buttons.item(3) as web.HTMLButtonElement;
+
+      // Initially, Item 1 is focused
+      expect(web.document.activeElement, equals(item1));
+
+      // ArrowDown skips Item 2 (disabled) and focuses Item 3
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item3));
+
+      // ArrowDown moves to Item 4
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item4));
+
+      // ArrowDown wraps around to Item 1
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item1));
+
+      // ArrowUp wraps around to Item 4
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowUp', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item4));
+
+      // ArrowUp moves to Item 3
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowUp', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item3));
+
+      // Home key moves to first enabled item (Item 1)
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'Home', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item1));
+
+      // End key moves to last enabled item (Item 4)
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'End', bubbles: true, cancelable: true)),
+      );
+      expect(web.document.activeElement, equals(item4));
+    });
+
+    testClient('activates focused item on Enter and Space keys', (tester) async {
+      var item1Triggered = false;
+      var item2Triggered = false;
+      var closedCount = 0;
+
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () => closedCount++,
+          items: [
+            ContextMenuItem(label: 'Item 1', onPressed: () => item1Triggered = true),
+            ContextMenuItem(label: 'Item 2', onPressed: () => item2Triggered = true),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      // Item 1 is focused by default -> trigger with Enter
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'Enter', bubbles: true, cancelable: true)),
+      );
+      await pumpEventQueue();
+      expect(item1Triggered, isTrue);
+      expect(closedCount, 1);
+
+      // Move focus to Item 2 -> trigger with Space
+      final buttons = web.document.querySelectorAll('.context-menu-item');
+      final item2 = buttons.item(1) as web.HTMLButtonElement;
+      item2.focus();
+
+      web.document.dispatchEvent(
+        web.KeyboardEvent('keydown', web.KeyboardEventInit(key: ' ', bubbles: true, cancelable: true)),
+      );
+      await pumpEventQueue();
+      expect(item2Triggered, isTrue);
+      expect(closedCount, 2);
+    });
+
+    testClient('handles keyboard events gracefully when all items are disabled or dividers', (tester) async {
+      tester.pumpComponent(
+        ContextMenu(
+          x: 10,
+          y: 10,
+          onClose: () {},
+          items: const [
+            ContextMenuDivider(),
+            ContextMenuItem(label: 'Disabled 1', disabled: true, onPressed: _noop),
+            ContextMenuDivider(),
+            ContextMenuItem(label: 'Disabled 2', disabled: true, onPressed: _noop),
+          ],
+        ),
+      );
+
+      await pumpEventQueue();
+
+      // Dispatching keys should not throw or crash
+      for (final key in ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', ' ']) {
+        web.document.dispatchEvent(
+          web.KeyboardEvent('keydown', web.KeyboardEventInit(key: key, bubbles: true, cancelable: true)),
+        );
+      }
+    });
+
+    testClient('retains opacity and adjusted position across component updates', (tester) async {
+      final itemsNotifier = ValueNotifier<List<ContextMenuEntry>>([
+        ContextMenuItem(label: 'Item A', onPressed: () {}),
+      ]);
+
+      tester.pumpComponent(
+        ListenableBuilder(
+          listenable: itemsNotifier,
+          builder: (context) => ContextMenu(
+            x: 20,
+            y: 30,
+            onClose: () {},
+            items: itemsNotifier.value,
+          ),
+        ),
+      );
+
+      await pumpEventQueue();
+
+      final menu = web.document.querySelector('.context-menu') as web.HTMLElement?;
+      expect(menu, isNotNull);
+      expect(menu?.style.opacity, '1');
+      expect(menu?.style.left, contains('px'));
+      expect(menu?.style.top, contains('px'));
+
+      // Update items without unmounting
+      itemsNotifier.value = [
+        ContextMenuItem(label: 'Item A Updated', onPressed: () {}),
+      ];
+      await pumpEventQueue();
+
+      // Verify opacity does not revert to 0 on re-render
+      expect(menu?.style.opacity, '1');
+    });
+  });
+
+  group('EditorTabBar Context Menu', () {
+    testClient('triggers context menu on tab right click', (tester) async {
+      final contextMenu = ContextMenuController();
+      final tab1 = _FakeEditorTab('lib/main.dart');
+      final tab2 = _FakeEditorTab('lib/helper.dart');
+
+      tester.pumpComponent(
+        EditorTabBar(
+          openTabs: [tab1, tab2],
+          activeFile: 'lib/main.dart',
+          onSwitchFile: (_) {},
+          onCloseFile: (_, {discardChanges = false}) => true,
+          contextMenu: contextMenu,
+        ),
+      );
+
+      final tabs = web.document.querySelectorAll('.editor-tab');
+      expect(tabs.length, 2);
+
+      final firstTab = tabs.item(0) as web.HTMLElement;
+      firstTab.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(clientX: 150, clientY: 250, bubbles: true, cancelable: true),
+        ),
+      );
+
+      expect(contextMenu.isOpen, isTrue);
+      expect(contextMenu.x, 150);
+      expect(contextMenu.y, 250);
+      expect(contextMenu.items.any((item) => item is ContextMenuItem && item.label == 'Close'), isTrue);
+      expect(contextMenu.items.any((item) => item is ContextMenuItem && item.label == 'Close others'), isTrue);
+      expect(contextMenu.items.any((item) => item is ContextMenuItem && item.label == 'Copy path'), isTrue);
+    });
+  });
+
+  group('ConsolePanel Context Menu', () {
+    testClient('keeps the native context menu when no controller is provided', (tester) async {
+      tester.pumpComponent(
+        const ConsolePanel(logs: []),
+      );
+
+      final panel = web.document.querySelector('.console-panel') as web.HTMLElement;
+      final event = web.MouseEvent(
+        'contextmenu',
+        web.MouseEventInit(bubbles: true, cancelable: true),
+      );
+      panel.dispatchEvent(event);
+
+      expect(event.defaultPrevented, isFalse);
+    });
+
+    testClient('triggers context menu on console right click', (tester) async {
+      final contextMenu = ContextMenuController();
+      var cleared = false;
+
+      tester.pumpComponent(
+        ConsolePanel(
+          logs: [
+            const ConsoleEntry(message: 'Hello World', level: Level.INFO),
+          ],
+          onClear: () => cleared = true,
+          contextMenu: contextMenu,
+        ),
+      );
+
+      final panel = web.document.querySelector('.console-panel') as web.HTMLElement;
+      panel.dispatchEvent(
+        web.MouseEvent(
+          'contextmenu',
+          web.MouseEventInit(clientX: 200, clientY: 300, bubbles: true, cancelable: true),
+        ),
+      );
+
+      expect(contextMenu.isOpen, isTrue);
+      expect(contextMenu.items.length, 2);
+
+      final clearItem = contextMenu.items.first as ContextMenuItem;
+      expect(clearItem.label, 'Clear console');
+      clearItem.onPressed();
+      expect(cleared, isTrue);
+    });
+  });
+
+  group('ContextMenu Dynamic Mount Lifecycle', () {
+    testClient('can be shown and hidden without replacing the component', (tester) async {
+      final open = ValueNotifier(false);
+
+      tester.pumpComponent(
+        ListenableBuilder(
+          listenable: open,
+          builder: (context) => ContextMenu(
+            key: const ValueKey('context-menu-host'),
+            x: 100,
+            y: 100,
+            items: [ContextMenuItem(label: 'Item', onPressed: () {})],
+            isOpen: open.value,
+            onClose: () {},
+          ),
+        ),
+      );
+      await pumpEventQueue();
+
+      final menu = web.document.querySelector('.context-menu') as web.HTMLElement;
+      expect(menu.style.display, 'none');
+
+      open.value = true;
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), same(menu));
+      expect(menu.style.display, 'flex');
+
+      open.value = false;
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), same(menu));
+      expect(menu.style.display, 'none');
+    });
+
+    testClient('mounts and unmounts cleanly without DOM fragment detachment errors', (tester) async {
+      final controller = ContextMenuController();
+
+      tester.pumpComponent(
+        div([
+          ListenableBuilder(
+            listenable: controller,
+            builder: (context) => controller.isOpen
+                ? ContextMenu(
+                    x: controller.x,
+                    y: controller.y,
+                    items: controller.items,
+                    onClose: controller.hide,
+                  )
+                : const Component.fragment([]),
+          ),
+        ]),
+      );
+
+      expect(web.document.querySelector('.context-menu'), isNull);
+
+      // Open menu
+      controller.show(100, 100, [
+        ContextMenuItem(label: 'Item A', onPressed: () {}),
+      ]);
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), isNotNull);
+
+      // Close menu
+      controller.hide();
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), isNull);
+
+      // Re-open menu
+      controller.show(150, 150, [
+        ContextMenuItem(label: 'Item B', onPressed: () {}),
+      ]);
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), isNotNull);
+
+      // Dismiss by Escape
+      web.document.dispatchEvent(
+        web.KeyboardEvent(
+          'keydown',
+          web.KeyboardEventInit(key: 'Escape', bubbles: true, cancelable: true),
+        ),
+      );
+      await pumpEventQueue();
+      expect(web.document.querySelector('.context-menu'), isNull);
+    });
+  });
+}
+
+void _noop() {}
+
+class _FakeEditorTab extends EditorTab<Component> {
+  _FakeEditorTab(super.path);
+
+  @override
+  Component build() => const Component.fragment([]);
+
+  @override
+  void discardUnsavedChanges() {}
+
+  @override
+  bool get hasUnsavedChanges => false;
+
+  @override
+  bool get keepAlive => false;
+
+  @override
+  Stream<void> get onUpdate => const Stream.empty();
+
+  @override
+  Future<void> save() async {}
+}


### PR DESCRIPTION
Adds a context menu to the following "areas"

- Editor
- EditorTabBar
- FileTree
- FileTreeItem
- ConsolePanel

<img width="1519" height="664" alt="grafik" src="https://github.com/user-attachments/assets/f1d5cc09-df52-4de8-a9b9-555fa8ebfe57" />


Rename is not working yet and will be implemented in a follow up