### PR TITLE
feat(dartpad-preview): dart lsp rename

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -39672,7 +39672,9 @@ ${text}</tr>
     // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
+    /** Updates the transient rename-message tooltip shown by an editor view. */
     const renameTooltipEffect = StateEffect.define();
+    /** Stores the currently visible rename-message tooltip, if any. */
     const renameTooltipField = StateField.define({
         create() {
             return null;
@@ -39690,6 +39692,7 @@ ${text}</tr>
         },
         provide: (field) => showTooltip.from(field),
     });
+    /** Returns a user-facing message for an unknown LSP or workspace error. */
     function getRenameErrorMessage(error) {
         if (!error)
             return "The element can't be renamed.";
@@ -39704,6 +39707,7 @@ ${text}</tr>
         }
         return "The element can't be renamed.";
     }
+    /** Creates the temporary tooltip used to report rename failures. */
     function createRenameTooltip(pos, message) {
         return {
             pos,
@@ -39738,6 +39742,7 @@ ${text}</tr>
             },
         };
     }
+    /** Shows a rename message at `pos` and removes it automatically after a delay. */
     function showRenameMessage(view, pos, message) {
         const effects = [closeHoverTooltips];
         if (view.state.field(renameTooltipField, false) === undefined) {
@@ -39780,7 +39785,10 @@ ${text}</tr>
                 end: toPosition(doc, mapping.mapPosition(uri, edit.range.end, -1)),
             } })));
     }
-    /** Rebase edits for open CodeMirror documents while preserving the LSP shape. */
+    /**
+     * Rebases edits for tracked CodeMirror documents to their current versions
+     * while preserving the original `WorkspaceEdit` shape.
+     */
     function rebaseWorkspaceEdit(plugin, mapping, edit) {
         const rebased = Object.assign({}, edit);
         if (edit.changes) {
@@ -39798,7 +39806,10 @@ ${text}</tr>
         }
         return rebased;
     }
-    /** Requests a symbol rename and forwards the resulting workspace edit. */
+    /**
+     * Requests a symbol rename, rebases the returned edits, and waits until the
+     * workspace has applied them. Returns false when the request cannot complete.
+     */
     function renameSymbolAsync(view_1, newName_1, applyWorkspaceEdit_1) {
         return __awaiter(this, arguments, void 0, function* (view, newName, applyWorkspaceEdit, getPlugin = LSPPlugin.get, targetPos) {
             const plugin = getPlugin(view);
@@ -39828,7 +39839,10 @@ ${text}</tr>
             }
         });
     }
-    /** Handles checking prepareRename and opening the rename prompt. */
+    /**
+     * Validates the symbol with `textDocument/prepareRename` and opens the rename
+     * prompt. Servers without prepare support fall back to the current word.
+     */
     function startRename(view_1, applyWorkspaceEdit_1) {
         return __awaiter(this, arguments, void 0, function* (view, applyWorkspaceEdit, getPlugin = LSPPlugin.get) {
             var _a, _b;
@@ -39897,7 +39911,10 @@ ${text}</tr>
             return true;
         });
     }
-    /** Creates the F2 rename command for a specific workspace-edit handler. */
+    /**
+     * Creates the F2 rename command and Escape handler for a workspace-edit
+     * callback.
+     */
     function createRenameKeymap(applyWorkspaceEdit) {
         const renameSymbol = (view) => {
             if (view.state.field(renameTooltipField, false)) {
@@ -39928,6 +39945,7 @@ ${text}</tr>
     // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
+    /** Creates hover support that stays hidden while rename UI is active. */
     function lspHoverTooltips(config = {}) {
         return hoverTooltip((view, pos, _side) => __awaiter(this, void 0, void 0, function* () {
             var _a, _b;
@@ -39972,6 +39990,12 @@ ${text}</tr>
             hoverTime: config.hoverTime,
         });
     }
+    /**
+     * Connects a shared CodeMirror LSP client to the supplied transport callbacks.
+     *
+     * `onWorkspaceEdit` is awaited for editor-initiated workspace operations so
+     * callers can update open views and persist edits to files without editors.
+     */
     function createLspClient(sendToServer, rootUri, onInitialized, onDisplayFile, onWorkspaceEdit, notificationHandlers, language) {
         let handlers = [];
         let disposed = false;

--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -18176,6 +18176,10 @@
         return found < 0 ? null : plugin.manager.tooltipViews[found];
     }
     const closeHoverTooltipEffect = /*@__PURE__*/StateEffect.define();
+    /**
+    Transaction effect that closes all hover tooltips.
+    */
+    const closeHoverTooltips = /*@__PURE__*/closeHoverTooltipEffect.of(null);
 
     const panelConfig = /*@__PURE__*/Facet.define({
         combine(configs) {
@@ -34861,7 +34865,7 @@ ${text}</tr>
         }
     }
 
-    function toPosition(doc, pos) {
+    function toPosition$1(doc, pos) {
         let line = doc.lineAt(pos);
         return { line: line.number - 1, character: pos - line.from };
     }
@@ -34906,7 +34910,7 @@ ${text}</tr>
         document, but can be given another one.
         */
         toPosition(pos, doc = this.view.state.doc) {
-            return toPosition(doc, pos);
+            return toPosition$1(doc, pos);
         }
         /**
         Convert an LSP `{line, character}` object to a CodeMirror
@@ -35600,7 +35604,7 @@ ${text}</tr>
         let events = [];
         changes.iterChanges((fromA, toA, fromB, toB, inserted) => {
             events.push({
-                range: { start: toPosition(startDoc, fromA), end: toPosition(startDoc, toA) },
+                range: { start: toPosition$1(startDoc, fromA), end: toPosition$1(startDoc, toA) },
                 text: inserted.toString()
             });
         });
@@ -35773,74 +35777,6 @@ ${text}</tr>
         22: "class", // Struct
         25: "type" // TypeParameter
     };
-
-    /**
-    Create an extension that queries the language server for hover
-    tooltips when the user hovers over the code with their pointer,
-    and displays a tooltip when the server provides one.
-    */
-    function hoverTooltips(config = {}) {
-        return hoverTooltip(lspTooltipSource, {
-            hideOn: tr => tr.docChanged,
-            hoverTime: config.hoverTime
-        });
-    }
-    function hoverRequest(plugin, pos) {
-        if (plugin.client.hasCapability("hoverProvider") === false)
-            return Promise.resolve(null);
-        plugin.client.sync();
-        return plugin.client.request("textDocument/hover", {
-            position: plugin.toPosition(pos),
-            textDocument: { uri: plugin.uri },
-        });
-    }
-    function lspTooltipSource(view, pos) {
-        const plugin = LSPPlugin.get(view);
-        if (!plugin)
-            return Promise.resolve(null);
-        return hoverRequest(plugin, pos).then(result => {
-            if (!result)
-                return null;
-            return {
-                pos: result.range ? fromPosition(view.state.doc, result.range.start) : pos,
-                end: result.range ? fromPosition(view.state.doc, result.range.end) : pos,
-                create() {
-                    let elt = document.createElement("div");
-                    elt.className = "cm-lsp-hover-tooltip cm-lsp-documentation";
-                    elt.innerHTML = renderTooltipContent(plugin, result.contents);
-                    return { dom: elt };
-                },
-                above: true
-            };
-        });
-    }
-    function renderTooltipContent(plugin, value) {
-        if (Array.isArray(value))
-            return value.map(m => renderCode(plugin, m)).join("<br>");
-        if (typeof value == "string" || typeof value == "object" && "language" in value)
-            return renderCode(plugin, value);
-        return plugin.docToHTML(value);
-    }
-    function renderCode(plugin, code) {
-        if (typeof code == "string")
-            return plugin.docToHTML(code, "markdown");
-        let { language: language$1, value } = code;
-        let lang = plugin.client.config.highlightLanguage && plugin.client.config.highlightLanguage(language$1 || "");
-        if (!lang) {
-            let viewLang = plugin.view.state.facet(language);
-            if (viewLang && (!language$1 || viewLang.name == language$1))
-                lang = viewLang;
-        }
-        if (!lang)
-            return escHTML(value);
-        let result = "";
-        highlightCode(value, lang.parser.parse(value), { style: tags => highlightingFor(plugin.view.state, tags) }, (text, cls) => {
-            result += cls ? `<span class="${cls}">${escHTML(text)}</span>` : escHTML(text);
-        }, () => {
-            result += "<br>";
-        });
-        return result;
-    }
 
     function getFormatting(plugin, options) {
         return plugin.client.request("textDocument/formatting", {
@@ -39398,6 +39334,42 @@ ${text}</tr>
             border: "none",
             padding: "0 3px",
         },
+        ".cm-tooltip.cm-rename-message-tooltip": {
+            border: "1px solid #1B86F5 !important",
+            borderRadius: "3px !important",
+            backgroundColor: "#ffffff !important",
+            color: "#1E1E1E !important",
+            boxShadow: "0 2px 6px rgba(0, 0, 0, 0.15) !important",
+            maxWidth: "max-content !important",
+            width: "max-content !important",
+            whiteSpace: "nowrap !important",
+            padding: "3px 8px !important",
+            fontSize: "12px !important",
+            lineHeight: "1.3 !important",
+            userSelect: "none",
+            cursor: "default",
+        },
+        ".cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::before": {
+            borderTopColor: "#1B86F5 !important",
+            borderBottomColor: "#1B86F5 !important",
+        },
+        ".cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::after": {
+            borderTopColor: "#1B86F5 !important",
+            borderBottomColor: "#1B86F5 !important",
+        },
+        '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip': {
+            borderColor: "#208FFD !important",
+            backgroundColor: "#1E1E1E !important",
+            color: "#FFFFFF !important",
+        },
+        '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::before': {
+            borderTopColor: "#208FFD !important",
+            borderBottomColor: "#208FFD !important",
+        },
+        '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::after': {
+            borderTopColor: "#208FFD !important",
+            borderBottomColor: "#208FFD !important",
+        },
     });
     const dartpadHighlightStyle = HighlightStyle.define([
         { tag: tags$1.keyword, color: "var(--cm-keyword)" },
@@ -39700,7 +39672,307 @@ ${text}</tr>
     // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
-    function createLspClient(sendToServer, rootUri, onInitialized, onDisplayFile, notificationHandlers, language) {
+    const renameTooltipEffect = StateEffect.define();
+    const renameTooltipField = StateField.define({
+        create() {
+            return null;
+        },
+        update(tooltip, tr) {
+            if (tr.docChanged || tr.selection) {
+                return null;
+            }
+            for (const effect of tr.effects) {
+                if (effect.is(renameTooltipEffect)) {
+                    return effect.value;
+                }
+            }
+            return tooltip;
+        },
+        provide: (field) => showTooltip.from(field),
+    });
+    function getRenameErrorMessage(error) {
+        if (!error)
+            return "The element can't be renamed.";
+        if (typeof error === "string" && error.trim().length > 0)
+            return error;
+        if (typeof error === "object") {
+            const errObj = error;
+            if (typeof errObj.message === "string" &&
+                errObj.message.trim().length > 0) {
+                return errObj.message;
+            }
+        }
+        return "The element can't be renamed.";
+    }
+    function createRenameTooltip(pos, message) {
+        return {
+            pos,
+            above: true,
+            strictSide: true,
+            arrow: true,
+            create(view) {
+                const dom = document.createElement("div");
+                dom.className = "cm-rename-message-tooltip";
+                dom.textContent = message;
+                dom.addEventListener("click", () => {
+                    view.dispatch({ effects: renameTooltipEffect.of(null) });
+                });
+                const attachClass = () => {
+                    if (dom.parentElement) {
+                        dom.parentElement.classList.add("cm-rename-message-tooltip-wrapper");
+                    }
+                };
+                if (typeof queueMicrotask === "function") {
+                    queueMicrotask(attachClass);
+                }
+                setTimeout(attachClass, 0);
+                return {
+                    dom,
+                    mount() {
+                        attachClass();
+                    },
+                    positioned() {
+                        attachClass();
+                    },
+                };
+            },
+        };
+    }
+    function showRenameMessage(view, pos, message) {
+        const effects = [closeHoverTooltips];
+        if (view.state.field(renameTooltipField, false) === undefined) {
+            effects.push(StateEffect.appendConfig.of(renameTooltipField));
+        }
+        const tooltip = createRenameTooltip(pos, message);
+        effects.push(renameTooltipEffect.of(tooltip));
+        view.dispatch({ effects });
+        setTimeout(() => {
+            try {
+                const current = view.state.field(renameTooltipField, false);
+                if (current && current.pos === pos) {
+                    view.dispatch({ effects: renameTooltipEffect.of(null) });
+                }
+            }
+            catch (_a) {
+                // Ignore if view destroyed
+            }
+        }, 5000);
+    }
+    function isTextDocumentEdit(change) {
+        var _a;
+        if (!change || typeof change !== "object")
+            return false;
+        const candidate = change;
+        return !!((_a = candidate.textDocument) === null || _a === void 0 ? void 0 : _a.uri) && Array.isArray(candidate.edits);
+    }
+    function toPosition(doc, offset) {
+        const line = doc.lineAt(offset);
+        return { line: line.number - 1, character: offset - line.from };
+    }
+    function rebaseEdits(plugin, mapping, uri, edits) {
+        var _a, _b;
+        const file = plugin.client.workspace.getFile(uri);
+        const doc = (_b = (_a = file === null || file === void 0 ? void 0 : file.getView()) === null || _a === void 0 ? void 0 : _a.state.doc) !== null && _b !== void 0 ? _b : file === null || file === void 0 ? void 0 : file.doc;
+        if (!doc || !mapping.getMapping(uri))
+            return edits;
+        return edits.map((edit) => (Object.assign(Object.assign({}, edit), { range: {
+                start: toPosition(doc, mapping.mapPosition(uri, edit.range.start, 1)),
+                end: toPosition(doc, mapping.mapPosition(uri, edit.range.end, -1)),
+            } })));
+    }
+    /** Rebase edits for open CodeMirror documents while preserving the LSP shape. */
+    function rebaseWorkspaceEdit(plugin, mapping, edit) {
+        const rebased = Object.assign({}, edit);
+        if (edit.changes) {
+            rebased.changes = Object.fromEntries(Object.entries(edit.changes).map(([uri, edits]) => [
+                uri,
+                rebaseEdits(plugin, mapping, uri, edits),
+            ]));
+        }
+        if (edit.documentChanges) {
+            rebased.documentChanges = edit.documentChanges.map((change) => {
+                if (!isTextDocumentEdit(change))
+                    return change;
+                return Object.assign(Object.assign({}, change), { edits: rebaseEdits(plugin, mapping, change.textDocument.uri, change.edits) });
+            });
+        }
+        return rebased;
+    }
+    /** Requests a symbol rename and forwards the resulting workspace edit. */
+    function renameSymbolAsync(view_1, newName_1, applyWorkspaceEdit_1) {
+        return __awaiter(this, arguments, void 0, function* (view, newName, applyWorkspaceEdit, getPlugin = LSPPlugin.get, targetPos) {
+            const plugin = getPlugin(view);
+            const pos = targetPos !== null && targetPos !== void 0 ? targetPos : view.state.selection.main.head;
+            const word = view.state.wordAt(pos);
+            if (!plugin || !word) {
+                showRenameMessage(view, pos, "The element can't be renamed.");
+                return false;
+            }
+            try {
+                plugin.client.sync();
+                yield plugin.client.withMapping((mapping) => __awaiter(this, void 0, void 0, function* () {
+                    const response = yield plugin.client.request("textDocument/rename", {
+                        newName,
+                        position: plugin.toPosition(word.from),
+                        textDocument: { uri: plugin.uri },
+                    });
+                    if (response) {
+                        yield applyWorkspaceEdit(rebaseWorkspaceEdit(plugin, mapping, response));
+                    }
+                }));
+                return true;
+            }
+            catch (error) {
+                showRenameMessage(view, pos, getRenameErrorMessage(error));
+                return false;
+            }
+        });
+    }
+    /** Handles checking prepareRename and opening the rename prompt. */
+    function startRename(view_1, applyWorkspaceEdit_1) {
+        return __awaiter(this, arguments, void 0, function* (view, applyWorkspaceEdit, getPlugin = LSPPlugin.get) {
+            var _a, _b;
+            const pos = view.state.selection.main.head;
+            const wordRange = view.state.wordAt(pos);
+            const plugin = getPlugin(view);
+            if (!wordRange ||
+                !plugin ||
+                ((_b = (_a = plugin.client).hasCapability) === null || _b === void 0 ? void 0 : _b.call(_a, "renameProvider")) === false) {
+                showRenameMessage(view, pos, "The element can't be renamed.");
+                return true;
+            }
+            let initialName = view.state.sliceDoc(wordRange.from, wordRange.to);
+            try {
+                plugin.client.sync();
+                const prepareResult = yield plugin.client.request("textDocument/prepareRename", {
+                    textDocument: { uri: plugin.uri },
+                    position: plugin.toPosition(pos),
+                });
+                if (prepareResult === null) {
+                    showRenameMessage(view, pos, "The element can't be renamed.");
+                    return true;
+                }
+                if (typeof prepareResult === "object" && prepareResult !== null) {
+                    if ("placeholder" in prepareResult &&
+                        typeof prepareResult.placeholder === "string") {
+                        initialName = prepareResult.placeholder;
+                    }
+                }
+            }
+            catch (error) {
+                // If the server doesn't support prepareRename (e.g. -32601 Method not found),
+                // proceed to open the rename dialog.
+                if ((error === null || error === void 0 ? void 0 : error.code) === -32601 ||
+                    (typeof (error === null || error === void 0 ? void 0 : error.message) === "string" &&
+                        error.message.includes("Method not found"))) ;
+                else {
+                    showRenameMessage(view, pos, getRenameErrorMessage(error));
+                    return true;
+                }
+            }
+            const panel = getDialog(view, "cm-lsp-rename-panel");
+            if (panel) {
+                const input = panel.dom.querySelector("[name=name]");
+                if (input) {
+                    input.value = initialName;
+                    input.select();
+                }
+            }
+            else {
+                const { close, result } = showDialog(view, {
+                    label: view.state.phrase("New name"),
+                    input: { name: "name", value: initialName },
+                    focus: true,
+                    submitLabel: view.state.phrase("rename"),
+                    class: "cm-lsp-rename-panel",
+                });
+                void result.then((form) => {
+                    view.dispatch({ effects: close });
+                    if (form) {
+                        const input = form.elements.namedItem("name");
+                        void renameSymbolAsync(view, input.value, applyWorkspaceEdit, getPlugin, pos);
+                    }
+                });
+            }
+            return true;
+        });
+    }
+    /** Creates the F2 rename command for a specific workspace-edit handler. */
+    function createRenameKeymap(applyWorkspaceEdit) {
+        const renameSymbol = (view) => {
+            if (view.state.field(renameTooltipField, false)) {
+                view.dispatch({
+                    effects: [renameTooltipEffect.of(null), closeHoverTooltips],
+                });
+                return true;
+            }
+            view.dispatch({ effects: closeHoverTooltips });
+            void startRename(view, applyWorkspaceEdit);
+            return true;
+        };
+        const closeRenameTooltip = (view) => {
+            if (view.state.field(renameTooltipField, false)) {
+                view.dispatch({
+                    effects: [renameTooltipEffect.of(null), closeHoverTooltips],
+                });
+                return true;
+            }
+            return false;
+        };
+        return [
+            { key: "F2", run: renameSymbol, preventDefault: true },
+            { key: "Escape", run: closeRenameTooltip },
+        ];
+    }
+
+    // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
+    function lspHoverTooltips(config = {}) {
+        return hoverTooltip((view, pos, _side) => __awaiter(this, void 0, void 0, function* () {
+            var _a, _b;
+            if (view.state.field(renameTooltipField, false) ||
+                getDialog(view, "cm-lsp-rename-panel")) {
+                return null;
+            }
+            const plugin = LSPPlugin.get(view);
+            if (!plugin ||
+                ((_b = (_a = plugin.client).hasCapability) === null || _b === void 0 ? void 0 : _b.call(_a, "hoverProvider")) === false) {
+                return null;
+            }
+            plugin.client.sync();
+            try {
+                const result = yield plugin.client.request("textDocument/hover", {
+                    position: plugin.toPosition(pos),
+                    textDocument: { uri: plugin.uri },
+                });
+                if (!result)
+                    return null;
+                if (view.state.field(renameTooltipField, false) ||
+                    getDialog(view, "cm-lsp-rename-panel")) {
+                    return null;
+                }
+                return {
+                    pos: result.range ? plugin.fromPosition(result.range.start) : pos,
+                    end: result.range ? plugin.fromPosition(result.range.end) : pos,
+                    create() {
+                        const elt = document.createElement("div");
+                        elt.className = "cm-lsp-hover-tooltip cm-lsp-documentation";
+                        elt.innerHTML = plugin.docToHTML(result.contents);
+                        return { dom: elt };
+                    },
+                    above: true,
+                };
+            }
+            catch (_c) {
+                return null;
+            }
+        }), {
+            hideOn: (tr) => tr.docChanged,
+            hoverTime: config.hoverTime,
+        });
+    }
+    function createLspClient(sendToServer, rootUri, onInitialized, onDisplayFile, onWorkspaceEdit, notificationHandlers, language) {
         let handlers = [];
         let disposed = false;
         const transport = {
@@ -39731,6 +40003,7 @@ ${text}</tr>
             },
             extensions: [
                 semanticExtension,
+                renameTooltipField,
                 {
                     clientCapabilities: {
                         workspace: {
@@ -39762,11 +40035,11 @@ ${text}</tr>
                     },
                 },
                 serverCompletion(),
-                [hoverTooltips({ hoverTime: 800 })],
+                [lspHoverTooltips({ hoverTime: 800 })],
                 [
                     keymap.of([
                         ...formatKeymap,
-                        ...renameKeymap,
+                        ...createRenameKeymap(onWorkspaceEdit),
                         ...jumpToDefinitionKeymap,
                         ...findReferencesKeymap,
                     ]),
@@ -40102,6 +40375,10 @@ ${text}</tr>
     }
     function diagnosticHoverToolbar(actions) {
         return hoverTooltip((view, pos, side) => {
+            if (view.state.field(renameTooltipField, false) ||
+                getDialog(view, "cm-lsp-rename-panel")) {
+                return null;
+            }
             const activeDiagnostics = [];
             forEachDiagnostic(view.state, (diagnostic, from, to) => {
                 if (pos >= from && pos <= to) {
@@ -40395,6 +40672,9 @@ ${text}</tr>
         selectionAction,
         diagnosticHoverToolbar,
         forceSemanticTokensRefresh,
+        renameTooltipField,
+        showRenameMessage,
+        startRename,
         // test utilities
         getRegisteredKeys,
         formatKeymap,

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/lsp_client.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/lsp_client.dart
@@ -18,6 +18,7 @@ external _LspClientHandle _createLspClient(
   JSString rootUri,
   JSFunction onInitialized,
   JSFunction onDisplayFile,
+  JSFunction onWorkspaceEdit,
   JSArray<NotificationHandler> notificationHandlers,
   JSAny language,
 );
@@ -68,10 +69,16 @@ class CodeMirrorLspClient {
   ///
   /// The [rootUri] anchors the virtual workspace directory used during the
   /// initialize handshake.
+  ///
+  /// The [onWorkspaceEdit] callback applies workspace-wide edits returned by
+  /// editor-initiated LSP operations such as symbol rename. Its future is
+  /// awaited before the operation completes, and failures are propagated back
+  /// to CodeMirror so they can be reported to the user.
   factory CodeMirrorLspClient(
     void Function(String) sendToServer,
     String rootUri, {
     required Future<void> Function(String) onDisplayFile,
+    required Future<void> Function(Map<String, Object?>) onWorkspaceEdit,
     // Expects a JS LanguageSupport object (from dartLanguage()), not the
     // bundled array returned by dart().
     required JSObject language,
@@ -143,6 +150,10 @@ class CodeMirrorLspClient {
       }).toJS,
       ((JSString uri) {
         return onDisplayFile(uri.toDart).toJS;
+      }).toJS,
+      ((JSObject edit) {
+        final dartEdit = (edit.dartify() as Map).cast<String, Object?>();
+        return onWorkspaceEdit(dartEdit).toJS;
       }).toJS,
       notificationHandlers,
       language,

--- a/pkgs/dartpad_preview/codemirror-dart/src/diagnosticHoverToolbar.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/diagnosticHoverToolbar.ts
@@ -3,8 +3,9 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import { Extension } from "@codemirror/state";
-import { EditorView, hoverTooltip } from "@codemirror/view";
+import { EditorView, getDialog, hoverTooltip } from "@codemirror/view";
 import { forEachDiagnostic, setDiagnosticsEffect } from "@codemirror/lint";
+import { renameTooltipField } from "./rename";
 
 export interface ToolbarAction {
   label: string;
@@ -30,6 +31,12 @@ function hideTooltip(tr: any, tooltip: any) {
 export function diagnosticHoverToolbar(actions: ToolbarAction[]): Extension {
   return hoverTooltip(
     (view, pos, side) => {
+      if (
+        view.state.field(renameTooltipField, false) ||
+        getDialog(view, "cm-lsp-rename-panel")
+      ) {
+        return null;
+      }
       const activeDiagnostics: any[] = [];
       forEachDiagnostic(view.state, (diagnostic, from, to) => {
         if (pos >= from && pos <= to) {

--- a/pkgs/dartpad_preview/codemirror-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/index.ts
@@ -42,6 +42,7 @@ import { diagnosticHoverToolbar } from "./diagnosticHoverToolbar";
 import { forceSemanticTokensRefresh } from "./semanticHighlighting";
 import { formatDocument, formatDocumentAsync } from "./formatting";
 import { selectionAction } from "./selectionAction";
+import { renameTooltipField, showRenameMessage, startRename } from "./rename";
 
 declare global {
   interface Window {
@@ -84,6 +85,9 @@ declare global {
       selectionAction: typeof selectionAction;
       diagnosticHoverToolbar: typeof diagnosticHoverToolbar;
       forceSemanticTokensRefresh: typeof forceSemanticTokensRefresh;
+      renameTooltipField: typeof renameTooltipField;
+      showRenameMessage: typeof showRenameMessage;
+      startRename: typeof startRename;
 
       // test utilities
       getRegisteredKeys: (state: EditorState) => string[];
@@ -161,6 +165,9 @@ window._codemirror = {
   selectionAction,
   diagnosticHoverToolbar,
   forceSemanticTokensRefresh,
+  renameTooltipField,
+  showRenameMessage,
+  startRename,
 
   // test utilities
   getRegisteredKeys,

--- a/pkgs/dartpad_preview/codemirror-dart/src/lspClient.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/lspClient.ts
@@ -3,17 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import { Extension, Text } from "@codemirror/state";
-import { EditorView, keymap } from "@codemirror/view";
+import { EditorView, getDialog, hoverTooltip, keymap } from "@codemirror/view";
 import {
   LSPClient,
   Workspace,
   WorkspaceFile,
   LSPPlugin,
   serverCompletion,
-  hoverTooltips,
   signatureHelp,
   formatKeymap,
-  renameKeymap,
   jumpToDefinitionKeymap,
   findReferencesKeymap,
   serverDiagnostics,
@@ -23,6 +21,11 @@ import {
   semanticExtension,
 } from "./semanticHighlighting";
 import { LanguageSupport } from "@codemirror/language";
+import {
+  createRenameKeymap,
+  renameTooltipField,
+  type ApplyWorkspaceEdit,
+} from "./rename";
 
 export type LspClientBindings = {
   createExtension: (uri: string) => Extension;
@@ -35,11 +38,69 @@ export type NotificationHandler = {
   callback: (client: LSPClient, params: any) => boolean;
 };
 
+function lspHoverTooltips(config: { hoverTime?: number } = {}) {
+  return hoverTooltip(
+    async (view, pos, _side) => {
+      if (
+        view.state.field(renameTooltipField, false) ||
+        getDialog(view, "cm-lsp-rename-panel")
+      ) {
+        return null;
+      }
+      const plugin = LSPPlugin.get(view);
+      if (
+        !plugin ||
+        (plugin.client as any).hasCapability?.("hoverProvider") === false
+      ) {
+        return null;
+      }
+      plugin.client.sync();
+      try {
+        const result = await plugin.client.request<
+          {
+            position: { line: number; character: number };
+            textDocument: { uri: string };
+          },
+          any
+        >("textDocument/hover", {
+          position: plugin.toPosition(pos),
+          textDocument: { uri: plugin.uri },
+        });
+        if (!result) return null;
+        if (
+          view.state.field(renameTooltipField, false) ||
+          getDialog(view, "cm-lsp-rename-panel")
+        ) {
+          return null;
+        }
+        return {
+          pos: result.range ? plugin.fromPosition(result.range.start) : pos,
+          end: result.range ? plugin.fromPosition(result.range.end) : pos,
+          create() {
+            const elt = document.createElement("div");
+            elt.className = "cm-lsp-hover-tooltip cm-lsp-documentation";
+            elt.innerHTML = plugin.docToHTML(result.contents);
+            return { dom: elt };
+          },
+          above: true,
+        };
+      } catch {
+        return null;
+      }
+    },
+    {
+      hideOn: (tr) => tr.docChanged,
+      hoverTime: config.hoverTime,
+    },
+  );
+}
+
 export function createLspClient(
   sendToServer: (msg: string) => void,
   rootUri: string,
   onInitialized: () => void,
   onDisplayFile: (uri: string) => any,
+  onWorkspaceEdit: ApplyWorkspaceEdit,
   notificationHandlers: NotificationHandler[],
   language: LanguageSupport,
 ): LspClientBindings {
@@ -75,6 +136,7 @@ export function createLspClient(
     },
     extensions: [
       semanticExtension,
+      renameTooltipField,
       {
         clientCapabilities: {
           workspace: {
@@ -106,11 +168,11 @@ export function createLspClient(
         },
       },
       serverCompletion(),
-      [hoverTooltips({ hoverTime: 800 })],
+      [lspHoverTooltips({ hoverTime: 800 })],
       [
         keymap.of([
           ...formatKeymap,
-          ...renameKeymap,
+          ...createRenameKeymap(onWorkspaceEdit),
           ...jumpToDefinitionKeymap,
           ...findReferencesKeymap,
         ]),

--- a/pkgs/dartpad_preview/codemirror-dart/src/lspClient.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/lspClient.ts
@@ -27,17 +27,20 @@ import {
   type ApplyWorkspaceEdit,
 } from "./rename";
 
+/** Browser-facing operations exposed by one connected CodeMirror LSP client. */
 export type LspClientBindings = {
   createExtension: (uri: string) => Extension;
   receiveFromServer: (msg: string) => void;
   dispose: () => void;
 };
 
+/** Handles a server notification before it reaches CodeMirror extensions. */
 export type NotificationHandler = {
   method: string;
   callback: (client: LSPClient, params: any) => boolean;
 };
 
+/** Creates hover support that stays hidden while rename UI is active. */
 function lspHoverTooltips(config: { hoverTime?: number } = {}) {
   return hoverTooltip(
     async (view, pos, _side) => {
@@ -95,6 +98,12 @@ function lspHoverTooltips(config: { hoverTime?: number } = {}) {
   );
 }
 
+/**
+ * Connects a shared CodeMirror LSP client to the supplied transport callbacks.
+ *
+ * `onWorkspaceEdit` is awaited for editor-initiated workspace operations so
+ * callers can update open views and persist edits to files without editors.
+ */
 export function createLspClient(
   sendToServer: (msg: string) => void,
   rootUri: string,

--- a/pkgs/dartpad_preview/codemirror-dart/src/rename.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/rename.ts
@@ -1,0 +1,385 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import {
+  StateEffect,
+  StateField,
+  type Extension,
+  type Text,
+} from "@codemirror/state";
+import {
+  closeHoverTooltips,
+  getDialog,
+  showDialog,
+  showTooltip,
+  type Command,
+  type EditorView,
+  type KeyBinding,
+  type Tooltip,
+} from "@codemirror/view";
+import { LSPPlugin, type WorkspaceMapping } from "@codemirror/lsp-client";
+
+interface Position {
+  line: number;
+  character: number;
+}
+
+interface TextEdit {
+  range: { start: Position; end: Position };
+  newText: string;
+  [key: string]: unknown;
+}
+
+interface TextDocumentEdit {
+  textDocument: { uri: string; [key: string]: unknown };
+  edits: TextEdit[];
+}
+
+export interface WorkspaceEdit {
+  changes?: Record<string, TextEdit[]>;
+  documentChanges?: unknown[];
+  [key: string]: unknown;
+}
+
+/**
+ * Applies a workspace-wide edit returned by an editor-initiated LSP request.
+ * Async handlers are awaited, and rejected promises are reported by the
+ * initiating editor operation.
+ */
+export type ApplyWorkspaceEdit = (edit: WorkspaceEdit) => Promise<void> | void;
+type PluginLookup = (view: Parameters<Command>[0]) => LSPPlugin | null;
+
+export const renameTooltipEffect = StateEffect.define<Tooltip | null>();
+
+export const renameTooltipField = StateField.define<Tooltip | null>({
+  create() {
+    return null;
+  },
+  update(tooltip, tr) {
+    if (tr.docChanged || tr.selection) {
+      return null;
+    }
+    for (const effect of tr.effects) {
+      if (effect.is(renameTooltipEffect)) {
+        return effect.value;
+      }
+    }
+    return tooltip;
+  },
+  provide: (field) => showTooltip.from(field),
+});
+
+export function getRenameErrorMessage(error: unknown): string {
+  if (!error) return "The element can't be renamed.";
+  if (typeof error === "string" && error.trim().length > 0) return error;
+  if (typeof error === "object") {
+    const errObj = error as Record<string, unknown>;
+    if (
+      typeof errObj.message === "string" &&
+      errObj.message.trim().length > 0
+    ) {
+      return errObj.message;
+    }
+  }
+  return "The element can't be renamed.";
+}
+
+export function createRenameTooltip(pos: number, message: string): Tooltip {
+  return {
+    pos,
+    above: true,
+    strictSide: true,
+    arrow: true,
+    create(view) {
+      const dom = document.createElement("div");
+      dom.className = "cm-rename-message-tooltip";
+      dom.textContent = message;
+      dom.addEventListener("click", () => {
+        view.dispatch({ effects: renameTooltipEffect.of(null) });
+      });
+
+      const attachClass = () => {
+        if (dom.parentElement) {
+          dom.parentElement.classList.add("cm-rename-message-tooltip-wrapper");
+        }
+      };
+
+      if (typeof queueMicrotask === "function") {
+        queueMicrotask(attachClass);
+      }
+      setTimeout(attachClass, 0);
+
+      return {
+        dom,
+        mount() {
+          attachClass();
+        },
+        positioned() {
+          attachClass();
+        },
+      };
+    },
+  };
+}
+
+export function showRenameMessage(
+  view: EditorView,
+  pos: number,
+  message: string,
+) {
+  const effects: StateEffect<unknown>[] = [closeHoverTooltips];
+  if (view.state.field(renameTooltipField, false) === undefined) {
+    effects.push(StateEffect.appendConfig.of(renameTooltipField));
+  }
+  const tooltip = createRenameTooltip(pos, message);
+  effects.push(renameTooltipEffect.of(tooltip));
+  view.dispatch({ effects });
+
+  setTimeout(() => {
+    try {
+      const current = view.state.field(renameTooltipField, false);
+      if (current && current.pos === pos) {
+        view.dispatch({ effects: renameTooltipEffect.of(null) });
+      }
+    } catch {
+      // Ignore if view destroyed
+    }
+  }, 5000);
+}
+
+function isTextDocumentEdit(change: unknown): change is TextDocumentEdit {
+  if (!change || typeof change !== "object") return false;
+  const candidate = change as Partial<TextDocumentEdit>;
+  return !!candidate.textDocument?.uri && Array.isArray(candidate.edits);
+}
+
+function toPosition(doc: Text, offset: number): Position {
+  const line = doc.lineAt(offset);
+  return { line: line.number - 1, character: offset - line.from };
+}
+
+function rebaseEdits(
+  plugin: LSPPlugin,
+  mapping: WorkspaceMapping,
+  uri: string,
+  edits: TextEdit[],
+): TextEdit[] {
+  const file = plugin.client.workspace.getFile(uri);
+  const doc = file?.getView()?.state.doc ?? file?.doc;
+  if (!doc || !mapping.getMapping(uri)) return edits;
+
+  return edits.map((edit) => ({
+    ...edit,
+    range: {
+      start: toPosition(doc, mapping.mapPosition(uri, edit.range.start, 1)),
+      end: toPosition(doc, mapping.mapPosition(uri, edit.range.end, -1)),
+    },
+  }));
+}
+
+/** Rebase edits for open CodeMirror documents while preserving the LSP shape. */
+export function rebaseWorkspaceEdit(
+  plugin: LSPPlugin,
+  mapping: WorkspaceMapping,
+  edit: WorkspaceEdit,
+): WorkspaceEdit {
+  const rebased: WorkspaceEdit = { ...edit };
+
+  if (edit.changes) {
+    rebased.changes = Object.fromEntries(
+      Object.entries(edit.changes).map(([uri, edits]) => [
+        uri,
+        rebaseEdits(plugin, mapping, uri, edits),
+      ]),
+    );
+  }
+
+  if (edit.documentChanges) {
+    rebased.documentChanges = edit.documentChanges.map((change) => {
+      if (!isTextDocumentEdit(change)) return change;
+      return {
+        ...change,
+        edits: rebaseEdits(
+          plugin,
+          mapping,
+          change.textDocument.uri,
+          change.edits,
+        ),
+      };
+    });
+  }
+
+  return rebased;
+}
+
+/** Requests a symbol rename and forwards the resulting workspace edit. */
+export async function renameSymbolAsync(
+  view: Parameters<Command>[0],
+  newName: string,
+  applyWorkspaceEdit: ApplyWorkspaceEdit,
+  getPlugin: PluginLookup = LSPPlugin.get,
+  targetPos?: number,
+): Promise<boolean> {
+  const plugin = getPlugin(view);
+  const pos = targetPos ?? view.state.selection.main.head;
+  const word = view.state.wordAt(pos);
+  if (!plugin || !word) {
+    showRenameMessage(view, pos, "The element can't be renamed.");
+    return false;
+  }
+
+  try {
+    plugin.client.sync();
+    await plugin.client.withMapping(async (mapping) => {
+      const response = await plugin.client.request<
+        {
+          newName: string;
+          position: Position;
+          textDocument: { uri: string };
+        },
+        WorkspaceEdit | null
+      >("textDocument/rename", {
+        newName,
+        position: plugin.toPosition(word.from),
+        textDocument: { uri: plugin.uri },
+      });
+
+      if (response) {
+        await applyWorkspaceEdit(
+          rebaseWorkspaceEdit(plugin, mapping, response),
+        );
+      }
+    });
+    return true;
+  } catch (error) {
+    showRenameMessage(view, pos, getRenameErrorMessage(error));
+    return false;
+  }
+}
+
+/** Handles checking prepareRename and opening the rename prompt. */
+export async function startRename(
+  view: EditorView,
+  applyWorkspaceEdit: ApplyWorkspaceEdit,
+  getPlugin: PluginLookup = LSPPlugin.get,
+): Promise<boolean> {
+  const pos = view.state.selection.main.head;
+  const wordRange = view.state.wordAt(pos);
+  const plugin = getPlugin(view);
+
+  if (
+    !wordRange ||
+    !plugin ||
+    (plugin.client as any).hasCapability?.("renameProvider") === false
+  ) {
+    showRenameMessage(view, pos, "The element can't be renamed.");
+    return true;
+  }
+
+  let initialName = view.state.sliceDoc(wordRange.from, wordRange.to);
+
+  try {
+    plugin.client.sync();
+    const prepareResult = await plugin.client.request<
+      { textDocument: { uri: string }; position: Position },
+      | { range: { start: Position; end: Position }; placeholder?: string }
+      | { start: Position; end: Position }
+      | { defaultBehavior: boolean }
+      | null
+    >("textDocument/prepareRename", {
+      textDocument: { uri: plugin.uri },
+      position: plugin.toPosition(pos),
+    });
+
+    if (prepareResult === null) {
+      showRenameMessage(view, pos, "The element can't be renamed.");
+      return true;
+    }
+
+    if (typeof prepareResult === "object" && prepareResult !== null) {
+      if (
+        "placeholder" in prepareResult &&
+        typeof prepareResult.placeholder === "string"
+      ) {
+        initialName = prepareResult.placeholder;
+      }
+    }
+  } catch (error: any) {
+    // If the server doesn't support prepareRename (e.g. -32601 Method not found),
+    // proceed to open the rename dialog.
+    if (
+      error?.code === -32601 ||
+      (typeof error?.message === "string" &&
+        error.message.includes("Method not found"))
+    ) {
+      // Continue to open dialog
+    } else {
+      showRenameMessage(view, pos, getRenameErrorMessage(error));
+      return true;
+    }
+  }
+
+  const panel = getDialog(view, "cm-lsp-rename-panel");
+  if (panel) {
+    const input = panel.dom.querySelector<HTMLInputElement>("[name=name]");
+    if (input) {
+      input.value = initialName;
+      input.select();
+    }
+  } else {
+    const { close, result } = showDialog(view, {
+      label: view.state.phrase("New name"),
+      input: { name: "name", value: initialName },
+      focus: true,
+      submitLabel: view.state.phrase("rename"),
+      class: "cm-lsp-rename-panel",
+    });
+    void result.then((form) => {
+      view.dispatch({ effects: close });
+      if (form) {
+        const input = form.elements.namedItem("name") as HTMLInputElement;
+        void renameSymbolAsync(
+          view,
+          input.value,
+          applyWorkspaceEdit,
+          getPlugin,
+          pos,
+        );
+      }
+    });
+  }
+  return true;
+}
+
+/** Creates the F2 rename command for a specific workspace-edit handler. */
+export function createRenameKeymap(
+  applyWorkspaceEdit: ApplyWorkspaceEdit,
+): readonly KeyBinding[] {
+  const renameSymbol: Command = (view) => {
+    if (view.state.field(renameTooltipField, false)) {
+      view.dispatch({
+        effects: [renameTooltipEffect.of(null), closeHoverTooltips],
+      });
+      return true;
+    }
+    view.dispatch({ effects: closeHoverTooltips });
+    void startRename(view, applyWorkspaceEdit);
+    return true;
+  };
+
+  const closeRenameTooltip: Command = (view) => {
+    if (view.state.field(renameTooltipField, false)) {
+      view.dispatch({
+        effects: [renameTooltipEffect.of(null), closeHoverTooltips],
+      });
+      return true;
+    }
+    return false;
+  };
+
+  return [
+    { key: "F2", run: renameSymbol, preventDefault: true },
+    { key: "Escape", run: closeRenameTooltip },
+  ];
+}

--- a/pkgs/dartpad_preview/codemirror-dart/src/rename.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/rename.ts
@@ -36,6 +36,7 @@ interface TextDocumentEdit {
   edits: TextEdit[];
 }
 
+/** Text and resource changes returned by an LSP workspace operation. */
 export interface WorkspaceEdit {
   changes?: Record<string, TextEdit[]>;
   documentChanges?: unknown[];
@@ -50,8 +51,10 @@ export interface WorkspaceEdit {
 export type ApplyWorkspaceEdit = (edit: WorkspaceEdit) => Promise<void> | void;
 type PluginLookup = (view: Parameters<Command>[0]) => LSPPlugin | null;
 
+/** Updates the transient rename-message tooltip shown by an editor view. */
 export const renameTooltipEffect = StateEffect.define<Tooltip | null>();
 
+/** Stores the currently visible rename-message tooltip, if any. */
 export const renameTooltipField = StateField.define<Tooltip | null>({
   create() {
     return null;
@@ -70,6 +73,7 @@ export const renameTooltipField = StateField.define<Tooltip | null>({
   provide: (field) => showTooltip.from(field),
 });
 
+/** Returns a user-facing message for an unknown LSP or workspace error. */
 export function getRenameErrorMessage(error: unknown): string {
   if (!error) return "The element can't be renamed.";
   if (typeof error === "string" && error.trim().length > 0) return error;
@@ -85,6 +89,7 @@ export function getRenameErrorMessage(error: unknown): string {
   return "The element can't be renamed.";
 }
 
+/** Creates the temporary tooltip used to report rename failures. */
 export function createRenameTooltip(pos: number, message: string): Tooltip {
   return {
     pos,
@@ -123,6 +128,7 @@ export function createRenameTooltip(pos: number, message: string): Tooltip {
   };
 }
 
+/** Shows a rename message at `pos` and removes it automatically after a delay. */
 export function showRenameMessage(
   view: EditorView,
   pos: number,
@@ -178,7 +184,10 @@ function rebaseEdits(
   }));
 }
 
-/** Rebase edits for open CodeMirror documents while preserving the LSP shape. */
+/**
+ * Rebases edits for tracked CodeMirror documents to their current versions
+ * while preserving the original `WorkspaceEdit` shape.
+ */
 export function rebaseWorkspaceEdit(
   plugin: LSPPlugin,
   mapping: WorkspaceMapping,
@@ -213,7 +222,10 @@ export function rebaseWorkspaceEdit(
   return rebased;
 }
 
-/** Requests a symbol rename and forwards the resulting workspace edit. */
+/**
+ * Requests a symbol rename, rebases the returned edits, and waits until the
+ * workspace has applied them. Returns false when the request cannot complete.
+ */
 export async function renameSymbolAsync(
   view: Parameters<Command>[0],
   newName: string,
@@ -258,7 +270,10 @@ export async function renameSymbolAsync(
   }
 }
 
-/** Handles checking prepareRename and opening the rename prompt. */
+/**
+ * Validates the symbol with `textDocument/prepareRename` and opens the rename
+ * prompt. Servers without prepare support fall back to the current word.
+ */
 export async function startRename(
   view: EditorView,
   applyWorkspaceEdit: ApplyWorkspaceEdit,
@@ -352,7 +367,10 @@ export async function startRename(
   return true;
 }
 
-/** Creates the F2 rename command for a specific workspace-edit handler. */
+/**
+ * Creates the F2 rename command and Escape handler for a workspace-edit
+ * callback.
+ */
 export function createRenameKeymap(
   applyWorkspaceEdit: ApplyWorkspaceEdit,
 ): readonly KeyBinding[] {

--- a/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/theme.ts
@@ -115,6 +115,44 @@ export const dartpadTheme = EditorView.theme({
     border: "none",
     padding: "0 3px",
   },
+  ".cm-tooltip.cm-rename-message-tooltip": {
+    border: "1px solid #1B86F5 !important",
+    borderRadius: "3px !important",
+    backgroundColor: "#ffffff !important",
+    color: "#1E1E1E !important",
+    boxShadow: "0 2px 6px rgba(0, 0, 0, 0.15) !important",
+    maxWidth: "max-content !important",
+    width: "max-content !important",
+    whiteSpace: "nowrap !important",
+    padding: "3px 8px !important",
+    fontSize: "12px !important",
+    lineHeight: "1.3 !important",
+    userSelect: "none",
+    cursor: "default",
+  },
+  ".cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::before": {
+    borderTopColor: "#1B86F5 !important",
+    borderBottomColor: "#1B86F5 !important",
+  },
+  ".cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::after": {
+    borderTopColor: "#1B86F5 !important",
+    borderBottomColor: "#1B86F5 !important",
+  },
+  '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip': {
+    borderColor: "#208FFD !important",
+    backgroundColor: "#1E1E1E !important",
+    color: "#FFFFFF !important",
+  },
+  '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::before':
+    {
+      borderTopColor: "#208FFD !important",
+      borderBottomColor: "#208FFD !important",
+    },
+  '[data-theme="dark"] & .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::after':
+    {
+      borderTopColor: "#208FFD !important",
+      borderBottomColor: "#208FFD !important",
+    },
 });
 
 export const dartpadHighlightStyle = HighlightStyle.define([

--- a/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/lspClient.test.ts
@@ -274,6 +274,7 @@ test("createLspClient accepts dartLanguage() and language.name is 'dart'", () =>
     "file:///workspace",
     () => {},
     () => {},
+    () => {},
     [],
     support,
   );

--- a/pkgs/dartpad_preview/codemirror-dart/test/lsp_client_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/lsp_client_test.dart
@@ -20,6 +20,7 @@ void main() {
   late JSFunction sendToServerCallback;
   late JSFunction initializedCallback;
   late JSFunction displayFileCallback;
+  late JSFunction workspaceEditCallback;
   late JSFunction analyzerStatusCallback;
   late JSObject fakeHandle;
   late JSObject language;
@@ -64,12 +65,14 @@ void main() {
             JSString rootUri,
             JSFunction onInitialized,
             JSFunction onDisplayFile,
+            JSFunction onWorkspaceEdit,
             JSArray notificationHandlers,
             JSAny capturedLanguage,
           ) {
             sendToServerCallback = sendToServer;
             initializedCallback = onInitialized;
             displayFileCallback = onDisplayFile;
+            workspaceEditCallback = onWorkspaceEdit;
             capturedRootUri = rootUri.toDart;
             expect(capturedLanguage, same(language));
 
@@ -97,13 +100,19 @@ void main() {
   test('bridges callbacks and delegates messages and extensions', () async {
     final outgoingMessages = <String>[];
     final displayedUris = <String>[];
+    final appliedWorkspaceEdits = <Map<String, Object?>>[];
     final displayCompleter = Completer<void>();
+    final workspaceEditCompleter = Completer<void>();
     final client = CodeMirrorLspClient(
       outgoingMessages.add,
       'file:///workspace',
       onDisplayFile: (uri) {
         displayedUris.add(uri);
         return displayCompleter.future;
+      },
+      onWorkspaceEdit: (edit) {
+        appliedWorkspaceEdits.add(edit);
+        return workspaceEditCompleter.future;
       },
       language: language,
     );
@@ -137,6 +146,45 @@ void main() {
     await displayFuture;
     expect(displayCompleted, isTrue);
 
+    final workspaceEditPromise =
+        workspaceEditCallback.callAsFunction(
+              null,
+              {
+                    'documentChanges': [
+                      {
+                        'textDocument': {
+                          'uri': 'file:///main.dart',
+                          'version': 1,
+                        },
+                        'edits': [
+                          {
+                            'range': {
+                              'start': {'line': 0, 'character': 0},
+                              'end': {'line': 0, 'character': 4},
+                            },
+                            'newText': 'entrypoint',
+                          },
+                        ],
+                      },
+                    ],
+                  }.jsify()
+                  as JSObject,
+            )!
+            as JSPromise;
+    expect(appliedWorkspaceEdits, hasLength(1));
+    expect(
+      appliedWorkspaceEdits.single['documentChanges'],
+      isA<List<Object?>>(),
+    );
+    var workspaceEditCompleted = false;
+    final workspaceEditFuture = workspaceEditPromise.toDart;
+    unawaited(workspaceEditFuture.then((_) => workspaceEditCompleted = true));
+    await pumpEventQueue();
+    expect(workspaceEditCompleted, isFalse);
+    workspaceEditCompleter.complete();
+    await workspaceEditFuture;
+    expect(workspaceEditCompleted, isTrue);
+
     final extension = client.createExtension('file:///main.dart');
     expect(createdExtensionUri, 'file:///main.dart');
     expect(
@@ -159,6 +207,7 @@ void main() {
       (_) {},
       'file:///workspace',
       onDisplayFile: (_) async {},
+      onWorkspaceEdit: (_) async {},
       language: language,
     );
     final statuses = <bool>[];
@@ -211,6 +260,7 @@ void main() {
       (_) {},
       'file:///workspace',
       onDisplayFile: (_) async {},
+      onWorkspaceEdit: (_) async {},
       language: language,
     );
     final jsClient = JSObject();

--- a/pkgs/dartpad_preview/codemirror-dart/test/rename.test.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/test/rename.test.ts
@@ -1,0 +1,385 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EditorSelection, EditorState, Text } from "@codemirror/state";
+import type { EditorView } from "@codemirror/view";
+import type { LSPPlugin, WorkspaceMapping } from "@codemirror/lsp-client";
+
+import {
+  createRenameKeymap,
+  createRenameTooltip,
+  getRenameErrorMessage,
+  rebaseWorkspaceEdit,
+  renameSymbolAsync,
+  renameTooltipEffect,
+  renameTooltipField,
+  showRenameMessage,
+  startRename,
+  type WorkspaceEdit,
+} from "../src/rename";
+
+class MockElement {
+  className = "";
+  textContent = "";
+  children: MockElement[] = [];
+  parentElement: MockElement | null = null;
+  classList = {
+    add: (cls: string) => {
+      this.className = this.className ? `${this.className} ${cls}` : cls;
+    },
+  };
+
+  listeners: Record<string, Function[]> = {};
+
+  appendChild(child: MockElement) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(event: string, listener: Function) {
+    if (!this.listeners[event]) {
+      this.listeners[event] = [];
+    }
+    this.listeners[event].push(listener);
+  }
+
+  click() {
+    if (this.listeners["click"]) {
+      for (const listener of this.listeners["click"]) {
+        listener();
+      }
+    }
+  }
+}
+
+(globalThis as any).document = {
+  createElement(_tag: string) {
+    return new MockElement();
+  },
+};
+
+function fakeView(
+  contents = "final oldName = oldName;",
+  selectionPos = 6,
+): EditorView {
+  let state = EditorState.create({
+    doc: contents,
+    selection: EditorSelection.cursor(selectionPos),
+    extensions: [renameTooltipField],
+  });
+  return {
+    get state() {
+      return state;
+    },
+    dispatch(tr: any) {
+      state = state.update(tr).state;
+    },
+  } as unknown as EditorView;
+}
+
+function fakePlugin(
+  response: WorkspaceEdit | null,
+  options: {
+    requestError?: unknown;
+    prepareResponse?: unknown;
+    prepareError?: unknown;
+  } = {},
+) {
+  const events: string[] = [];
+  const mapping = {
+    getMapping() {
+      return null;
+    },
+  } as unknown as WorkspaceMapping;
+  const plugin = {
+    uri: "file:///workspace/main.dart",
+    toPosition(position: number) {
+      return { line: 0, character: position };
+    },
+    client: {
+      hasCapability() {
+        return true;
+      },
+      workspace: { getFile() {} },
+      sync() {
+        events.push("sync");
+      },
+      async withMapping<T>(
+        callback: (mapping: WorkspaceMapping) => Promise<T>,
+      ) {
+        return callback(mapping);
+      },
+      async request(method: string) {
+        events.push(method);
+        if (method === "textDocument/prepareRename") {
+          if (options.prepareError) throw options.prepareError;
+          return options.prepareResponse !== undefined
+            ? options.prepareResponse
+            : { placeholder: "oldName" };
+        }
+        if (options.requestError) throw options.requestError;
+        return response;
+      },
+    },
+  } as unknown as LSPPlugin;
+  return {
+    plugin,
+    events,
+  };
+}
+
+test("rename forwards changes and documentChanges workspace edits", async () => {
+  const edits: WorkspaceEdit[] = [
+    {
+      changes: {
+        "file:///workspace/main.dart": [
+          {
+            range: {
+              start: { line: 0, character: 6 },
+              end: { line: 0, character: 13 },
+            },
+            newText: "newName",
+          },
+        ],
+      },
+    },
+    {
+      documentChanges: [
+        {
+          textDocument: {
+            uri: "file:///workspace/main.dart",
+            version: 1,
+          },
+          edits: [
+            {
+              range: {
+                start: { line: 0, character: 6 },
+                end: { line: 0, character: 13 },
+              },
+              newText: "newName",
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  for (const edit of edits) {
+    const fake = fakePlugin(edit);
+    let applied: WorkspaceEdit | undefined;
+    const result = await renameSymbolAsync(
+      fakeView(),
+      "newName",
+      async (workspaceEdit) => {
+        applied = workspaceEdit;
+      },
+      () => fake.plugin,
+    );
+
+    assert.equal(result, true);
+    assert.deepEqual(fake.events, ["sync", "textDocument/rename"]);
+    assert.deepEqual(applied, edit);
+  }
+});
+
+test("rename ignores a null result", async () => {
+  const fake = fakePlugin(null);
+  let applyCalls = 0;
+
+  assert.equal(
+    await renameSymbolAsync(
+      fakeView(),
+      "newName",
+      () => {
+        applyCalls++;
+      },
+      () => fake.plugin,
+    ),
+    true,
+  );
+  assert.equal(applyCalls, 0);
+});
+
+test("rename displays request failures as inline tooltip", async () => {
+  const requestError = new Error(
+    "The class 'Padding' is defined outside of the project, so cannot be renamed.",
+  );
+  const failedRequest = fakePlugin(null, { requestError });
+  const view = fakeView();
+  assert.equal(
+    await renameSymbolAsync(
+      view,
+      "newName",
+      () => {},
+      () => failedRequest.plugin,
+    ),
+    false,
+  );
+
+  const tooltip = view.state.field(renameTooltipField);
+  assert.ok(tooltip);
+  const created = tooltip.create(view);
+  assert.equal(
+    created.dom.textContent,
+    "The class 'Padding' is defined outside of the project, so cannot be renamed.",
+  );
+});
+
+test("startRename shows tooltip on empty space or whitespace", async () => {
+  const view = fakeView("   \n   ", 1);
+  const fake = fakePlugin(null);
+  const result = await startRename(
+    view,
+    () => {},
+    () => fake.plugin,
+  );
+
+  assert.equal(result, true);
+  const tooltip = view.state.field(renameTooltipField);
+  assert.ok(tooltip);
+  const created = tooltip.create(view);
+  assert.equal(created.dom.textContent, "The element can't be renamed.");
+});
+
+test("startRename shows tooltip when prepareRename rejects with outside project error", async () => {
+  const view = fakeView("expect(true, isTrue);", 2);
+  const fake = fakePlugin(null, {
+    prepareError: {
+      message:
+        "The function 'expect' is defined outside of the project, so cannot be renamed.",
+    },
+  });
+  const result = await startRename(
+    view,
+    () => {},
+    () => fake.plugin,
+  );
+
+  assert.equal(result, true);
+  const tooltip = view.state.field(renameTooltipField);
+  assert.ok(tooltip);
+  const created = tooltip.create(view);
+  assert.equal(
+    created.dom.textContent,
+    "The function 'expect' is defined outside of the project, so cannot be renamed.",
+  );
+});
+
+test("startRename shows tooltip when prepareRename returns null", async () => {
+  const view = fakeView("final a = 1;", 0);
+  const fake = fakePlugin(null, { prepareResponse: null });
+  const result = await startRename(
+    view,
+    () => {},
+    () => fake.plugin,
+  );
+
+  assert.equal(result, true);
+  const tooltip = view.state.field(renameTooltipField);
+  assert.ok(tooltip);
+  const created = tooltip.create(view);
+  assert.equal(created.dom.textContent, "The element can't be renamed.");
+});
+
+test("tooltip clears on selection or doc change", () => {
+  const view = fakeView("hello world", 0);
+  showRenameMessage(view, 0, "Test error");
+  assert.ok(view.state.field(renameTooltipField));
+
+  view.dispatch({ selection: { anchor: 4 } });
+  assert.equal(view.state.field(renameTooltipField), null);
+
+  showRenameMessage(view, 0, "Test error");
+  assert.ok(view.state.field(renameTooltipField));
+
+  view.dispatch({ changes: { from: 0, insert: "a" } });
+  assert.equal(view.state.field(renameTooltipField), null);
+});
+
+test("rename rebases edits for documents changed while awaiting the server", () => {
+  const currentDoc = Text.of(["x final oldName = oldName;"]);
+  const plugin = {
+    client: {
+      workspace: {
+        getFile() {
+          return { doc: currentDoc, getView: () => null };
+        },
+      },
+    },
+  } as unknown as LSPPlugin;
+  const mapping = {
+    getMapping() {
+      return {};
+    },
+    mapPosition(_uri: string, position: { line: number; character: number }) {
+      return position.character + 2;
+    },
+  } as unknown as WorkspaceMapping;
+
+  const result = rebaseWorkspaceEdit(plugin, mapping, {
+    changes: {
+      "file:///workspace/main.dart": [
+        {
+          range: {
+            start: { line: 0, character: 6 },
+            end: { line: 0, character: 13 },
+          },
+          newText: "newName",
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(result.changes?.["file:///workspace/main.dart"][0].range, {
+    start: { line: 0, character: 8 },
+    end: { line: 0, character: 15 },
+  });
+});
+
+test("custom rename keymap keeps F2 registration", () => {
+  const keymap = createRenameKeymap(() => {});
+  assert.equal(keymap[0].key, "F2");
+  assert.equal(keymap[0].preventDefault, true);
+});
+
+test("F2 closes tooltip when one is already active", () => {
+  const view = fakeView("hello world", 0);
+  showRenameMessage(view, 0, "Test error");
+  assert.ok(view.state.field(renameTooltipField));
+
+  const keymap = createRenameKeymap(() => {});
+  const f2Command = keymap.find((k) => k.key === "F2")?.run;
+  assert.ok(f2Command);
+  f2Command(view);
+
+  assert.equal(view.state.field(renameTooltipField), null);
+});
+
+test("Escape closes tooltip when active", () => {
+  const view = fakeView("hello world", 0);
+  showRenameMessage(view, 0, "Test error");
+  assert.ok(view.state.field(renameTooltipField));
+
+  const keymap = createRenameKeymap(() => {});
+  const escCommand = keymap.find((k) => k.key === "Escape")?.run;
+  assert.ok(escCommand);
+  escCommand(view);
+
+  assert.equal(view.state.field(renameTooltipField), null);
+});
+
+test("clicking tooltip closes it", () => {
+  const view = fakeView("hello world", 0);
+  showRenameMessage(view, 0, "Test error");
+  const tooltip = view.state.field(renameTooltipField);
+  assert.ok(tooltip);
+
+  const created = tooltip.create(view);
+  (created.dom as any).click?.();
+  assert.equal(view.state.field(renameTooltipField), null);
+});

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
@@ -95,6 +95,7 @@ class LanguageServerClient {
             await handler(relativePath);
           }
         },
+        onWorkspaceEdit: applyWorkspaceEdit,
         // Use dartLanguage() (single LanguageSupport object), NOT dart()
         // (bundled array of extensions). The LSP client's highlightLanguage
         // callback accesses language.language to get the Language instance

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/codemirror_styles.dart
@@ -290,6 +290,41 @@ List<StyleRule> get codemirrorStyles => [
       'border-bottom-color': colorBorder.value,
     },
   ),
+  css('.editor-container .cm-tooltip.cm-rename-message-tooltip').styles(
+    padding: .symmetric(vertical: 3.px, horizontal: 8.px),
+    radius: .circular(3.px),
+    shadow: BoxShadow(
+      offsetX: 0.px,
+      offsetY: 2.px,
+      blur: 6.px,
+      color: const Color.rgba(0, 0, 0, 0.15),
+    ),
+    color: colorOnContainer,
+    fontSize: 12.px,
+    lineHeight: 1.3.em,
+    backgroundColor: colorContainer,
+    raw: {
+      'border': '1px solid ${colorPrimary.value} !important',
+      'background-color': '${colorContainer.value} !important',
+      'max-width': 'max-content !important',
+      'width': 'max-content !important',
+      'white-space': 'nowrap !important',
+      'user-select': 'none',
+      'cursor': 'default',
+    },
+  ),
+  css('.editor-container .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::before').styles(
+    raw: {
+      'border-top-color': '${colorPrimary.value} !important',
+      'border-bottom-color': '${colorPrimary.value} !important',
+    },
+  ),
+  css('.editor-container .cm-tooltip.cm-rename-message-tooltip .cm-tooltip-arrow::after').styles(
+    raw: {
+      'border-top-color': '${colorPrimary.value} !important',
+      'border-bottom-color': '${colorPrimary.value} !important',
+    },
+  ),
   css('.editor-container .cm-selection-action-tooltip').styles(
     padding: .zero,
     radius: .circular(6.px),


### PR DESCRIPTION
Fix Dart symbol rename by forwarding LSP workspace edits from CodeMirror to the Dart workspace layer. 

Errors are shown inline:
<img width="602" height="63" alt="grafik" src="https://github.com/user-attachments/assets/4409f758-05e7-4d00-b6c8-bf7a1d748744" />
