### PR TITLE
feat(dartpad-preivew): add shortuct alternatives

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 // Third-party licenses are listed in THIRD_PARTY_NOTICES.txt.
-(function () {
+(function (exports) {
     'use strict';
 
     /**
@@ -40635,6 +40635,15 @@ ${text}</tr>
     // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
+    const extraKeymap = [
+        { key: "Shift-Mod-\\", run: cursorMatchingBracket },
+        { key: "Alt-m", run: cursorMatchingBracket },
+        { key: "Alt--", run: foldCode },
+        { key: "Alt-+", run: unfoldCode },
+        { key: "Alt-=", run: unfoldCode },
+        { key: "Alt-0", run: foldAll },
+        { key: "Alt-9", run: unfoldAll },
+    ];
     /**
      * Returns all key binding strings registered in the given editor state.
      *
@@ -40701,10 +40710,15 @@ ${text}</tr>
         startRename,
         // test utilities
         getRegisteredKeys,
+        extraKeymap,
         formatKeymap,
         renameKeymap,
         jumpToDefinitionKeymap,
         findReferencesKeymap,
     };
 
-})();
+    exports.extraKeymap = extraKeymap;
+
+    return exports;
+
+})({});

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
@@ -138,6 +138,10 @@ external StateEffectType get forceSemanticTokensRefresh;
 @JS()
 external JSArray<JSString> getRegisteredKeys(EditorState state);
 
+/// Extra keymap containing navigation and folding keybindings (e.g. Alt+M, Alt+-, Alt++).
+@JS()
+external JSArray<KeyBinding> get extraKeymap;
+
 /// LSP keymaps exported individually so tests can register them
 /// without creating a full LSP client.
 @JS()

--- a/pkgs/dartpad_preview/codemirror-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/index.ts
@@ -27,12 +27,20 @@ import {
 } from "@codemirror/lsp-client";
 import { basicSetup } from "codemirror";
 import { dartpad as dartpadTheme } from "./theme";
-import { indentWithTab, toggleLineComment } from "@codemirror/commands";
+import {
+  indentWithTab,
+  toggleLineComment,
+  cursorMatchingBracket,
+} from "@codemirror/commands";
 import {
   syntaxHighlighting,
   defaultHighlightStyle,
   HighlightStyle,
   indentUnit,
+  foldCode,
+  unfoldCode,
+  foldAll,
+  unfoldAll,
 } from "@codemirror/language";
 import { lintGutter, linter } from "@codemirror/lint";
 import { LSPPlugin } from "@codemirror/lsp-client";
@@ -43,6 +51,16 @@ import { forceSemanticTokensRefresh } from "./semanticHighlighting";
 import { formatDocument, formatDocumentAsync } from "./formatting";
 import { selectionAction } from "./selectionAction";
 import { renameTooltipField, showRenameMessage, startRename } from "./rename";
+
+export const extraKeymap: readonly KeyBinding[] = [
+  { key: "Shift-Mod-\\", run: cursorMatchingBracket },
+  { key: "Alt-m", run: cursorMatchingBracket },
+  { key: "Alt--", run: foldCode },
+  { key: "Alt-+", run: unfoldCode },
+  { key: "Alt-=", run: unfoldCode },
+  { key: "Alt-0", run: foldAll },
+  { key: "Alt-9", run: unfoldAll },
+];
 
 declare global {
   interface Window {
@@ -91,6 +109,7 @@ declare global {
 
       // test utilities
       getRegisteredKeys: (state: EditorState) => string[];
+      extraKeymap: readonly KeyBinding[];
       formatKeymap: readonly KeyBinding[];
       renameKeymap: readonly KeyBinding[];
       jumpToDefinitionKeymap: readonly KeyBinding[];
@@ -171,6 +190,7 @@ window._codemirror = {
 
   // test utilities
   getRegisteredKeys,
+  extraKeymap,
   formatKeymap,
   renameKeymap,
   jumpToDefinitionKeymap,

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -51,6 +51,7 @@ void main() {
       'diagnosticHoverToolbar',
       'forceSemanticTokensRefresh',
       'getRegisteredKeys',
+      'extraKeymap',
       'formatKeymap',
       'renameKeymap',
       'jumpToDefinitionKeymap',
@@ -290,5 +291,54 @@ void main() {
     expect(commentTokens.getProperty<JSString>('line'.toJS).toDart, '//');
     expect(block.getProperty<JSString>('open'.toJS).toDart, '/*');
     expect(block.getProperty<JSString>('close'.toJS).toDart, '*/');
+  });
+
+  test('extraKeymap Alt-m jumps cursor to matching bracket', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+
+    // Document: "void main() {}"
+    // indices:   01234567890123
+    // '(' is at 9, ')' is at 10, '{' is at 12, '}' is at 13
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(
+          EditorStateConfig(
+            doc: 'void main() {}'.toJS,
+            selection: EditorSelection.single(12), // at '{'
+            extensions: <JSAny>[
+              keymapOf(extraKeymap),
+              basicSetup,
+              dart(),
+            ].toJS,
+          ),
+        ),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    expect(view.state.selection.main.head, 12);
+
+    // Dispatch Alt-m
+    final content = view.dom.querySelector('.cm-content')!;
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: 'm',
+          altKey: true,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    // Cursor should have jumped to matching '}' (index 14 / after '}')
+    expect(view.state.selection.main.head, 14);
   });
 }

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -63,6 +63,7 @@ final class CodeMirrorEditor {
               cm.KeyBinding(key: 'Mod-Shift-M'.toJS, run: ((cm.EditorView view) => true.toJS).toJS),
             ].toJS,
           ),
+          cm.keymapOf(cm.extraKeymap),
           cm.basicSetup,
           cm.indentUnitOf('  '.toJS),
           cm.gotoDefinitionOnClick(),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -181,8 +181,8 @@ class ShortcutDefinition {
 
   static const jumpToMatchingBracket = ShortcutDefinition(
     label: 'Jump to matching bracket',
-    displayKey: r'Mod + Shift + \',
-    codemirrorKeys: [r'Shift-Mod-\'],
+    displayKey: r'Mod + Shift + \ / Alt + M',
+    codemirrorKeys: [r'Shift-Mod-\', 'Alt-m'],
     category: ShortcutCategory.editing,
     isPrimary: false,
   );
@@ -245,32 +245,32 @@ class ShortcutDefinition {
 
   static const foldCode = ShortcutDefinition(
     label: 'Fold code',
-    displayKey: 'Ctrl + Shift + [',
-    codemirrorKeys: ['Ctrl-Shift-['],
+    displayKey: 'Ctrl + Shift + [ / Alt + -',
+    codemirrorKeys: ['Ctrl-Shift-[', 'Alt--'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
   static const unfoldCode = ShortcutDefinition(
     label: 'Unfold code',
-    displayKey: 'Ctrl + Shift + ]',
-    codemirrorKeys: ['Ctrl-Shift-]'],
+    displayKey: 'Ctrl + Shift + ] / Alt + +',
+    codemirrorKeys: ['Ctrl-Shift-]', 'Alt-+', 'Alt-='],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
   static const foldAll = ShortcutDefinition(
     label: 'Fold all',
-    displayKey: 'Ctrl + Alt + [',
-    codemirrorKeys: ['Ctrl-Alt-['],
+    displayKey: 'Ctrl + Alt + [ / Alt + 0',
+    codemirrorKeys: ['Ctrl-Alt-[', 'Alt-0'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
   static const unfoldAll = ShortcutDefinition(
     label: 'Unfold all',
-    displayKey: 'Ctrl + Alt + ]',
-    codemirrorKeys: ['Ctrl-Alt-]'],
+    displayKey: 'Ctrl + Alt + ] / Alt + 9',
+    codemirrorKeys: ['Ctrl-Alt-]', 'Alt-9'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );


### PR DESCRIPTION
## Description

Add ergonomic `Alt`-based keyboard shortcuts for code folding and matching bracket navigation in CodeMirror.

### Motivation
Standard shortcuts relying on brackets (`[`, `]`, `\`) like `Ctrl + Shift + [` or `Ctrl + Shift + \` dont work on some non-US keyboard.

## Introduced Shortcuts

| Action | New Layout-Agnostic Shortcut | Existing US Shortcut |
| :--- | :--- | :--- |
| **Jump to matching bracket** | `Alt + M` | `Mod + Shift + \` (`Ctrl/⌘ + Shift + \`) |
| **Fold code** | `Alt + -` | `Ctrl + Shift + [` |
| **Unfold code** | `Alt + +`, `Alt + =` | `Ctrl + Shift + ]` |
| **Fold all** | `Alt + 0` | `Ctrl + Alt + [` |
| **Unfold all** | `Alt + 9` | `Ctrl + Alt + ]` |

