### PR TITLE
feat(dartpad-preview): make path param optional and fallback to READM…

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -190,7 +190,7 @@ package links show one file while running another.
 | GitHub Gist     | `lib/main.dart`, then `main.dart`; otherwise the only Dart file; otherwise `README.md` when present.                  | The same detected path. It is auto-run only when it is a Dart file. |
 | Bundled sample  | The entry file recorded in `examples.g.dart`; currently `lib/main.dart` for every sample.                             | The same configured entry file.                            |
 
-For an archive where `path` is omitted, or for a pub.dev package, example-file
+For an archive where `path` is omitted, or for a pub.dev package, default file
 detection checks these paths in order and uses the first one present in the
 downloaded archive:
 
@@ -204,9 +204,9 @@ downloaded archive:
 8. `example/lib/example.dart`
 9. `example/example.md`
 10. `example/README.md`
-
-If no example file is found in an archive, the loader searches for `README.md` or
-`readme.md` (at the root or within the project folder) as a fallback.
+11. `example/readme.md`
+12. `README.md`
+13. `readme.md`
 
 When loading a Gist, root-level Dart files are first moved under `lib/` while
 non-Dart files stay at the workspace root. Detection then prefers

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -88,15 +88,18 @@ default `counter` sample.
 
 | Query string                             | Description |
 | :--------------------------------------- | :--- |
-| `?archive=<url>&path=<path>`             | Load a `.tar` or `.tar.gz` archive from `<url>` and initially open `<path>`. DartPad detects gzip compression from the downloaded bytes. |
+| `?archive=<url>`                         | Load a `.tar` or `.tar.gz` archive from `<url>` and auto-detect an example or `README.md` file. DartPad detects gzip compression from the downloaded bytes. |
+| `?archive=<url>&path=<path>`             | Load an archive and initially open `<path>`. |
+| `?archive=<url>&main=<main>`             | Load an archive, auto-detect the initially opened file, and use `<main>` as the run entrypoint. |
 | `?archive=<url>&path=<path>&main=<main>` | Load an archive, initially open `<path>`, and use `<main>` as the run entrypoint. |
 | `?package=<package>`                     | Load the latest version of `<package>` reported by pub.dev and auto-detect a file from its `example/` directory. |
 | `?package=<package>&main=<main>`         | Load the latest package version, auto-detect the initially opened file, and use `<main>` as the run entrypoint. |
 | `?gist=<gistId>`                         | Load the files of a public GitHub Gist. |
 | `?sample=<sampleId>`                     | Load a bundled example. Valid IDs are `counter`, `sunflower`, `fibonacci`, `hello-world`, `flame-game`, `dart`, and `flutter`. |
 
-For an archive, `archive` and `path` must be supplied together. `<path>` and
-`<main>` are paths inside the extracted workspace, not URLs.
+For an archive, `path` is optional. If omitted, DartPad searches for an example
+file or falls back to `README.md` / `readme.md`. `<path>` and `<main>` are paths
+inside the extracted workspace, not URLs.
 
 `package` always resolves the release in
 the `latest` field of the pub.dev package API response.
@@ -180,15 +183,16 @@ The frontend distinguishes between two paths:
 They are usually the same file. The `main` query parameter lets archive and
 package links show one file while running another.
 
-| Project source  | Initial editor file                                                                                  | Run entrypoint |
-| :-------------- | :--------------------------------------------------------------------------------------------------- | :--- |
-| Archive         | The required `path` query parameter.                                                                 | `main` when supplied; otherwise `path`. |
-| pub.dev package | The first recognized example file listed below.                                                      | `main` when supplied; otherwise the detected example file. |
-| GitHub Gist     | `lib/main.dart`, then `main.dart`; otherwise the only Dart file; otherwise `README.md` when present. | The same detected path. It is auto-run only when it is a Dart file. |
-| Bundled sample  | The entry file recorded in `examples.g.dart`; currently `lib/main.dart` for every sample.           | The same configured entry file. |
+| Project source  | Initial editor file                                                                                                    | Run entrypoint                                             |
+| :-------------- | :--------------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------- |
+| Archive         | `path` when supplied; otherwise the first recognized example file; otherwise `README.md` / `readme.md` when present. | `main` when supplied; otherwise the detected editor file.  |
+| pub.dev package | The first recognized example file listed below.                                                                        | `main` when supplied; otherwise the detected example file. |
+| GitHub Gist     | `lib/main.dart`, then `main.dart`; otherwise the only Dart file; otherwise `README.md` when present.                  | The same detected path. It is auto-run only when it is a Dart file. |
+| Bundled sample  | The entry file recorded in `examples.g.dart`; currently `lib/main.dart` for every sample.                             | The same configured entry file.                            |
 
-For a pub.dev package, example-file detection checks these paths in order and
-uses the first one present in the downloaded archive:
+For an archive where `path` is omitted, or for a pub.dev package, example-file
+detection checks these paths in order and uses the first one present in the
+downloaded archive:
 
 1. `example/main.dart`
 2. `example/lib/main.dart`
@@ -200,6 +204,9 @@ uses the first one present in the downloaded archive:
 8. `example/lib/example.dart`
 9. `example/example.md`
 10. `example/README.md`
+
+If no example file is found in an archive, the loader searches for `README.md` or
+`readme.md` (at the root or within the project folder) as a fallback.
 
 When loading a Gist, root-level Dart files are first moved under `lib/` while
 non-Dart files stay at the workspace root. Detection then prefers

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -437,16 +437,14 @@ class AppState extends State<App> {
 
     try {
       final LoadedProject project;
-      if (params case {
-        'archive': final String archiveUrlParam,
-        'path': final String filePathParam,
-      }) {
+      if (params case {'archive': final String archiveUrlParam}) {
         userErrorMessage =
             'The project archive could not be downloaded. '
             'Please check that the URL is correct and accessible.';
         _updateLoadingStatus(session, 'Downloading Archive...', clearError: true);
         final archiveUrl = Uri.decodeComponent(archiveUrlParam);
-        final filePath = Uri.decodeComponent(filePathParam);
+        final filePathParam = params['path'];
+        final filePath = filePathParam != null ? Uri.decodeComponent(filePathParam) : null;
         final pathToMainParam = params['main'];
         final pathToMain = pathToMainParam != null ? Uri.decodeComponent(pathToMainParam) : null;
         final loader = ArchiveLoader(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -64,8 +64,8 @@ class ArchiveLoader {
   /// Scans the archive files to find the nearest parent directory containing
   /// a `pubspec.yaml` file for the active target file.
   ///
-  /// The returned entrypoint is either [filePath] or a well-known example file
-  /// discovered in package archives.
+  /// The returned entrypoint is either [filePath], a well-known example file
+  /// discovered in package archives, or a fallback `README.md` file.
   Future<LoadedProject> loadArchive(WorkspaceFolder root) async {
     final Uri uri = Uri.base.resolve(archiveUrl);
     if (!uri.isAbsolute) {
@@ -85,7 +85,7 @@ class ArchiveLoader {
 
     final Archive archive = TarDecoder().decodeBytes(tarBytes);
 
-    final targetFilePath = filePath ?? findExampleFile(archive);
+    final targetFilePath = filePath ?? findExampleFile(archive) ?? findReadmeFile(archive);
     final files = <ProjectFile>[];
     for (final ArchiveFile file in archive.files) {
       if (!file.isFile) {
@@ -146,5 +146,36 @@ class ArchiveLoader {
     }
 
     return null;
+  }
+
+  /// Finds the README file in the archive, returning null if not found.
+  String? findReadmeFile(Archive archive) {
+    const readmeFilenames = ['README.md', 'readme.md'];
+
+    for (final filename in readmeFilenames) {
+      final ArchiveFile? file = archive.find(filename);
+      if (file != null) {
+        return filename;
+      }
+    }
+
+    String? bestCandidate;
+    var minDepth = double.infinity;
+
+    for (final file in archive.files) {
+      if (!file.isFile) {
+        continue;
+      }
+      final path = _relativePath(file.name);
+      final segments = path.split('/');
+      if (segments.last.toLowerCase() == 'readme.md') {
+        if (segments.length < minDepth) {
+          minDepth = segments.length.toDouble();
+          bestCandidate = path;
+        }
+      }
+    }
+
+    return bestCandidate;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -85,7 +85,7 @@ class ArchiveLoader {
 
     final Archive archive = TarDecoder().decodeBytes(tarBytes);
 
-    final targetFilePath = filePath ?? findExampleFile(archive) ?? findReadmeFile(archive);
+    final targetFilePath = filePath ?? findDefaultFile(archive);
     final files = <ProjectFile>[];
     for (final ArchiveFile file in archive.files) {
       if (!file.isFile) {
@@ -121,9 +121,10 @@ class ArchiveLoader {
     return path;
   }
 
-  /// Finds the example file in the archive, returning null if not found.
-  String? findExampleFile(Archive archive) {
-    final List<String> exampleFilenames = [
+  /// Finds the default file to open in the archive if none was specified,
+  /// searching for well-known example and README file paths in priority order.
+  String? findDefaultFile(Archive archive) {
+    final List<String> candidateFilenames = [
       'example/main.dart',
       'example/lib/main.dart',
       if (packageName != null) ...[
@@ -136,46 +137,18 @@ class ArchiveLoader {
       'example/lib/example.dart',
       'example/example.md',
       'example/README.md',
+      'example/readme.md',
+      'README.md',
+      'readme.md',
     ];
 
-    for (final String exampleFilename in exampleFilenames) {
-      final ArchiveFile? file = archive.find(exampleFilename);
+    for (final String candidate in candidateFilenames) {
+      final ArchiveFile? file = archive.find(candidate);
       if (file != null) {
-        return exampleFilename;
+        return candidate;
       }
     }
 
     return null;
-  }
-
-  /// Finds the README file in the archive, returning null if not found.
-  String? findReadmeFile(Archive archive) {
-    const readmeFilenames = ['README.md', 'readme.md'];
-
-    for (final filename in readmeFilenames) {
-      final ArchiveFile? file = archive.find(filename);
-      if (file != null) {
-        return filename;
-      }
-    }
-
-    String? bestCandidate;
-    var minDepth = double.infinity;
-
-    for (final file in archive.files) {
-      if (!file.isFile) {
-        continue;
-      }
-      final path = _relativePath(file.name);
-      final segments = path.split('/');
-      if (segments.last.toLowerCase() == 'readme.md') {
-        if (segments.length < minDepth) {
-          minDepth = segments.length.toDouble();
-          bestCandidate = path;
-        }
-      }
-    }
-
-    return bestCandidate;
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -244,11 +244,11 @@ void main() {
       expect(await api.readFileAsText('README.md'), '# My Package\n');
     });
 
-    test('falls back to nested README.md when filePath is not specified', () async {
+    test('falls back to readme.md when filePath is not specified', () async {
       final Map<String, String> archiveFiles = {
-        'my_project/pubspec.yaml': 'name: my_project\n',
-        'my_project/lib/main.dart': 'void main() {}',
-        'my_project/README.md': '# My Project\n',
+        'pubspec.yaml': 'name: my_package\n',
+        'lib/main.dart': 'void main() {}',
+        'readme.md': '# Readme Lowercase\n',
       };
       final Uint8List archiveBytes = createTarArchive(archiveFiles);
 
@@ -264,37 +264,11 @@ void main() {
         }),
       );
 
-      expect(result.entryPath, 'my_project/README.md');
-      expect(result.pathToMain, 'my_project/README.md');
-      expect(result.projectDir, 'my_project');
-      expect(await api.fileExist('my_project/README.md'), isTrue);
-      expect(await api.readFileAsText('my_project/README.md'), '# My Project\n');
-    });
-
-    test('falls back to readme.md case-insensitively when filePath is not specified', () async {
-      final Map<String, String> archiveFiles = {
-        'my_project/pubspec.yaml': 'name: my_project\n',
-        'my_project/lib/main.dart': 'void main() {}',
-        'my_project/readme.md': '# Readme Lowercase\n',
-      };
-      final Uint8List archiveBytes = createTarArchive(archiveFiles);
-
-      const ArchiveLoader loader = ArchiveLoader(
-        archiveUrl: absoluteUrl,
-      );
-      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
-
-      final result = await http.runWithClient(
-        () => loader.loadArchive(api.root),
-        () => MockClient((http.Request request) async {
-          return http.Response.bytes(archiveBytes, 200);
-        }),
-      );
-
-      expect(result.entryPath, 'my_project/readme.md');
-      expect(result.pathToMain, 'my_project/readme.md');
-      expect(result.projectDir, 'my_project');
-      expect(await api.readFileAsText('my_project/readme.md'), '# Readme Lowercase\n');
+      expect(result.entryPath, 'readme.md');
+      expect(result.pathToMain, 'readme.md');
+      expect(result.projectDir, '');
+      expect(await api.fileExist('readme.md'), isTrue);
+      expect(await api.readFileAsText('readme.md'), '# Readme Lowercase\n');
     });
 
     test('prefers example file over README.md when filePath is not specified', () async {
@@ -319,6 +293,30 @@ void main() {
 
       expect(result.entryPath, 'example/main.dart');
       expect(result.pathToMain, 'example/main.dart');
+    });
+
+    test('finds example/readme.md over root README.md when filePath is not specified', () async {
+      final Map<String, String> archiveFiles = {
+        'pubspec.yaml': 'name: my_package\n',
+        'example/readme.md': '# Example Readme\n',
+        'README.md': '# Root Readme\n',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'example/readme.md');
+      expect(result.pathToMain, 'example/readme.md');
     });
 
     test('prefers explicit filePath over example file and README.md', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -216,5 +216,135 @@ void main() {
       expect(result.entryPath, 'my_project/example/hello.dart');
       expect(result.pathToMain, 'my_project/example/main.dart');
     });
+
+    test('falls back to root README.md when filePath is not specified', () async {
+      final Map<String, String> archiveFiles = {
+        'pubspec.yaml': 'name: my_package\n',
+        'lib/main.dart': 'void main() {}',
+        'README.md': '# My Package\n',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'README.md');
+      expect(result.pathToMain, 'README.md');
+      expect(result.projectDir, '');
+      expect(await api.fileExist('README.md'), isTrue);
+      expect(await api.readFileAsText('README.md'), '# My Package\n');
+    });
+
+    test('falls back to nested README.md when filePath is not specified', () async {
+      final Map<String, String> archiveFiles = {
+        'my_project/pubspec.yaml': 'name: my_project\n',
+        'my_project/lib/main.dart': 'void main() {}',
+        'my_project/README.md': '# My Project\n',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'my_project/README.md');
+      expect(result.pathToMain, 'my_project/README.md');
+      expect(result.projectDir, 'my_project');
+      expect(await api.fileExist('my_project/README.md'), isTrue);
+      expect(await api.readFileAsText('my_project/README.md'), '# My Project\n');
+    });
+
+    test('falls back to readme.md case-insensitively when filePath is not specified', () async {
+      final Map<String, String> archiveFiles = {
+        'my_project/pubspec.yaml': 'name: my_project\n',
+        'my_project/lib/main.dart': 'void main() {}',
+        'my_project/readme.md': '# Readme Lowercase\n',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'my_project/readme.md');
+      expect(result.pathToMain, 'my_project/readme.md');
+      expect(result.projectDir, 'my_project');
+      expect(await api.readFileAsText('my_project/readme.md'), '# Readme Lowercase\n');
+    });
+
+    test('prefers example file over README.md when filePath is not specified', () async {
+      final Map<String, String> archiveFiles = {
+        'pubspec.yaml': 'name: my_package\n',
+        'example/main.dart': 'void main() {}',
+        'README.md': '# My Package\n',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'example/main.dart');
+      expect(result.pathToMain, 'example/main.dart');
+    });
+
+    test('prefers explicit filePath over example file and README.md', () async {
+      final Map<String, String> archiveFiles = {
+        'pubspec.yaml': 'name: my_package\n',
+        'example/main.dart': 'void main() {}',
+        'README.md': '# My Package\n',
+        'lib/custom.dart': 'void custom() {}',
+      };
+      final Uint8List archiveBytes = createTarArchive(archiveFiles);
+
+      const ArchiveLoader loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'lib/custom.dart',
+      );
+      final MemoryWorkspaceResourceApi api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.entryPath, 'lib/custom.dart');
+      expect(result.pathToMain, 'lib/custom.dart');
+    });
   });
 }


### PR DESCRIPTION
Makes the path URL query parameter optional when loading projects via .tar or .tar.gz archives (?archive=...) in DartPad Preview and adds a fallback search for README.md / readme.md.

Fixes #3777 