### PR TITLE
fix(dartpad-preview): update placeholder message to reflect auto-start

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -87,7 +87,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
           NodeContainer(viewModel.containerElement),
           if (state is PreviewInitial)
             const div(classes: 'preview-placeholder', [
-              span([.text('Start your app to see the preview.')]),
+              span([.text('The preview will start momentarily.')]),
             ]),
           if (isRunning && !viewModel.isFlutter) ConsolePanel(logs: viewModel.appLogs),
           ?statusToast,


### PR DESCRIPTION
Update the initial preview placeholder text to "The preview will start momentarily."
since applications start automatically after initialization.