### PR TITLE
fix(dartpad-preview): scope problems to project root

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -275,6 +275,7 @@ class AppState extends State<App> {
         server: languageServer,
         client: languageServerClient,
         onAnalyzerActivity: (activity) => _updateAnalyzerStatus(session, activity),
+        projectRoot: project?.packageRoot,
       );
 
       setState(() {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
@@ -22,6 +22,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
   final TabsViewModel tabs;
 
   List<DiagnosticEntry> _diagnostics = const [];
+  String? _projectRoot;
 
   StreamSubscription<Map<String, dynamic>>? _diagnosticsSubscription;
 
@@ -47,14 +48,26 @@ class DiagnosticsViewModel extends ChangeNotifier {
   /// Subscribes to diagnostic updates from [lsc].
   ///
   /// Cancels any previous subscription before attaching to the new client.
-  void attachLanguageServer(LanguageServerClient lsc) {
+  void attachLanguageServer(
+    LanguageServerClient lsc, {
+    String? projectRoot,
+  }) {
     _diagnosticsSubscription?.cancel();
-    _diagnostics = lsc.allDiagnostics;
+    _projectRoot = projectRoot == null ? null : workspaceContext.normalize(projectRoot);
+    _updateDiagnostics(lsc);
     _diagnosticsSubscription = lsc.diagnosticsStream.listen((_) {
-      _diagnostics = lsc.allDiagnostics;
+      _updateDiagnostics(lsc);
       notifyListeners();
     });
     notifyListeners();
+  }
+
+  void _updateDiagnostics(LanguageServerClient lsc) {
+    _diagnostics = lsc.allDiagnostics
+        .where(
+          (entry) => _projectRoot == null || workspaceContext.isWithinFolder(entry.fileName, _projectRoot!),
+        )
+        .toList(growable: false);
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
@@ -90,6 +90,7 @@ final class WorkspaceSession {
     required LanguageServer server,
     required LanguageServerClient client,
     required void Function(AnalyzerActivity activity) onAnalyzerActivity,
+    String? projectRoot,
   }) {
     if (_disposed) {
       throw StateError('Cannot attach a language server to a disposed session.');
@@ -104,7 +105,7 @@ final class WorkspaceSession {
       onAnalyzerActivity,
     );
     fileTree.languageServerClient = client;
-    diagnostics.attachLanguageServer(client);
+    diagnostics.attachLanguageServer(client, projectRoot: projectRoot);
     _codemirrorAdapter.attachLanguageServerClient(client);
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/diagnostics_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/diagnostics_view_model_test.dart
@@ -1,0 +1,149 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:codemirror_dart/codemirror_dart.dart';
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/bottom_panel/view_models/diagnostics_view_model.dart';
+import 'package:dartpad_frontend/features/editor/view_models/tabs_view_model.dart';
+import 'package:test/test.dart';
+
+final class _FakeWorkspace implements WorkspaceResourceApi {
+  @override
+  Stream<WorkspaceChangeEvent> get changeEvents => const Stream.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+final class _FakeCodeMirrorLspClient implements CodeMirrorLspClient {
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  void receiveFromServer(String message) {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('DiagnosticsViewModel', () {
+    late StreamController<Object?> languageServerMessages;
+    late StreamController<WorkspaceChangeEvent> workspaceEvents;
+    late LanguageServerClient languageServerClient;
+    late TabsViewModel tabs;
+    late DiagnosticsViewModel viewModel;
+
+    setUp(() {
+      languageServerMessages = StreamController<Object?>();
+      workspaceEvents = StreamController<WorkspaceChangeEvent>();
+      languageServerClient = LanguageServerClient(
+        languageServer: null,
+        rootWorkspaceUri: Uri.parse('file:///workspace/'),
+        workspaceChangeEvents: workspaceEvents.stream,
+        sendToLanguageServer: (_) {},
+        languageServerMessages: languageServerMessages.stream,
+        createCodeMirrorLspClient: (_, _) => _FakeCodeMirrorLspClient(),
+      );
+      tabs = TabsViewModel(
+        workspaceResourceApi: _FakeWorkspace(),
+        adapters: const [],
+      );
+      viewModel = DiagnosticsViewModel(tabs: tabs);
+    });
+
+    tearDown(() async {
+      viewModel.dispose();
+      tabs.dispose();
+      await languageServerClient.dispose();
+      await languageServerMessages.close();
+      await workspaceEvents.close();
+    });
+
+    test('only includes diagnostics within the project root', () async {
+      await _publishDiagnostics(languageServerClient, languageServerMessages, 'example/lib/main.dart');
+      await _publishDiagnostics(languageServerClient, languageServerMessages, 'lib/main.dart');
+
+      viewModel.attachLanguageServer(languageServerClient, projectRoot: 'example');
+
+      await _publishDiagnostics(languageServerClient, languageServerMessages, 'example_other/main.dart');
+
+      expect(
+        viewModel.diagnostics.map((entry) => entry.fileName),
+        ['example/lib/main.dart'],
+      );
+      expect(viewModel.hasMoreDiagnostics, isFalse);
+      expect(languageServerClient.allDiagnostics, hasLength(3));
+    });
+
+    for (final entry in <String, String?>{'unset': null, 'the workspace root': ''}.entries) {
+      test('includes all diagnostics when project root is ${entry.key}', () async {
+        final projectRoot = entry.value;
+        viewModel.attachLanguageServer(languageServerClient, projectRoot: projectRoot);
+
+        await _publishDiagnostics(languageServerClient, languageServerMessages, 'example/lib/main.dart');
+        await _publishDiagnostics(languageServerClient, languageServerMessages, 'lib/main.dart');
+
+        expect(viewModel.diagnostics, hasLength(2));
+      });
+    }
+
+    test('applies the display limit after filtering', () async {
+      viewModel.attachLanguageServer(languageServerClient, projectRoot: 'example');
+
+      await _publishDiagnostics(
+        languageServerClient,
+        languageServerMessages,
+        'lib/unrelated.dart',
+        count: DiagnosticsViewModel.maxDisplayedDiagnostics + 1,
+      );
+      await _publishDiagnostics(languageServerClient, languageServerMessages, 'example/lib/main.dart');
+
+      expect(viewModel.diagnostics, hasLength(1));
+      expect(viewModel.hasMoreDiagnostics, isFalse);
+
+      await _publishDiagnostics(
+        languageServerClient,
+        languageServerMessages,
+        'example/lib/main.dart',
+        count: DiagnosticsViewModel.maxDisplayedDiagnostics + 1,
+      );
+
+      expect(
+        viewModel.diagnostics,
+        hasLength(DiagnosticsViewModel.maxDisplayedDiagnostics),
+      );
+      expect(viewModel.hasMoreDiagnostics, isTrue);
+    });
+  });
+}
+
+Future<void> _publishDiagnostics(
+  LanguageServerClient client,
+  StreamController<Object?> messages,
+  String path, {
+  int count = 1,
+}) async {
+  final published = client.diagnosticsStream.first;
+  messages.add({
+    'method': 'textDocument/publishDiagnostics',
+    'params': {
+      'uri': 'file:///workspace/$path',
+      'diagnostics': [
+        for (var index = 0; index < count; index++)
+          {
+            'range': {
+              'start': {'line': index, 'character': 0},
+              'end': {'line': index, 'character': 1},
+            },
+            'message': 'Problem $index',
+            'severity': 1,
+          },
+      ],
+    },
+  });
+  await published;
+}


### PR DESCRIPTION
Filters the Problems panel to only show diagnostics within the active project root. This prevents unrelated errors from hidden packages.