### PR TITLE
fix(dartpad-preview): recover pub action buttons visability

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
@@ -112,22 +112,26 @@ class _PubspecEditorActionsState extends State<PubspecEditorActions> {
   @override
   Component build(BuildContext context) {
     final fileName = workspaceContext.basename(component.activeFile);
-    if (fileName != 'pubspec.yaml' && fileName != 'pubspec.lock') {
-      return const Component.fragment([]);
-    }
-
     final directory = workspaceContext.dirname(component.activeFile);
-    return div(classes: 'pubspec-editor-actions', [
-      Button(
-        label: 'Pub get',
-        disabled: _busy,
-        onClick: () => unawaited(_pubGet(directory)),
-      ),
-      Button(
-        label: 'Pub clean',
-        disabled: _busy,
-        onClick: () => unawaited(_pubClean(directory)),
-      ),
+    final isPubspecFile = fileName == 'pubspec.yaml' || fileName == 'pubspec.lock';
+
+    // Keep the stateful component's root render object stable while switching
+    // between editor tabs. Jaspr cannot safely replace an empty fragment root
+    // with an element when this component is nested in the editor overlay.
+    return div(classes: 'pubspec-editor-actions-host', [
+      if (isPubspecFile)
+        div(classes: 'pubspec-editor-actions', [
+          Button(
+            label: 'Pub get',
+            disabled: _busy,
+            onClick: () => unawaited(_pubGet(directory)),
+          ),
+          Button(
+            label: 'Pub clean',
+            disabled: _busy,
+            onClick: () => unawaited(_pubClean(directory)),
+          ),
+        ]),
     ]);
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
@@ -79,6 +79,34 @@ void main() {
     expect(web.document.querySelector('.pubspec-editor-actions'), isNull);
   });
 
+  testClient('renders actions after switching from another active file', (tester) async {
+    tester.pumpComponent(
+      PubspecEditorActions(
+        activeFile: 'main.dart',
+        saveAllFiles: () async {},
+        events: events,
+        onPubGet: (_) async {},
+        onPubClean: (_) async {},
+      ),
+    );
+    await pumpEventQueue();
+    expect(web.document.querySelector('.pubspec-editor-actions'), isNull);
+
+    tester.pumpComponent(
+      PubspecEditorActions(
+        activeFile: 'pubspec.yaml',
+        saveAllFiles: () async {},
+        events: events,
+        onPubGet: (_) async {},
+        onPubClean: (_) async {},
+      ),
+    );
+    await pumpEventQueue();
+
+    expect(web.document.querySelector('[aria-label="Pub get"]'), isNotNull);
+    expect(web.document.querySelector('[aria-label="Pub clean"]'), isNotNull);
+  });
+
   testClient('saves all files before running Pub Get', (tester) async {
     final operations = <String>[];
     tester.pumpComponent(


### PR DESCRIPTION
Brings back the visibility of the buttons shown in pubspec.yaml/.lock files.

Fixes #3804 