### PR TITLE
feat(dartpad-preview): add task tracker for preview and footer #3714

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -23,11 +23,12 @@ import 'features/preview/view/preview_container.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
 import 'features/shared/components/context_menu.dart';
-import 'features/shared/components/error_dialog.dart';
 import 'features/shared/components/footer.dart';
 import 'features/shared/components/split_panel.dart';
 import 'features/shared/events/log_event.dart';
+import 'features/shared/events/open_console_event.dart';
 import 'features/shared/sdk_info.dart';
+import 'features/shared/task_status.dart';
 import 'features/startup/archive_loader.dart';
 import 'features/startup/example_project.dart';
 import 'features/startup/gist_loader.dart';
@@ -105,9 +106,8 @@ class AppState extends State<App> {
   int _workspaceGeneration = 0;
 
   bool _isInitializingWorkspace = true;
-  String loadingStatus = 'Loading Workspace...';
   String _projectDir = '';
-  String? _errorMessage;
+  String? _workspacePreparationFailure;
 
   bool _isLargeScreen = true;
   SmallScreenTab _selectedSmallScreenTab = .code;
@@ -124,10 +124,16 @@ class AppState extends State<App> {
     });
 
     final events = AppEventBus();
+    final taskStatus = TaskStatusController();
+    final preparationTask = taskStatus.startTask(
+      TaskKind.preparingWorkspace,
+      blocksPreview: true,
+    );
     _session = WorkspaceSession.create(
       WorkspaceRepository.create(
         events: events,
         sdk: _currentSdk,
+        taskStatus: taskStatus,
       ),
     );
     _session.preview.addListener(_onPreviewStateChanged);
@@ -135,6 +141,7 @@ class AppState extends State<App> {
       _initializeWorkspace(
         _session,
         source: ProjectSource.fromUri(Uri.base),
+        preparationTask: preparationTask,
       ),
     );
   }
@@ -169,6 +176,7 @@ class AppState extends State<App> {
   Future<void> _initializeWorkspace(
     WorkspaceSession session, {
     required ProjectSource source,
+    required TaskStatusHandle preparationTask,
   }) async {
     final projectFuture = _loadProject(session, source: source);
 
@@ -178,6 +186,7 @@ class AppState extends State<App> {
         projectReady: projectFuture,
       );
       if (!_isCurrent(session)) {
+        preparationTask.cancel();
         return;
       }
 
@@ -185,14 +194,40 @@ class AppState extends State<App> {
         _isInitializingWorkspace = false;
       });
 
-      unawaited(_initializeWorkspaceTools(session, workspace, project));
-    } catch (error) {
-      if (!_isCurrent(session)) {
+      if (project == null) {
+        preparationTask.fail();
+        setState(() {
+          _workspacePreparationFailure ??= 'The project could not be loaded.';
+        });
+        unawaited(_initializeAnalyzer(session, workspace, null));
         return;
       }
+
+      unawaited(
+        _initializeWorkspaceTools(
+          session,
+          workspace,
+          project,
+          preparationTask,
+        ),
+      );
+    } catch (error, stackTrace) {
+      if (!_isCurrent(session)) {
+        preparationTask.cancel();
+        return;
+      }
+      preparationTask.fail();
+      session.events.dispatch(
+        LogEvent(
+          'Workspace preparation failed.',
+          level: Level.SEVERE,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      );
       setState(() {
         _isInitializingWorkspace = false;
-        _errorMessage = 'The workspace could not be initialized.';
+        _workspacePreparationFailure = 'The workspace could not be initialized.';
       });
     }
   }
@@ -200,48 +235,61 @@ class AppState extends State<App> {
   Future<void> _initializeWorkspaceTools(
     WorkspaceSession session,
     Workspace workspace,
-    LoadedProject? project,
+    LoadedProject project,
+    TaskStatusHandle preparationTask,
   ) async {
-    try {
-      if (project?.packageRoot case final String packageRoot) {
-        if (!_isCurrent(session)) {
-          return;
-        }
-        setState(() {
-          loadingStatus = 'Running Pub Get...';
-        });
-
-        try {
-          await session.repository.pubGet(
-            path: packageRoot,
-            projectRoot: packageRoot,
-          );
-        } catch (error, stackTrace) {
-          if (_isCurrent(session)) {
-            session.events.dispatch(
-              LogEvent(
-                'Pub get failed.',
-                level: Level.SEVERE,
-                error: error,
-                stackTrace: stackTrace,
-              ),
-            );
-          }
-        }
-      }
-
+    var preparationSucceeded = true;
+    if (project.packageRoot case final String packageRoot) {
       if (!_isCurrent(session)) {
+        preparationTask.cancel();
         return;
       }
+      try {
+        await session.repository.pubGet(
+          path: packageRoot,
+          projectRoot: packageRoot,
+        );
+      } catch (error, stackTrace) {
+        preparationSucceeded = false;
+        if (_isCurrent(session)) {
+          preparationTask.fail();
+          session.events.dispatch(
+            LogEvent(
+              'Pub get failed.',
+              level: Level.SEVERE,
+              error: error,
+              stackTrace: stackTrace,
+            ),
+          );
+          setState(() {
+            _workspacePreparationFailure = 'Pub get failed while preparing the workspace.';
+          });
+        }
+      }
+    }
 
-      if (project?.pathToMain case final String pathToMain when pathToMain.isNotEmpty && pathToMain.endsWith('.dart')) {
+    if (!_isCurrent(session)) {
+      preparationTask.cancel();
+      return;
+    }
+
+    if (preparationSucceeded) {
+      preparationTask.succeed();
+      if (project.pathToMain case final String pathToMain when pathToMain.isNotEmpty && pathToMain.endsWith('.dart')) {
         unawaited(session.preview.runCode(pathToMain));
       }
+    }
 
-      setState(() {
-        loadingStatus = 'Initializing Analyzer...';
-      });
+    await _initializeAnalyzer(session, workspace, project.packageRoot);
+  }
 
+  Future<void> _initializeAnalyzer(
+    WorkspaceSession session,
+    Workspace workspace,
+    String? projectRoot,
+  ) async {
+    try {
+      session.analyzerStatus.beginInitialization();
       final languageServer = await workspace.startLanguageServer();
       if (!_isCurrent(session)) {
         await languageServer.stop();
@@ -274,17 +322,13 @@ class AppState extends State<App> {
       session.attachLanguageServer(
         server: languageServer,
         client: languageServerClient,
-        onAnalyzerActivity: (activity) => _updateAnalyzerStatus(session, activity),
-        projectRoot: project?.packageRoot,
+        projectRoot: projectRoot,
       );
-
-      setState(() {
-        loadingStatus = 'Analyzing Project...';
-      });
     } catch (error, stackTrace) {
       if (!_isCurrent(session)) {
         return;
       }
+      session.analyzerStatus.markUnavailable();
       session.events.dispatch(
         LogEvent(
           'Analyzer initialization failed.',
@@ -293,9 +337,6 @@ class AppState extends State<App> {
           stackTrace: stackTrace,
         ),
       );
-      setState(() {
-        loadingStatus = 'Analyzer initialization failed.';
-      });
     }
   }
 
@@ -311,11 +352,17 @@ class AppState extends State<App> {
 
     final previousWorkspaceDisposed = Completer<void>();
     final events = AppEventBus();
+    final taskStatus = TaskStatusController();
+    final preparationTask = taskStatus.startTask(
+      TaskKind.preparingWorkspace,
+      blocksPreview: true,
+    );
     final nextSession = WorkspaceSession.create(
       WorkspaceRepository.resetAndCreate(
         events: events,
         worker: worker,
         sdk: _currentSdk,
+        taskStatus: taskStatus,
         previousWorkspaceDisposed: previousWorkspaceDisposed.future,
       ),
     );
@@ -335,8 +382,7 @@ class AppState extends State<App> {
       _workspaceGeneration++;
       _session = nextSession;
       _isInitializingWorkspace = true;
-      loadingStatus = 'Initializing Workspace...';
-      _errorMessage = null;
+      _workspacePreparationFailure = null;
       _projectDir = '';
     });
 
@@ -344,6 +390,7 @@ class AppState extends State<App> {
       _initializeWorkspace(
         nextSession,
         source: source,
+        preparationTask: preparationTask,
       ),
     );
     disposeAfterWorkspaceUnmount(
@@ -372,10 +419,16 @@ class AppState extends State<App> {
     };
 
     final events = AppEventBus();
+    final taskStatus = TaskStatusController();
+    final preparationTask = taskStatus.startTask(
+      TaskKind.preparingWorkspace,
+      blocksPreview: true,
+    );
     final nextSession = WorkspaceSession.create(
       WorkspaceRepository.create(
         events: events,
         sdk: newSdk,
+        taskStatus: taskStatus,
         localApi: oldLocalApi,
       ),
     );
@@ -385,11 +438,12 @@ class AppState extends State<App> {
       _session = nextSession;
       _currentSdk = newSdk;
       _isInitializingWorkspace = true;
-      loadingStatus = 'Switching to ${newSdk.name}...';
-      _errorMessage = null;
+      _workspacePreparationFailure = null;
     });
 
-    unawaited(_initializeSwitchSdkWorkspace(nextSession));
+    unawaited(
+      _initializeSwitchSdkWorkspace(nextSession, preparationTask),
+    );
 
     disposeAfterWorkspaceUnmount(
       context,
@@ -399,10 +453,14 @@ class AppState extends State<App> {
     );
   }
 
-  Future<void> _initializeSwitchSdkWorkspace(WorkspaceSession session) async {
+  Future<void> _initializeSwitchSdkWorkspace(
+    WorkspaceSession session,
+    TaskStatusHandle preparationTask,
+  ) async {
     try {
       final workspace = await session.repository.readyWorkspace;
       if (!_isCurrent(session)) {
+        preparationTask.cancel();
         return;
       }
 
@@ -417,14 +475,39 @@ class AppState extends State<App> {
               entryPath: null,
             )
           : null;
-      unawaited(_initializeWorkspaceTools(session, workspace, project));
-    } catch (error) {
-      if (!_isCurrent(session)) {
+      if (project == null) {
+        preparationTask.fail();
+        setState(() {
+          _workspacePreparationFailure = 'The current project could not be prepared for the selected SDK.';
+        });
+        unawaited(_initializeAnalyzer(session, workspace, null));
         return;
       }
+      unawaited(
+        _initializeWorkspaceTools(
+          session,
+          workspace,
+          project,
+          preparationTask,
+        ),
+      );
+    } catch (error, stackTrace) {
+      if (!_isCurrent(session)) {
+        preparationTask.cancel();
+        return;
+      }
+      preparationTask.fail();
+      session.events.dispatch(
+        LogEvent(
+          'Workspace preparation failed.',
+          level: Level.SEVERE,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      );
       setState(() {
         _isInitializingWorkspace = false;
-        _errorMessage = 'The workspace could not be initialized for the selected SDK.';
+        _workspacePreparationFailure = 'The workspace could not be initialized for the selected SDK.';
       });
     }
   }
@@ -442,7 +525,6 @@ class AppState extends State<App> {
         userErrorMessage =
             'The project archive could not be downloaded. '
             'Please check that the URL is correct and accessible.';
-        _updateLoadingStatus(session, 'Downloading Archive...', clearError: true);
         final archiveUrl = Uri.decodeComponent(archiveUrlParam);
         final filePathParam = params['path'];
         final filePath = filePathParam != null ? Uri.decodeComponent(filePathParam) : null;
@@ -453,39 +535,64 @@ class AppState extends State<App> {
           filePath: filePath,
           pathToMain: pathToMain,
         );
-        project = await loader.loadArchive(session.repository.root);
+        project = await session.taskStatus.runTask(
+          TaskKind.downloadingArchive,
+          () => loader.loadArchive(session.repository.root),
+          scope: archiveUrl,
+          blocksPreview: true,
+        );
       } else if (params case {'package': final String packageName}) {
         userErrorMessage =
             'The package "$packageName" could not be resolved from pub.dev. '
             'Please verify the package name in the URL.';
-        _updateLoadingStatus(session, 'Resolving Package...', clearError: true);
         final pathToMainParam = params['main'];
         final pathToMain = pathToMainParam != null ? Uri.decodeComponent(pathToMainParam) : null;
-        final loader = await ArchiveLoader.forPackage(
-          packageName,
-          pathToMain: pathToMain,
+        final loader = await session.taskStatus.runTask(
+          TaskKind.resolvingPackage,
+          () => ArchiveLoader.forPackage(
+            packageName,
+            pathToMain: pathToMain,
+          ),
+          label: 'Resolving package $packageName',
+          scope: packageName,
+          blocksPreview: true,
         );
-        _updateLoadingStatus(session, 'Downloading Package...');
-        project = await loader.loadArchive(session.repository.root);
+        project = await session.taskStatus.runTask(
+          TaskKind.downloadingPackage,
+          () => loader.loadArchive(session.repository.root),
+          label: 'Downloading package $packageName',
+          scope: packageName,
+          blocksPreview: true,
+        );
       } else if (params['gist'] case final String gistId) {
         userErrorMessage =
             'The GitHub Gist could not be loaded. '
             'Please check that the Gist ID "$gistId" in the URL is correct.';
-        _updateLoadingStatus(session, 'Downloading Gist...', clearError: true);
         final loader = GistLoader(gistId: gistId);
-        project = await loader.loadGist(session.repository.root);
+        project = await session.taskStatus.runTask(
+          TaskKind.downloadingGist,
+          () => loader.loadGist(session.repository.root),
+          scope: gistId,
+          blocksPreview: true,
+        );
       } else if (params['sample'] case final String sampleId) {
         userErrorMessage = 'The requested sample "$sampleId" could not be loaded.';
-        _updateLoadingStatus(session, 'Loading Sample...', clearError: true);
-        project = await loadSampleProject(
-          session.repository.root,
-          sampleId: sampleId,
+        project = await session.taskStatus.runTask(
+          TaskKind.loadingSample,
+          () => loadSampleProject(
+            session.repository.root,
+            sampleId: sampleId,
+          ),
+          label: 'Loading sample $sampleId',
+          scope: sampleId,
+          blocksPreview: true,
         );
       } else {
         userErrorMessage = 'The default project could not be loaded.';
-        _updateLoadingStatus(session, 'Initializing Workspace...', clearError: true);
-        project = await loadSampleProject(
-          session.repository.root,
+        project = await session.taskStatus.runTask(
+          TaskKind.loadingDefaultSample,
+          () => loadSampleProject(session.repository.root),
+          blocksPreview: true,
         );
       }
 
@@ -502,51 +609,22 @@ class AppState extends State<App> {
       }
 
       return project;
-    } catch (error) {
+    } catch (error, stackTrace) {
       if (_isCurrent(session)) {
+        session.events.dispatch(
+          LogEvent(
+            'Project loading failed.',
+            level: Level.SEVERE,
+            error: error,
+            stackTrace: stackTrace,
+          ),
+        );
         setState(() {
-          _errorMessage = userErrorMessage;
+          _workspacePreparationFailure = userErrorMessage;
         });
       }
       return null;
     }
-  }
-
-  void _updateLoadingStatus(
-    WorkspaceSession session,
-    String status, {
-    bool clearError = false,
-  }) {
-    if (!_isCurrent(session)) {
-      return;
-    }
-    if (loadingStatus == status && (!clearError || _errorMessage == null)) {
-      return;
-    }
-    setState(() {
-      loadingStatus = status;
-      if (clearError) {
-        _errorMessage = null;
-      }
-    });
-  }
-
-  void _updateAnalyzerStatus(
-    WorkspaceSession session,
-    AnalyzerActivity activity,
-  ) {
-    if (!_isCurrent(session) || activity is! AnalyzerStatusActivity) {
-      return;
-    }
-
-    final status = activity.isAnalyzing ? 'Analyzing Project...' : 'Done';
-    if (loadingStatus == status) {
-      return;
-    }
-
-    setState(() {
-      loadingStatus = status;
-    });
   }
 
   @override
@@ -606,14 +684,15 @@ class AppState extends State<App> {
           ]),
           if (!isEmbedMode)
             Footer(
-              statusLabel: session.tabs.errorMessage ?? session.tabs.warningMessage ?? loadingStatus,
+              taskStatus: session.taskStatus,
+              analyzerStatus: session.analyzerStatus,
+              statusMessage: session.tabs.errorMessage ?? session.tabs.warningMessage,
               isSmallScreen: !_isLargeScreen,
               currentSdk: _currentSdk,
               onSelectSdk: _isInitializingWorkspace ? null : switchSdk,
             ),
         ]),
       ),
-      if (_errorMessage case final String message) ErrorDialog(errorMessage: message),
       ListenableBuilder(
         listenable: session.contextMenu,
         builder: (context) => ContextMenu(
@@ -639,6 +718,7 @@ class AppState extends State<App> {
           activeFile: session.tabs.activeFile,
           logs: session.console.logs,
           onClearConsole: session.console.clear,
+          events: session.events,
           contextMenu: session.contextMenu,
           onOpenDiagnostic: (fileName, diagnostic) {
             unawaited(session.diagnostics.openDiagnostic(fileName, diagnostic));
@@ -683,9 +763,30 @@ class AppState extends State<App> {
       listenable: session.preview,
       builder: (context) => PreviewContainer(
         preview: session.preview,
+        taskStatus: session.taskStatus,
         activeFile: session.tabs.activeFile,
+        workspacePreparationFailure: _workspacePreparationFailure,
+        onOpenConsole: () => _openConsole(session),
       ),
     );
+  }
+
+  void _openConsole(WorkspaceSession session) {
+    if (!_isCurrent(session)) {
+      return;
+    }
+    if (!_isLargeScreen && _selectedSmallScreenTab != SmallScreenTab.code) {
+      setState(() {
+        _selectedSmallScreenTab = SmallScreenTab.code;
+      });
+      context.binding.addPostFrameCallback(() {
+        if (_isCurrent(session)) {
+          session.events.dispatch(const OpenConsoleEvent());
+        }
+      });
+      return;
+    }
+    session.events.dispatch(const OpenConsoleEvent());
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -125,10 +125,6 @@ class AppState extends State<App> {
 
     final events = AppEventBus();
     final taskStatus = TaskStatusController();
-    final preparationTask = taskStatus.startTask(
-      TaskKind.preparingWorkspace,
-      blocksPreview: true,
-    );
     _session = WorkspaceSession.create(
       WorkspaceRepository.create(
         events: events,
@@ -141,7 +137,6 @@ class AppState extends State<App> {
       _initializeWorkspace(
         _session,
         source: ProjectSource.fromUri(Uri.base),
-        preparationTask: preparationTask,
       ),
     );
   }
@@ -176,7 +171,6 @@ class AppState extends State<App> {
   Future<void> _initializeWorkspace(
     WorkspaceSession session, {
     required ProjectSource source,
-    required TaskStatusHandle preparationTask,
   }) async {
     final projectFuture = _loadProject(session, source: source);
 
@@ -186,7 +180,6 @@ class AppState extends State<App> {
         projectReady: projectFuture,
       );
       if (!_isCurrent(session)) {
-        preparationTask.cancel();
         return;
       }
 
@@ -195,7 +188,6 @@ class AppState extends State<App> {
       });
 
       if (project == null) {
-        preparationTask.fail();
         setState(() {
           _workspacePreparationFailure ??= 'The project could not be loaded.';
         });
@@ -208,15 +200,12 @@ class AppState extends State<App> {
           session,
           workspace,
           project,
-          preparationTask,
         ),
       );
     } catch (error, stackTrace) {
       if (!_isCurrent(session)) {
-        preparationTask.cancel();
         return;
       }
-      preparationTask.fail();
       session.events.dispatch(
         LogEvent(
           'Workspace preparation failed.',
@@ -236,12 +225,10 @@ class AppState extends State<App> {
     WorkspaceSession session,
     Workspace workspace,
     LoadedProject project,
-    TaskStatusHandle preparationTask,
   ) async {
     var preparationSucceeded = true;
     if (project.packageRoot case final String packageRoot) {
       if (!_isCurrent(session)) {
-        preparationTask.cancel();
         return;
       }
       try {
@@ -252,7 +239,6 @@ class AppState extends State<App> {
       } catch (error, stackTrace) {
         preparationSucceeded = false;
         if (_isCurrent(session)) {
-          preparationTask.fail();
           session.events.dispatch(
             LogEvent(
               'Pub get failed.',
@@ -269,12 +255,10 @@ class AppState extends State<App> {
     }
 
     if (!_isCurrent(session)) {
-      preparationTask.cancel();
       return;
     }
 
     if (preparationSucceeded) {
-      preparationTask.succeed();
       if (project.pathToMain case final String pathToMain when pathToMain.isNotEmpty && pathToMain.endsWith('.dart')) {
         unawaited(session.preview.runCode(pathToMain));
       }
@@ -353,10 +337,6 @@ class AppState extends State<App> {
     final previousWorkspaceDisposed = Completer<void>();
     final events = AppEventBus();
     final taskStatus = TaskStatusController();
-    final preparationTask = taskStatus.startTask(
-      TaskKind.preparingWorkspace,
-      blocksPreview: true,
-    );
     final nextSession = WorkspaceSession.create(
       WorkspaceRepository.resetAndCreate(
         events: events,
@@ -390,7 +370,6 @@ class AppState extends State<App> {
       _initializeWorkspace(
         nextSession,
         source: source,
-        preparationTask: preparationTask,
       ),
     );
     disposeAfterWorkspaceUnmount(
@@ -420,10 +399,6 @@ class AppState extends State<App> {
 
     final events = AppEventBus();
     final taskStatus = TaskStatusController();
-    final preparationTask = taskStatus.startTask(
-      TaskKind.preparingWorkspace,
-      blocksPreview: true,
-    );
     final nextSession = WorkspaceSession.create(
       WorkspaceRepository.create(
         events: events,
@@ -442,7 +417,7 @@ class AppState extends State<App> {
     });
 
     unawaited(
-      _initializeSwitchSdkWorkspace(nextSession, preparationTask),
+      _initializeSwitchSdkWorkspace(nextSession),
     );
 
     disposeAfterWorkspaceUnmount(
@@ -455,12 +430,10 @@ class AppState extends State<App> {
 
   Future<void> _initializeSwitchSdkWorkspace(
     WorkspaceSession session,
-    TaskStatusHandle preparationTask,
   ) async {
     try {
       final workspace = await session.repository.readyWorkspace;
       if (!_isCurrent(session)) {
-        preparationTask.cancel();
         return;
       }
 
@@ -476,7 +449,6 @@ class AppState extends State<App> {
             )
           : null;
       if (project == null) {
-        preparationTask.fail();
         setState(() {
           _workspacePreparationFailure = 'The current project could not be prepared for the selected SDK.';
         });
@@ -488,15 +460,12 @@ class AppState extends State<App> {
           session,
           workspace,
           project,
-          preparationTask,
         ),
       );
     } catch (error, stackTrace) {
       if (!_isCurrent(session)) {
-        preparationTask.cancel();
         return;
       }
-      preparationTask.fail();
       session.events.dispatch(
         LogEvent(
           'Workspace preparation failed.',
@@ -536,7 +505,7 @@ class AppState extends State<App> {
           pathToMain: pathToMain,
         );
         project = await session.taskStatus.runTask(
-          TaskKind.downloadingArchive,
+          TaskKind.loadingCode,
           () => loader.loadArchive(session.repository.root),
           scope: archiveUrl,
           blocksPreview: true,
@@ -547,20 +516,16 @@ class AppState extends State<App> {
             'Please verify the package name in the URL.';
         final pathToMainParam = params['main'];
         final pathToMain = pathToMainParam != null ? Uri.decodeComponent(pathToMainParam) : null;
-        final loader = await session.taskStatus.runTask(
-          TaskKind.resolvingPackage,
-          () => ArchiveLoader.forPackage(
-            packageName,
-            pathToMain: pathToMain,
-          ),
-          label: 'Resolving package $packageName',
-          scope: packageName,
-          blocksPreview: true,
-        );
         project = await session.taskStatus.runTask(
-          TaskKind.downloadingPackage,
-          () => loader.loadArchive(session.repository.root),
-          label: 'Downloading package $packageName',
+          TaskKind.loadingCode,
+          () async {
+            final loader = await ArchiveLoader.forPackage(
+              packageName,
+              pathToMain: pathToMain,
+            );
+            return await loader.loadArchive(session.repository.root);
+          },
+          label: 'Loading package $packageName',
           scope: packageName,
           blocksPreview: true,
         );
@@ -570,7 +535,7 @@ class AppState extends State<App> {
             'Please check that the Gist ID "$gistId" in the URL is correct.';
         final loader = GistLoader(gistId: gistId);
         project = await session.taskStatus.runTask(
-          TaskKind.downloadingGist,
+          TaskKind.loadingCode,
           () => loader.loadGist(session.repository.root),
           scope: gistId,
           blocksPreview: true,
@@ -578,7 +543,7 @@ class AppState extends State<App> {
       } else if (params['sample'] case final String sampleId) {
         userErrorMessage = 'The requested sample "$sampleId" could not be loaded.';
         project = await session.taskStatus.runTask(
-          TaskKind.loadingSample,
+          TaskKind.loadingCode,
           () => loadSampleProject(
             session.repository.root,
             sampleId: sampleId,
@@ -590,7 +555,7 @@ class AppState extends State<App> {
       } else {
         userErrorMessage = 'The default project could not be loaded.';
         project = await session.taskStatus.runTask(
-          TaskKind.loadingDefaultSample,
+          TaskKind.loadingCode,
           () => loadSampleProject(session.repository.root),
           blocksPreview: true,
         );

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
+import '../../shared/app_event_bus.dart';
 import '../../shared/components/context_menu.dart';
+import '../../shared/events/open_console_event.dart';
 import '../models/console_entry.dart';
 import 'bottom_panel_tabs.dart';
 import 'console_panel.dart';
@@ -30,6 +34,7 @@ class BottomPanel extends StatefulComponent {
     required this.onOpenDiagnostic,
     required this.logs,
     required this.onClearConsole,
+    required this.events,
     this.contextMenu,
     super.key,
   });
@@ -52,6 +57,9 @@ class BottomPanel extends StatefulComponent {
   /// Clears the debug output.
   final void Function() onClearConsole;
 
+  /// Workspace events used to react to requests from the preview panel.
+  final AppEventBus events;
+
   /// The context menu controller used to show right-click menus.
   final ContextMenuController? contextMenu;
 
@@ -64,6 +72,30 @@ class BottomPanel extends StatefulComponent {
 
 class _BottomPanelState extends State<BottomPanel> {
   BottomPanelTab _activeTab = BottomPanelTab.problems;
+  StreamSubscription<OpenConsoleEvent>? _openConsoleSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _listenForOpenConsole();
+  }
+
+  @override
+  void didUpdateComponent(BottomPanel oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (!identical(oldComponent.events, component.events)) {
+      unawaited(_openConsoleSubscription?.cancel());
+      _listenForOpenConsole();
+    }
+  }
+
+  void _listenForOpenConsole() {
+    _openConsoleSubscription = component.events.on<OpenConsoleEvent>().listen((_) {
+      if (mounted && _activeTab != BottomPanelTab.console) {
+        _selectTab(BottomPanelTab.console);
+      }
+    });
+  }
 
   void _selectTab(BottomPanelTab tab) {
     setState(() {
@@ -100,6 +132,12 @@ class _BottomPanelState extends State<BottomPanel> {
         ),
       },
     ]);
+  }
+
+  @override
+  void dispose() {
+    unawaited(_openConsoleSubscription?.cancel());
+    super.dispose();
   }
 
   static List<StyleRule> get styles => [

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import '../../shared/task_status.dart';
+
 /// Base sealed class representing the current visual and execution state of
 /// the preview.
 sealed class PreviewState {
@@ -45,14 +47,28 @@ class PreviewHotReloading extends _ActivePreviewState {
 /// State representing an active stop/shutdown execution process.
 class PreviewStopping extends PreviewState {}
 
+/// The user action that initiated a preview launch lifecycle.
+enum PreviewLaunchAction { start, restart }
+
 /// State representing a compiler or runtime failure while compiling the
 /// [entrypoint].
 class PreviewCompileError extends PreviewState {
-  PreviewCompileError(this.entrypoint, this.message);
+  PreviewCompileError(
+    this.entrypoint,
+    this.message, {
+    required this.action,
+    required this.failedTask,
+  });
 
   @override
   final String entrypoint;
 
   /// The error message describing the failure.
   final String message;
+
+  /// Whether the failed launch was a fresh start or a cached restart.
+  final PreviewLaunchAction action;
+
+  /// The typed task phase that failed.
+  final TaskKind failedTask;
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -8,25 +8,39 @@ import 'package:jaspr/jaspr.dart';
 import '../../../app_styles.dart';
 import '../../bottom_panel/views/console_panel.dart';
 import '../../shared/components/button_group.dart';
+import '../../shared/components/task_status_indicator.dart';
 import '../../shared/node_container.dart';
+import '../../shared/task_status.dart';
 import '../components/runtime_button.dart';
 import '../models/preview_state.dart';
 import '../view_models/preview_view_model.dart';
 
-/// A container component that hosts the preview frame toolbar, status toast
-/// messages, and the sandbox node where the compiled application runs.
+/// A container component that hosts the preview toolbar, task status, and the
+/// sandbox node where the compiled application runs.
 class PreviewContainer extends StatefulComponent {
   const PreviewContainer({
     required this.preview,
+    required this.taskStatus,
     required this.activeFile,
+    required this.onOpenConsole,
+    this.workspacePreparationFailure,
     super.key,
   });
 
   /// The view model that manages compilation and run operations for the preview.
   final PreviewViewModel preview;
 
+  /// Tracks prerequisite and runtime tasks shown in an empty preview.
+  final TaskStatusController taskStatus;
+
   /// The path of the currently active file in the editor workspace.
   final String activeFile;
+
+  /// A persistent failure from the one-time workspace preparation lifecycle.
+  final String? workspacePreparationFailure;
+
+  /// Opens the workspace Console tab.
+  final void Function() onOpenConsole;
 
   @override
   State<PreviewContainer> createState() => _PreviewContainerState();
@@ -42,42 +56,40 @@ class _PreviewContainerState extends State<PreviewContainer> {
     final state = viewModel.state;
     final isRunning = viewModel.isRunning;
 
-    final statusToast = switch (state) {
-      PreviewStarting() => const div(classes: 'preview-toast', [
-        div(classes: 'status-spinner', []),
-        span([.text('Starting...')]),
-      ]),
-      PreviewRestarting() => const div(classes: 'preview-toast', [
-        div(classes: 'status-spinner', []),
-        span([.text('Restarting...')]),
-      ]),
-      PreviewHotReloading() => null,
-      PreviewStopping() => const div(classes: 'preview-toast', [
-        div(classes: 'status-spinner', []),
-        span([.text('Stopping...')]),
-      ]),
-      PreviewCompileError() => const div(classes: 'preview-toast preview-toast-error', [
-        span(classes: 'status-icon', [.text('⚠️')]),
-        span([.text('Start failed')]),
-      ]),
+    final previewFailure = state is PreviewCompileError ? state : null;
+    final failureKind =
+        previewFailure?.failedTask ??
+        (component.workspacePreparationFailure == null ? null : TaskKind.preparingWorkspace);
+    final failureMessage = previewFailure?.message ?? component.workspacePreparationFailure;
+    final taskStatusMode = switch (state) {
+      PreviewInitial() => PreviewTaskStatusMode.workspacePreparation,
+      PreviewStarting() => PreviewTaskStatusMode.startup,
+      PreviewRestarting() => PreviewTaskStatusMode.restart,
+      PreviewCompileError(:final action) => switch (action) {
+        PreviewLaunchAction.start => PreviewTaskStatusMode.startup,
+        PreviewLaunchAction.restart => PreviewTaskStatusMode.restart,
+      },
       _ => null,
     };
 
     return div(classes: 'preview-container', [
       div(classes: 'preview-toolbar', [
         div(classes: 'preview-controls', [
-          ButtonGroup(
-            children: [
-              if (isRunning)
-                RuntimeButton.restart(previewViewModel: viewModel)
-              else
-                RuntimeButton.start(
-                  previewViewModel: viewModel,
-                  activeFile: component.activeFile,
-                ),
-              RuntimeButton.hotReload(previewViewModel: viewModel),
-              RuntimeButton.stop(previewViewModel: viewModel),
-            ],
+          ListenableBuilder(
+            listenable: component.taskStatus,
+            builder: (context) => ButtonGroup(
+              children: [
+                if (isRunning)
+                  RuntimeButton.restart(previewViewModel: viewModel)
+                else
+                  RuntimeButton.start(
+                    previewViewModel: viewModel,
+                    activeFile: component.activeFile,
+                  ),
+                RuntimeButton.hotReload(previewViewModel: viewModel),
+                RuntimeButton.stop(previewViewModel: viewModel),
+              ],
+            ),
           ),
         ]),
       ]),
@@ -85,22 +97,22 @@ class _PreviewContainerState extends State<PreviewContainer> {
         classes: 'preview-content ${!isRunning ? 'status-stopped' : ''} ${!viewModel.isFlutter ? 'is-dart' : ''}',
         [
           NodeContainer(viewModel.containerElement),
-          if (state is PreviewInitial)
-            const div(classes: 'preview-placeholder', [
-              span([.text('The preview will start momentarily.')]),
-            ]),
+          if (taskStatusMode != null)
+            PreviewTaskStatus(
+              controller: component.taskStatus,
+              mode: taskStatusMode,
+              persistentFailureKind: failureKind,
+              persistentFailureMessage: failureMessage,
+              onOpenConsole: component.onOpenConsole,
+            ),
           if (isRunning && !viewModel.isFlutter) ConsolePanel(logs: viewModel.appLogs),
-          ?statusToast,
         ],
       ),
     ]);
   }
 
   static List<StyleRule> get styles => [
-    css.keyframes('spin', {
-      '0%': Styles(transform: .rotate(0.deg)),
-      '100%': Styles(transform: .rotate(360.deg)),
-    }),
+    ...PreviewTaskStatus.styles,
     css('.preview-container', [
       css('&').styles(
         display: .flex,
@@ -170,56 +182,6 @@ class _PreviewContainerState extends State<PreviewContainer> {
           border: .none,
           radius: .circular(0.px),
           shadow: .none,
-        ),
-        css('.preview-toast', [
-          css('&').styles(
-            display: .flex,
-            position: .absolute(top: 16.px, left: 16.px),
-            zIndex: const ZIndex(10),
-            padding: .symmetric(vertical: 8.px, horizontal: 16.px),
-            border: const .all(color: Color('rgba(255, 255, 255, 0.12)')),
-            radius: .circular(8.px),
-            shadow: BoxShadow(
-              offsetX: 0.px,
-              offsetY: 4.px,
-              blur: 12.px,
-              color: Colors.black.withOpacity(0.3),
-            ),
-            backdropFilter: .blur(8.px),
-            alignItems: .center,
-            gap: .all(8.px),
-            color: colorOnSurface,
-            fontSize: 14.px,
-            fontWeight: .w500,
-            backgroundColor: const Color('rgba(15, 23, 42, 0.8)'),
-          ),
-          css('.status-spinner').styles(
-            width: 14.px,
-            height: 14.px,
-            border: .only(
-              top: .solid(color: Colors.white, width: 2.px),
-              right: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
-              bottom: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
-              left: .solid(color: const .rgba(255, 255, 255, 0.3), width: 2.px),
-            ),
-            radius: .circular(50.percent),
-            animation: Animation(name: 'spin', duration: 1.seconds, curve: .linear, count: 10e6),
-          ),
-          css('.status-icon').styles(
-            display: .flex,
-            alignItems: .center,
-          ),
-          css('&.preview-toast-error').styles(
-            backgroundColor: const Color('rgba(127, 29, 29, 0.9)'),
-          ),
-        ]),
-        css('.preview-placeholder').styles(
-          display: .flex,
-          position: .absolute(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
-          justifyContent: .center,
-          alignItems: .center,
-          color: colorOnSurface,
-          fontSize: 14.px,
         ),
       ]),
     ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -57,9 +57,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
     final isRunning = viewModel.isRunning;
 
     final previewFailure = state is PreviewCompileError ? state : null;
-    final failureKind =
-        previewFailure?.failedTask ??
-        (component.workspacePreparationFailure == null ? null : TaskKind.preparingWorkspace);
+    final failureKind = previewFailure?.failedTask;
     final failureMessage = previewFailure?.message ?? component.workspacePreparationFailure;
     final taskStatusMode = switch (state) {
       PreviewInitial() => PreviewTaskStatusMode.workspacePreparation,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -12,6 +12,7 @@ import 'package:web/web.dart' as web;
 import '../../bottom_panel/models/console_entry.dart';
 import '../../shared/app_event_bus.dart';
 import '../../shared/events/log_event.dart';
+import '../../shared/task_status.dart';
 import '../../workspace/data/workspace_repository.dart';
 import '../models/compiler_session.dart';
 import '../models/preview_sandbox.dart';
@@ -66,13 +67,19 @@ class PreviewViewModel extends ChangeNotifier {
   final List<ConsoleEntry> _appLogs = [];
 
   /// Whether the compiler or execution setup can be started.
-  bool get canStart => !_busy && (_state is PreviewInitial || _state is PreviewCompileError);
+  bool get canStart =>
+      !_busy &&
+      !workspaceRepository.taskStatus.hasBlockingPreviewTask &&
+      (_state is PreviewInitial || _state is PreviewCompileError);
 
   /// Whether the running preview can be restarted.
-  bool get canRestart => !_busy && _state is PreviewRunning;
+  bool get canRestart =>
+      !_busy &&
+      _state is PreviewRunning &&
+      (_lastCompiledCode != null || !workspaceRepository.taskStatus.hasBlockingPreviewTask);
 
   /// Whether the running preview can accept a hot reload.
-  bool get canHotReload => !_busy && _state is PreviewRunning;
+  bool get canHotReload => !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
 
   /// Whether the preview run process can be stopped.
   bool get canStop => _state is! PreviewStopping && (_busy || _sandbox != null);
@@ -110,21 +117,33 @@ class PreviewViewModel extends ChangeNotifier {
     if (_busy) {
       return;
     }
+    final compileNeeded = !skipRecompilation || _lastCompiledCode == null;
+    if (compileNeeded && workspaceRepository.taskStatus.hasBlockingPreviewTask) {
+      return;
+    }
 
     final operationId = _beginOperation();
+    final isRestart =
+        _state is PreviewRunning ||
+        _state is PreviewRestarting ||
+        _state is PreviewHotReloading ||
+        _state is PreviewStopping;
+    final launchAction = isRestart ? PreviewLaunchAction.restart : PreviewLaunchAction.start;
+    final launchTask = isRestart ? TaskKind.restartingPreview : TaskKind.startingPreview;
+    final statusTask = workspaceRepository.taskStatus.startTask(
+      launchTask,
+      blocksPreview: true,
+    );
 
     _appLogs.clear();
 
-    final compileNeeded = !skipRecompilation || _lastCompiledCode == null;
+    var failedTask = launchTask;
     eventBus.dispatch(LogEvent('Run $entrypoint'));
     if (compileNeeded) {
       eventBus.dispatch(const LogEvent('Starting compiler...'));
     }
 
-    if (_state is PreviewRunning ||
-        _state is PreviewRestarting ||
-        _state is PreviewHotReloading ||
-        _state is PreviewStopping) {
+    if (isRestart) {
       _state = PreviewRestarting(entrypoint);
     } else {
       _state = PreviewStarting(entrypoint);
@@ -156,12 +175,18 @@ class PreviewViewModel extends ChangeNotifier {
         _hotReloadCompiler = compiler;
 
         eventBus.dispatch(const LogEvent('Compiling application...'));
-        final result = await compiler.compile();
+        failedTask = TaskKind.compilingApplication;
+        final result = await workspaceRepository.taskStatus.runTask(
+          TaskKind.compilingApplication,
+          compiler.compile,
+          blocksPreview: true,
+        );
         if (!_isCurrentOperation(operationId)) {
           return;
         }
         eventBus.dispatch(LogEvent(result.log ?? ''));
         eventBus.dispatch(const LogEvent('Compilation succeeded.'));
+        failedTask = launchTask;
         _lastCompiledCode = result.code;
         codeToLoad = result.code!;
       } else {
@@ -222,14 +247,33 @@ class PreviewViewModel extends ChangeNotifier {
         eventBus.dispatch(
           LogEvent('Compilation failed', level: Level.SEVERE, error: e, stackTrace: st),
         );
-        _state = PreviewCompileError(entrypoint, e.message);
+        _state = PreviewCompileError(
+          entrypoint,
+          e.message,
+          action: launchAction,
+          failedTask: failedTask,
+        );
       }
     } catch (e, st) {
       if (_isCurrentOperation(operationId)) {
         eventBus.dispatch(LogEvent('Run failed', level: Level.SEVERE, error: e, stackTrace: st));
-        _state = PreviewCompileError(entrypoint, e.toString());
+        _state = PreviewCompileError(
+          entrypoint,
+          e.toString(),
+          action: launchAction,
+          failedTask: failedTask,
+        );
       }
     } finally {
+      if (!_isCurrentOperation(operationId)) {
+        statusTask.cancel();
+      } else if (_state is PreviewRunning) {
+        statusTask.succeed();
+      } else if (_state is PreviewCompileError) {
+        statusTask.fail();
+      } else {
+        statusTask.cancel();
+      }
       if (!_disposed) {
         notifyListeners();
       }
@@ -243,12 +287,17 @@ class PreviewViewModel extends ChangeNotifier {
     if (entry == null) {
       return;
     }
-    if (_busy) {
+    if (_busy || workspaceRepository.taskStatus.hasBlockingPreviewTask) {
       return;
     }
     final operationId = _beginOperation();
+    final statusTask = workspaceRepository.taskStatus.startTask(
+      TaskKind.hotReload,
+      blocksPreview: true,
+    );
     final sandbox = _sandbox;
     if (sandbox == null) {
+      statusTask.cancel();
       return;
     }
     eventBus.dispatch(LogEvent('Hot reload $entry'));
@@ -256,6 +305,7 @@ class PreviewViewModel extends ChangeNotifier {
 
     _state = PreviewHotReloading(entry);
     notifyListeners();
+    var reloadSucceeded = false;
 
     try {
       eventBus.dispatch(const LogEvent('Preparing compiler...'));
@@ -273,7 +323,11 @@ class PreviewViewModel extends ChangeNotifier {
       }
 
       eventBus.dispatch(const LogEvent('Compiling changes...'));
-      final result = await compiler.compile();
+      final result = await workspaceRepository.taskStatus.runTask(
+        TaskKind.compilingChanges,
+        compiler.compile,
+        blocksPreview: true,
+      );
       if (!_isCurrentOperation(operationId)) {
         return;
       }
@@ -291,21 +345,31 @@ class PreviewViewModel extends ChangeNotifier {
       eventBus.dispatch(const LogEvent('Hot reload completed successfully.'));
       _lastCompiledCode = result.code;
       _state = PreviewRunning(entry);
+      reloadSucceeded = true;
     } on HotReloadRejectedException catch (e, st) {
       if (_isCurrentOperation(operationId)) {
         eventBus.dispatch(
           LogEvent('Hot reload rejected', level: Level.WARNING, error: e, stackTrace: st),
         );
-        _state = PreviewCompileError(entry, e.message);
+        _state = PreviewRunning(entry);
       }
     } catch (e, st) {
       if (_isCurrentOperation(operationId)) {
         eventBus.dispatch(
           LogEvent('Hot reload failed', level: Level.SEVERE, error: e, stackTrace: st),
         );
-        _state = PreviewCompileError(entry, e.toString());
+        _state = PreviewRunning(entry);
       }
     } finally {
+      if (!_isCurrentOperation(operationId)) {
+        statusTask.cancel();
+      } else if (reloadSucceeded) {
+        statusTask.succeed();
+      } else if (_state is PreviewRunning) {
+        statusTask.fail();
+      } else {
+        statusTask.cancel();
+      }
       if (!_disposed) {
         notifyListeners();
       }
@@ -319,6 +383,10 @@ class PreviewViewModel extends ChangeNotifier {
       return;
     }
     final operationId = _beginOperation();
+    final statusTask = workspaceRepository.taskStatus.startTask(
+      TaskKind.stoppingPreview,
+      blocksPreview: true,
+    );
     eventBus.dispatch(const LogEvent('Stopping app...'));
     _state = PreviewStopping();
     _lastCompiledCode = null;
@@ -338,15 +406,24 @@ class PreviewViewModel extends ChangeNotifier {
         await hotReloadCompiler.close();
       }
       eventBus.dispatch(const LogEvent('Stopped app.'));
+    } catch (_) {
+      if (_isCurrentOperation(operationId)) {
+        statusTask.fail();
+      } else {
+        statusTask.cancel();
+      }
+      rethrow;
     } finally {
       operationStillCurrent = _isCurrentOperation(operationId);
     }
 
     if (!operationStillCurrent) {
+      statusTask.cancel();
       return;
     }
 
     _state = PreviewInitial();
+    statusTask.succeed();
     if (!_disposed) {
       notifyListeners();
     }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
@@ -1,0 +1,83 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:jaspr/jaspr.dart';
+
+import 'task_status.dart';
+
+/// The session-scoped lifecycle of the Dart analyzer.
+enum AnalyzerStatusPhase { waiting, analyzing, ready, unavailable }
+
+/// Tracks analyzer readiness separately from user-visible application tasks.
+///
+/// Analyzer startup and the first complete analysis are represented by one
+/// normal task. Later analysis cycles only toggle [AnalyzerStatusPhase.analyzing]
+/// and never replace or restart that initialization task.
+final class AnalyzerStatusController extends ChangeNotifier {
+  AnalyzerStatusController(this._taskStatus);
+
+  final TaskStatusController _taskStatus;
+
+  AnalyzerStatusPhase _phase = AnalyzerStatusPhase.waiting;
+  TaskStatusHandle? _initializationTask;
+  bool _initializationFinished = false;
+  bool _disposed = false;
+
+  AnalyzerStatusPhase get phase => _phase;
+
+  /// Starts the single task spanning analyzer startup and initial analysis.
+  void beginInitialization() {
+    if (_disposed || _initializationTask != null || _initializationFinished) {
+      return;
+    }
+    _initializationTask = _taskStatus.startTask(TaskKind.analyzingWorkspace);
+    _setPhase(AnalyzerStatusPhase.analyzing);
+  }
+
+  /// Applies an analyzer busy/idle notification.
+  void update({required bool isAnalyzing}) {
+    if (_disposed) {
+      return;
+    }
+    if (isAnalyzing) {
+      _setPhase(AnalyzerStatusPhase.analyzing);
+      return;
+    }
+
+    _initializationTask?.succeed();
+    _initializationTask = null;
+    _initializationFinished = true;
+    _setPhase(AnalyzerStatusPhase.ready);
+  }
+
+  /// Marks the analyzer as unavailable after startup or stream failure.
+  void markUnavailable() {
+    if (_disposed) {
+      return;
+    }
+    _initializationTask?.fail();
+    _initializationTask = null;
+    _initializationFinished = true;
+    _setPhase(AnalyzerStatusPhase.unavailable);
+  }
+
+  void _setPhase(AnalyzerStatusPhase phase) {
+    if (_phase == phase) {
+      return;
+    }
+    _phase = phase;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _initializationTask?.cancel();
+    _initializationTask = null;
+    super.dispose();
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -7,25 +7,36 @@ import 'package:jaspr/jaspr.dart';
 
 import '../../../app_styles.dart';
 import '../../../sdks.g.dart';
+import '../analyzer_status.dart';
 import '../icons.dart';
 import '../sdk_info.dart';
+import '../task_status.dart';
 import 'dropdown_menu.dart';
 import 'icon_button.dart';
 import 'shortcuts_dialog.dart';
+import 'task_status_indicator.dart';
 
 /// The application footer with links, runtime information, and shortcuts.
 final class Footer extends StatefulComponent {
   /// Creates the application footer.
   const Footer({
-    required this.statusLabel,
+    required this.taskStatus,
+    required this.analyzerStatus,
+    this.statusMessage,
     this.isSmallScreen = false,
     this.currentSdk,
     this.onSelectSdk,
     super.key,
   });
 
-  /// Human-readable label for the current application status.
-  final String statusLabel;
+  /// Recent application task activity.
+  final TaskStatusController taskStatus;
+
+  /// Readiness and background activity of the session analyzer.
+  final AnalyzerStatusController analyzerStatus;
+
+  /// An optional editor error or warning shown alongside task activity.
+  final String? statusMessage;
 
   /// Whether the footer is rendered in a small-screen layout.
   final bool isSmallScreen;
@@ -77,9 +88,12 @@ class _FooterState extends State<Footer> {
             _buildFeedbackLink(),
           ],
         ]),
-        div(classes: 'app-footer-status', [
-          .text(component.statusLabel),
-        ]),
+        if (component.statusMessage case final message?)
+          div(classes: 'app-footer-message', [.text(message)])
+        else
+          const div(classes: 'app-footer-spacer', []),
+        TaskStatusIndicator(controller: component.taskStatus),
+        AnalyzerStatusIndicator(controller: component.analyzerStatus),
         _buildRuntimeVersions(),
       ]),
       if (_showShortcuts)
@@ -159,6 +173,8 @@ class _FooterState extends State<Footer> {
   }
 
   static List<StyleRule> get styles => [
+    ...TaskStatusIndicator.styles,
+    ...AnalyzerStatusIndicator.styles,
     css('.app-footer').styles(
       display: .flex,
       minHeight: 34.px,
@@ -225,10 +241,10 @@ class _FooterState extends State<Footer> {
       opacity: 0.7,
       cursor: .notAllowed,
     ),
-    css('.app-footer-status').styles(
-      width: 120.px,
-      minWidth: 120.px,
-      margin: Margin.only(left: Unit.auto, right: 8.px),
+    css('.app-footer-spacer').styles(flex: const .grow(1)),
+    css('.app-footer-message').styles(
+      minWidth: .zero,
+      margin: const Margin.only(left: Unit.auto),
       overflow: .hidden,
       textAlign: .right,
       fontSize: 11.px,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
@@ -1,0 +1,652 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import '../analyzer_status.dart';
+import '../icons.dart';
+import '../task_status.dart';
+
+/// Compact footer status with a detailed recent-task popover.
+final class TaskStatusIndicator extends StatefulComponent {
+  const TaskStatusIndicator({required this.controller, super.key});
+
+  final TaskStatusController controller;
+
+  @override
+  State<TaskStatusIndicator> createState() => _TaskStatusIndicatorState();
+
+  @css
+  static List<StyleRule> get styles => _TaskStatusIndicatorState.styles;
+}
+
+class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
+  final GlobalNodeKey<web.HTMLElement> _anchorKey = GlobalNodeKey();
+  StreamSubscription<web.KeyboardEvent>? _keySubscription;
+  StreamSubscription<web.MouseEvent>? _mouseSubscription;
+  Timer? _ticker;
+  bool _hovered = false;
+  bool _focused = false;
+  bool _pinned = false;
+  bool _forceClosed = false;
+
+  bool get _showPopover =>
+      component.controller.entries.isNotEmpty && !_forceClosed && (_hovered || _focused || _pinned);
+
+  @override
+  void initState() {
+    super.initState();
+    component.controller.addListener(_onTasksChanged);
+    _keySubscription = web.EventStreamProviders.keyDownEvent.forTarget(web.document).listen(_onKeyDown);
+    _mouseSubscription = web.EventStreamProviders.mouseDownEvent.forTarget(web.document).listen(_onMouseDown);
+    _syncTicker();
+  }
+
+  @override
+  void didUpdateComponent(TaskStatusIndicator oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (!identical(oldComponent.controller, component.controller)) {
+      oldComponent.controller.removeListener(_onTasksChanged);
+      component.controller.addListener(_onTasksChanged);
+      _syncTicker();
+    }
+  }
+
+  void _onTasksChanged() {
+    if (!mounted) {
+      return;
+    }
+    _syncTicker();
+    setState(() {});
+  }
+
+  void _syncTicker() {
+    final needsTicker = component.controller.entries.any((entry) => entry.isRunning);
+    if (!needsTicker) {
+      _ticker?.cancel();
+      _ticker = null;
+    } else {
+      _ticker ??= Timer.periodic(const Duration(milliseconds: 100), (_) {
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    }
+  }
+
+  void _onKeyDown(web.KeyboardEvent event) {
+    if (event.key != 'Escape' || !_showPopover) {
+      return;
+    }
+    event.preventDefault();
+    setState(() {
+      _pinned = false;
+      _forceClosed = true;
+    });
+  }
+
+  void _onMouseDown(web.MouseEvent event) {
+    if (!_pinned) {
+      return;
+    }
+    final anchor = _anchorKey.currentNode;
+    final target = event.target as web.Node?;
+    if (anchor != null && target != null && !anchor.contains(target)) {
+      setState(() {
+        _pinned = false;
+        _forceClosed = true;
+      });
+    }
+  }
+
+  void _onFocusOut(web.Event event) {
+    final anchor = _anchorKey.currentNode;
+    final relatedTarget = (event as web.FocusEvent).relatedTarget as web.Node?;
+    if (anchor == null || relatedTarget == null || !anchor.contains(relatedTarget)) {
+      setState(() {
+        _focused = false;
+        if (!_pinned) {
+          _forceClosed = false;
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    component.controller.removeListener(_onTasksChanged);
+    _keySubscription?.cancel();
+    _mouseSubscription?.cancel();
+    _ticker?.cancel();
+    _keySubscription = null;
+    _mouseSubscription = null;
+    _ticker = null;
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final entries = component.controller.entries;
+    final current = entries.firstOrNull;
+    final now = DateTime.now();
+    final label = current?.label ?? 'Ready';
+    final duration = current == null ? null : formatTaskDuration(current.durationAt(now));
+
+    return div(
+      key: _anchorKey,
+      classes: 'task-status-anchor',
+      events: {
+        'mouseenter': (_) => setState(() {
+          _hovered = true;
+          _forceClosed = false;
+        }),
+        'mouseleave': (_) => setState(() {
+          _hovered = false;
+          _forceClosed = false;
+        }),
+        'focusin': (_) => setState(() {
+          _focused = true;
+          _forceClosed = false;
+        }),
+        'focusout': _onFocusOut,
+      },
+      [
+        button(
+          classes: 'task-status-trigger${entries.isEmpty ? ' empty' : ''}',
+          attributes: {
+            'aria-label': current == null ? 'Task status: Ready' : 'Task status: $label, $duration',
+            'aria-expanded': _showPopover.toString(),
+            if (entries.isNotEmpty) 'aria-controls': 'task-status-popover',
+          },
+          onClick: () {
+            if (entries.isEmpty) {
+              return;
+            }
+            setState(() {
+              _pinned = !_pinned;
+              _forceClosed = false;
+            });
+          },
+          [
+            _TaskStatusIcon(entry: current, size: 16),
+            span(classes: 'task-status-label', [.text(label)]),
+            if (duration != null)
+              span(
+                classes: 'task-status-duration',
+                attributes: {'aria-hidden': 'true'},
+                [.text(duration)],
+              ),
+          ],
+        ),
+        if (_showPopover)
+          div(
+            id: 'task-status-popover',
+            classes: 'task-status-popover',
+            attributes: {'role': 'dialog', 'aria-label': 'Recent tasks'},
+            [
+              const div(classes: 'task-status-popover-title', [.text('Recent tasks')]),
+              table(classes: 'task-status-table', [
+                tbody([
+                  for (final entry in entries)
+                    tr([
+                      td(classes: 'task-status-cell-icon', [_TaskStatusIcon(entry: entry, size: 16)]),
+                      td(classes: 'task-status-cell-name', [.text(entry.label)]),
+                      td(
+                        classes: 'task-status-cell-duration',
+                        attributes: {'aria-label': formatTaskDuration(entry.durationAt(now))},
+                        [.text(formatTaskDuration(entry.durationAt(now)))],
+                      ),
+                    ]),
+                ]),
+              ]),
+            ],
+          ),
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css.keyframes('task-status-spin', {
+      '0%': Styles(transform: .rotate(0.deg)),
+      '100%': Styles(transform: .rotate(360.deg)),
+    }),
+    css('.task-status-anchor').styles(
+      position: const .relative(),
+      minWidth: .zero,
+    ),
+    css('.task-status-trigger').styles(
+      display: .flex,
+      height: 28.px,
+      maxWidth: 260.px,
+      padding: .symmetric(horizontal: 8.px),
+      border: .none,
+      radius: .circular(4.px),
+      outline: const Outline(style: .none),
+      cursor: .pointer,
+      alignItems: .center,
+      gap: Gap.all(6.px),
+      color: colorOnSurface,
+      fontFamily: const .list([FontFamilies.sansSerif]),
+      fontSize: 11.px,
+      backgroundColor: Colors.transparent,
+    ),
+    css('.task-status-trigger:hover, .task-status-trigger:focus-visible').styles(
+      backgroundColor: colorSurface.highlight(colorOnSurface, 0.1),
+    ),
+    css('.task-status-trigger.empty').styles(raw: {'cursor': 'default'}),
+    css('.task-status-label').styles(
+      minWidth: .zero,
+      overflow: .hidden,
+      textOverflow: .ellipsis,
+      whiteSpace: .noWrap,
+    ),
+    css('.task-status-duration').styles(
+      flex: const .shrink(0),
+      color: colorOnContainer,
+      raw: {'font-variant-numeric': 'tabular-nums'},
+    ),
+    css('.task-status-icon').styles(
+      display: .flex,
+      justifyContent: .center,
+      alignItems: .center,
+      flex: const .shrink(0),
+    ),
+    css('.task-status-icon.running').styles(
+      width: 14.px,
+      height: 14.px,
+      border: .only(
+        top: .solid(color: colorPrimary, width: 2.px),
+        right: .solid(color: colorBorder, width: 2.px),
+        bottom: .solid(color: colorBorder, width: 2.px),
+        left: .solid(color: colorBorder, width: 2.px),
+      ),
+      radius: .circular(50.percent),
+      animation: Animation(name: 'task-status-spin', duration: 1.seconds, curve: .linear, count: 10e6),
+    ),
+    css('.task-status-icon.succeeded').styles(color: colorSuccess),
+    css('.task-status-icon.failed').styles(color: colorError),
+    css('.task-status-popover').styles(
+      position: .absolute(bottom: 100.percent, right: 0.px),
+      zIndex: const ZIndex(100),
+      minWidth: 320.px,
+      maxWidth: 480.px,
+      maxHeight: 320.px,
+      padding: .all(8.px),
+      margin: Margin.only(bottom: 4.px),
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(8.px),
+      overflow: .auto,
+      shadow: BoxShadow(
+        offsetX: .zero,
+        offsetY: (-4).px,
+        blur: 12.px,
+        color: const .rgba(0, 0, 0, 0.15),
+      ),
+      color: colorOnContainer,
+      backgroundColor: colorContainer,
+    ),
+    css('.task-status-popover-title').styles(
+      padding: .symmetric(horizontal: 8.px, vertical: 6.px),
+      fontSize: 12.px,
+      fontWeight: .w700,
+    ),
+    css('.task-status-table').styles(
+      width: 100.percent,
+      fontSize: 12.px,
+      raw: {'border-collapse': 'collapse'},
+    ),
+    css('.task-status-table td').styles(
+      padding: .symmetric(horizontal: 8.px, vertical: 6.px),
+      border: .only(
+        top: .solid(color: colorBorder, width: 1.px),
+      ),
+    ),
+    css('.task-status-cell-icon').styles(width: 24.px),
+    css('.task-status-cell-name').styles(
+      maxWidth: 320.px,
+      overflow: .hidden,
+      textOverflow: .ellipsis,
+      whiteSpace: .noWrap,
+    ),
+    css('.task-status-cell-duration').styles(
+      textAlign: .right,
+      whiteSpace: .noWrap,
+      raw: {'font-variant-numeric': 'tabular-nums'},
+    ),
+    css.media(MediaQuery.screen(maxWidth: 700.px), [
+      css('.task-status-popover').styles(
+        position: .fixed(bottom: 38.px, left: 8.px, right: 8.px),
+        minWidth: .zero,
+        raw: {'max-width': 'none'},
+      ),
+    ]),
+  ];
+}
+
+/// Stable analyzer readiness indicator with a non-timed update pulse.
+final class AnalyzerStatusIndicator extends StatefulComponent {
+  const AnalyzerStatusIndicator({required this.controller, super.key});
+
+  final AnalyzerStatusController controller;
+
+  @override
+  State<AnalyzerStatusIndicator> createState() => _AnalyzerStatusIndicatorState();
+
+  @css
+  static List<StyleRule> get styles => _AnalyzerStatusIndicatorState.styles;
+}
+
+class _AnalyzerStatusIndicatorState extends State<AnalyzerStatusIndicator> {
+  @override
+  void initState() {
+    super.initState();
+    component.controller.addListener(_onStatusChanged);
+  }
+
+  @override
+  void didUpdateComponent(AnalyzerStatusIndicator oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (!identical(oldComponent.controller, component.controller)) {
+      oldComponent.controller.removeListener(_onStatusChanged);
+      component.controller.addListener(_onStatusChanged);
+    }
+  }
+
+  void _onStatusChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    component.controller.removeListener(_onStatusChanged);
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final phase = component.controller.phase;
+    final unavailable = phase == AnalyzerStatusPhase.unavailable;
+    final running = phase == AnalyzerStatusPhase.waiting || phase == AnalyzerStatusPhase.analyzing;
+
+    return div(
+      classes: 'analyzer-status ${phase.name}',
+      attributes: {'aria-label': 'Analyzer: ${phase.name}'},
+      [
+        _TaskStatusIcon.outcome(
+          outcome: running
+              ? TaskStatusOutcome.running
+              : unavailable
+              ? TaskStatusOutcome.failed
+              : TaskStatusOutcome.succeeded,
+          size: 16,
+        ),
+        const span(classes: 'analyzer-status-label', [.text('Analyzer')]),
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css('.analyzer-status').styles(
+      display: .flex,
+      height: 28.px,
+      minWidth: .zero,
+      padding: .symmetric(horizontal: 6.px),
+      alignItems: .center,
+      gap: Gap.all(6.px),
+      fontSize: 11.px,
+      whiteSpace: .noWrap,
+    ),
+    css('.analyzer-status-label').styles(
+      minWidth: .zero,
+      overflow: .hidden,
+      textOverflow: .ellipsis,
+    ),
+    css('.analyzer-status .task-status-icon.running').styles(
+      width: 10.px,
+      height: 10.px,
+      border: .only(
+        top: .solid(color: colorPrimary, width: 2.px),
+        right: .solid(color: colorBorder, width: 2.px),
+        bottom: .solid(color: colorBorder, width: 2.px),
+        left: .solid(color: colorBorder, width: 2.px),
+      ),
+    ),
+  ];
+}
+
+/// The exclusive task group shown in an empty preview panel.
+enum PreviewTaskStatusMode { workspacePreparation, startup, restart }
+
+/// A prominent status surface for the initial workspace and preview startup.
+final class PreviewTaskStatus extends StatefulComponent {
+  const PreviewTaskStatus({
+    required this.controller,
+    required this.mode,
+    required this.onOpenConsole,
+    this.persistentFailureKind,
+    this.persistentFailureMessage,
+    super.key,
+  });
+
+  final TaskStatusController controller;
+  final PreviewTaskStatusMode mode;
+  final void Function() onOpenConsole;
+  final TaskKind? persistentFailureKind;
+  final String? persistentFailureMessage;
+
+  @override
+  State<PreviewTaskStatus> createState() => _PreviewTaskStatusState();
+
+  @css
+  static List<StyleRule> get styles => _PreviewTaskStatusState.styles;
+}
+
+class _PreviewTaskStatusState extends State<PreviewTaskStatus> {
+  Timer? _ticker;
+
+  @override
+  void initState() {
+    super.initState();
+    component.controller.addListener(_onTasksChanged);
+    _syncTicker();
+  }
+
+  @override
+  void didUpdateComponent(PreviewTaskStatus oldComponent) {
+    super.didUpdateComponent(oldComponent);
+    if (!identical(oldComponent.controller, component.controller)) {
+      oldComponent.controller.removeListener(_onTasksChanged);
+      component.controller.addListener(_onTasksChanged);
+    }
+    _syncTicker();
+  }
+
+  void _onTasksChanged() {
+    if (mounted) {
+      _syncTicker();
+      setState(() {});
+    }
+  }
+
+  TaskStatusEntry? get _visibleTask {
+    final entries = component.controller.entries;
+    final visibleKinds = switch (component.mode) {
+      PreviewTaskStatusMode.workspacePreparation => const [TaskKind.preparingWorkspace],
+      PreviewTaskStatusMode.startup => const [
+        TaskKind.compilingApplication,
+        TaskKind.startingPreview,
+      ],
+      PreviewTaskStatusMode.restart => const [
+        TaskKind.compilingApplication,
+        TaskKind.restartingPreview,
+      ],
+    };
+    for (final kind in visibleKinds) {
+      final entry = entries
+          .where((entry) => entry.kind == kind && entry.outcome != TaskStatusOutcome.succeeded)
+          .firstOrNull;
+      if (entry != null) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  void _syncTicker() {
+    if (_visibleTask?.isRunning ?? false) {
+      _ticker ??= Timer.periodic(const Duration(milliseconds: 100), (_) {
+        if (mounted) {
+          setState(() {});
+        }
+      });
+    } else {
+      _ticker?.cancel();
+      _ticker = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    component.controller.removeListener(_onTasksChanged);
+    _ticker?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final task = _visibleTask;
+    final failureKind = component.persistentFailureKind;
+    if (task == null && failureKind == null) {
+      return const div(classes: 'preview-task-status idle', [
+        span(classes: 'preview-task-title', [
+          .text('Start the preview when you’re ready.'),
+        ]),
+      ]);
+    }
+
+    final failed = failureKind != null || task?.outcome == TaskStatusOutcome.failed;
+    final label = failureKind?.label ?? task!.label;
+    final duration = task == null ? null : formatTaskDuration(task.durationAt(DateTime.now()));
+    return div(
+      classes: 'preview-task-status ${failed ? 'failed' : 'running'}',
+      attributes: {
+        'aria-label': failed ? '$label failed' : '$label running',
+      },
+      [
+        _TaskStatusIcon.outcome(
+          outcome: failed ? TaskStatusOutcome.failed : TaskStatusOutcome.running,
+          size: 24,
+        ),
+        span(classes: 'preview-task-title', [.text(label)]),
+        if (duration != null)
+          span(
+            classes: 'preview-task-duration',
+            attributes: {'aria-hidden': 'true'},
+            [.text(duration)],
+          ),
+        if (failed) ...[
+          if (component.persistentFailureMessage case final String message when message.isNotEmpty)
+            span(classes: 'preview-task-error', [.text(message)]),
+          button(
+            classes: 'preview-task-console-link',
+            onClick: component.onOpenConsole,
+            [const .text('Open Console')],
+          ),
+        ],
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css('.preview-task-status').styles(
+      display: .flex,
+      position: .absolute(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
+      zIndex: const ZIndex(5),
+      padding: .all(24.px),
+      flexDirection: .column,
+      justifyContent: .center,
+      alignItems: .center,
+      gap: Gap.all(8.px),
+      color: colorOnSurface,
+      textAlign: .center,
+      backgroundColor: colorContainer,
+    ),
+    css('.preview-task-status .task-status-icon.running').styles(
+      width: 24.px,
+      height: 24.px,
+      border: .only(
+        top: .solid(color: colorPrimary, width: 3.px),
+        right: .solid(color: colorBorder, width: 3.px),
+        bottom: .solid(color: colorBorder, width: 3.px),
+        left: .solid(color: colorBorder, width: 3.px),
+      ),
+    ),
+    css('.preview-task-title').styles(fontSize: 16.px, fontWeight: .w600),
+    css('.preview-task-duration').styles(
+      fontSize: 13.px,
+      raw: {'font-variant-numeric': 'tabular-nums'},
+    ),
+    css('.preview-task-error').styles(
+      maxWidth: 560.px,
+      overflow: .hidden,
+      color: colorOnSurface,
+      fontSize: 13.px,
+      raw: {
+        'display': '-webkit-box',
+        '-webkit-box-orient': 'vertical',
+        '-webkit-line-clamp': '4',
+        'white-space': 'pre-wrap',
+      },
+    ),
+    css('.preview-task-console-link').styles(
+      padding: .zero,
+      border: .none,
+      cursor: .pointer,
+      color: colorPrimary,
+      fontFamily: const .list([FontFamilies.sansSerif]),
+      fontSize: 13.px,
+      textDecoration: const TextDecoration(line: .underline),
+      backgroundColor: Colors.transparent,
+    ),
+    css('.preview-task-status.failed .preview-task-title').styles(color: colorError),
+  ];
+}
+
+final class _TaskStatusIcon extends StatelessComponent {
+  _TaskStatusIcon({required TaskStatusEntry? entry, required this.size}) : outcome = entry?.outcome;
+
+  const _TaskStatusIcon.outcome({required this.outcome, required this.size});
+
+  final TaskStatusOutcome? outcome;
+  final double size;
+
+  @override
+  Component build(BuildContext context) {
+    return switch (outcome) {
+      TaskStatusOutcome.running => const span(
+        classes: 'task-status-icon running',
+        attributes: {'aria-label': 'Running'},
+        [],
+      ),
+      TaskStatusOutcome.failed => span(
+        classes: 'task-status-icon failed',
+        attributes: {'aria-label': 'Failed'},
+        [Icon('close', size: size)],
+      ),
+      TaskStatusOutcome.succeeded || null => span(
+        classes: 'task-status-icon succeeded',
+        attributes: {'aria-label': 'Succeeded'},
+        [Icon('check', size: size)],
+      ),
+    };
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
@@ -657,7 +657,10 @@ final class _TaskStatusIcon extends StatelessComponent {
       ),
       TaskStatusOutcome.failed => span(
         classes: 'task-status-icon failed',
-        attributes: {'aria-label': 'Failed'},
+        attributes: {
+          'aria-label': 'Failed',
+          'title': "See 'Console' for details",
+        },
         [Icon('close', size: size)],
       ),
       TaskStatusOutcome.succeeded || null => span(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
@@ -81,7 +81,7 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
   }
 
   void _onKeyDown(web.KeyboardEvent event) {
-    if (event.key != 'Escape' || !_showPopover) {
+    if (!mounted || event.key != 'Escape' || !_showPopover) {
       return;
     }
     event.preventDefault();
@@ -92,7 +92,7 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
   }
 
   void _onMouseDown(web.MouseEvent event) {
-    if (!_pinned) {
+    if (!mounted || !_pinned) {
       return;
     }
     final anchor = _anchorKey.currentNode;
@@ -106,6 +106,9 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
   }
 
   void _onFocusOut(web.Event event) {
+    if (!mounted) {
+      return;
+    }
     final anchor = _anchorKey.currentNode;
     final relatedTarget = (event as web.FocusEvent).relatedTarget as web.Node?;
     if (anchor == null || relatedTarget == null || !anchor.contains(relatedTarget)) {
@@ -142,18 +145,33 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
       key: _anchorKey,
       classes: 'task-status-anchor',
       events: {
-        'mouseenter': (_) => setState(() {
-          _hovered = true;
-          _forceClosed = false;
-        }),
-        'mouseleave': (_) => setState(() {
-          _hovered = false;
-          _forceClosed = false;
-        }),
-        'focusin': (_) => setState(() {
-          _focused = true;
-          _forceClosed = false;
-        }),
+        'mouseenter': (_) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _hovered = true;
+            _forceClosed = false;
+          });
+        },
+        'mouseleave': (_) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _hovered = false;
+            _forceClosed = false;
+          });
+        },
+        'focusin': (_) {
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _focused = true;
+            _forceClosed = false;
+          });
+        },
         'focusout': _onFocusOut,
       },
       [
@@ -165,7 +183,7 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
             if (entries.isNotEmpty) 'aria-controls': 'task-status-popover',
           },
           onClick: () {
-            if (entries.isEmpty) {
+            if (!mounted || entries.isEmpty) {
               return;
             }
             setState(() {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
@@ -498,7 +498,11 @@ class _PreviewTaskStatusState extends State<PreviewTaskStatus> {
   TaskStatusEntry? get _visibleTask {
     final entries = component.controller.entries;
     final visibleKinds = switch (component.mode) {
-      PreviewTaskStatusMode.workspacePreparation => const [TaskKind.preparingWorkspace],
+      PreviewTaskStatusMode.workspacePreparation => const [
+        TaskKind.initializingDartPadWorker,
+        TaskKind.loadingCode,
+        TaskKind.pubGet,
+      ],
       PreviewTaskStatusMode.startup => const [
         TaskKind.compilingApplication,
         TaskKind.startingPreview,
@@ -543,7 +547,8 @@ class _PreviewTaskStatusState extends State<PreviewTaskStatus> {
   Component build(BuildContext context) {
     final task = _visibleTask;
     final failureKind = component.persistentFailureKind;
-    if (task == null && failureKind == null) {
+    final failureMessage = component.persistentFailureMessage;
+    if (task == null && failureKind == null && failureMessage == null) {
       return const div(classes: 'preview-task-status idle', [
         span(classes: 'preview-task-title', [
           .text('Start the preview when you’re ready.'),
@@ -551,8 +556,8 @@ class _PreviewTaskStatusState extends State<PreviewTaskStatus> {
       ]);
     }
 
-    final failed = failureKind != null || task?.outcome == TaskStatusOutcome.failed;
-    final label = failureKind?.label ?? task!.label;
+    final failed = failureKind != null || failureMessage != null || task?.outcome == TaskStatusOutcome.failed;
+    final label = failureKind?.label ?? task?.label ?? 'Workspace preparation';
     final duration = task == null ? null : formatTaskDuration(task.durationAt(DateTime.now()));
     return div(
       classes: 'preview-task-status ${failed ? 'failed' : 'running'}',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/events/open_console_event.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/events/open_console_event.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../app_event_bus.dart';
+
+/// Requests that the workspace bottom panel switch to the Console tab.
+final class OpenConsoleEvent extends AppEvent {
+  const OpenConsoleEvent();
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -10,7 +10,30 @@ import 'package:jaspr/jaspr.dart';
 /// The lifecycle state of a tracked application task.
 enum TaskStatusOutcome { running, succeeded, failed }
 
-/// The stable identity and default display label of a tracked task.
+/// The typed identity and default display label of a tracked task.
+///
+/// ### Trade-offs of Merging Task Kinds
+///
+/// **Pros of merging:**
+/// - **Simpler UI & less noise:** Groups implementation details and sub-steps
+///   into high-level user actions (e.g. downloading gists, packages, archives, or
+///   samples are all merged into [loadingCode]), avoiding rapid status flicker.
+/// - **Smaller enum surface:** Reduces maintenance overhead for transient steps.
+///
+/// **Cons of merging:**
+/// - **Loss of entry slot independence:** [TaskStatusController] keys entries by
+///   `({TaskKind kind, String? scope})`. If two operations share the same kind,
+///   starting one replaces the other's status or recent history in the UI.
+/// - **Coarser error & state attribution:** Code and UI widgets cannot distinguish
+///   which specific phase failed (e.g. worker setup vs compilation) without inspecting
+///   raw string labels.
+///
+/// The following [TaskKind]s provide 2 kinds for startup and worker initialization
+/// ([loadingCode], [initializingDartPadWorker]), specific kinds for Pub and
+/// analysis operations ([pubGet], [pubClean], [analyzingWorkspace]), and
+/// dedicated kinds for each compiling and preview action ([startingPreview],
+/// [restartingPreview], [stoppingPreview], [compilingApplication], [hotReload],
+/// [compilingChanges]).
 enum TaskKind {
   loadingCode('Loading code'),
   initializingDartPadWorker('Initializing DartPad worker'),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -103,13 +103,16 @@ final class TaskStatusController extends ChangeNotifier {
   final Duration retention;
 
   final Map<_TaskKey, _TrackedTask> _tasks = {};
-  Timer? _expiryTimer;
   bool _disposed = false;
 
   /// Running tasks first (newest start first), then completed tasks (newest
   /// finish first).
   List<TaskStatusEntry> get entries {
-    final result = _tasks.values.map((task) => task.entry).toList();
+    final cutoff = clock.now().subtract(retention);
+    final result = _tasks.values
+        .map((task) => task.entry)
+        .where((entry) => entry.finishedAt == null || entry.finishedAt!.isAfter(cutoff))
+        .toList();
     result.sort(_compareEntries);
     return List.unmodifiable(result);
   }
@@ -147,7 +150,6 @@ final class TaskStatusController extends ChangeNotifier {
         blocksPreview: blocksPreview,
       ),
     );
-    _scheduleExpiry();
     notifyListeners();
     return TaskStatusHandle._(this, key, token);
   }
@@ -189,7 +191,6 @@ final class TaskStatusController extends ChangeNotifier {
       return;
     }
     _tasks[key] = _TrackedTask(token, task.entry._finish(clock.now(), outcome));
-    _scheduleExpiry();
     notifyListeners();
   }
 
@@ -202,7 +203,6 @@ final class TaskStatusController extends ChangeNotifier {
       return;
     }
     _tasks.remove(key);
-    _scheduleExpiry();
     notifyListeners();
   }
 
@@ -211,39 +211,6 @@ final class TaskStatusController extends ChangeNotifier {
     _tasks.removeWhere((_, task) {
       final finishedAt = task.entry.finishedAt;
       return finishedAt != null && !finishedAt.isAfter(cutoff);
-    });
-  }
-
-  void _scheduleExpiry() {
-    _expiryTimer?.cancel();
-    _expiryTimer = null;
-    if (_disposed) {
-      return;
-    }
-
-    DateTime? nextExpiry;
-    for (final task in _tasks.values) {
-      final finishedAt = task.entry.finishedAt;
-      if (finishedAt == null) {
-        continue;
-      }
-      final expiry = finishedAt.add(retention);
-      if (nextExpiry == null || expiry.isBefore(nextExpiry)) {
-        nextExpiry = expiry;
-      }
-    }
-    if (nextExpiry == null) {
-      return;
-    }
-
-    final delay = nextExpiry.difference(clock.now());
-    _expiryTimer = Timer(delay.isNegative ? Duration.zero : delay, () {
-      if (_disposed) {
-        return;
-      }
-      _removeExpiredTasks();
-      _scheduleExpiry();
-      notifyListeners();
     });
   }
 
@@ -260,8 +227,6 @@ final class TaskStatusController extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
-    _expiryTimer?.cancel();
-    _expiryTimer = null;
     _tasks.clear();
     super.dispose();
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -12,15 +12,8 @@ enum TaskStatusOutcome { running, succeeded, failed }
 
 /// The stable identity and default display label of a tracked task.
 enum TaskKind {
-  preparingWorkspace('Preparing workspace'),
-  resolvingPackage('Resolving package'),
-  downloadingPackage('Downloading package'),
-  downloadingArchive('Downloading archive'),
-  downloadingGist('Downloading gist'),
-  loadingSample('Loading sample'),
-  loadingDefaultSample('Loading default sample'),
-  startingDartPadWorker('Starting DartPad worker'),
-  creatingWorkspace('Creating workspace'),
+  loadingCode('Loading code'),
+  initializingDartPadWorker('Initializing DartPad worker'),
   pubGet('Pub get'),
   pubClean('Pub clean'),
   analyzingWorkspace('Analyzing workspace'),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -168,13 +168,16 @@ final class TaskStatusController extends ChangeNotifier {
       scope: scope,
       blocksPreview: blocksPreview,
     );
+    var success = false;
     try {
       final result = await Future<T>.sync(operation);
       handle.succeed();
+      success = true;
       return result;
-    } catch (_) {
-      handle.fail();
-      rethrow;
+    } finally {
+      if (!success) {
+        handle.fail();
+      }
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:clock/clock.dart';
 import 'package:jaspr/jaspr.dart';
 
 /// The lifecycle state of a tracked application task.
@@ -95,14 +96,12 @@ final class TaskStatusEntry {
 /// new one.
 final class TaskStatusController extends ChangeNotifier {
   TaskStatusController({
-    DateTime Function()? now,
     this.retention = const Duration(minutes: 5),
-  }) : _now = now ?? DateTime.now;
+  });
 
   /// How long completed tasks remain visible.
   final Duration retention;
 
-  final DateTime Function() _now;
   final Map<_TaskKey, _TrackedTask> _tasks = {};
   Timer? _expiryTimer;
   bool _disposed = false;
@@ -143,7 +142,7 @@ final class TaskStatusController extends ChangeNotifier {
         kind: kind,
         label: label ?? kind.label,
         scope: scope,
-        startedAt: _now(),
+        startedAt: clock.now(),
         outcome: TaskStatusOutcome.running,
         blocksPreview: blocksPreview,
       ),
@@ -189,7 +188,7 @@ final class TaskStatusController extends ChangeNotifier {
     if (task == null || !identical(task.token, token)) {
       return;
     }
-    _tasks[key] = _TrackedTask(token, task.entry._finish(_now(), outcome));
+    _tasks[key] = _TrackedTask(token, task.entry._finish(clock.now(), outcome));
     _scheduleExpiry();
     notifyListeners();
   }
@@ -208,7 +207,7 @@ final class TaskStatusController extends ChangeNotifier {
   }
 
   void _removeExpiredTasks() {
-    final cutoff = _now().subtract(retention);
+    final cutoff = clock.now().subtract(retention);
     _tasks.removeWhere((_, task) {
       final finishedAt = task.entry.finishedAt;
       return finishedAt != null && !finishedAt.isAfter(cutoff);
@@ -237,7 +236,7 @@ final class TaskStatusController extends ChangeNotifier {
       return;
     }
 
-    final delay = nextExpiry.difference(_now());
+    final delay = nextExpiry.difference(clock.now());
     _expiryTimer = Timer(delay.isNegative ? Duration.zero : delay, () {
       if (_disposed) {
         return;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -1,0 +1,330 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/jaspr.dart';
+
+/// The lifecycle state of a tracked application task.
+enum TaskStatusOutcome { running, succeeded, failed }
+
+/// The stable identity and default display label of a tracked task.
+enum TaskKind {
+  preparingWorkspace('Preparing workspace'),
+  resolvingPackage('Resolving package'),
+  downloadingPackage('Downloading package'),
+  downloadingArchive('Downloading archive'),
+  downloadingGist('Downloading gist'),
+  loadingSample('Loading sample'),
+  loadingDefaultSample('Loading default sample'),
+  startingDartPadWorker('Starting DartPad worker'),
+  creatingWorkspace('Creating workspace'),
+  pubGet('Pub get'),
+  pubClean('Pub clean'),
+  analyzingWorkspace('Analyzing workspace'),
+  startingPreview('Starting preview'),
+  restartingPreview('Restarting preview'),
+  stoppingPreview('Stopping preview'),
+  compilingApplication('Compiling application'),
+  hotReload('Hot reload'),
+  compilingChanges('Compiling changes');
+
+  const TaskKind(this.label);
+
+  /// The label used when a task does not provide a more specific one.
+  final String label;
+}
+
+/// An immutable snapshot of one tracked application task.
+final class TaskStatusEntry {
+  const TaskStatusEntry({
+    required this.kind,
+    required this.label,
+    required this.startedAt,
+    required this.outcome,
+    required this.blocksPreview,
+    this.scope,
+    this.finishedAt,
+  });
+
+  /// The stable task category used by application behavior.
+  final TaskKind kind;
+
+  /// The user-facing task label.
+  final String label;
+
+  /// An optional identity within [kind], such as a path or package name.
+  final String? scope;
+
+  /// When the task started.
+  final DateTime startedAt;
+
+  /// When the task finished, or `null` while it is running.
+  final DateTime? finishedAt;
+
+  /// The current task outcome.
+  final TaskStatusOutcome outcome;
+
+  /// Whether this task must finish before compiling preview code.
+  final bool blocksPreview;
+
+  /// Whether the task is still running.
+  bool get isRunning => outcome == TaskStatusOutcome.running;
+
+  /// The elapsed or final duration at [now].
+  Duration durationAt(DateTime now) => (finishedAt ?? now).difference(startedAt);
+
+  TaskStatusEntry _finish(DateTime finishedAt, TaskStatusOutcome outcome) {
+    return TaskStatusEntry(
+      kind: kind,
+      label: label,
+      scope: scope,
+      startedAt: startedAt,
+      finishedAt: finishedAt,
+      outcome: outcome,
+      blocksPreview: blocksPreview,
+    );
+  }
+}
+
+/// Tracks the recent lifecycle of long-running application tasks.
+///
+/// Starting another task with the same kind and scope replaces the previous
+/// entry. A handle belonging to the replaced entry can no longer mutate the
+/// new one.
+final class TaskStatusController extends ChangeNotifier {
+  TaskStatusController({
+    DateTime Function()? now,
+    this.retention = const Duration(minutes: 5),
+  }) : _now = now ?? DateTime.now;
+
+  /// How long completed tasks remain visible.
+  final Duration retention;
+
+  final DateTime Function() _now;
+  final Map<_TaskKey, _TrackedTask> _tasks = {};
+  Timer? _expiryTimer;
+  bool _disposed = false;
+
+  /// Running tasks first (newest start first), then completed tasks (newest
+  /// finish first).
+  List<TaskStatusEntry> get entries {
+    final result = _tasks.values.map((task) => task.entry).toList();
+    result.sort(_compareEntries);
+    return List.unmodifiable(result);
+  }
+
+  /// The task shown in the compact status summary.
+  TaskStatusEntry? get current => entries.firstOrNull;
+
+  /// Whether a running task currently blocks preview compilation.
+  bool get hasBlockingPreviewTask {
+    return _tasks.values.any((task) => task.entry.isRunning && task.entry.blocksPreview);
+  }
+
+  /// Starts a task and returns a handle used to finish it later.
+  TaskStatusHandle startTask(
+    TaskKind kind, {
+    String? label,
+    String? scope,
+    bool blocksPreview = false,
+  }) {
+    if (_disposed) {
+      throw StateError('Cannot start a task on a disposed controller.');
+    }
+
+    _removeExpiredTasks();
+    final token = Object();
+    final key = (kind: kind, scope: scope);
+    _tasks[key] = _TrackedTask(
+      token,
+      TaskStatusEntry(
+        kind: kind,
+        label: label ?? kind.label,
+        scope: scope,
+        startedAt: _now(),
+        outcome: TaskStatusOutcome.running,
+        blocksPreview: blocksPreview,
+      ),
+    );
+    _scheduleExpiry();
+    notifyListeners();
+    return TaskStatusHandle._(this, key, token);
+  }
+
+  /// Runs [operation] while tracking its success or failure.
+  Future<T> runTask<T>(
+    TaskKind kind,
+    FutureOr<T> Function() operation, {
+    String? label,
+    String? scope,
+    bool blocksPreview = false,
+  }) async {
+    final handle = startTask(
+      kind,
+      label: label,
+      scope: scope,
+      blocksPreview: blocksPreview,
+    );
+    try {
+      final result = await Future<T>.sync(operation);
+      handle.succeed();
+      return result;
+    } catch (_) {
+      handle.fail();
+      rethrow;
+    }
+  }
+
+  void _finishTask(
+    _TaskKey key,
+    Object token,
+    TaskStatusOutcome outcome,
+  ) {
+    if (_disposed) {
+      return;
+    }
+    final task = _tasks[key];
+    if (task == null || !identical(task.token, token)) {
+      return;
+    }
+    _tasks[key] = _TrackedTask(token, task.entry._finish(_now(), outcome));
+    _scheduleExpiry();
+    notifyListeners();
+  }
+
+  void _cancelTask(_TaskKey key, Object token) {
+    if (_disposed) {
+      return;
+    }
+    final task = _tasks[key];
+    if (task == null || !identical(task.token, token)) {
+      return;
+    }
+    _tasks.remove(key);
+    _scheduleExpiry();
+    notifyListeners();
+  }
+
+  void _removeExpiredTasks() {
+    final cutoff = _now().subtract(retention);
+    _tasks.removeWhere((_, task) {
+      final finishedAt = task.entry.finishedAt;
+      return finishedAt != null && !finishedAt.isAfter(cutoff);
+    });
+  }
+
+  void _scheduleExpiry() {
+    _expiryTimer?.cancel();
+    _expiryTimer = null;
+    if (_disposed) {
+      return;
+    }
+
+    DateTime? nextExpiry;
+    for (final task in _tasks.values) {
+      final finishedAt = task.entry.finishedAt;
+      if (finishedAt == null) {
+        continue;
+      }
+      final expiry = finishedAt.add(retention);
+      if (nextExpiry == null || expiry.isBefore(nextExpiry)) {
+        nextExpiry = expiry;
+      }
+    }
+    if (nextExpiry == null) {
+      return;
+    }
+
+    final delay = nextExpiry.difference(_now());
+    _expiryTimer = Timer(delay.isNegative ? Duration.zero : delay, () {
+      if (_disposed) {
+        return;
+      }
+      _removeExpiredTasks();
+      _scheduleExpiry();
+      notifyListeners();
+    });
+  }
+
+  static int _compareEntries(TaskStatusEntry a, TaskStatusEntry b) {
+    if (a.isRunning != b.isRunning) {
+      return a.isRunning ? -1 : 1;
+    }
+    if (a.isRunning) {
+      return b.startedAt.compareTo(a.startedAt);
+    }
+    return b.finishedAt!.compareTo(a.finishedAt!);
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _expiryTimer?.cancel();
+    _expiryTimer = null;
+    _tasks.clear();
+    super.dispose();
+  }
+}
+
+/// A capability for finishing one specific task run.
+final class TaskStatusHandle {
+  TaskStatusHandle._(this._controller, this._key, this._token);
+
+  final TaskStatusController _controller;
+  final _TaskKey _key;
+  final Object _token;
+  bool _finished = false;
+
+  /// Marks the task as successful.
+  void succeed() => _finish(TaskStatusOutcome.succeeded);
+
+  /// Marks the task as failed.
+  void fail() => _finish(TaskStatusOutcome.failed);
+
+  /// Removes an externally-driven task without recording an outcome.
+  void cancel() {
+    if (_finished) {
+      return;
+    }
+    _finished = true;
+    _controller._cancelTask(_key, _token);
+  }
+
+  void _finish(TaskStatusOutcome outcome) {
+    if (_finished) {
+      return;
+    }
+    _finished = true;
+    _controller._finishTask(_key, _token, outcome);
+  }
+}
+
+typedef _TaskKey = ({TaskKind kind, String? scope});
+
+final class _TrackedTask {
+  const _TrackedTask(this.token, this.entry);
+
+  final Object token;
+  final TaskStatusEntry entry;
+}
+
+/// Formats a task duration for compact status UI.
+String formatTaskDuration(Duration duration) {
+  final milliseconds = duration.isNegative ? 0 : duration.inMilliseconds;
+  if (milliseconds < Duration.millisecondsPerMinute) {
+    return '${(milliseconds / Duration.millisecondsPerSecond).toStringAsFixed(1)}s';
+  }
+
+  final totalSeconds = milliseconds ~/ Duration.millisecondsPerSecond;
+  final seconds = totalSeconds % Duration.secondsPerMinute;
+  final totalMinutes = totalSeconds ~/ Duration.secondsPerMinute;
+  if (totalMinutes < Duration.minutesPerHour) {
+    return '${totalMinutes}m ${seconds.toString().padLeft(2, '0')}s';
+  }
+
+  final hours = totalMinutes ~/ Duration.minutesPerHour;
+  final minutes = totalMinutes % Duration.minutesPerHour;
+  return '${hours}h ${minutes.toString().padLeft(2, '0')}m ${seconds.toString().padLeft(2, '0')}s';
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -113,7 +113,15 @@ final class TaskStatusController extends ChangeNotifier {
         .map((task) => task.entry)
         .where((entry) => entry.finishedAt == null || entry.finishedAt!.isAfter(cutoff))
         .toList();
-    result.sort(_compareEntries);
+    result.sort((a, b) {
+      if (a.isRunning != b.isRunning) {
+        return a.isRunning ? -1 : 1;
+      }
+      if (a.isRunning) {
+        return b.startedAt.compareTo(a.startedAt);
+      }
+      return b.finishedAt!.compareTo(a.finishedAt!);
+    });
     return List.unmodifiable(result);
   }
 
@@ -215,16 +223,6 @@ final class TaskStatusController extends ChangeNotifier {
       final finishedAt = task.entry.finishedAt;
       return finishedAt != null && !finishedAt.isAfter(cutoff);
     });
-  }
-
-  static int _compareEntries(TaskStatusEntry a, TaskStatusEntry b) {
-    if (a.isRunning != b.isRunning) {
-      return a.isRunning ? -1 : 1;
-    }
-    if (a.isRunning) {
-      return b.startedAt.compareTo(a.startedAt);
-    }
-    return b.finishedAt!.compareTo(a.finishedAt!);
   }
 
   @override

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -59,18 +59,15 @@ class WorkspaceRepository {
 
     final workspaceFuture = (() async {
       final dartpadSdk = DartPadSdk(assetBaseUrl: sdk.assetBaseUrl);
-      final dartpad = await taskStatus.runTask(
-        TaskKind.startingDartPadWorker,
-        dartpadSdk.dedicatedWorker,
+      return await taskStatus.runTask(
+        TaskKind.initializingDartPadWorker,
+        () async {
+          final dartpad = await dartpadSdk.dedicatedWorker();
+          repository.dartpad = dartpad;
+          return await dartpad.createWorkspace();
+        },
         blocksPreview: true,
       );
-      repository.dartpad = dartpad;
-      final workspace = await taskStatus.runTask(
-        TaskKind.creatingWorkspace,
-        dartpad.createWorkspace,
-        blocksPreview: true,
-      );
-      return workspace;
     })();
     final api = SyncedWorkspaceResourceApi(
       localApi: localApi ?? MemoryWorkspaceResourceApi(),
@@ -193,7 +190,7 @@ class WorkspaceRepository {
     final workspaceFuture = (() async {
       await previousWorkspaceDisposed;
       final workspace = await taskStatus.runTask(
-        TaskKind.creatingWorkspace,
+        TaskKind.initializingDartPadWorker,
         worker.createWorkspace,
         blocksPreview: true,
       );

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -11,12 +11,14 @@ import '../../shared/app_event_bus.dart';
 import '../../shared/events/error_toast_event.dart';
 import '../../shared/events/log_event.dart';
 import '../../shared/sdk_info.dart';
+import '../../shared/task_status.dart';
 import 'synced_workspace_resource_api.dart';
 
 /// Owns the complete worker-side workspace lifecycle for the transient app.
 class WorkspaceRepository {
   WorkspaceRepository({
     required this.events,
+    required this.taskStatus,
     required this.workspaceResourceApi,
     required this.sdk,
     required Future<Workspace> workspaceFuture,
@@ -26,6 +28,7 @@ class WorkspaceRepository {
 
   /// Shared event bus for lifecycle and diagnostic logging.
   final AppEventBus events;
+  final TaskStatusController taskStatus;
   final WorkspaceResourceApi workspaceResourceApi;
   final SdkInfo sdk;
   final Future<Workspace> _workspaceFuture;
@@ -49,15 +52,24 @@ class WorkspaceRepository {
   factory WorkspaceRepository.create({
     required AppEventBus events,
     required SdkInfo sdk,
+    required TaskStatusController taskStatus,
     WorkspaceResourceApi? localApi,
   }) {
     late final WorkspaceRepository repository;
 
     final workspaceFuture = (() async {
       final dartpadSdk = DartPadSdk(assetBaseUrl: sdk.assetBaseUrl);
-      final dartpad = await dartpadSdk.dedicatedWorker();
+      final dartpad = await taskStatus.runTask(
+        TaskKind.startingDartPadWorker,
+        dartpadSdk.dedicatedWorker,
+        blocksPreview: true,
+      );
       repository.dartpad = dartpad;
-      final workspace = await dartpad.createWorkspace();
+      final workspace = await taskStatus.runTask(
+        TaskKind.creatingWorkspace,
+        dartpad.createWorkspace,
+        blocksPreview: true,
+      );
       return workspace;
     })();
     final api = SyncedWorkspaceResourceApi(
@@ -73,6 +85,7 @@ class WorkspaceRepository {
     final readyWorkspaceFuture = api.apiReady.then((_) => workspaceFuture);
     return repository = WorkspaceRepository(
       events: events,
+      taskStatus: taskStatus,
       workspaceResourceApi: api,
       sdk: sdk,
       workspaceFuture: workspaceFuture,
@@ -80,30 +93,56 @@ class WorkspaceRepository {
     );
   }
 
-  Future<void> pubGet({String path = '', String projectRoot = ''}) => runWorkspacePubGet(
-    events: events,
-    path: path,
-    projectRoot: projectRoot,
-    command: (normalizedPath) async {
-      final workspace = await _workspaceFuture;
-      final api = workspaceResourceApi;
-      if (api is SyncedWorkspaceResourceApi) {
-        await api.flush();
-      }
-      final result = await workspace.pub(uri: normalizedPath, command: 'get');
-      return result.log;
-    },
-  );
+  Future<void> pubGet({String path = '', String projectRoot = ''}) {
+    final normalizedPath = workspaceContext.normalize(path);
+    final pathLabel = workspaceContext.relativeDisplayPath(
+      path: normalizedPath,
+      projectRoot: projectRoot,
+    );
+    return taskStatus.runTask(
+      TaskKind.pubGet,
+      () => runWorkspacePubGet(
+        events: events,
+        path: path,
+        projectRoot: projectRoot,
+        command: (normalizedPath) async {
+          final workspace = await _workspaceFuture;
+          final api = workspaceResourceApi;
+          if (api is SyncedWorkspaceResourceApi) {
+            await api.flush();
+          }
+          final result = await workspace.pub(uri: normalizedPath, command: 'get');
+          return result.log;
+        },
+      ),
+      label: 'Pub get in $pathLabel',
+      scope: normalizedPath.toString(),
+      blocksPreview: true,
+    );
+  }
 
   /// Removes generated Pub and build output from the workspace.
   Future<void> pubClean({String path = ''}) async {
-    events.dispatch(const LogEvent('Cleaning workspace...'));
-    final api = workspaceResourceApi;
-    if (api is SyncedWorkspaceResourceApi) {
-      await api.flush();
-    }
-    await cleanGeneratedOutput(workspaceResourceApi, path: path);
-    events.dispatch(const LogEvent('Cleaning workspace... Done'));
+    final normalizedPath = workspaceContext.normalize(path);
+    final pathLabel = workspaceContext.relativeDisplayPath(
+      path: normalizedPath,
+      projectRoot: '',
+    );
+    await taskStatus.runTask(
+      TaskKind.pubClean,
+      () async {
+        events.dispatch(const LogEvent('Cleaning workspace...'));
+        final api = workspaceResourceApi;
+        if (api is SyncedWorkspaceResourceApi) {
+          await api.flush();
+        }
+        await cleanGeneratedOutput(workspaceResourceApi, path: path);
+        events.dispatch(const LogEvent('Cleaning workspace... Done'));
+      },
+      label: 'Pub clean in $pathLabel',
+      scope: normalizedPath.toString(),
+      blocksPreview: true,
+    );
   }
 
   /// Deletes generated directories when they exist.
@@ -147,12 +186,17 @@ class WorkspaceRepository {
     required AppEventBus events,
     required DartPad worker,
     required SdkInfo sdk,
+    required TaskStatusController taskStatus,
     required Future<void> previousWorkspaceDisposed,
     WorkspaceResourceApi? localApi,
   }) {
     final workspaceFuture = (() async {
       await previousWorkspaceDisposed;
-      final workspace = await worker.createWorkspace();
+      final workspace = await taskStatus.runTask(
+        TaskKind.creatingWorkspace,
+        worker.createWorkspace,
+        blocksPreview: true,
+      );
       return workspace;
     })();
 
@@ -169,6 +213,7 @@ class WorkspaceRepository {
     final readyWorkspaceFuture = api.apiReady.then((_) => workspaceFuture);
     return WorkspaceRepository(
       events: events,
+      taskStatus: taskStatus,
       workspaceResourceApi: api,
       sdk: sdk,
       workspaceFuture: workspaceFuture,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
@@ -16,14 +16,18 @@ import '../editor/view_models/tabs_view_model.dart';
 import '../filetree/file_tree_tabs_adapter.dart';
 import '../filetree/file_tree_view_model.dart';
 import '../preview/view_models/preview_view_model.dart';
+import '../shared/analyzer_status.dart';
 import '../shared/app_event_bus.dart';
 import '../shared/components/context_menu.dart';
+import '../shared/task_status.dart';
 import 'data/workspace_repository.dart';
 
 /// Owns every resource whose lifetime is tied to one worker workspace.
 final class WorkspaceSession {
   WorkspaceSession._({
     required this.events,
+    required this.taskStatus,
+    required this.analyzerStatus,
     required this.repository,
     required this.console,
     required this.tabs,
@@ -56,6 +60,8 @@ final class WorkspaceSession {
 
     return WorkspaceSession._(
       events: repository.events,
+      taskStatus: repository.taskStatus,
+      analyzerStatus: AnalyzerStatusController(repository.taskStatus),
       repository: repository,
       console: ConsoleViewModel(events: repository.events),
       tabs: tabs,
@@ -71,6 +77,8 @@ final class WorkspaceSession {
   }
 
   final AppEventBus events;
+  final TaskStatusController taskStatus;
+  final AnalyzerStatusController analyzerStatus;
   final WorkspaceRepository repository;
   final ConsoleViewModel console;
   final TabsViewModel tabs;
@@ -89,7 +97,6 @@ final class WorkspaceSession {
   void attachLanguageServer({
     required LanguageServer server,
     required LanguageServerClient client,
-    required void Function(AnalyzerActivity activity) onAnalyzerActivity,
     String? projectRoot,
   }) {
     if (_disposed) {
@@ -102,11 +109,19 @@ final class WorkspaceSession {
     _languageServer = server;
     _languageServerClient = client;
     _analyzerSubscription = client.analyzerActivityStream.listen(
-      onAnalyzerActivity,
+      _onAnalyzerActivity,
+      onError: (_) => analyzerStatus.markUnavailable(),
     );
     fileTree.languageServerClient = client;
     diagnostics.attachLanguageServer(client, projectRoot: projectRoot);
     _codemirrorAdapter.attachLanguageServerClient(client);
+  }
+
+  void _onAnalyzerActivity(AnalyzerActivity activity) {
+    if (_disposed || activity is! AnalyzerStatusActivity) {
+      return;
+    }
+    analyzerStatus.update(isAnalyzing: activity.isAnalyzing);
   }
 
   /// Disposes the complete workspace session at most once.
@@ -139,6 +154,8 @@ final class WorkspaceSession {
       closeWorker ? repository.close() : repository.closeWorkspaceOnly(),
     );
     await _safeAwait(events.dispose());
+    analyzerStatus.dispose();
+    taskStatus.dispose();
   }
 
   /// Awaits a (possibly null) [future] and swallows errors so that a

--- a/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
+++ b/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
@@ -10,6 +10,7 @@ resolution: workspace
 
 dependencies:
   archive: ^4.0.9
+  clock: ^1.1.2
   codemirror_dart: any
   dartpad: 0.0.5
   dartpad_editor: any

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -7,6 +7,8 @@ library;
 
 import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
 import 'package:dartpad_frontend/features/bottom_panel/views/bottom_panel.dart';
+import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/events/open_console_event.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
@@ -14,6 +16,7 @@ import 'package:web/web.dart' as web;
 void main() {
   testClient('switches to the console and invokes clear', (tester) async {
     var clearCalls = 0;
+    final events = AppEventBus();
     tester.pumpComponent(
       BottomPanel(
         diagnostics: const [],
@@ -22,6 +25,7 @@ void main() {
         logs: const [ConsoleEntry(message: 'Running pub get in /', level: Level.INFO)],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () => clearCalls++,
+        events: events,
       ),
     );
 
@@ -42,6 +46,7 @@ void main() {
   });
 
   testClient('keeps clear enabled when the console is empty', (tester) async {
+    final events = AppEventBus();
     tester.pumpComponent(
       BottomPanel(
         diagnostics: const [],
@@ -50,6 +55,7 @@ void main() {
         logs: const [],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () {},
+        events: events,
       ),
     );
 
@@ -62,6 +68,7 @@ void main() {
   });
 
   testClient('shows a diagnostic limit notice in the problems panel', (tester) async {
+    final events = AppEventBus();
     tester.pumpComponent(
       BottomPanel(
         diagnostics: const [],
@@ -70,6 +77,7 @@ void main() {
         logs: const [],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () {},
+        events: events,
       ),
     );
 
@@ -77,5 +85,25 @@ void main() {
       web.document.querySelector('.diagnostics-limit-notice')!.textContent,
       contains('Only the first 1,000 problems are shown.'),
     );
+  });
+
+  testClient('opens the Console when requested by another workspace component', (tester) async {
+    final events = AppEventBus();
+    tester.pumpComponent(
+      BottomPanel(
+        diagnostics: const [],
+        hasMoreDiagnostics: false,
+        activeFile: '',
+        logs: const [],
+        onOpenDiagnostic: (_, _) {},
+        onClearConsole: () {},
+        events: events,
+      ),
+    );
+
+    expect(web.document.querySelector('.console-panel'), isNull);
+    events.dispatch(const OpenConsoleEvent());
+    await pumpEventQueue();
+    expect(web.document.querySelector('.console-panel'), isNotNull);
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
@@ -11,8 +11,17 @@ import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
 
 void main() {
+  late TaskStatusController controller;
+
+  setUp(() {
+    controller = TaskStatusController();
+  });
+
+  tearDown(() {
+    controller.dispose();
+  });
+
   testClient('shows only the one-time workspace preparation task', (tester) async {
-    final controller = TaskStatusController();
     tester.pumpComponent(
       PreviewTaskStatus(
         controller: controller,
@@ -50,12 +59,9 @@ void main() {
     );
     await pumpEventQueue();
     expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
-
-    controller.dispose();
   });
 
   testClient('moves directly from compilation to preview startup', (tester) async {
-    final controller = TaskStatusController();
     tester.pumpComponent(
       PreviewTaskStatus(
         controller: controller,
@@ -79,12 +85,9 @@ void main() {
     starting.succeed();
     await pumpEventQueue();
     expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
-
-    controller.dispose();
   });
 
   testClient('shows an explicit preview restart without showing stop tasks', (tester) async {
-    final controller = TaskStatusController();
     tester.pumpComponent(
       PreviewTaskStatus(
         controller: controller,
@@ -102,12 +105,9 @@ void main() {
     restarting.succeed();
     await pumpEventQueue();
     expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
-
-    controller.dispose();
   });
 
   testClient('keeps failures visible and opens the Console', (tester) async {
-    final controller = TaskStatusController();
     var openConsoleCalls = 0;
     tester.pumpComponent(
       PreviewTaskStatus(
@@ -127,8 +127,6 @@ void main() {
     link.click();
     await pumpEventQueue();
     expect(openConsoleCalls, 1);
-
-    controller.dispose();
   });
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
@@ -1,0 +1,135 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/task_status_indicator.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  testClient('shows only the one-time workspace preparation task', (tester) async {
+    final controller = TaskStatusController();
+    tester.pumpComponent(
+      PreviewTaskStatus(
+        controller: controller,
+        mode: PreviewTaskStatusMode.workspacePreparation,
+        onOpenConsole: () {},
+      ),
+    );
+
+    controller.startTask(TaskKind.analyzingWorkspace);
+    controller.startTask(
+      TaskKind.pubClean,
+      label: 'Pub clean in /',
+      scope: '/',
+    );
+    await pumpEventQueue();
+    expect(_statusText, contains('Start the preview when you’re ready.'));
+
+    final preparing = controller.startTask(
+      TaskKind.preparingWorkspace,
+      blocksPreview: true,
+    );
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-status.running'), isNotNull);
+    expect(_statusText, contains('Preparing workspace'));
+    expect(_statusText, isNot(contains('Pub clean')));
+
+    preparing.succeed();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
+
+    controller.startTask(
+      TaskKind.pubGet,
+      label: 'Pub get in /',
+      scope: '/',
+    );
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
+
+    controller.dispose();
+  });
+
+  testClient('moves directly from compilation to preview startup', (tester) async {
+    final controller = TaskStatusController();
+    tester.pumpComponent(
+      PreviewTaskStatus(
+        controller: controller,
+        mode: PreviewTaskStatusMode.startup,
+        onOpenConsole: () {},
+      ),
+    );
+
+    final starting = controller.startTask(TaskKind.startingPreview);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-title')?.textContent, 'Starting preview');
+
+    final compiling = controller.startTask(TaskKind.compilingApplication);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-title')?.textContent, 'Compiling application');
+
+    compiling.succeed();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-title')?.textContent, 'Starting preview');
+
+    starting.succeed();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
+
+    controller.dispose();
+  });
+
+  testClient('shows an explicit preview restart without showing stop tasks', (tester) async {
+    final controller = TaskStatusController();
+    tester.pumpComponent(
+      PreviewTaskStatus(
+        controller: controller,
+        mode: PreviewTaskStatusMode.restart,
+        onOpenConsole: () {},
+      ),
+    );
+
+    controller.startTask(TaskKind.stoppingPreview);
+    final restarting = controller.startTask(TaskKind.restartingPreview);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-title')?.textContent, 'Restarting preview');
+    expect(_statusText, isNot(contains('Stopping preview')));
+
+    restarting.succeed();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
+
+    controller.dispose();
+  });
+
+  testClient('keeps failures visible and opens the Console', (tester) async {
+    final controller = TaskStatusController();
+    var openConsoleCalls = 0;
+    tester.pumpComponent(
+      PreviewTaskStatus(
+        controller: controller,
+        mode: PreviewTaskStatusMode.workspacePreparation,
+        persistentFailureKind: TaskKind.preparingWorkspace,
+        persistentFailureMessage: 'Pub get failed.',
+        onOpenConsole: () => openConsoleCalls++,
+      ),
+    );
+
+    expect(web.document.querySelector('.preview-task-status.failed'), isNotNull);
+    expect(_statusText, contains('Preparing workspace'));
+    expect(_statusText, contains('Pub get failed.'));
+
+    final link = web.document.querySelector('.preview-task-console-link')! as web.HTMLButtonElement;
+    link.click();
+    await pumpEventQueue();
+    expect(openConsoleCalls, 1);
+
+    controller.dispose();
+  });
+}
+
+String? get _statusText => web.document.querySelector('.preview-task-status')?.textContent;

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
@@ -21,7 +21,7 @@ void main() {
     controller.dispose();
   });
 
-  testClient('shows only the one-time workspace preparation task', (tester) async {
+  testClient('shows workspace preparation tasks', (tester) async {
     tester.pumpComponent(
       PreviewTaskStatus(
         controller: controller,
@@ -39,24 +39,16 @@ void main() {
     await pumpEventQueue();
     expect(_statusText, contains('Start the preview when you’re ready.'));
 
-    final preparing = controller.startTask(
-      TaskKind.preparingWorkspace,
+    final initializingWorker = controller.startTask(
+      TaskKind.initializingDartPadWorker,
       blocksPreview: true,
     );
     await pumpEventQueue();
     expect(web.document.querySelector('.preview-task-status.running'), isNotNull);
-    expect(_statusText, contains('Preparing workspace'));
+    expect(_statusText, contains('Initializing DartPad worker'));
     expect(_statusText, isNot(contains('Pub clean')));
 
-    preparing.succeed();
-    await pumpEventQueue();
-    expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
-
-    controller.startTask(
-      TaskKind.pubGet,
-      label: 'Pub get in /',
-      scope: '/',
-    );
+    initializingWorker.succeed();
     await pumpEventQueue();
     expect(web.document.querySelector('.preview-task-status.idle'), isNotNull);
   });
@@ -113,14 +105,13 @@ void main() {
       PreviewTaskStatus(
         controller: controller,
         mode: PreviewTaskStatusMode.workspacePreparation,
-        persistentFailureKind: TaskKind.preparingWorkspace,
         persistentFailureMessage: 'Pub get failed.',
         onOpenConsole: () => openConsoleCalls++,
       ),
     );
 
     expect(web.document.querySelector('.preview-task-status.failed'), isNotNull);
-    expect(_statusText, contains('Preparing workspace'));
+    expect(_statusText, contains('Workspace preparation'));
     expect(_statusText, contains('Pub get failed.'));
 
     final link = web.document.querySelector('.preview-task-console-link')! as web.HTMLButtonElement;

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
@@ -16,6 +16,7 @@ import 'package:dartpad_frontend/features/preview/view_models/preview_view_model
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
 import 'package:dartpad_frontend/features/shared/sdk_info.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
 import 'package:dartpad_frontend/sdks.g.dart';
 import 'package:logging/logging.dart';
@@ -136,6 +137,7 @@ class FakeWorkspaceRepository extends WorkspaceRepository {
     SdkInfo? sdk,
   }) : super(
          events: events,
+         taskStatus: TaskStatusController(),
          workspaceResourceApi: workspaceResourceApi,
          sdk: sdk ?? defaultSdk,
          workspaceFuture: Completer<Workspace>().future,
@@ -190,6 +192,7 @@ void main() {
 
     tearDown(() async {
       await logSubscription.cancel();
+      repository.taskStatus.dispose();
       await events.dispose();
     });
 
@@ -206,6 +209,32 @@ void main() {
       expect(viewModel.canStop, isFalse);
       expect(viewModel.isRunning, isFalse);
 
+      viewModel.dispose();
+    });
+
+    test('blocking prerequisite disables and rejects compiling actions', () async {
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+      );
+      final pubGet = repository.taskStatus.startTask(
+        TaskKind.pubGet,
+        label: 'Pub get in /',
+        scope: '/',
+        blocksPreview: true,
+      );
+
+      expect(viewModel.canStart, isFalse);
+      await viewModel.runCode('lib/main.dart');
+      expect(viewModel.state, isA<PreviewInitial>());
+      expect(repository.startHotReloadCompilerCount, 0);
+
+      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      expect(viewModel.state, isA<PreviewInitial>());
+      expect(repository.startHotReloadCompilerCount, 0);
+
+      pubGet.succeed();
+      expect(viewModel.canStart, isTrue);
       viewModel.dispose();
     });
 
@@ -246,6 +275,15 @@ void main() {
       expect(fakeSandbox.loadedCode, 'compiled_code');
       expect(fakeSandbox.runAppCount, 1);
       expect(fakeSandbox.runUri, Uri.parse('package:app/main.dart'));
+      expect(
+        repository.taskStatus.entries
+            .where(
+              (entry) => entry.kind == TaskKind.startingPreview || entry.kind == TaskKind.compilingApplication,
+            )
+            .map((entry) => entry.outcome)
+            .toList(),
+        [TaskStatusOutcome.succeeded, TaskStatusOutcome.succeeded],
+      );
 
       final logMessages = loggedEvents.map((e) => e.message).toList();
       expect(
@@ -340,6 +378,7 @@ void main() {
       expect(viewModel.isFlutter, isFalse);
 
       viewModel.dispose();
+      dartRepository.taskStatus.dispose();
     });
 
     test('runCode fails compilation with CompilationFailedException', () async {
@@ -359,7 +398,17 @@ void main() {
       final errState = viewModel.state as PreviewCompileError;
       expect(errState.message, 'syntax error');
       expect(errState.entrypoint, 'lib/main.dart');
-
+      expect(errState.action, PreviewLaunchAction.start);
+      expect(errState.failedTask, TaskKind.compilingApplication);
+      expect(
+        repository.taskStatus.entries
+            .where(
+              (entry) => entry.kind == TaskKind.startingPreview || entry.kind == TaskKind.compilingApplication,
+            )
+            .map((entry) => entry.outcome)
+            .toList(),
+        [TaskStatusOutcome.failed, TaskStatusOutcome.failed],
+      );
       expect(loggedEvents.any((e) => e.message == 'Compilation failed' && e.level == Level.SEVERE), isTrue);
 
       viewModel.dispose();
@@ -380,6 +429,8 @@ void main() {
       expect(viewModel.state, isA<PreviewCompileError>());
       final errState = viewModel.state as PreviewCompileError;
       expect(errState.message, contains('load crash'));
+      expect(errState.action, PreviewLaunchAction.start);
+      expect(errState.failedTask, TaskKind.startingPreview);
 
       expect(loggedEvents.any((e) => e.message == 'Run failed' && e.level == Level.SEVERE), isTrue);
 
@@ -407,7 +458,15 @@ void main() {
       expect(fakeCompiler.compileCount, 1);
       expect(fakeSandbox1.loadModuleCount, 1);
 
-      // Trigger restart which skips recompilation
+      final pubGet = repository.taskStatus.startTask(
+        TaskKind.pubGet,
+        label: 'Pub get in /',
+        scope: '/',
+        blocksPreview: true,
+      );
+      expect(viewModel.canRestart, isTrue);
+
+      // A cached restart remains available during a blocking workspace task.
       await viewModel.runCode('lib/main.dart', skipRecompilation: true);
 
       // Compiler should NOT be called again
@@ -415,6 +474,36 @@ void main() {
       expect(fakeSandbox1.disposeCount, 1);
       expect(fakeSandbox2.loadModuleCount, 1);
       expect(fakeSandbox2.loadedCode, 'compiled_code'); // Reuses compiled code
+
+      pubGet.succeed();
+      viewModel.dispose();
+    });
+
+    test('cached restart reports a typed restart failure', () async {
+      final firstSandbox = FakePreviewSandbox();
+      final failingSandbox = FakePreviewSandbox()..onRunApp = (_) => throw StateError('restart failed');
+      final fakeCompiler = FakeCompilerSession();
+      repository.onStartHotReloadCompiler = (_) => fakeCompiler;
+
+      var sandboxIndex = 0;
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async {
+          sandboxIndex++;
+          return sandboxIndex == 1 ? firstSandbox : failingSandbox;
+        },
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+
+      expect(viewModel.state, isA<PreviewCompileError>());
+      final error = viewModel.state as PreviewCompileError;
+      expect(error.action, PreviewLaunchAction.restart);
+      expect(error.failedTask, TaskKind.restartingPreview);
+      expect(error.message, contains('restart failed'));
+      expect(fakeCompiler.compileCount, 1);
 
       viewModel.dispose();
     });
@@ -457,6 +546,15 @@ void main() {
       expect(fakeSandbox.reloadedLibraries, [Uri.parse('package:app/main.dart')]);
 
       expect(loggedEvents.map((e) => e.message), contains('Hot reload completed successfully.'));
+      expect(
+        repository.taskStatus.entries
+            .where(
+              (entry) => entry.kind == TaskKind.hotReload || entry.kind == TaskKind.compilingChanges,
+            )
+            .map((entry) => entry.outcome)
+            .toList(),
+        [TaskStatusOutcome.succeeded, TaskStatusOutcome.succeeded],
+      );
 
       viewModel.dispose();
     });
@@ -475,8 +573,11 @@ void main() {
       await viewModel.hotReloadCode();
       await pump();
 
-      expect(viewModel.state, isA<PreviewCompileError>());
-      expect((viewModel.state as PreviewCompileError).message, 'rejected reload');
+      expect(viewModel.state, isA<PreviewRunning>());
+      expect(
+        repository.taskStatus.entries.firstWhere((entry) => entry.kind == TaskKind.hotReload).outcome,
+        TaskStatusOutcome.failed,
+      );
 
       expect(loggedEvents.any((e) => e.message == 'Hot reload rejected' && e.level == Level.WARNING), isTrue);
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad_frontend/features/shared/analyzer_status.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('tracks startup and initial analysis as one task', () {
+    var now = DateTime.utc(2026, 8, 31, 12);
+    final taskStatus = TaskStatusController(now: () => now);
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.beginInitialization();
+    controller.beginInitialization();
+    expect(controller.phase, AnalyzerStatusPhase.analyzing);
+    expect(taskStatus.entries, hasLength(1));
+    expect(taskStatus.current?.kind, TaskKind.analyzingWorkspace);
+    expect(taskStatus.current?.label, 'Analyzing workspace');
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+
+    now = now.add(const Duration(seconds: 3));
+    controller.update(isAnalyzing: true);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
+    controller.update(isAnalyzing: false);
+    expect(controller.phase, AnalyzerStatusPhase.ready);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
+    expect(taskStatus.current?.durationAt(now), const Duration(seconds: 3));
+
+    controller.dispose();
+    taskStatus.dispose();
+  });
+
+  test('later analysis cycles do not replace or restart the initial task', () {
+    var now = DateTime.utc(2026, 8, 31, 12);
+    final taskStatus = TaskStatusController(now: () => now);
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.beginInitialization();
+    now = now.add(const Duration(seconds: 2));
+    controller.update(isAnalyzing: false);
+    final initialTask = taskStatus.current!;
+
+    now = now.add(const Duration(minutes: 1));
+    controller.update(isAnalyzing: true);
+    expect(controller.phase, AnalyzerStatusPhase.analyzing);
+    expect(taskStatus.entries, [same(initialTask)]);
+
+    now = now.add(const Duration(seconds: 1));
+    controller.update(isAnalyzing: false);
+    expect(controller.phase, AnalyzerStatusPhase.ready);
+    expect(taskStatus.entries, [same(initialTask)]);
+    expect(initialTask.durationAt(now), const Duration(seconds: 2));
+
+    controller.dispose();
+    taskStatus.dispose();
+  });
+
+  test('fails the pending task and can later recover its activity state', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.beginInitialization();
+    controller.markUnavailable();
+    expect(controller.phase, AnalyzerStatusPhase.unavailable);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+    controller.update(isAnalyzing: true);
+    expect(controller.phase, AnalyzerStatusPhase.analyzing);
+    controller.update(isAnalyzing: false);
+    expect(controller.phase, AnalyzerStatusPhase.ready);
+    expect(taskStatus.entries, hasLength(1));
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+    controller.dispose();
+    taskStatus.dispose();
+  });
+
+  test('dispose cancels a pending initialization task', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+    controller.beginInitialization();
+
+    controller.dispose();
+
+    expect(taskStatus.entries, isEmpty);
+    taskStatus.dispose();
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:clock/clock.dart';
 import 'package:dartpad_frontend/features/shared/analyzer_status.dart';
 import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:test/test.dart';
@@ -9,54 +10,58 @@ import 'package:test/test.dart';
 void main() {
   test('tracks startup and initial analysis as one task', () {
     var now = DateTime.utc(2026, 8, 31, 12);
-    final taskStatus = TaskStatusController(now: () => now);
-    final controller = AnalyzerStatusController(taskStatus);
+    withClock(Clock(() => now), () {
+      final taskStatus = TaskStatusController();
+      final controller = AnalyzerStatusController(taskStatus);
 
-    controller.beginInitialization();
-    controller.beginInitialization();
-    expect(controller.phase, AnalyzerStatusPhase.analyzing);
-    expect(taskStatus.entries, hasLength(1));
-    expect(taskStatus.current?.kind, TaskKind.analyzingWorkspace);
-    expect(taskStatus.current?.label, 'Analyzing workspace');
-    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
-    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+      controller.beginInitialization();
+      controller.beginInitialization();
+      expect(controller.phase, AnalyzerStatusPhase.analyzing);
+      expect(taskStatus.entries, hasLength(1));
+      expect(taskStatus.current?.kind, TaskKind.analyzingWorkspace);
+      expect(taskStatus.current?.label, 'Analyzing workspace');
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+      expect(taskStatus.hasBlockingPreviewTask, isFalse);
 
-    now = now.add(const Duration(seconds: 3));
-    controller.update(isAnalyzing: true);
-    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+      now = now.add(const Duration(seconds: 3));
+      controller.update(isAnalyzing: true);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
 
-    controller.update(isAnalyzing: false);
-    expect(controller.phase, AnalyzerStatusPhase.ready);
-    expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
-    expect(taskStatus.current?.durationAt(now), const Duration(seconds: 3));
+      controller.update(isAnalyzing: false);
+      expect(controller.phase, AnalyzerStatusPhase.ready);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
+      expect(taskStatus.current?.durationAt(now), const Duration(seconds: 3));
 
-    controller.dispose();
-    taskStatus.dispose();
+      controller.dispose();
+      taskStatus.dispose();
+    });
   });
 
   test('later analysis cycles do not replace or restart the initial task', () {
     var now = DateTime.utc(2026, 8, 31, 12);
-    final taskStatus = TaskStatusController(now: () => now);
-    final controller = AnalyzerStatusController(taskStatus);
+    withClock(Clock(() => now), () {
+      final taskStatus = TaskStatusController();
+      final controller = AnalyzerStatusController(taskStatus);
 
-    controller.beginInitialization();
-    now = now.add(const Duration(seconds: 2));
-    controller.update(isAnalyzing: false);
-    final initialTask = taskStatus.current!;
+      controller.beginInitialization();
+      now = now.add(const Duration(seconds: 2));
+      controller.update(isAnalyzing: false);
+      final initialTask = taskStatus.current!;
 
-    now = now.add(const Duration(minutes: 1));
-    controller.update(isAnalyzing: true);
-    expect(controller.phase, AnalyzerStatusPhase.analyzing);
-    expect(taskStatus.entries, [same(initialTask)]);
+      now = now.add(const Duration(minutes: 1));
+      controller.update(isAnalyzing: true);
+      expect(controller.phase, AnalyzerStatusPhase.analyzing);
+      expect(taskStatus.entries, [same(initialTask)]);
 
-    now = now.add(const Duration(seconds: 1));
-    controller.update(isAnalyzing: false);
-    expect(controller.phase, AnalyzerStatusPhase.ready);
-    expect(taskStatus.entries, [same(initialTask)]);
-    expect(initialTask.durationAt(now), const Duration(seconds: 2));
+      now = now.add(const Duration(seconds: 1));
+      controller.update(isAnalyzing: false);
+      expect(controller.phase, AnalyzerStatusPhase.ready);
+      expect(taskStatus.entries, [same(initialTask)]);
+      expect(initialTask.durationAt(now), const Duration(seconds: 2));
 
-    controller.dispose();
-    taskStatus.dispose();
+      controller.dispose();
+      taskStatus.dispose();
+    });
   });
 
   test('fails the pending task and can later recover its activity state', () {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
@@ -5,35 +5,67 @@
 @TestOn('browser')
 library;
 
+import 'package:dartpad_frontend/features/shared/analyzer_status.dart';
 import 'package:dartpad_frontend/features/shared/components/footer.dart';
 import 'package:dartpad_frontend/features/shared/components/shortcut_definitions.dart';
-import 'package:jaspr/jaspr.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
 
 void main() {
+  late TaskStatusController taskStatus;
+  late AnalyzerStatusController analyzerStatus;
+
+  setUp(() {
+    taskStatus = TaskStatusController();
+    analyzerStatus = AnalyzerStatusController(taskStatus);
+  });
+
+  tearDown(() {
+    analyzerStatus.dispose();
+    taskStatus.dispose();
+  });
+
   testClient('renders desktop footer with privacy and feedback links', (tester) {
-    tester.pumpComponent(const Footer(statusLabel: 'Ready', isSmallScreen: false));
+    tester.pumpComponent(
+      Footer(
+        taskStatus: taskStatus,
+        analyzerStatus: analyzerStatus,
+        isSmallScreen: false,
+      ),
+    );
 
     final links = web.document.querySelectorAll('.app-footer-link');
     expect(links.length, 2);
 
-    final status = web.document.querySelector('.app-footer-status');
-    expect(status?.textContent, 'Ready');
+    final status = web.document.querySelector('.task-status-trigger');
+    expect(status?.textContent, contains('Ready'));
   });
 
   testClient('renders small-screen footer without privacy and feedback links', (tester) {
-    tester.pumpComponent(const Footer(statusLabel: 'Ready', isSmallScreen: true));
+    tester.pumpComponent(
+      Footer(
+        taskStatus: taskStatus,
+        analyzerStatus: analyzerStatus,
+        isSmallScreen: true,
+      ),
+    );
 
     final links = web.document.querySelectorAll('.app-footer-link');
     expect(links.length, 0);
 
-    final status = web.document.querySelector('.app-footer-status');
-    expect(status?.textContent, 'Ready');
+    final status = web.document.querySelector('.task-status-trigger');
+    expect(status?.textContent, contains('Ready'));
   });
 
   testClient('opens shortcuts dialog and toggles show more shortcuts', (tester) async {
-    tester.pumpComponent(const Footer(statusLabel: 'Ready', isSmallScreen: false));
+    tester.pumpComponent(
+      Footer(
+        taskStatus: taskStatus,
+        analyzerStatus: analyzerStatus,
+        isSmallScreen: false,
+      ),
+    );
 
     // Initially dialog is not in the DOM.
     expect(web.document.querySelector('.shortcuts-dialog'), isNull);
@@ -71,11 +103,19 @@ void main() {
 
     rows = web.document.querySelectorAll('.shortcuts-dialog-row');
     expect(rows.length, primaryShortcutCount);
+
+    (web.document.querySelector('[aria-label="Close shortcuts dialog"]')! as web.HTMLButtonElement).click();
+    await pumpEventQueue();
   });
 
-  testClient('footer status update does not dismiss active shortcuts dialog', (tester) async {
-    late void Function(String) setStatus;
-    tester.pumpComponent(_StatusHolder(onController: (fn) => setStatus = fn));
+  testClient('task status update does not dismiss active shortcuts dialog', (tester) async {
+    tester.pumpComponent(
+      Footer(
+        taskStatus: taskStatus,
+        analyzerStatus: analyzerStatus,
+        isSmallScreen: false,
+      ),
+    );
 
     // Open dialog.
     final keyboardBtn = web.document.querySelector('.app-footer-buttons button') as web.HTMLButtonElement?;
@@ -84,40 +124,100 @@ void main() {
 
     expect(web.document.querySelector('.shortcuts-dialog'), isNotNull);
 
-    // Update status to 'Done' from parent.
-    setStatus('Done');
+    taskStatus.startTask(TaskKind.creatingWorkspace).succeed();
     await pumpEventQueue();
 
     // Dialog must still be open.
     expect(web.document.querySelector('.shortcuts-dialog'), isNotNull);
-    final status = web.document.querySelector('.app-footer-status');
-    expect(status?.textContent, 'Done');
+    final status = web.document.querySelector('.task-status-trigger');
+    expect(status?.textContent, contains('Creating workspace'));
+
+    (web.document.querySelector('[aria-label="Close shortcuts dialog"]')! as web.HTMLButtonElement).click();
+    await pumpEventQueue();
   });
-}
 
-class _StatusHolder extends StatefulComponent {
-  const _StatusHolder({required this.onController});
-  final void Function(void Function(String)) onController;
+  testClient('shows active and completed tasks in the status popover', (tester) async {
+    final completed = taskStatus.startTask(TaskKind.creatingWorkspace);
+    completed.succeed();
+    taskStatus.startTask(
+      TaskKind.pubGet,
+      label: 'Pub get in /',
+      scope: '/',
+    );
+    tester.pumpComponent(
+      Footer(
+        taskStatus: taskStatus,
+        analyzerStatus: analyzerStatus,
+        statusMessage: 'Could not save all files.',
+      ),
+    );
 
-  @override
-  State<_StatusHolder> createState() => _StatusHolderState();
-}
+    final anchor = web.document.querySelector('.task-status-anchor')!;
+    anchor.dispatchEvent(web.MouseEvent('mouseenter'));
+    await pumpEventQueue();
 
-class _StatusHolderState extends State<_StatusHolder> {
-  String _status = 'Analyzing project...';
+    final rows = web.document.querySelectorAll('.task-status-table tr');
+    expect(rows.length, 2);
+    expect(rows.item(0)?.textContent, contains('Pub get in /'));
+    expect(rows.item(1)?.textContent, contains('Creating workspace'));
+    expect(web.document.querySelector('.app-footer-message')?.textContent, 'Could not save all files.');
+  });
 
-  @override
-  void initState() {
-    super.initState();
-    component.onController((newStatus) {
-      setState(() {
-        _status = newStatus;
-      });
-    });
-  }
+  testClient('shows a fixed analyzer label with activity, ready, and failure icons', (tester) async {
+    tester.pumpComponent(
+      Footer(taskStatus: taskStatus, analyzerStatus: analyzerStatus),
+    );
 
-  @override
-  Component build(BuildContext context) {
-    return Footer(statusLabel: _status, isSmallScreen: false);
-  }
+    expect(web.document.querySelector('.analyzer-status.waiting'), isNotNull);
+    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
+    expect(web.document.querySelector('.analyzer-status .task-status-icon.running'), isNotNull);
+
+    analyzerStatus.beginInitialization();
+    analyzerStatus.update(isAnalyzing: true);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.analyzer-status.analyzing'), isNotNull);
+    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
+    expect(web.document.querySelector('.analyzer-status-duration'), isNull);
+
+    analyzerStatus.update(isAnalyzing: false);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.analyzer-status.ready'), isNotNull);
+    expect(web.document.querySelector('.analyzer-status .task-status-icon.succeeded'), isNotNull);
+
+    analyzerStatus.update(isAnalyzing: true);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.analyzer-status.analyzing'), isNotNull);
+    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
+    expect(taskStatus.entries, hasLength(1));
+
+    analyzerStatus.markUnavailable();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.analyzer-status.unavailable'), isNotNull);
+    expect(web.document.querySelector('.analyzer-status .task-status-icon.failed'), isNotNull);
+  });
+
+  testClient('opens by focus or click and closes with Escape', (tester) async {
+    taskStatus.startTask(TaskKind.analyzingWorkspace);
+    tester.pumpComponent(
+      Footer(taskStatus: taskStatus, analyzerStatus: analyzerStatus),
+    );
+
+    final trigger = web.document.querySelector('.task-status-trigger') as web.HTMLButtonElement;
+    trigger.focus();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.task-status-popover'), isNotNull);
+
+    web.document.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(key: 'Escape', bubbles: true, cancelable: true),
+      ),
+    );
+    await pumpEventQueue();
+    expect(web.document.querySelector('.task-status-popover'), isNull);
+
+    trigger.click();
+    await pumpEventQueue();
+    expect(web.document.querySelector('.task-status-popover'), isNotNull);
+  });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
@@ -124,20 +124,20 @@ void main() {
 
     expect(web.document.querySelector('.shortcuts-dialog'), isNotNull);
 
-    taskStatus.startTask(TaskKind.creatingWorkspace).succeed();
+    taskStatus.startTask(TaskKind.initializingDartPadWorker).succeed();
     await pumpEventQueue();
 
     // Dialog must still be open.
     expect(web.document.querySelector('.shortcuts-dialog'), isNotNull);
     final status = web.document.querySelector('.task-status-trigger');
-    expect(status?.textContent, contains('Creating workspace'));
+    expect(status?.textContent, contains('Initializing DartPad worker'));
 
     (web.document.querySelector('[aria-label="Close shortcuts dialog"]')! as web.HTMLButtonElement).click();
     await pumpEventQueue();
   });
 
   testClient('shows active and completed tasks in the status popover', (tester) async {
-    final completed = taskStatus.startTask(TaskKind.creatingWorkspace);
+    final completed = taskStatus.startTask(TaskKind.initializingDartPadWorker);
     completed.succeed();
     taskStatus.startTask(
       TaskKind.pubGet,
@@ -159,7 +159,7 @@ void main() {
     final rows = web.document.querySelectorAll('.task-status-table tr');
     expect(rows.length, 2);
     expect(rows.item(0)?.textContent, contains('Pub get in /'));
-    expect(rows.item(1)?.textContent, contains('Creating workspace'));
+    expect(rows.item(1)?.textContent, contains('Initializing DartPad worker'));
     expect(web.document.querySelector('.app-footer-message')?.textContent, 'Could not save all files.');
   });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:clock/clock.dart';
 import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:test/test.dart';
 
@@ -12,7 +13,7 @@ void main() {
 
     setUp(() {
       now = DateTime.utc(2026, 8, 28, 12);
-      controller = TaskStatusController(now: () => now);
+      controller = TaskStatusController();
     });
 
     tearDown(() {
@@ -20,154 +21,172 @@ void main() {
     });
 
     test('orders running tasks before completed tasks', () {
-      final first = controller.startTask(
-        TaskKind.loadingSample,
-        label: 'First',
-        scope: 'first',
-      );
-      now = now.add(const Duration(seconds: 1));
-      final second = controller.startTask(
-        TaskKind.pubGet,
-        label: 'Second',
-        scope: '/',
-      );
-      first.succeed();
+      withClock(Clock(() => now), () {
+        final first = controller.startTask(
+          TaskKind.loadingSample,
+          label: 'First',
+          scope: 'first',
+        );
+        now = now.add(const Duration(seconds: 1));
+        final second = controller.startTask(
+          TaskKind.pubGet,
+          label: 'Second',
+          scope: '/',
+        );
+        first.succeed();
 
-      expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
-      expect(controller.current?.label, 'Second');
+        expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
+        expect(controller.current?.label, 'Second');
 
-      now = now.add(const Duration(seconds: 1));
-      second.succeed();
-      expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
+        now = now.add(const Duration(seconds: 1));
+        second.succeed();
+        expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
+      });
     });
 
     test('replaces the same kind and scope and ignores its stale handle', () {
-      final stale = controller.startTask(
-        TaskKind.pubGet,
-        label: 'First pub get',
-        scope: '/example',
-      );
-      now = now.add(const Duration(seconds: 1));
-      final current = controller.startTask(
-        TaskKind.pubGet,
-        label: 'Current pub get',
-        scope: '/example',
-      );
+      withClock(Clock(() => now), () {
+        final stale = controller.startTask(
+          TaskKind.pubGet,
+          label: 'First pub get',
+          scope: '/example',
+        );
+        now = now.add(const Duration(seconds: 1));
+        final current = controller.startTask(
+          TaskKind.pubGet,
+          label: 'Current pub get',
+          scope: '/example',
+        );
 
-      stale.fail();
-      expect(controller.entries, hasLength(1));
-      expect(controller.current?.label, 'Current pub get');
-      expect(controller.current?.outcome, TaskStatusOutcome.running);
+        stale.fail();
+        expect(controller.entries, hasLength(1));
+        expect(controller.current?.label, 'Current pub get');
+        expect(controller.current?.outcome, TaskStatusOutcome.running);
 
-      current.succeed();
-      expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+        current.succeed();
+        expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+      });
     });
 
     test('keeps the same kind with different scopes independently', () {
-      controller.startTask(
-        TaskKind.pubGet,
-        label: 'Pub get in /first',
-        scope: '/first',
-      );
-      controller.startTask(
-        TaskKind.pubGet,
-        label: 'Pub get in /second',
-        scope: '/second',
-      );
+      withClock(Clock(() => now), () {
+        controller.startTask(
+          TaskKind.pubGet,
+          label: 'Pub get in /first',
+          scope: '/first',
+        );
+        controller.startTask(
+          TaskKind.pubGet,
+          label: 'Pub get in /second',
+          scope: '/second',
+        );
 
-      expect(controller.entries, hasLength(2));
-      expect(
-        controller.entries.map((entry) => entry.scope),
-        unorderedEquals(['/first', '/second']),
-      );
-      expect(controller.entries.every((entry) => entry.kind == TaskKind.pubGet), isTrue);
+        expect(controller.entries, hasLength(2));
+        expect(
+          controller.entries.map((entry) => entry.scope),
+          unorderedEquals(['/first', '/second']),
+        );
+        expect(controller.entries.every((entry) => entry.kind == TaskKind.pubGet), isTrue);
+      });
     });
 
     test('runTask records success and preserves the result', () async {
-      final result = await controller.runTask(
-        TaskKind.loadingSample,
-        () async => 42,
-        label: 'Load sample counter',
-        scope: 'counter',
-      );
+      await withClock(Clock(() => now), () async {
+        final result = await controller.runTask(
+          TaskKind.loadingSample,
+          () async => 42,
+          label: 'Load sample counter',
+          scope: 'counter',
+        );
 
-      expect(result, 42);
-      expect(controller.current?.label, 'Load sample counter');
-      expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+        expect(result, 42);
+        expect(controller.current?.label, 'Load sample counter');
+        expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+      });
     });
 
     test('runTask records and rethrows synchronous and asynchronous errors', () async {
-      expect(
-        () => controller.runTask<void>(
-          TaskKind.loadingSample,
-          () => throw StateError('sync'),
-          scope: 'sync',
-        ),
-        throwsStateError,
-      );
-      await pumpEventQueue();
-      expect(controller.current?.outcome, TaskStatusOutcome.failed);
+      await withClock(Clock(() => now), () async {
+        expect(
+          () => controller.runTask<void>(
+            TaskKind.loadingSample,
+            () => throw StateError('sync'),
+            scope: 'sync',
+          ),
+          throwsStateError,
+        );
+        await pumpEventQueue();
+        expect(controller.current?.outcome, TaskStatusOutcome.failed);
 
-      now = now.add(const Duration(seconds: 1));
-      await expectLater(
-        controller.runTask<void>(
-          TaskKind.loadingSample,
-          () async => throw StateError('async'),
-          label: 'Async failure',
-          scope: 'async',
-        ),
-        throwsStateError,
-      );
-      expect(controller.current?.label, 'Async failure');
-      expect(controller.current?.outcome, TaskStatusOutcome.failed);
+        now = now.add(const Duration(seconds: 1));
+        await expectLater(
+          controller.runTask<void>(
+            TaskKind.loadingSample,
+            () async => throw StateError('async'),
+            label: 'Async failure',
+            scope: 'async',
+          ),
+          throwsStateError,
+        );
+        expect(controller.current?.label, 'Async failure');
+        expect(controller.current?.outcome, TaskStatusOutcome.failed);
+      });
     });
 
     test('tracks whether a running task blocks preview compilation', () {
-      final passive = controller.startTask(TaskKind.analyzingWorkspace);
-      expect(controller.hasBlockingPreviewTask, isFalse);
+      withClock(Clock(() => now), () {
+        final passive = controller.startTask(TaskKind.analyzingWorkspace);
+        expect(controller.hasBlockingPreviewTask, isFalse);
 
-      final blocking = controller.startTask(
-        TaskKind.pubGet,
-        scope: '/',
-        blocksPreview: true,
-      );
-      expect(controller.hasBlockingPreviewTask, isTrue);
+        final blocking = controller.startTask(
+          TaskKind.pubGet,
+          scope: '/',
+          blocksPreview: true,
+        );
+        expect(controller.hasBlockingPreviewTask, isTrue);
 
-      blocking.succeed();
-      expect(controller.hasBlockingPreviewTask, isFalse);
-      passive.cancel();
+        blocking.succeed();
+        expect(controller.hasBlockingPreviewTask, isFalse);
+        passive.cancel();
+      });
     });
 
     test('removes completed tasks after retention but keeps running tasks', () {
-      controller.startTask(TaskKind.loadingSample, scope: 'completed').succeed();
-      controller.startTask(TaskKind.analyzingWorkspace);
+      withClock(Clock(() => now), () {
+        controller.startTask(TaskKind.loadingSample, scope: 'completed').succeed();
+        controller.startTask(TaskKind.analyzingWorkspace);
 
-      now = now.add(const Duration(minutes: 5, milliseconds: 1));
-      controller.startTask(TaskKind.pubClean, scope: '/').cancel();
+        now = now.add(const Duration(minutes: 5, milliseconds: 1));
+        controller.startTask(TaskKind.pubClean, scope: '/').cancel();
 
-      expect(controller.entries.map((entry) => entry.kind), [TaskKind.analyzingWorkspace]);
+        expect(controller.entries.map((entry) => entry.kind), [TaskKind.analyzingWorkspace]);
+      });
     });
 
     test('cancel removes only the handle-owned task', () {
-      final handle = controller.startTask(TaskKind.hotReload);
-      handle.cancel();
+      withClock(Clock(() => now), () {
+        final handle = controller.startTask(TaskKind.hotReload);
+        handle.cancel();
 
-      expect(controller.entries, isEmpty);
+        expect(controller.entries, isEmpty);
+      });
     });
 
     test('dispose clears tasks and makes existing handles inert', () {
-      final handle = controller.startTask(TaskKind.analyzingWorkspace);
+      withClock(Clock(() => now), () {
+        final handle = controller.startTask(TaskKind.analyzingWorkspace);
 
-      controller.dispose();
-      handle.succeed();
+        controller.dispose();
+        handle.succeed();
 
-      expect(controller.entries, isEmpty);
-      expect(
-        () => controller.startTask(TaskKind.pubGet),
-        throwsStateError,
-      );
+        expect(controller.entries, isEmpty);
+        expect(
+          () => controller.startTask(TaskKind.pubGet),
+          throwsStateError,
+        );
 
-      controller = TaskStatusController(now: () => now);
+        controller = TaskStatusController();
+      });
     });
   });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
@@ -163,6 +163,17 @@ void main() {
       });
     });
 
+    test('hides expired completed tasks from entries even without starting new tasks', () {
+      withClock(Clock(() => now), () {
+        controller.startTask(TaskKind.loadingSample).succeed();
+        expect(controller.entries, hasLength(1));
+
+        now = now.add(const Duration(minutes: 5, milliseconds: 1));
+        expect(controller.entries, isEmpty);
+        expect(controller.current, isNull);
+      });
+    });
+
     test('cancel removes only the handle-owned task', () {
       withClock(Clock(() => now), () {
         final handle = controller.startTask(TaskKind.hotReload);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
@@ -1,0 +1,185 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TaskStatusController', () {
+    late DateTime now;
+    late TaskStatusController controller;
+
+    setUp(() {
+      now = DateTime.utc(2026, 8, 28, 12);
+      controller = TaskStatusController(now: () => now);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('orders running tasks before completed tasks', () {
+      final first = controller.startTask(
+        TaskKind.loadingSample,
+        label: 'First',
+        scope: 'first',
+      );
+      now = now.add(const Duration(seconds: 1));
+      final second = controller.startTask(
+        TaskKind.pubGet,
+        label: 'Second',
+        scope: '/',
+      );
+      first.succeed();
+
+      expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
+      expect(controller.current?.label, 'Second');
+
+      now = now.add(const Duration(seconds: 1));
+      second.succeed();
+      expect(controller.entries.map((entry) => entry.label), ['Second', 'First']);
+    });
+
+    test('replaces the same kind and scope and ignores its stale handle', () {
+      final stale = controller.startTask(
+        TaskKind.pubGet,
+        label: 'First pub get',
+        scope: '/example',
+      );
+      now = now.add(const Duration(seconds: 1));
+      final current = controller.startTask(
+        TaskKind.pubGet,
+        label: 'Current pub get',
+        scope: '/example',
+      );
+
+      stale.fail();
+      expect(controller.entries, hasLength(1));
+      expect(controller.current?.label, 'Current pub get');
+      expect(controller.current?.outcome, TaskStatusOutcome.running);
+
+      current.succeed();
+      expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+    });
+
+    test('keeps the same kind with different scopes independently', () {
+      controller.startTask(
+        TaskKind.pubGet,
+        label: 'Pub get in /first',
+        scope: '/first',
+      );
+      controller.startTask(
+        TaskKind.pubGet,
+        label: 'Pub get in /second',
+        scope: '/second',
+      );
+
+      expect(controller.entries, hasLength(2));
+      expect(
+        controller.entries.map((entry) => entry.scope),
+        unorderedEquals(['/first', '/second']),
+      );
+      expect(controller.entries.every((entry) => entry.kind == TaskKind.pubGet), isTrue);
+    });
+
+    test('runTask records success and preserves the result', () async {
+      final result = await controller.runTask(
+        TaskKind.loadingSample,
+        () async => 42,
+        label: 'Load sample counter',
+        scope: 'counter',
+      );
+
+      expect(result, 42);
+      expect(controller.current?.label, 'Load sample counter');
+      expect(controller.current?.outcome, TaskStatusOutcome.succeeded);
+    });
+
+    test('runTask records and rethrows synchronous and asynchronous errors', () async {
+      expect(
+        () => controller.runTask<void>(
+          TaskKind.loadingSample,
+          () => throw StateError('sync'),
+          scope: 'sync',
+        ),
+        throwsStateError,
+      );
+      await pumpEventQueue();
+      expect(controller.current?.outcome, TaskStatusOutcome.failed);
+
+      now = now.add(const Duration(seconds: 1));
+      await expectLater(
+        controller.runTask<void>(
+          TaskKind.loadingSample,
+          () async => throw StateError('async'),
+          label: 'Async failure',
+          scope: 'async',
+        ),
+        throwsStateError,
+      );
+      expect(controller.current?.label, 'Async failure');
+      expect(controller.current?.outcome, TaskStatusOutcome.failed);
+    });
+
+    test('tracks whether a running task blocks preview compilation', () {
+      final passive = controller.startTask(TaskKind.analyzingWorkspace);
+      expect(controller.hasBlockingPreviewTask, isFalse);
+
+      final blocking = controller.startTask(
+        TaskKind.pubGet,
+        scope: '/',
+        blocksPreview: true,
+      );
+      expect(controller.hasBlockingPreviewTask, isTrue);
+
+      blocking.succeed();
+      expect(controller.hasBlockingPreviewTask, isFalse);
+      passive.cancel();
+    });
+
+    test('removes completed tasks after retention but keeps running tasks', () {
+      controller.startTask(TaskKind.loadingSample, scope: 'completed').succeed();
+      controller.startTask(TaskKind.analyzingWorkspace);
+
+      now = now.add(const Duration(minutes: 5, milliseconds: 1));
+      controller.startTask(TaskKind.pubClean, scope: '/').cancel();
+
+      expect(controller.entries.map((entry) => entry.kind), [TaskKind.analyzingWorkspace]);
+    });
+
+    test('cancel removes only the handle-owned task', () {
+      final handle = controller.startTask(TaskKind.hotReload);
+      handle.cancel();
+
+      expect(controller.entries, isEmpty);
+    });
+
+    test('dispose clears tasks and makes existing handles inert', () {
+      final handle = controller.startTask(TaskKind.analyzingWorkspace);
+
+      controller.dispose();
+      handle.succeed();
+
+      expect(controller.entries, isEmpty);
+      expect(
+        () => controller.startTask(TaskKind.pubGet),
+        throwsStateError,
+      );
+
+      controller = TaskStatusController(now: () => now);
+    });
+  });
+
+  group('formatTaskDuration', () {
+    test('formats tenths of seconds, minutes, and hours', () {
+      expect(formatTaskDuration(const Duration(milliseconds: 950)), '0.9s');
+      expect(formatTaskDuration(const Duration(seconds: 61)), '1m 01s');
+      expect(formatTaskDuration(const Duration(hours: 1, minutes: 2, seconds: 3)), '1h 02m 03s');
+    });
+
+    test('clamps negative durations', () {
+      expect(formatTaskDuration(const Duration(milliseconds: -1)), '0.0s');
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
@@ -23,7 +23,7 @@ void main() {
     test('orders running tasks before completed tasks', () {
       withClock(Clock(() => now), () {
         final first = controller.startTask(
-          TaskKind.loadingSample,
+          TaskKind.loadingCode,
           label: 'First',
           scope: 'first',
         );
@@ -93,7 +93,7 @@ void main() {
     test('runTask records success and preserves the result', () async {
       await withClock(Clock(() => now), () async {
         final result = await controller.runTask(
-          TaskKind.loadingSample,
+          TaskKind.loadingCode,
           () async => 42,
           label: 'Load sample counter',
           scope: 'counter',
@@ -109,7 +109,7 @@ void main() {
       await withClock(Clock(() => now), () async {
         expect(
           () => controller.runTask<void>(
-            TaskKind.loadingSample,
+            TaskKind.loadingCode,
             () => throw StateError('sync'),
             scope: 'sync',
           ),
@@ -121,7 +121,7 @@ void main() {
         now = now.add(const Duration(seconds: 1));
         await expectLater(
           controller.runTask<void>(
-            TaskKind.loadingSample,
+            TaskKind.loadingCode,
             () async => throw StateError('async'),
             label: 'Async failure',
             scope: 'async',
@@ -153,7 +153,7 @@ void main() {
 
     test('removes completed tasks after retention but keeps running tasks', () {
       withClock(Clock(() => now), () {
-        controller.startTask(TaskKind.loadingSample, scope: 'completed').succeed();
+        controller.startTask(TaskKind.loadingCode, scope: 'completed').succeed();
         controller.startTask(TaskKind.analyzingWorkspace);
 
         now = now.add(const Duration(minutes: 5, milliseconds: 1));
@@ -165,7 +165,7 @@ void main() {
 
     test('hides expired completed tasks from entries even without starting new tasks', () {
       withClock(Clock(() => now), () {
-        controller.startTask(TaskKind.loadingSample).succeed();
+        controller.startTask(TaskKind.loadingCode).succeed();
         expect(controller.entries, hasLength(1));
 
         now = now.add(const Duration(minutes: 5, milliseconds: 1));

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
@@ -11,6 +11,7 @@ import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
 import 'package:dartpad_frontend/sdks.g.dart';
 import 'package:test/test.dart';
@@ -146,11 +147,36 @@ void main() {
     },
   );
 
+  test('Pub Clean exposes a blocking task status', () async {
+    final workspace = _Workspace()..folders.add('example/build');
+    final taskStatus = TaskStatusController();
+    final repository = WorkspaceRepository(
+      events: AppEventBus(),
+      taskStatus: taskStatus,
+      workspaceResourceApi: workspace,
+      sdk: defaultSdk,
+      workspaceFuture: Completer<Workspace>().future,
+    );
+
+    final future = repository.pubClean(path: 'example');
+    expect(taskStatus.current?.kind, TaskKind.pubClean);
+    expect(taskStatus.current?.label, 'Pub clean in example');
+    expect(taskStatus.current?.scope, 'example');
+    expect(taskStatus.hasBlockingPreviewTask, isTrue);
+    await future;
+
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+    taskStatus.dispose();
+    await repository.events.dispose();
+  });
+
   group('workspace reset cleanup', () {
     test('disposes the workspace without disposing the worker', () async {
       final workspace = _Workspace();
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: workspace,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,
@@ -166,6 +192,7 @@ void main() {
       final workspace = _Workspace()..disposeError = StateError('workspace already removed');
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: workspace,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,
@@ -184,6 +211,7 @@ void main() {
       final api = MemoryWorkspaceResourceApi();
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: api,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,
@@ -213,6 +241,7 @@ void main() {
       final api = MemoryWorkspaceResourceApi();
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: api,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,
@@ -242,6 +271,7 @@ void main() {
       final api = MemoryWorkspaceResourceApi();
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: api,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,
@@ -255,6 +285,7 @@ void main() {
       final api = MemoryWorkspaceResourceApi();
       final repository = WorkspaceRepository(
         events: AppEventBus(),
+        taskStatus: TaskStatusController(),
         workspaceResourceApi: api,
         sdk: defaultSdk,
         workspaceFuture: Completer<Workspace>().future,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
@@ -11,6 +11,7 @@ import 'dart:typed_data';
 import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
 import 'package:dartpad_frontend/features/workspace/workspace_session.dart';
 import 'package:dartpad_frontend/sdks.g.dart';
@@ -74,6 +75,7 @@ void main() {
     final workspace = _Workspace();
     final repository = WorkspaceRepository(
       events: events,
+      taskStatus: TaskStatusController(),
       workspaceResourceApi: workspace,
       sdk: defaultSdk,
       workspaceFuture: Completer<Workspace>().future,
@@ -82,11 +84,16 @@ void main() {
 
     expect(session.repository, same(repository));
     expect(session.events, same(events));
+    expect(session.taskStatus, same(repository.taskStatus));
 
     await session.dispose(closeWorker: false);
     await session.dispose(closeWorker: false);
 
     expect(workspace.disposeCount, 1);
+    expect(
+      () => session.taskStatus.startTask(TaskKind.analyzingWorkspace),
+      throwsStateError,
+    );
     await expectLater(
       events.dispatchAsync(_TestEvent()),
       throwsA(isA<StateError>()),


### PR DESCRIPTION
**Summary**
This PR introduces session-scoped task tracking and improves how DartPad communicates workspace, analyzer, and preview activity. This improves the UX, especially after loading the page as the user prominently sees that something is happening.

<img width="1163" height="1792" alt="Screenshot 2026-08-31 132119" src="https://github.com/user-attachments/assets/bbfd25ef-30e3-4253-a122-29a72564d42a" />


On initial page load
The empty preview panel shows Preparing workspace.
This single status covers the complete initial setup:
- Resolving and downloading the selected package, archive, Gist, or sample
- Starting the DartPad worker
- Creating the workspace
- Running the initial pub get

Preparing workspace is shown once per workspace session. It runs again when loading another example, changing the SDK, or otherwise creating a new workspace session.
The motivation to only show a more general status and not the individuel steps (pub get, starting dart pad worker) is that these tasks run for only 0.0/0.1 s most of the time. So showing these would introduce a lot of flicker.

After preparation completes, the preview shows:
1. Compiling application
2. Starting preview
3. The running application

**Footer**

The footer is used for more details:
- Initial Analyzer run
- pub get/pub clean
- Hot reload
- Cached restart
- Stopping the preview
- Other background tasks

Footer task history
The footer status button shows the currently running task or the most recently completed task. Its popover contains recent task activity, including success and failure states, for up to five minutes.

<img width="725" height="505" alt="Screenshot 2026-08-31 132134" src="https://github.com/user-attachments/assets/db6c8d3b-dc89-467f-9542-5c296045bb25" />



**Analyzer status**
The footer always shows a separate Analyzer indicator:
- Spinner while the Analyzer is starting or analyzing
- Green check while it is ready
- Red X when it is unavailable

The initial Analyzer startup is additionally tracked as `Analyzing workspace` in the task history. Later analysis cycles only update the fixed Analyzer indicator and do not create or restart task timers as they would clutter the task tracker

**Failures**
Failures during workspace preparation, application compilation, or preview startup remain visible in the preview panel until the user retries or starts a new session.
The error includes an Open Console link that switches the bottom panel to the Console tab. On small screens, it also switches back to the Code view before opening the Console.
Failures from later background operations remain in the footer task history. A failed hot reload keeps the existing application visible and reports the failure through the footer and Console.

<img width="1148" height="1749" alt="Screenshot 2026-08-31 132040" src="https://github.com/user-attachments/assets/6e2108ab-ae5d-46c0-90f4-cfb70d11852c" />


**Additional changes**
This removes the need for the old toast which showed "Starting Preview" so it was removed.

Fixes #3714, #3803 


