### PR TITLE
feat(dartpad-preview): scope LSP to editor root

### DIFF
--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
@@ -62,9 +62,15 @@ class _AnalyzerNotificationQueue {
 /// Coordinates communication with the Dart Language Server Protocol (LSP) worker,
 /// handles diagnostics, and processes filesystem edits requested by the LSP.
 class LanguageServerClient {
+  /// Creates a client for an editor project inside a virtual workspace.
+  ///
+  /// [rootWorkspaceUri] remains the base for all workspace-relative file
+  /// operations. [editorRootUri] is sent to the language server as its root
+  /// URI and may point to a nested package within that workspace.
   LanguageServerClient({
     required LanguageServer? languageServer,
     required this.rootWorkspaceUri,
+    required this.editorRootUri,
     required Stream<WorkspaceChangeEvent> workspaceChangeEvents,
     this._documentEditsHandler,
     this._displayFileHandler,
@@ -82,12 +88,12 @@ class LanguageServerClient {
     if (createCodeMirrorLspClient != null) {
       _codeMirrorLspClient = createCodeMirrorLspClient(
         (String msg) => _sendToLanguageServer(jsonDecode(msg)),
-        rootWorkspaceUri.toString(),
+        editorRootUri.toString(),
       );
     } else {
       _codeMirrorLspClient = CodeMirrorLspClient(
         (String msg) => _sendToLanguageServer(jsonDecode(msg)),
-        rootWorkspaceUri.toString(),
+        editorRootUri.toString(),
         onDisplayFile: (String uri) async {
           final handler = _displayFileHandler;
           if (handler != null) {
@@ -115,7 +121,14 @@ class LanguageServerClient {
     });
   }
 
+  /// Root of the complete virtual workspace used to resolve file paths.
   final Uri rootWorkspaceUri;
+
+  /// Root of the active editor project supplied during LSP initialization.
+  ///
+  /// This may equal [rootWorkspaceUri] when the active package is rooted at the
+  /// complete workspace or when no more specific package root was detected.
+  final Uri editorRootUri;
   late final void Function(Object? message) _sendToLanguageServer;
 
   late final StreamSubscription<WorkspaceChangeEvent> _workspaceSubscription;

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/language_server_client.dart
@@ -64,9 +64,9 @@ class _AnalyzerNotificationQueue {
 class LanguageServerClient {
   /// Creates a client for an editor project inside a virtual workspace.
   ///
-  /// [rootWorkspaceUri] remains the base for all workspace-relative file
-  /// operations. [editorRootUri] is sent to the language server as its root
-  /// URI and may point to a nested package within that workspace.
+  /// [rootWorkspaceUri] is the base URI for workspace-relative file operations.
+  /// [editorRootUri] is sent to the language server as its root URI and may
+  /// point to a nested package within that workspace.
   LanguageServerClient({
     required LanguageServer? languageServer,
     required this.rootWorkspaceUri,

--- a/pkgs/dartpad_preview/dartpad_editor/test/lsp/language_server_client_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/lsp/language_server_client_test.dart
@@ -69,6 +69,36 @@ void main() {
     late StreamController<Object?> outgoingMessages;
     late LanguageServerClient client;
     late Future<void> Function(String file, List<Object?> edits)? documentEditsHandler;
+    late String initializedRootUri;
+
+    LanguageServerClient createClient({required Uri editorRootUri}) {
+      return LanguageServerClient(
+        languageServer: null,
+        rootWorkspaceUri: workspace.workspaceFolder,
+        editorRootUri: editorRootUri,
+        workspaceChangeEvents: workspaceEvents.stream,
+        documentEditsHandler: (file, edits) async {
+          if (documentEditsHandler != null) {
+            await documentEditsHandler!.call(file, edits);
+          } else {
+            final text = await workspace.readFileAsText(file);
+            await workspace.writeFileFromText(
+              file,
+              LanguageServerClient.applyEdits(text, edits),
+            );
+          }
+        },
+        sendToLanguageServer: (message) {
+          sentMessages.add(message);
+          outgoingMessages.add(message);
+        },
+        languageServerMessages: serverMessages.stream,
+        createCodeMirrorLspClient: (_, rootUri) {
+          initializedRootUri = rootUri;
+          return codeMirrorClient;
+        },
+      );
+    }
 
     setUp(() {
       workspace = FakeWorkspace();
@@ -78,24 +108,9 @@ void main() {
       sentMessages = [];
       outgoingMessages = StreamController<Object?>.broadcast();
       documentEditsHandler = null;
-      client = LanguageServerClient(
-        languageServer: null,
-        rootWorkspaceUri: workspace.workspaceFolder,
-        workspaceChangeEvents: workspaceEvents.stream,
-        documentEditsHandler: (file, edits) async {
-          if (documentEditsHandler != null) {
-            await documentEditsHandler!.call(file, edits);
-          } else {
-            final text = await workspace.readFileAsText(file);
-            await workspace.writeFileFromText(file, LanguageServerClient.applyEdits(text, edits));
-          }
-        },
-        sendToLanguageServer: (message) {
-          sentMessages.add(message);
-          outgoingMessages.add(message);
-        },
-        languageServerMessages: serverMessages.stream,
-        createCodeMirrorLspClient: (_, _) => codeMirrorClient,
+      initializedRootUri = '';
+      client = createClient(
+        editorRootUri: Uri.parse('file:///workspace/example/'),
       );
     });
 
@@ -104,6 +119,53 @@ void main() {
       await serverMessages.close();
       await workspaceEvents.close();
       await outgoingMessages.close();
+    });
+
+    test('initializes at the project root while preserving workspace-relative paths', () async {
+      expect(initializedRootUri, 'file:///workspace/example/');
+
+      final diagnosticActivity = client.analyzerActivityStream.first;
+      serverMessages.add({
+        'method': 'textDocument/publishDiagnostics',
+        'params': {
+          'uri': 'file:///workspace/example/lib/main.dart',
+          'diagnostics': [
+            {
+              'range': {
+                'start': {'line': 0, 'character': 0},
+              },
+              'message': 'problem',
+            },
+          ],
+        },
+      });
+      await diagnosticActivity;
+
+      expect(client.allDiagnostics.single.fileName, 'example/lib/main.dart');
+
+      final renameFuture = client.willRenameFiles(
+        'example/lib/old.dart',
+        'example/lib/new.dart',
+      );
+      expect(sentMessages.single, {
+        'jsonrpc': '2.0',
+        'id': -1,
+        'method': 'workspace/willRenameFiles',
+        'params': {
+          'files': [
+            {
+              'oldUri': 'file:///workspace/example/lib/old.dart',
+              'newUri': 'file:///workspace/example/lib/new.dart',
+            },
+          ],
+        },
+      });
+      serverMessages.add({
+        'jsonrpc': '2.0',
+        'id': -1,
+        'result': null,
+      });
+      await renameFuture;
     });
 
     test('serializes diagnostics and analyzer status into observable state', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -104,6 +104,13 @@ inside the extracted workspace, not URLs.
 `package` always resolves the release in
 the `latest` field of the pub.dev package API response.
 
+DartPad loads the complete archive into the workspace, but initializes the
+language server at the nearest package root for the file it opens. The package
+root is the closest parent directory containing a `pubspec.yaml`. For example,
+`?package=flutter_animate` opens `example/lib/main.dart` and analyzes only the
+package under `example/`, while the rest of the downloaded archive remains in
+the workspace.
+
 Examples:
 
 ```text

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -267,10 +267,16 @@ class AppState extends State<App> {
     await _initializeAnalyzer(session, workspace, project.packageRoot);
   }
 
+  /// Starts the language server with an editor root derived from [packageRoot].
+  ///
+  /// [packageRoot] is relative to the complete virtual [workspace]. It is
+  /// `null` when no Dart package was detected and empty when the package is
+  /// rooted at the workspace itself. The resulting editor root URI determines
+  /// where analysis starts.
   Future<void> _initializeAnalyzer(
     WorkspaceSession session,
     Workspace workspace,
-    String? projectRoot,
+    String? packageRoot,
   ) async {
     try {
       session.analyzerStatus.beginInitialization();
@@ -280,9 +286,15 @@ class AppState extends State<App> {
         return;
       }
 
+      final rootWorkspaceUri = workspace.workspaceFolder;
+      final editorRootUri = resolveEditorRootUri(
+        rootWorkspaceUri,
+        packageRoot,
+      );
       final languageServerClient = LanguageServerClient(
         languageServer: languageServer,
-        rootWorkspaceUri: workspace.workspaceFolder,
+        rootWorkspaceUri: rootWorkspaceUri,
+        editorRootUri: editorRootUri,
         workspaceChangeEvents: session.repository.workspaceResourceApi.changeEvents,
         documentEditsHandler: (filePath, edits) async {
           final tab = session.tabs.getTab(filePath);
@@ -306,7 +318,7 @@ class AppState extends State<App> {
       session.attachLanguageServer(
         server: languageServer,
         client: languageServerClient,
-        projectRoot: projectRoot,
+        projectRoot: packageRoot,
       );
     } catch (error, stackTrace) {
       if (!_isCurrent(session)) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
@@ -19,9 +19,6 @@ final class ProjectFile {
 
 /// The workspace state produced by a project loader.
 ///
-/// [projectDir] is the folder shown in the file tree. [packageRoot] is null
-/// when the loaded files do not form a Dart package; it is an empty string for
-/// a package rooted at the workspace root.
 final class LoadedProject {
   const LoadedProject({
     required this.projectDir,
@@ -30,10 +27,36 @@ final class LoadedProject {
     this.pathToMain,
   });
 
+  /// Workspace-relative folder shown as the root of the file tree.
   final String projectDir;
+
+  /// Workspace-relative file opened after the project is loaded.
   final String? entryPath;
+
+  /// Workspace-relative root of the Dart package containing [entryPath].
+  ///
+  /// This is `null` when no Dart package was detected and an empty string when
+  /// the package is rooted at the complete workspace.
   final String? packageRoot;
+
+  /// Workspace-relative Dart entrypoint executed in the preview.
   final String? pathToMain;
+}
+
+/// Resolves [packageRoot] to the editor and language-server root URI.
+///
+/// [rootWorkspaceUri] identifies the complete virtual workspace, while
+/// [packageRoot] is a workspace-relative path. A missing package root or a
+/// package rooted at the workspace both use [rootWorkspaceUri] directly.
+Uri resolveEditorRootUri(Uri rootWorkspaceUri, String? packageRoot) {
+  if (packageRoot == null || packageRoot.isEmpty) {
+    return rootWorkspaceUri;
+  }
+
+  final normalizedPackageRoot = workspaceContext.normalize(packageRoot);
+  return rootWorkspaceUri.resolveUri(
+    Uri(path: '$normalizedPackageRoot/'),
+  );
 }
 
 /// Shared workspace import operations for externally loaded projects.

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/diagnostics_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/view_models/diagnostics_view_model_test.dart
@@ -43,6 +43,7 @@ void main() {
       languageServerClient = LanguageServerClient(
         languageServer: null,
         rootWorkspaceUri: Uri.parse('file:///workspace/'),
+        editorRootUri: Uri.parse('file:///workspace/'),
         workspaceChangeEvents: workspaceEvents.stream,
         sendToLanguageServer: (_) {},
         languageServerMessages: languageServerMessages.stream,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/project_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/project_loader_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dartpad_frontend/features/startup/project_loader.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('resolveEditorRootUri', () {
+    final rootWorkspaceUri = Uri.parse('file:///workspace/pad_1/');
+
+    test('resolves a nested package as a directory', () {
+      expect(
+        resolveEditorRootUri(rootWorkspaceUri, 'example'),
+        Uri.parse('file:///workspace/pad_1/example/'),
+      );
+      expect(
+        resolveEditorRootUri(rootWorkspaceUri, 'packages/demo'),
+        Uri.parse('file:///workspace/pad_1/packages/demo/'),
+      );
+    });
+
+    for (final entry in <String, String?>{
+      'missing': null,
+      'empty': '',
+    }.entries) {
+      test('uses the workspace root when the package root is ${entry.key}', () {
+        expect(
+          resolveEditorRootUri(rootWorkspaceUri, entry.value),
+          rootWorkspaceUri,
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
Introduces an explicit editorRootUri for LSP initialization while retaining rootWorkspaceUri for workspace-relative file operations. Now Packages with example/ folders use their nested example package as the editor root, preventing analysis of unrelated files elsewhere in the loaded archive.

Fixes #3809 