### PR TITLE
fix(dartpad-preview): isolate archived workspace packages

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -111,6 +111,15 @@ root is the closest parent directory containing a `pubspec.yaml`. For example,
 package under `example/`, while the rest of the downloaded archive remains in
 the workspace.
 
+If the active package in a remote archive or pub.dev package declares
+`resolution: workspace`, DartPad resolves that package independently of its
+original workspace. It creates or updates a package-local
+`pubspec_overrides.yaml` with a null `resolution` value while leaving the
+downloaded `pubspec.yaml` unchanged. Existing valid override fields and
+comments are preserved. Because Pub resolves an `example/` package by default,
+DartPad applies the same isolation recursively to nested example packages that
+declare workspace resolution.
+
 Examples:
 
 ```text

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -113,12 +113,12 @@ the workspace.
 
 If the active package in a remote archive or pub.dev package declares
 `resolution: workspace`, DartPad resolves that package independently of its
-original workspace. It creates or updates a package-local
+original workspace. It writes a package-local
 `pubspec_overrides.yaml` with a null `resolution` value while leaving the
-downloaded `pubspec.yaml` unchanged. Existing valid override fields and
-comments are preserved. Because Pub resolves an `example/` package by default,
-DartPad applies the same isolation recursively to nested example packages that
-declare workspace resolution.
+downloaded `pubspec.yaml` unchanged. An existing overrides file in an isolated
+package is replaced. Because Pub resolves an `example/` package by
+default, DartPad applies the same isolation recursively to nested example
+packages that declare workspace resolution.
 
 Examples:
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -100,7 +100,7 @@ class ArchiveLoader {
     final mainPath = pathToMain != null ? ProjectLoader.normalizePath(pathToMain!) : entryPath;
     final projectDir = entryPath == null ? '' : ProjectLoader.findProjectDirectory(project, entryPath) ?? '';
 
-    _disableWorkspaceResolution(project, projectDir);
+    _disableWorkspaceResolution(project);
     await ProjectLoader.writeFiles(root, project);
 
     return LoadedProject(
@@ -111,27 +111,20 @@ class ArchiveLoader {
     );
   }
 
-  /// Isolates the active package from a workspace that is not part of the
-  /// loaded archive.
+  /// Isolates packages in the loaded archive from a workspace that is not part
+  /// of the archive.
   ///
   /// This mirrors `dart pub unpack`: the original pubspec remains unchanged,
   /// while `resolution: workspace` is disabled through a package-local
-  /// `pubspec_overrides.yaml` file. Pub runs dependency resolution for an
-  /// `example/` package by default. Therefore, workspace resolution must also
-  /// be disabled for nested example packages to prevent `pub get` from failing
-  /// there.
-  void _disableWorkspaceResolution(Project project, String projectDir) {
-    final normalizedProjectDir = workspaceContext.normalize(projectDir);
-    var packageDir = normalizedProjectDir;
-    while (true) {
-      _disableWorkspaceResolutionForPackage(project, packageDir);
-
-      final exampleDir = workspaceContext.join(packageDir, 'example');
-      final examplePubspecPath = workspaceContext.join(exampleDir, 'pubspec.yaml');
-      if (!project.containsFile(examplePubspecPath)) {
-        return;
+  /// `pubspec_overrides.yaml` file.
+  void _disableWorkspaceResolution(Project project) {
+    for (final path in project.paths.toList()) {
+      if (workspaceContext.basename(path) == 'pubspec.yaml') {
+        _disableWorkspaceResolutionForPackage(
+          project,
+          workspaceContext.dirname(path),
+        );
       }
-      packageDir = exampleDir;
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -9,7 +9,6 @@ import 'package:archive/archive.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:http/http.dart' as http;
 import 'package:yaml/yaml.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 import 'project_loader.dart';
 
@@ -153,38 +152,14 @@ class ArchiveLoader {
       return;
     }
 
-    // No override is needed unless the package uses workspace resolution.
     if (!_usesWorkspaceResolution(pubspecContents)) {
       return;
     }
 
     final overridesPath = workspaceContext.join(projectDir, 'pubspec_overrides.yaml');
-    final overridesBytes = project.readFile(overridesPath);
-    // Create a package-local override when the archive does not provide one.
-    if (overridesBytes == null) {
-      project.writeFile(
-        overridesPath,
-        Uint8List.fromList(utf8.encode(jsonEncode({'resolution': null}))),
-      );
-      return;
-    }
-
-    // Preserve an existing override and only disable workspace resolution.
-    final String overridesContents;
-    try {
-      overridesContents = utf8.decode(overridesBytes);
-    } on FormatException {
-      return;
-    }
-
-    final updatedOverrides = _setResolutionToNull(overridesContents);
-    if (updatedOverrides == null) {
-      return;
-    }
-
     project.writeFile(
       overridesPath,
-      Uint8List.fromList(utf8.encode(updatedOverrides)),
+      Uint8List.fromList(utf8.encode(jsonEncode({'resolution': null}))),
     );
   }
 
@@ -194,23 +169,6 @@ class ArchiveLoader {
       return rootValue is Map && rootValue['resolution'] == 'workspace';
     } on YamlException {
       return false;
-    }
-  }
-
-  String? _setResolutionToNull(String overridesContents) {
-    try {
-      final editor = YamlEditor(overridesContents);
-      final rootValue = editor.parseAt(const []).value;
-      if (rootValue == null) {
-        editor.update(const [], {'resolution': null});
-      } else if (rootValue is Map) {
-        editor.update(const ['resolution'], null);
-      } else {
-        return null;
-      }
-      return editor.toString();
-    } on FormatException {
-      return null;
     }
   }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:http/http.dart' as http;
+import 'package:yaml_edit/yaml_edit.dart';
 
 import 'project_loader.dart';
 
@@ -101,6 +102,7 @@ class ArchiveLoader {
     final mainPath = pathToMain != null ? ProjectLoader.normalizePath(pathToMain!) : entryPath;
     final projectDir = entryPath == null ? '' : ProjectLoader.findProjectDirectory(files, entryPath) ?? '';
 
+    _disableWorkspaceResolution(files, projectDir);
     await ProjectLoader.writeFiles(root, files);
 
     return LoadedProject(
@@ -109,6 +111,118 @@ class ArchiveLoader {
       packageRoot: projectDir,
       pathToMain: mainPath,
     );
+  }
+
+  /// Isolates the active package from a workspace that is not part of the
+  /// loaded archive.
+  ///
+  /// This mirrors `dart pub unpack`: the original pubspec remains unchanged,
+  /// while `resolution: workspace` is disabled through a package-local
+  /// `pubspec_overrides.yaml` file. Pub runs dependency resolution for an
+  /// `example/` package by default. Therefore, workspace resolution must also
+  /// be disabled for nested example packages to prevent `pub get` from failing
+  /// there.
+  void _disableWorkspaceResolution(List<ProjectFile> files, String projectDir) {
+    var packageDir = projectDir;
+    while (true) {
+      _disableWorkspaceResolutionForPackage(files, packageDir);
+
+      final exampleDir = _packageFilePath(packageDir, 'example');
+      final examplePubspecPath = _packageFilePath(exampleDir, 'pubspec.yaml');
+      if (_findFile(files, examplePubspecPath) == -1) {
+        return;
+      }
+      packageDir = exampleDir;
+    }
+  }
+
+  void _disableWorkspaceResolutionForPackage(
+    List<ProjectFile> files,
+    String projectDir,
+  ) {
+    final pubspecPath = _packageFilePath(projectDir, 'pubspec.yaml');
+    final pubspecIndex = _findFile(files, pubspecPath);
+    if (pubspecIndex == -1) {
+      return;
+    }
+
+    final String pubspecContents;
+    try {
+      pubspecContents = utf8.decode(files[pubspecIndex].bytes);
+    } on FormatException {
+      return;
+    }
+
+    if (!_usesWorkspaceResolution(pubspecContents)) {
+      return;
+    }
+
+    final overridesPath = _packageFilePath(projectDir, 'pubspec_overrides.yaml');
+    final overridesIndex = _findFile(files, overridesPath);
+    if (overridesIndex == -1) {
+      files.add(
+        ProjectFile(
+          path: overridesPath,
+          bytes: Uint8List.fromList(utf8.encode('resolution:\n')),
+        ),
+      );
+      return;
+    }
+
+    final ProjectFile overridesFile = files[overridesIndex];
+    final String overridesContents;
+    try {
+      overridesContents = utf8.decode(overridesFile.bytes);
+    } on FormatException {
+      return;
+    }
+
+    final updatedOverrides = _setResolutionToNull(overridesContents);
+    if (updatedOverrides == null) {
+      return;
+    }
+
+    files[overridesIndex] = ProjectFile(
+      path: overridesFile.path,
+      bytes: Uint8List.fromList(utf8.encode(updatedOverrides)),
+    );
+  }
+
+  bool _usesWorkspaceResolution(String pubspecContents) {
+    try {
+      final editor = YamlEditor(pubspecContents);
+      final rootValue = editor.parseAt(const []).value;
+      return rootValue is Map && rootValue['resolution'] == 'workspace';
+    } on FormatException {
+      return false;
+    }
+  }
+
+  String? _setResolutionToNull(String overridesContents) {
+    try {
+      final editor = YamlEditor(overridesContents);
+      final rootValue = editor.parseAt(const []).value;
+      if (rootValue == null) {
+        editor.update(const [], {'resolution': null});
+      } else if (rootValue is Map) {
+        editor.update(const ['resolution'], null);
+      } else {
+        return null;
+      }
+      return editor.toString();
+    } on FormatException {
+      return null;
+    }
+  }
+
+  int _findFile(List<ProjectFile> files, String path) {
+    return files.indexWhere(
+      (file) => ProjectLoader.normalizePath(file.path) == path,
+    );
+  }
+
+  String _packageFilePath(String projectDir, String filename) {
+    return projectDir.isEmpty ? filename : '$projectDir/$filename';
   }
 
   String _relativePath(String path) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -8,6 +8,7 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:http/http.dart' as http;
+import 'package:yaml/yaml.dart';
 import 'package:yaml_edit/yaml_edit.dart';
 
 import 'project_loader.dart';
@@ -87,23 +88,21 @@ class ArchiveLoader {
     final Archive archive = TarDecoder().decodeBytes(tarBytes);
 
     final targetFilePath = filePath ?? findDefaultFile(archive);
-    final files = <ProjectFile>[];
-    for (final ArchiveFile file in archive.files) {
-      if (!file.isFile) {
-        continue;
-      }
-
-      files.add(
-        ProjectFile(path: _relativePath(file.name), bytes: file.content),
-      );
-    }
+    final project = Project([
+      for (final ArchiveFile file in archive.files)
+        if (file.isFile)
+          ProjectFile(
+            path: _relativePath(file.name),
+            bytes: file.content,
+          ),
+    ]);
 
     final entryPath = targetFilePath == null ? null : ProjectLoader.normalizePath(targetFilePath);
     final mainPath = pathToMain != null ? ProjectLoader.normalizePath(pathToMain!) : entryPath;
-    final projectDir = entryPath == null ? '' : ProjectLoader.findProjectDirectory(files, entryPath) ?? '';
+    final projectDir = entryPath == null ? '' : ProjectLoader.findProjectDirectory(project, entryPath) ?? '';
 
-    _disableWorkspaceResolution(files, projectDir);
-    await ProjectLoader.writeFiles(root, files);
+    _disableWorkspaceResolution(project, projectDir);
+    await ProjectLoader.writeFiles(root, project);
 
     return LoadedProject(
       projectDir: projectDir,
@@ -122,14 +121,15 @@ class ArchiveLoader {
   /// `example/` package by default. Therefore, workspace resolution must also
   /// be disabled for nested example packages to prevent `pub get` from failing
   /// there.
-  void _disableWorkspaceResolution(List<ProjectFile> files, String projectDir) {
-    var packageDir = projectDir;
+  void _disableWorkspaceResolution(Project project, String projectDir) {
+    final normalizedProjectDir = workspaceContext.normalize(projectDir);
+    var packageDir = normalizedProjectDir;
     while (true) {
-      _disableWorkspaceResolutionForPackage(files, packageDir);
+      _disableWorkspaceResolutionForPackage(project, packageDir);
 
-      final exampleDir = _packageFilePath(packageDir, 'example');
-      final examplePubspecPath = _packageFilePath(exampleDir, 'pubspec.yaml');
-      if (_findFile(files, examplePubspecPath) == -1) {
+      final exampleDir = workspaceContext.join(packageDir, 'example');
+      final examplePubspecPath = workspaceContext.join(exampleDir, 'pubspec.yaml');
+      if (!project.containsFile(examplePubspecPath)) {
         return;
       }
       packageDir = exampleDir;
@@ -137,42 +137,42 @@ class ArchiveLoader {
   }
 
   void _disableWorkspaceResolutionForPackage(
-    List<ProjectFile> files,
+    Project project,
     String projectDir,
   ) {
-    final pubspecPath = _packageFilePath(projectDir, 'pubspec.yaml');
-    final pubspecIndex = _findFile(files, pubspecPath);
-    if (pubspecIndex == -1) {
+    final pubspecPath = workspaceContext.join(projectDir, 'pubspec.yaml');
+    final pubspecBytes = project.readFile(pubspecPath);
+    if (pubspecBytes == null) {
       return;
     }
 
     final String pubspecContents;
     try {
-      pubspecContents = utf8.decode(files[pubspecIndex].bytes);
+      pubspecContents = utf8.decode(pubspecBytes);
     } on FormatException {
       return;
     }
 
+    // No override is needed unless the package uses workspace resolution.
     if (!_usesWorkspaceResolution(pubspecContents)) {
       return;
     }
 
-    final overridesPath = _packageFilePath(projectDir, 'pubspec_overrides.yaml');
-    final overridesIndex = _findFile(files, overridesPath);
-    if (overridesIndex == -1) {
-      files.add(
-        ProjectFile(
-          path: overridesPath,
-          bytes: Uint8List.fromList(utf8.encode('resolution:\n')),
-        ),
+    final overridesPath = workspaceContext.join(projectDir, 'pubspec_overrides.yaml');
+    final overridesBytes = project.readFile(overridesPath);
+    // Create a package-local override when the archive does not provide one.
+    if (overridesBytes == null) {
+      project.writeFile(
+        overridesPath,
+        Uint8List.fromList(utf8.encode(jsonEncode({'resolution': null}))),
       );
       return;
     }
 
-    final ProjectFile overridesFile = files[overridesIndex];
+    // Preserve an existing override and only disable workspace resolution.
     final String overridesContents;
     try {
-      overridesContents = utf8.decode(overridesFile.bytes);
+      overridesContents = utf8.decode(overridesBytes);
     } on FormatException {
       return;
     }
@@ -182,18 +182,17 @@ class ArchiveLoader {
       return;
     }
 
-    files[overridesIndex] = ProjectFile(
-      path: overridesFile.path,
-      bytes: Uint8List.fromList(utf8.encode(updatedOverrides)),
+    project.writeFile(
+      overridesPath,
+      Uint8List.fromList(utf8.encode(updatedOverrides)),
     );
   }
 
   bool _usesWorkspaceResolution(String pubspecContents) {
     try {
-      final editor = YamlEditor(pubspecContents);
-      final rootValue = editor.parseAt(const []).value;
+      final rootValue = loadYaml(pubspecContents);
       return rootValue is Map && rootValue['resolution'] == 'workspace';
-    } on FormatException {
+    } on YamlException {
       return false;
     }
   }
@@ -213,16 +212,6 @@ class ArchiveLoader {
     } on FormatException {
       return null;
     }
-  }
-
-  int _findFile(List<ProjectFile> files, String path) {
-    return files.indexWhere(
-      (file) => ProjectLoader.normalizePath(file.path) == path,
-    );
-  }
-
-  String _packageFilePath(String projectDir, String filename) {
-    return projectDir.isEmpty ? filename : '$projectDir/$filename';
   }
 
   String _relativePath(String path) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
@@ -50,20 +50,11 @@ class GistLoader {
     final fetchedFiles = await Future.wait(
       filesJson.values.map(_loadFile).toList(),
     );
-    final files = _moveRootDartFilesIntoLib(
-      fetchedFiles
-          .map(
-            (file) => ProjectFile(
-              path: ProjectLoader.normalizePath(file.path),
-              bytes: file.bytes,
-            ),
-          )
-          .toList(),
-    );
-    final entryPath = _findEntryPath(files);
-    final packageRoot = entryPath == null ? null : ProjectLoader.findProjectDirectory(files, entryPath);
+    final project = Project(_moveRootDartFilesIntoLib(fetchedFiles));
+    final entryPath = _findEntryPath(project);
+    final packageRoot = entryPath == null ? null : ProjectLoader.findProjectDirectory(project, entryPath);
 
-    await ProjectLoader.writeFiles(root, files);
+    await ProjectLoader.writeFiles(root, project);
     return LoadedProject(
       projectDir: packageRoot ?? '',
       entryPath: entryPath,
@@ -121,8 +112,8 @@ class GistLoader {
     ];
   }
 
-  String? _findEntryPath(List<ProjectFile> files) {
-    final paths = files.map((file) => file.path).toSet();
+  String? _findEntryPath(Project project) {
+    final paths = project.paths.toSet();
     for (final path in const ['lib/main.dart', 'main.dart']) {
       if (paths.contains(path)) {
         return path;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
@@ -17,6 +17,44 @@ final class ProjectFile {
   final Uint8List bytes;
 }
 
+/// An in-memory collection of files that can be imported into a workspace.
+final class Project {
+  Project(Iterable<ProjectFile> files) {
+    for (final file in files) {
+      final path = ProjectLoader.normalizePath(file.path);
+      if (_files.containsKey(path)) {
+        throw ArgumentError('Multiple files resolve to the same path: $path');
+      }
+      _files[path] = file.bytes;
+    }
+  }
+
+  final Map<String, Uint8List> _files = {};
+
+  /// The normalized workspace-relative paths in this project.
+  Iterable<String> get paths => _files.keys;
+
+  /// The files in this project.
+  Iterable<ProjectFile> get files => _files.entries.map(
+    (entry) => ProjectFile(path: entry.key, bytes: entry.value),
+  );
+
+  /// Whether the project contains a file at [path].
+  bool containsFile(String path) {
+    return _files.containsKey(ProjectLoader.normalizePath(path));
+  }
+
+  /// Returns the bytes at [path], or `null` when the file does not exist.
+  Uint8List? readFile(String path) {
+    return _files[ProjectLoader.normalizePath(path)];
+  }
+
+  /// Adds or replaces the file at [path].
+  void writeFile(String path, Uint8List bytes) {
+    _files[ProjectLoader.normalizePath(path)] = bytes;
+  }
+}
+
 /// The workspace state produced by a project loader.
 ///
 final class LoadedProject {
@@ -65,16 +103,15 @@ final class ProjectLoader {
   ///
   /// Returns null when no project root can be inferred.
   static String? findProjectDirectory(
-    Iterable<ProjectFile> files,
+    Project project,
     String entryPath,
   ) {
-    final filePaths = files.map((file) => normalizePath(file.path)).toSet();
     final segments = normalizePath(entryPath).split('/');
 
     for (var i = segments.length - 1; i >= 0; i--) {
       final parentDirectory = segments.sublist(0, i).join('/');
-      final pubspecPath = parentDirectory.isEmpty ? 'pubspec.yaml' : '$parentDirectory/pubspec.yaml';
-      if (filePaths.contains(pubspecPath)) {
+      final pubspecPath = workspaceContext.join(parentDirectory, 'pubspec.yaml');
+      if (project.containsFile(pubspecPath)) {
         return parentDirectory;
       }
     }
@@ -82,24 +119,13 @@ final class ProjectLoader {
     return null;
   }
 
-  /// Creates all folders and writes [files] into [root].
+  /// Creates all folders and writes [project] into [root].
   static Future<void> writeFiles(
     WorkspaceFolder root,
-    Iterable<ProjectFile> files,
+    Project project,
   ) async {
-    final normalizedFiles = <ProjectFile>[];
-    final paths = <String>{};
-
-    for (final file in files) {
-      final path = normalizePath(file.path);
-      if (!paths.add(path)) {
-        throw ArgumentError('Multiple files resolve to the same path: $path');
-      }
-      normalizedFiles.add(ProjectFile(path: path, bytes: file.bytes));
-    }
-
     final folders = <String>{};
-    for (final file in normalizedFiles) {
+    for (final file in project.files) {
       var directory = workspaceContext.dirname(file.path);
       while (directory.isNotEmpty) {
         folders.add(directory);
@@ -112,7 +138,7 @@ final class ProjectLoader {
       await root.getFolder(folder).create();
     }
 
-    for (final file in normalizedFiles) {
+    for (final file in project.files) {
       await root.workspace.writeFileFromBytes(
         root.getFile(file.path).path,
         file.bytes,

--- a/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
+++ b/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.1
   web: ^1.1.1
+  yaml_edit: ^2.2.4
 
 dev_dependencies:
   build_runner: ^2.10.0

--- a/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
+++ b/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.1
   web: ^1.1.1
+  yaml: ^3.1.3
   yaml_edit: ^2.2.4
 
 dev_dependencies:

--- a/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
+++ b/pkgs/dartpad_preview/dartpad_frontend/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   path: ^1.9.1
   web: ^1.1.1
   yaml: ^3.1.3
-  yaml_edit: ^2.2.4
 
 dev_dependencies:
   build_runner: ^2.10.0

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -209,7 +209,7 @@ void main() {
       );
     });
 
-    test('disables workspace resolution only for the active nested package', () async {
+    test('disables workspace resolution across all packages in the archive', () async {
       const rootPubspec = 'name: root_package\nresolution: workspace\n';
       const examplePubspec = 'name: example_package\nresolution: workspace\n';
       final archiveBytes = createTarArchive({
@@ -233,7 +233,10 @@ void main() {
       expect(result.packageRoot, 'example');
       expect(await api.readFileAsText('pubspec.yaml'), rootPubspec);
       expect(await api.readFileAsText('example/pubspec.yaml'), examplePubspec);
-      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+      expect(
+        await api.readFileAsText('pubspec_overrides.yaml'),
+        '{"resolution":null}',
+      );
       expect(
         await api.readFileAsText('example/pubspec_overrides.yaml'),
         '{"resolution":null}',
@@ -320,12 +323,12 @@ resolution: workspace
       );
     });
 
-    test('preserves overrides outside the active package', () async {
+    test('preserves overrides for packages not using workspace resolution', () async {
       const rootOverrides = 'dependency_overrides:\n  collection: any\n';
       final archiveBytes = createTarArchive({
-        'pubspec.yaml': 'name: root\nresolution: workspace\n',
+        'pubspec.yaml': 'name: root\n',
         'pubspec_overrides.yaml': rootOverrides,
-        'example/pubspec.yaml': 'name: example\n',
+        'example/pubspec.yaml': 'name: example\nresolution: workspace\n',
         'example/pubspec_overrides.yaml': 'workspace: []\n',
         'example/lib/main.dart': 'void main() {}',
       });
@@ -345,7 +348,41 @@ resolution: workspace
       expect(await api.readFileAsText('pubspec_overrides.yaml'), rootOverrides);
       expect(
         await api.readFileAsText('example/pubspec_overrides.yaml'),
-        'workspace: []\n',
+        '{"resolution":null}',
+      );
+    });
+
+    test('disables workspace resolution across arbitrary nested package directories', () async {
+      final archiveBytes = createTarArchive({
+        'packages/pkg_a/pubspec.yaml': 'name: pkg_a\nresolution: workspace\n',
+        'packages/pkg_b/pubspec.yaml': 'name: pkg_b\n',
+        'packages/nested/pkg_c/pubspec.yaml': 'name: pkg_c\nresolution: workspace\n',
+        'README.md': '# Multi-package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(
+        await api.readFileAsText('packages/pkg_a/pubspec_overrides.yaml'),
+        '{"resolution":null}',
+      );
+      expect(
+        await api.fileExist('packages/pkg_b/pubspec_overrides.yaml'),
+        isFalse,
+      );
+      expect(
+        await api.readFileAsText('packages/nested/pkg_c/pubspec_overrides.yaml'),
+        '{"resolution":null}',
       );
     });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -19,14 +19,19 @@ void main() {
   group('ArchiveLoader', () {
     const String absoluteUrl = 'https://example.com/archive.tar.gz';
 
-    Uint8List createTarArchive(Map<String, String> files) {
+    Uint8List createTarArchiveFromBytes(Map<String, List<int>> files) {
       final Archive archive = Archive();
-      for (final MapEntry<String, String> entry in files.entries) {
-        final List<int> contentBytes = entry.value.codeUnits;
-        archive.addFile(ArchiveFile(entry.key, contentBytes.length, contentBytes));
+      for (final entry in files.entries) {
+        archive.addFile(ArchiveFile(entry.key, entry.value.length, entry.value));
       }
       final List<int> encoded = TarEncoder().encode(archive);
       return Uint8List.fromList(encoded);
+    }
+
+    Uint8List createTarArchive(Map<String, String> files) {
+      return createTarArchiveFromBytes(
+        files.map((path, contents) => MapEntry(path, contents.codeUnits)),
+      );
     }
 
     Uint8List createTarGzArchive(Map<String, String> files) {
@@ -166,7 +171,7 @@ void main() {
       expect(await api.readFileAsText('pubspec.yaml'), pubspec);
       expect(
         await api.readFileAsText('pubspec_overrides.yaml'),
-        'resolution:\n',
+        '{"resolution":null}',
       );
     });
 
@@ -197,11 +202,11 @@ void main() {
       expect(await api.readFileAsText('example/pubspec.yaml'), examplePubspec);
       expect(
         await api.readFileAsText('pubspec_overrides.yaml'),
-        'resolution:\n',
+        '{"resolution":null}',
       );
       expect(
         await api.readFileAsText('example/pubspec_overrides.yaml'),
-        'resolution:\n',
+        '{"resolution":null}',
       );
     });
 
@@ -232,7 +237,7 @@ void main() {
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
       expect(
         await api.readFileAsText('example/pubspec_overrides.yaml'),
-        'resolution:\n',
+        '{"resolution":null}',
       );
     });
 
@@ -320,6 +325,35 @@ resolution: workspace
       expect(await api.readFileAsText('pubspec_overrides.yaml'), overrides);
     });
 
+    test('preserves overrides outside the active package', () async {
+      const rootOverrides = 'dependency_overrides:\n  collection: any\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': 'name: root\nresolution: workspace\n',
+        'pubspec_overrides.yaml': rootOverrides,
+        'example/pubspec.yaml': 'name: example\n',
+        'example/pubspec_overrides.yaml': 'workspace: []\n',
+        'example/lib/main.dart': 'void main() {}',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'example/lib/main.dart',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(await api.readFileAsText('pubspec_overrides.yaml'), rootOverrides);
+      expect(
+        await api.readFileAsText('example/pubspec_overrides.yaml'),
+        'workspace: []\n',
+      );
+    });
+
     test('preserves a malformed pubspec without creating overrides', () async {
       const pubspec = 'name: package\nresolution: [workspace\n';
       final archiveBytes = createTarArchive({
@@ -340,6 +374,27 @@ resolution: workspace
       );
 
       expect(await api.readFileAsText('pubspec.yaml'), pubspec);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+    });
+
+    test('preserves a non-UTF-8 pubspec without creating overrides', () async {
+      final archiveBytes = createTarArchiveFromBytes({
+        'pubspec.yaml': [0xFF],
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'pubspec.yaml',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(await api.readFileAsBytes('pubspec.yaml'), [0xFF]);
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
     });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -13,7 +13,6 @@ import 'package:dartpad_frontend/features/startup/archive_loader.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
   group('ArchiveLoader', () {
@@ -241,7 +240,7 @@ void main() {
       );
     });
 
-    test('merges workspace resolution into an existing overrides file', () async {
+    test('replaces an existing overrides file for the active package', () async {
       const overrides = '''
 # Preserve this comment.
 dependency_overrides:
@@ -269,17 +268,10 @@ resolution: workspace
       );
 
       final updated = await api.readFileAsText('pubspec_overrides.yaml');
-      final editor = YamlEditor(updated);
-      expect(updated, contains('# Preserve this comment.'));
-      expect(
-        editor.parseAt(const ['dependency_overrides', 'collection']).value,
-        '^1.19.0',
-      );
-      expect(editor.parseAt(const ['workspace', 0]).value, 'packages/*');
-      expect(editor.parseAt(const ['resolution']).value, isNull);
+      expect(updated, '{"resolution":null}');
     });
 
-    test('adds workspace resolution to an empty overrides file', () async {
+    test('replaces an empty overrides file', () async {
       final archiveBytes = createTarArchive({
         'pubspec.yaml': 'name: package\nresolution: workspace\n',
         'pubspec_overrides.yaml': '',
@@ -299,10 +291,10 @@ resolution: workspace
       );
 
       final updated = await api.readFileAsText('pubspec_overrides.yaml');
-      expect(YamlEditor(updated).parseAt(const ['resolution']).value, isNull);
+      expect(updated, '{"resolution":null}');
     });
 
-    test('preserves an invalid overrides file', () async {
+    test('replaces an invalid overrides file', () async {
       const overrides = '- not a map\n';
       final archiveBytes = createTarArchive({
         'pubspec.yaml': 'name: package\nresolution: workspace\n',
@@ -322,7 +314,10 @@ resolution: workspace
         }),
       );
 
-      expect(await api.readFileAsText('pubspec_overrides.yaml'), overrides);
+      expect(
+        await api.readFileAsText('pubspec_overrides.yaml'),
+        '{"resolution":null}',
+      );
     });
 
     test('preserves overrides outside the active package', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/archive_loader_test.dart
@@ -13,6 +13,7 @@ import 'package:dartpad_frontend/features/startup/archive_loader.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:test/test.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 void main() {
   group('ArchiveLoader', () {
@@ -106,6 +107,7 @@ void main() {
       expect(await api.fileExist('my_project/lib/src/helper.dart'), isTrue);
       expect(await api.fileExist('my_project/assets/image.png'), isTrue);
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+      expect(await api.fileExist('my_project/pubspec_overrides.yaml'), isFalse);
 
       // Verify content
       expect(await api.readFileAsText('my_project/pubspec.yaml'), 'name: my_project\n');
@@ -137,6 +139,207 @@ void main() {
 
       expect(await api.fileExist('project/pubspec.yaml'), isTrue);
       expect(await api.fileExist('project/lib/main.dart'), isTrue);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+      expect(await api.fileExist('project/pubspec_overrides.yaml'), isFalse);
+    });
+
+    test('disables workspace resolution for the active root package', () async {
+      const pubspec = 'name: root_package\nresolution: workspace\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': pubspec,
+        'README.md': '# Root package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.packageRoot, '');
+      expect(await api.readFileAsText('pubspec.yaml'), pubspec);
+      expect(
+        await api.readFileAsText('pubspec_overrides.yaml'),
+        'resolution:\n',
+      );
+    });
+
+    test('also isolates an example package resolved by Pub', () async {
+      const rootPubspec = 'name: root_package\nresolution: workspace\n';
+      const examplePubspec = 'name: example_package\nresolution: workspace\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': rootPubspec,
+        'README.md': '# Root package\n',
+        'example/pubspec.yaml': examplePubspec,
+        'example/lib/main.dart': 'void main() {}',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.packageRoot, '');
+      expect(await api.readFileAsText('pubspec.yaml'), rootPubspec);
+      expect(await api.readFileAsText('example/pubspec.yaml'), examplePubspec);
+      expect(
+        await api.readFileAsText('pubspec_overrides.yaml'),
+        'resolution:\n',
+      );
+      expect(
+        await api.readFileAsText('example/pubspec_overrides.yaml'),
+        'resolution:\n',
+      );
+    });
+
+    test('disables workspace resolution only for the active nested package', () async {
+      const rootPubspec = 'name: root_package\nresolution: workspace\n';
+      const examplePubspec = 'name: example_package\nresolution: workspace\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': rootPubspec,
+        'example/pubspec.yaml': examplePubspec,
+        'example/lib/main.dart': 'void main() {}',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'example/lib/main.dart',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      final result = await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(result.packageRoot, 'example');
+      expect(await api.readFileAsText('pubspec.yaml'), rootPubspec);
+      expect(await api.readFileAsText('example/pubspec.yaml'), examplePubspec);
+      expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
+      expect(
+        await api.readFileAsText('example/pubspec_overrides.yaml'),
+        'resolution:\n',
+      );
+    });
+
+    test('merges workspace resolution into an existing overrides file', () async {
+      const overrides = '''
+# Preserve this comment.
+dependency_overrides:
+  collection: ^1.19.0
+workspace:
+  - packages/*
+resolution: workspace
+''';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': 'name: package\nresolution: workspace\n',
+        'pubspec_overrides.yaml': overrides,
+        'README.md': '# Package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      final updated = await api.readFileAsText('pubspec_overrides.yaml');
+      final editor = YamlEditor(updated);
+      expect(updated, contains('# Preserve this comment.'));
+      expect(
+        editor.parseAt(const ['dependency_overrides', 'collection']).value,
+        '^1.19.0',
+      );
+      expect(editor.parseAt(const ['workspace', 0]).value, 'packages/*');
+      expect(editor.parseAt(const ['resolution']).value, isNull);
+    });
+
+    test('adds workspace resolution to an empty overrides file', () async {
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': 'name: package\nresolution: workspace\n',
+        'pubspec_overrides.yaml': '',
+        'README.md': '# Package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      final updated = await api.readFileAsText('pubspec_overrides.yaml');
+      expect(YamlEditor(updated).parseAt(const ['resolution']).value, isNull);
+    });
+
+    test('preserves an invalid overrides file', () async {
+      const overrides = '- not a map\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': 'name: package\nresolution: workspace\n',
+        'pubspec_overrides.yaml': overrides,
+        'README.md': '# Package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(await api.readFileAsText('pubspec_overrides.yaml'), overrides);
+    });
+
+    test('preserves a malformed pubspec without creating overrides', () async {
+      const pubspec = 'name: package\nresolution: [workspace\n';
+      final archiveBytes = createTarArchive({
+        'pubspec.yaml': pubspec,
+        'README.md': '# Package\n',
+      });
+      const loader = ArchiveLoader(
+        archiveUrl: absoluteUrl,
+        filePath: 'README.md',
+      );
+      final api = MemoryWorkspaceResourceApi();
+
+      await http.runWithClient(
+        () => loader.loadArchive(api.root),
+        () => MockClient((http.Request request) async {
+          return http.Response.bytes(archiveBytes, 200);
+        }),
+      );
+
+      expect(await api.readFileAsText('pubspec.yaml'), pubspec);
       expect(await api.fileExist('pubspec_overrides.yaml'), isFalse);
     });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/project_loader_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/startup/project_loader_test.dart
@@ -2,10 +2,47 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:dartpad_frontend/features/startup/project_loader.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('Project', () {
+    test('normalizes paths and supports file operations', () {
+      final originalBytes = Uint8List.fromList([1, 2, 3]);
+      final project = Project([
+        ProjectFile(path: './lib/src/../main.dart', bytes: originalBytes),
+      ]);
+
+      expect(project.paths, ['lib/main.dart']);
+      expect(project.containsFile('lib/./main.dart'), isTrue);
+      expect(project.readFile('./lib/main.dart'), orderedEquals(originalBytes));
+
+      final addedBytes = Uint8List.fromList([4, 5, 6]);
+      project.writeFile('./README.md', addedBytes);
+      expect(project.readFile('README.md'), orderedEquals(addedBytes));
+
+      final replacementBytes = Uint8List.fromList([7, 8, 9]);
+      project.writeFile('lib/main.dart', replacementBytes);
+      expect(project.readFile('lib/main.dart'), orderedEquals(replacementBytes));
+      expect(
+        project.files.map((file) => file.path),
+        ['lib/main.dart', 'README.md'],
+      );
+    });
+
+    test('rejects files whose normalized paths collide', () {
+      expect(
+        () => Project([
+          ProjectFile(path: 'lib/main.dart', bytes: Uint8List(0)),
+          ProjectFile(path: './lib/main.dart', bytes: Uint8List(0)),
+        ]),
+        throwsArgumentError,
+      );
+    });
+  });
+
   group('resolveEditorRootUri', () {
     final rootWorkspaceUri = Uri.parse('file:///workspace/pad_1/');
 


### PR DESCRIPTION
Archive and pub.dev packages can contain `resolution: workspace` even though the original workspace root is not included in the published archive. This causes `pub get` to fail because Pub cannot find a workspace containing the extracted package.

This change detects `resolution: workspace` in the active package and generates a package-local `pubspec_overrides.yaml` with a null `resolution` value. The original `pubspec.yaml` remains unchanged.

Because Pub also resolves an `example/` package by default, the same override is generated recursively for nested example packages when necessary. Existing valid override files are merged while preserving their fields and comments; invalid override files are left unchanged so Pub can report the original error.

Fixes #3710 