### PR TITLE
feat(dartpad-preview): add Cmd/Ctrl+Enter shortcut for Run and Hot Re…

### DIFF
--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -36,6 +36,7 @@ final class CodeMirrorEditor {
   /// Optional callbacks can be provided:
   /// - [onUpdate] is triggered when the document text changes.
   /// - [onSave] is triggered on Cmd/Ctrl+S keypress.
+  /// - [onRun] is triggered on Cmd/Ctrl+Enter keypress.
   /// - [onCodeActionRequested] is triggered on Cmd/Ctrl+. keypress.
   /// - [onQuickFixRequested] is triggered from a diagnostic hover action.
   /// - [onQuickFixAvailabilityRequested] controls whether that action is shown.
@@ -45,6 +46,7 @@ final class CodeMirrorEditor {
     String? initialDoc,
     void Function(String text)? onUpdate,
     void Function()? onSave,
+    void Function()? onRun,
     void Function()? onCodeActionRequested,
     void Function(int from, int to)? onQuickFixRequested,
     Future<bool> Function(int from, int to)? onQuickFixAvailabilityRequested,
@@ -63,6 +65,30 @@ final class CodeMirrorEditor {
               cm.KeyBinding(key: 'Mod-Shift-M'.toJS, run: ((cm.EditorView view) => true.toJS).toJS),
             ].toJS,
           ),
+          if (onSave != null)
+            cm.keymapOf(
+              [
+                cm.KeyBinding(
+                  key: 'Mod-s'.toJS,
+                  run: ((cm.EditorView view) {
+                    onSave();
+                    return true.toJS;
+                  }).toJS,
+                ),
+              ].toJS,
+            ),
+          if (onRun != null)
+            cm.keymapOf(
+              [
+                cm.KeyBinding(
+                  key: 'Mod-Enter'.toJS,
+                  run: ((cm.EditorView view) {
+                    onRun();
+                    return true.toJS;
+                  }).toJS,
+                ),
+              ].toJS,
+            ),
           cm.keymapOf(cm.extraKeymap),
           cm.basicSetup,
           cm.indentUnitOf('  '.toJS),
@@ -82,18 +108,6 @@ final class CodeMirrorEditor {
               }
             }).toJS,
           ),
-          if (onSave != null)
-            cm.keymapOf(
-              [
-                cm.KeyBinding(
-                  key: 'Mod-s'.toJS,
-                  run: ((cm.EditorView view) {
-                    onSave();
-                    return true.toJS;
-                  }).toJS,
-                ),
-              ].toJS,
-            ),
           langCompartment.of(_languageExtension(file, languageServerClient)),
           if (onCodeActionRequested != null)
             cm.keymapOf(

--- a/pkgs/dartpad_preview/dartpad_editor/test/editor/codemirror_editor_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/editor/codemirror_editor_test.dart
@@ -1,0 +1,87 @@
+﻿// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:codemirror_dart/codemirror_dart.dart' as cm;
+import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  setUpAll(() async {
+    final script = web.document.createElement('script') as web.HTMLScriptElement;
+    final loaded = web.EventStreamProviders.loadEvent.forTarget(script).first;
+    script.src = 'packages/codemirror_dart/assets/codemirror-dart.bundle.js';
+    web.document.head!.appendChild(script);
+    await loaded;
+  });
+
+  test('registers Mod-Enter in keymap', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.appendChild(parent);
+
+    final editor = CodeMirrorEditor(
+      parent,
+      file: 'lib/main.dart',
+      initialDoc: 'void main() {}',
+      onRun: () {},
+    );
+
+    addTearDown(() {
+      editor.destroy();
+      parent.remove();
+    });
+
+    final registeredKeys = cm.getRegisteredKeys(editor.view.state).toDart.map((k) => k.toDart).toSet();
+    expect(registeredKeys.contains('Mod-Enter'), isTrue);
+  });
+
+  test('triggers onRun callback on Mod-Enter key event', () async {
+    final parent = web.HTMLDivElement();
+    web.document.body!.appendChild(parent);
+
+    var runTriggered = false;
+    final editor = CodeMirrorEditor(
+      parent,
+      file: 'lib/main.dart',
+      initialDoc: 'void main() {}',
+      onRun: () {
+        runTriggered = true;
+      },
+    );
+
+    addTearDown(() {
+      editor.destroy();
+      parent.remove();
+    });
+
+    final isMac =
+        web.window.navigator.platform.toLowerCase().contains('mac') ||
+        web.window.navigator.userAgent.toLowerCase().contains('mac');
+
+    final event = web.KeyboardEvent(
+      'keydown',
+      web.KeyboardEventInit(
+        key: 'Enter',
+        code: 'Enter',
+        ctrlKey: !isMac,
+        metaKey: isMac,
+        bubbles: true,
+        cancelable: true,
+      ),
+    );
+    (event as JSObject).setProperty('keyCode'.toJS, 13.toJS);
+    (event as JSObject).setProperty('which'.toJS, 13.toJS);
+
+    editor.view.contentDOM.dispatchEvent(event);
+    await pumpEventQueue();
+
+    expect(runTriggered, isTrue);
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -24,6 +24,7 @@ import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
 import 'features/shared/components/context_menu.dart';
 import 'features/shared/components/footer.dart';
+import 'features/shared/components/shortcut_definitions.dart';
 import 'features/shared/components/split_panel.dart';
 import 'features/shared/events/log_event.dart';
 import 'features/shared/events/open_console_event.dart';
@@ -112,6 +113,7 @@ class AppState extends State<App> {
   bool _isLargeScreen = true;
   SmallScreenTab _selectedSmallScreenTab = .code;
   StreamSubscription<web.Event>? _resizeSubscription;
+  StreamSubscription<web.KeyboardEvent>? _keySubscription;
 
   SdkInfo _currentSdk = defaultSdk;
 
@@ -122,6 +124,7 @@ class AppState extends State<App> {
     _resizeSubscription = web.EventStreamProviders.resizeEvent.forTarget(web.window).listen((_) {
       _updateScreenSize();
     });
+    _keySubscription = web.EventStreamProviders.keyDownEvent.forTarget(web.document).listen(_handleGlobalKeyDown);
 
     final events = AppEventBus();
     final taskStatus = TaskStatusController();
@@ -767,9 +770,21 @@ class AppState extends State<App> {
     session.events.dispatch(const OpenConsoleEvent());
   }
 
+  void _handleGlobalKeyDown(web.KeyboardEvent event) {
+    if (event.defaultPrevented) {
+      return;
+    }
+    final isModifier = isMac ? event.metaKey : event.ctrlKey;
+    if (isModifier && !event.altKey && !event.shiftKey && event.key == 'Enter') {
+      event.preventDefault();
+      _session.runOrHotReload();
+    }
+  }
+
   @override
   void dispose() {
     _resizeSubscription?.cancel();
+    _keySubscription?.cancel();
     _session.preview.removeListener(_onPreviewStateChanged);
     unawaited(_session.dispose(closeWorker: true));
     super.dispose();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab.dart
@@ -24,6 +24,7 @@ final class CodeMirrorTab extends EditorTab<Component> {
     required String path,
     required String content,
     required this.onSaveAll,
+    this.onRun,
     required this.workspaceResourceApi,
     this.contextMenu,
     this.events,
@@ -38,6 +39,7 @@ final class CodeMirrorTab extends EditorTab<Component> {
       initialDoc: content,
       onUpdate: _handleEditorUpdate,
       onSave: onSaveAll,
+      onRun: onRun,
       onCodeActionRequested: () {
         unawaited(codeActionsController.triggerCodeActions());
       },
@@ -68,6 +70,9 @@ final class CodeMirrorTab extends EditorTab<Component> {
 
   /// Saves all dirty tabs when CodeMirror receives its save command.
   final void Function() onSaveAll;
+
+  /// Triggers run or hot reload on Cmd/Ctrl+Enter keystroke.
+  final void Function()? onRun;
 
   final WorkspaceResourceApi workspaceResourceApi;
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab_adapter.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/codemirror/code_mirror_tab_adapter.dart
@@ -20,10 +20,12 @@ final class CodeMirrorTabAdapter extends EditorTabAdapter<Component> {
   CodeMirrorTabAdapter({
     this.contextMenu,
     this.events,
+    this.onRun,
   });
 
   final ContextMenuController? contextMenu;
   final AppEventBus? events;
+  final void Function()? onRun;
 
   TabsController<Component>? _tabs;
   LanguageServerClient? _languageServerClient;
@@ -60,6 +62,7 @@ final class CodeMirrorTabAdapter extends EditorTabAdapter<Component> {
       path: path,
       content: content,
       onSaveAll: _saveAll,
+      onRun: onRun,
       workspaceResourceApi: tabs.workspaceResourceApi,
       languageServerClient: _languageServerClient,
       contextMenu: contextMenu,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -16,6 +16,7 @@ String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'C
 
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
+  execution('Execution'),
   refactoring('Refactoring & code intelligence'),
   editing('Editing'),
   search('Search'),
@@ -73,6 +74,14 @@ class ShortcutDefinition {
   /// When `false`, the shortcut is only visible after expanding the
   /// "Show more shortcuts" section.
   final bool isPrimary;
+
+  // ── Execution ────────────────────────────────────────────────────────────
+  static const runOrHotReload = ShortcutDefinition(
+    label: 'Run / Hot reload',
+    displayKey: 'Mod + Enter',
+    codemirrorKeys: ['Mod-Enter'],
+    category: ShortcutCategory.execution,
+  );
 
   // ── Refactoring & code intelligence ──────────────────────────────────────
   static const quickFix = ShortcutDefinition(
@@ -167,14 +176,6 @@ class ShortcutDefinition {
     label: 'Copy line up / down',
     displayKey: 'Shift + Alt + ↑ / ↓',
     codemirrorKeys: ['Shift-Alt-ArrowUp', 'Shift-Alt-ArrowDown'],
-    category: ShortcutCategory.editing,
-    isPrimary: false,
-  );
-
-  static const insertBlankLine = ShortcutDefinition(
-    label: 'Insert blank line',
-    displayKey: 'Mod + Enter',
-    codemirrorKeys: ['Mod-Enter'],
     category: ShortcutCategory.editing,
     isPrimary: false,
   );
@@ -300,6 +301,9 @@ class ShortcutDefinition {
 /// Display keys use `Mod` as a platform-agnostic placeholder for the primary
 /// modifier key. Call [resolveDisplayKey] to get the platform-specific string.
 const shortcutDefinitions = <ShortcutDefinition>[
+  // ── Execution ────────────────────────────────────────────────────────────
+  ShortcutDefinition.runOrHotReload,
+
   // ── Refactoring & code intelligence ──────────────────────────────────────
   ShortcutDefinition.quickFix,
   ShortcutDefinition.renameSymbol,
@@ -316,7 +320,6 @@ const shortcutDefinitions = <ShortcutDefinition>[
   ShortcutDefinition.indent,
   ShortcutDefinition.outdent,
   ShortcutDefinition.copyLine,
-  ShortcutDefinition.insertBlankLine,
   ShortcutDefinition.jumpToMatchingBracket,
 
   // ── Search ───────────────────────────────────────────────────────────────

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
@@ -40,9 +40,11 @@ final class WorkspaceSession {
 
   factory WorkspaceSession.create(WorkspaceRepository repository) {
     final contextMenu = ContextMenuController();
+    late final WorkspaceSession session;
     final codemirrorAdapter = CodeMirrorTabAdapter(
       contextMenu: contextMenu,
       events: repository.events,
+      onRun: () => session.runOrHotReload(),
     );
     final tabs = TabsViewModel(
       workspaceResourceApi: repository.workspaceResourceApi,
@@ -58,7 +60,7 @@ final class WorkspaceSession {
       workspace: repository.workspaceResourceApi,
     );
 
-    return WorkspaceSession._(
+    session = WorkspaceSession._(
       events: repository.events,
       taskStatus: repository.taskStatus,
       analyzerStatus: AnalyzerStatusController(repository.taskStatus),
@@ -74,6 +76,7 @@ final class WorkspaceSession {
       contextMenu: contextMenu,
       codemirrorAdapter: codemirrorAdapter,
     );
+    return session;
   }
 
   final AppEventBus events;
@@ -87,6 +90,21 @@ final class WorkspaceSession {
   final PreviewViewModel preview;
   final ContextMenuController contextMenu;
   final CodeMirrorTabAdapter _codemirrorAdapter;
+
+  /// Triggers a hot reload if the preview is running, or runs the active file/entrypoint
+  /// if the preview is ready to start.
+  void runOrHotReload() {
+    if (preview.canHotReload) {
+      unawaited(preview.hotReloadCode());
+    } else if (preview.canStart) {
+      final activeFile = tabs.activeFile;
+      unawaited(
+        preview.runCode(
+          activeFile.isNotEmpty ? activeFile : (preview.state.entrypoint ?? 'lib/main.dart'),
+        ),
+      );
+    }
+  }
 
   LanguageServer? _languageServer;
   LanguageServerClient? _languageServerClient;

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
@@ -10,6 +10,7 @@ import 'dart:typed_data';
 
 import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
+import 'package:dartpad_frontend/features/preview/models/preview_state.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
@@ -98,6 +99,28 @@ void main() {
       events.dispatchAsync(_TestEvent()),
       throwsA(isA<StateError>()),
     );
+  });
+
+  test('runOrHotReload calls runCode when preview canStart', () async {
+    final events = AppEventBus();
+    final workspace = _Workspace();
+    final repository = WorkspaceRepository(
+      events: events,
+      taskStatus: TaskStatusController(),
+      workspaceResourceApi: workspace,
+      sdk: defaultSdk,
+      workspaceFuture: Completer<Workspace>().future,
+    );
+    final session = WorkspaceSession.create(repository);
+
+    expect(session.preview.canStart, isTrue);
+    expect(session.preview.canHotReload, isFalse);
+
+    // runOrHotReload starts runCode
+    session.runOrHotReload();
+    expect(session.preview.state, isA<PreviewStarting>());
+
+    await session.dispose(closeWorker: false);
   });
 }
 


### PR DESCRIPTION
Adds a Cmd+Enter (macOS) / Ctrl+Enter (Windows/Linux) keyboard shortcut to trigger Run (when stopped or idle) or Hot Reload (when running). The shortcut is active both inside the CodeMirror editor and globally across the entire app.

Fixes #3708 