### PR TITLE
Dartpad Preview: fix recompile current sources on restart #3822

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -235,9 +235,8 @@ After dependency resolution, the frontend automatically runs the resolved
 entrypoint only if its path ends in `.dart`. The Start button is independent
 of that startup choice: it runs the currently active editor file, or
 `lib/main.dart` if no file is active. It does not replace an active non-Dart
-file with `lib/main.dart`. Restart uses the entrypoint of the current run and
-reuses the last successful compilation when one is available; Hot Reload
-recompiles changes for that same running entrypoint.
+file with `lib/main.dart`. Restart recompiles the entrypoint of the current run;
+Hot Reload recompiles changes for that same running entrypoint.
 
 Whether that entrypoint is presented as a Flutter application or a console
 program is determined as described in [SDK detection](#sdk-detection).

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -37,8 +37,8 @@ class RuntimeButton extends StatelessComponent {
     );
   }
 
-  /// Factory constructor for a 'Restart' button that restarts execution of
-  /// the currently running entrypoint, skipping recompilation.
+  /// Factory constructor for a 'Restart' button that recompiles and restarts
+  /// execution of the currently running entrypoint.
   factory RuntimeButton.restart({required PreviewViewModel previewViewModel}) {
     return RuntimeButton(
       title: 'Restart',
@@ -46,7 +46,6 @@ class RuntimeButton extends StatelessComponent {
       isEnabled: previewViewModel.canRestart,
       onClick: () => previewViewModel.runCode(
         previewViewModel.state.entrypoint ?? 'lib/main.dart',
-        skipRecompilation: true,
       ),
     );
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
@@ -33,8 +33,7 @@ class PreviewRunning extends _ActivePreviewState {
   PreviewRunning(super.entrypoint);
 }
 
-/// State representing a restart of the application execution using cached
-/// compiled assets.
+/// State representing an application restart after recompiling current sources.
 class PreviewRestarting extends _ActivePreviewState {
   PreviewRestarting(super.entrypoint);
 }
@@ -66,7 +65,7 @@ class PreviewCompileError extends PreviewState {
   /// The error message describing the failure.
   final String message;
 
-  /// Whether the failed launch was a fresh start or a cached restart.
+  /// Whether the failed launch was a fresh start or a restart.
   final PreviewLaunchAction action;
 
   /// The typed task phase that failed.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -73,11 +73,15 @@ class PreviewViewModel extends ChangeNotifier {
       (_state is PreviewInitial || _state is PreviewCompileError);
 
   /// Whether the running preview can be restarted.
-  bool get canRestart =>
-      !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning && _sandbox != null;
+  bool get canRestart => _canReloadOrRestart;
 
   /// Whether the running preview can accept a hot reload.
-  bool get canHotReload => !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
+  bool get canHotReload => _canReloadOrRestart;
+
+  bool get _canReloadOrRestart =>
+      !_busy &&
+      !workspaceRepository.taskStatus.hasBlockingPreviewTask &&
+      _state is PreviewRunning;
 
   /// Whether the preview run process can be stopped.
   bool get canStop => _state is! PreviewStopping && (_busy || _sandbox != null);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -74,9 +74,7 @@ class PreviewViewModel extends ChangeNotifier {
 
   /// Whether the running preview can be restarted.
   bool get canRestart =>
-      !_busy &&
-      _state is PreviewRunning &&
-      (_lastCompiledCode != null || !workspaceRepository.taskStatus.hasBlockingPreviewTask);
+      !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning && _sandbox != null;
 
   /// Whether the running preview can accept a hot reload.
   bool get canHotReload => !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
@@ -99,26 +97,15 @@ class PreviewViewModel extends ChangeNotifier {
   // so stale work cannot revive the preview after a stop or newer run.
   int _operationId = 0;
 
-  String? _lastCompiledCode;
-
   /// Starts the preview for [entrypoint].
   ///
-  /// By default this creates a fresh compiler session, compiles the current
+  /// This creates a fresh compiler session, compiles the current
   /// sources, loads the resulting module into a new sandbox, and runs the app.
-  ///
-  /// If [skipRecompilation] is `true`, this skips recompilation and reuses the
-  /// last successfully compiled module from [_lastCompiledCode] instead. This is
-  /// used for restart semantics where we want to recreate the sandbox and reset
-  /// runtime state without recompiling unchanged code.
-  ///
-  /// If no cached artifact is available yet, the code is compiled even when
-  /// [skipRecompilation] is `true`.
-  Future<void> runCode(String entrypoint, {bool skipRecompilation = false}) async {
+  Future<void> runCode(String entrypoint) async {
     if (_busy) {
       return;
     }
-    final compileNeeded = !skipRecompilation || _lastCompiledCode == null;
-    if (compileNeeded && workspaceRepository.taskStatus.hasBlockingPreviewTask) {
+    if (workspaceRepository.taskStatus.hasBlockingPreviewTask) {
       return;
     }
 
@@ -139,9 +126,7 @@ class PreviewViewModel extends ChangeNotifier {
 
     var failedTask = launchTask;
     eventBus.dispatch(LogEvent('Run $entrypoint'));
-    if (compileNeeded) {
-      eventBus.dispatch(const LogEvent('Starting compiler...'));
-    }
+    eventBus.dispatch(const LogEvent('Starting compiler...'));
 
     if (isRestart) {
       _state = PreviewRestarting(entrypoint);
@@ -151,47 +136,40 @@ class PreviewViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final String codeToLoad;
-
-      if (compileNeeded) {
-        final previousCompiler = _hotReloadCompiler;
-        if (previousCompiler != null) {
-          eventBus.dispatch(const LogEvent('Closing previous compiler session...'));
-          _hotReloadCompiler = null;
-          await previousCompiler.close();
-          if (!_isCurrentOperation(operationId)) {
-            return;
-          }
-        }
-
-        eventBus.dispatch(const LogEvent('Creating hot reload compiler...'));
-        final compiler = await workspaceRepository.startHotReloadCompiler(
-          Uri.parse(entrypoint),
-        );
-        if (!_isCurrentOperation(operationId)) {
-          await compiler.close();
-          return;
-        }
-        _hotReloadCompiler = compiler;
-
-        eventBus.dispatch(const LogEvent('Compiling application...'));
-        failedTask = TaskKind.compilingApplication;
-        final result = await workspaceRepository.taskStatus.runTask(
-          TaskKind.compilingApplication,
-          compiler.compile,
-          blocksPreview: true,
-        );
+      final previousCompiler = _hotReloadCompiler;
+      if (previousCompiler != null) {
+        eventBus.dispatch(const LogEvent('Closing previous compiler session...'));
+        _hotReloadCompiler = null;
+        await previousCompiler.close();
         if (!_isCurrentOperation(operationId)) {
           return;
         }
-        eventBus.dispatch(LogEvent(result.log ?? ''));
-        eventBus.dispatch(const LogEvent('Compilation succeeded.'));
-        failedTask = launchTask;
-        _lastCompiledCode = result.code;
-        codeToLoad = result.code!;
-      } else {
-        codeToLoad = _lastCompiledCode!;
       }
+
+      eventBus.dispatch(const LogEvent('Creating hot reload compiler...'));
+      final compiler = await workspaceRepository.startHotReloadCompiler(
+        Uri.parse(entrypoint),
+      );
+      if (!_isCurrentOperation(operationId)) {
+        await compiler.close();
+        return;
+      }
+      _hotReloadCompiler = compiler;
+
+      eventBus.dispatch(const LogEvent('Compiling application...'));
+      failedTask = TaskKind.compilingApplication;
+      final result = await workspaceRepository.taskStatus.runTask(
+        TaskKind.compilingApplication,
+        compiler.compile,
+        blocksPreview: true,
+      );
+      if (!_isCurrentOperation(operationId)) {
+        return;
+      }
+      eventBus.dispatch(LogEvent(result.log ?? ''));
+      eventBus.dispatch(const LogEvent('Compilation succeeded.'));
+      failedTask = launchTask;
+      final codeToLoad = result.code!;
 
       final previousSandbox = _sandbox;
       if (previousSandbox != null) {
@@ -343,7 +321,6 @@ class PreviewViewModel extends ChangeNotifier {
       }
 
       eventBus.dispatch(const LogEvent('Hot reload completed successfully.'));
-      _lastCompiledCode = result.code;
       _state = PreviewRunning(entry);
       reloadSucceeded = true;
     } on HotReloadRejectedException catch (e, st) {
@@ -389,7 +366,6 @@ class PreviewViewModel extends ChangeNotifier {
     );
     eventBus.dispatch(const LogEvent('Stopping app...'));
     _state = PreviewStopping();
-    _lastCompiledCode = null;
     notifyListeners();
     var operationStillCurrent = true;
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
@@ -229,7 +229,7 @@ void main() {
       expect(viewModel.state, isA<PreviewInitial>());
       expect(repository.startHotReloadCompilerCount, 0);
 
-      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      await viewModel.runCode('lib/main.dart');
       expect(viewModel.state, isA<PreviewInitial>());
       expect(repository.startHotReloadCompilerCount, 0);
 
@@ -437,10 +437,15 @@ void main() {
       viewModel.dispose();
     });
 
-    test('runCode skipRecompilation = true reuses previous compilation', () async {
+    test('runCode from a running state recompiles the latest sources', () async {
       final fakeSandbox1 = FakePreviewSandbox();
       final fakeSandbox2 = FakePreviewSandbox();
       final fakeCompiler = FakeCompilerSession();
+      fakeCompiler.onCompile = () => (
+        code: 'compiled_code_${fakeCompiler.compileCount}',
+        compiledLibraryUris: <String>['package:app/main.dart'],
+        log: 'compiled log',
+      );
 
       repository.onStartHotReloadCompiler = (_) => fakeCompiler;
 
@@ -457,29 +462,19 @@ void main() {
       await viewModel.runCode('lib/main.dart');
       expect(fakeCompiler.compileCount, 1);
       expect(fakeSandbox1.loadModuleCount, 1);
-
-      final pubGet = repository.taskStatus.startTask(
-        TaskKind.pubGet,
-        label: 'Pub get in /',
-        scope: '/',
-        blocksPreview: true,
-      );
       expect(viewModel.canRestart, isTrue);
 
-      // A cached restart remains available during a blocking workspace task.
-      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      await viewModel.runCode('lib/main.dart');
 
-      // Compiler should NOT be called again
-      expect(fakeCompiler.compileCount, 1);
+      expect(fakeCompiler.compileCount, 2);
       expect(fakeSandbox1.disposeCount, 1);
       expect(fakeSandbox2.loadModuleCount, 1);
-      expect(fakeSandbox2.loadedCode, 'compiled_code'); // Reuses compiled code
+      expect(fakeSandbox2.loadedCode, 'compiled_code_2');
 
-      pubGet.succeed();
       viewModel.dispose();
     });
 
-    test('cached restart reports a typed restart failure', () async {
+    test('restart reports a typed restart failure', () async {
       final firstSandbox = FakePreviewSandbox();
       final failingSandbox = FakePreviewSandbox()..onRunApp = (_) => throw StateError('restart failed');
       final fakeCompiler = FakeCompilerSession();
@@ -496,14 +491,14 @@ void main() {
       );
 
       await viewModel.runCode('lib/main.dart');
-      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      await viewModel.runCode('lib/main.dart');
 
       expect(viewModel.state, isA<PreviewCompileError>());
       final error = viewModel.state as PreviewCompileError;
       expect(error.action, PreviewLaunchAction.restart);
       expect(error.failedTask, TaskKind.restartingPreview);
       expect(error.message, contains('restart failed'));
-      expect(fakeCompiler.compileCount, 1);
+      expect(fakeCompiler.compileCount, 2);
 
       viewModel.dispose();
     });
@@ -615,9 +610,9 @@ void main() {
       expect(fakeSandbox.disposeCount, 1);
       expect(fakeCompiler.closeCount, 1);
 
-      // Subsequent skipRecompilation should trigger compile since cache was cleared
+      // A subsequent run compiles again after the previous session was stopped.
       fakeSandbox.loadModuleCount = 0;
-      await viewModel.runCode('lib/main.dart', skipRecompilation: true);
+      await viewModel.runCode('lib/main.dart');
       expect(fakeCompiler.compileCount, 2);
 
       viewModel.dispose();


### PR DESCRIPTION
Fixes #3822.

## What changed

- Remove the `skipRecompilation` path used by Restart.
- Recompile the current entrypoint before restarting the preview.
- Stop caching compiled output for later restarts.
- Update the restart documentation and tests.

Previously, Restart recreated the sandbox using the last compiled module. Source
changes made since that compilation were therefore not included, so the editor
could show newer code while the preview continued to run the old version.