### PR TITLE
Dartpad-Preview: read compiler metadata from worker to prevent sync race

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -79,9 +79,7 @@ class PreviewViewModel extends ChangeNotifier {
   bool get canHotReload => _canReloadOrRestart;
 
   bool get _canReloadOrRestart =>
-      !_busy &&
-      !workspaceRepository.taskStatus.hasBlockingPreviewTask &&
-      _state is PreviewRunning;
+      !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
 
   /// Whether the preview run process can be stopped.
   bool get canStop => _state is! PreviewStopping && (_busy || _sandbox != null);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -39,6 +39,25 @@ class WorkspaceRepository {
 
   WorkspaceFolder get root => workspaceResourceApi.root;
 
+  /// The workspace that owns generated metadata used by compilation.
+  ///
+  /// Pub commands run in the worker workspace. Their filesystem events are
+  /// mirrored back to the local editor workspace asynchronously, so generated
+  /// files such as `.dart_tool/package_config.json` may not be available
+  /// locally when compilation finishes. Prefer the worker API when it is
+  /// available and retain the local API for unsynchronized repositories and
+  /// tests.
+  WorkspaceFolder get _compilerMetadataRoot {
+    final api = workspaceResourceApi;
+    if (api is SyncedWorkspaceResourceApi) {
+      final remoteApi = api.remoteApi;
+      if (remoteApi != null) {
+        return remoteApi.root;
+      }
+    }
+    return api.root;
+  }
+
   /// Base URL where worker and sandbox assets are hosted.
   Uri get assetBaseUrl => sdk.assetBaseUrl;
 
@@ -231,11 +250,12 @@ class WorkspaceRepository {
   /// Converts a workspace [filePath] to a `package:` URI based on the nearest
   /// resolved package configuration or pubspec.yaml.
   Future<Uri> convertToPackageUri(String filePath) async {
+    final metadataRoot = _compilerMetadataRoot;
     String? resolvedPackageName;
     WorkspaceFolder? resolvedFolder;
 
     // 1. Search for package_config.json in all parent folders (from bottom to top)
-    WorkspaceFolder folder = root.getFile(filePath).parent;
+    WorkspaceFolder folder = metadataRoot.getFile(filePath).parent;
     while (true) {
       final config = folder.getFile('.dart_tool/package_config.json');
       if (await config.exists()) {
@@ -269,7 +289,7 @@ class WorkspaceRepository {
 
     // 2. Search for pubspec.yaml in all parent folders (from bottom to top)
     if (resolvedPackageName == null) {
-      folder = root.getFile(filePath).parent;
+      folder = metadataRoot.getFile(filePath).parent;
       while (true) {
         final pubspec = folder.getFile('pubspec.yaml');
         if (await pubspec.exists()) {
@@ -290,7 +310,7 @@ class WorkspaceRepository {
     }
 
     final packageName = resolvedPackageName ?? 'app';
-    final packageFolder = resolvedFolder ?? root;
+    final packageFolder = resolvedFolder ?? metadataRoot;
 
     final libFolder = workspaceContext.join(packageFolder.path, 'lib');
     if (workspacePath.isWithin(libFolder, filePath)) {
@@ -308,7 +328,7 @@ class WorkspaceRepository {
   /// Checks if the project containing [filePath] has a dependency on the
   /// flutter framework by reading its resolved `.dart_tool/package_config.json`.
   Future<bool> hasFlutterDependency(String filePath) async {
-    WorkspaceFolder folder = root.getFile(filePath).parent;
+    WorkspaceFolder folder = _compilerMetadataRoot.getFile(filePath).parent;
     while (true) {
       final config = folder.getFile('.dart_tool/package_config.json');
       if (await config.exists()) {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
@@ -12,6 +12,7 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/events/log_event.dart';
 import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:dartpad_frontend/features/workspace/data/synced_workspace_resource_api.dart';
 import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
 import 'package:dartpad_frontend/sdks.g.dart';
 import 'package:test/test.dart';
@@ -207,6 +208,39 @@ void main() {
   });
 
   group('hasFlutterDependency', () {
+    test('reads package_config.json from the worker before it is mirrored locally', () async {
+      final localApi = MemoryWorkspaceResourceApi();
+      final remoteApi = MemoryWorkspaceResourceApi();
+      await remoteApi.root.getFile('.dart_tool/package_config.json').writeContent('''
+      {
+        "configVersion": 2,
+        "packages": [
+          {
+            "name": "flutter",
+            "rootUri": "file:///path/to/flutter",
+            "packageUri": "lib/",
+            "languageVersion": "3.0"
+          }
+        ]
+      }
+      ''');
+      final syncedApi = SyncedWorkspaceResourceApi(
+        localApi: localApi,
+        remoteApi: Future.value(remoteApi),
+      );
+      await syncedApi.apiReady;
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        taskStatus: TaskStatusController(),
+        workspaceResourceApi: syncedApi,
+        sdk: defaultSdk,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      expect(await localApi.fileExist('.dart_tool/package_config.json'), isFalse);
+      expect(await repository.hasFlutterDependency('lib/main.dart'), isTrue);
+    });
+
     test('returns true when flutter is a dependency in package_config.json', () async {
       final api = MemoryWorkspaceResourceApi();
       final repository = WorkspaceRepository(
@@ -309,6 +343,44 @@ void main() {
 
       final hasFlutter = await repository.hasFlutterDependency('subproject/lib/src/helpers/util.dart');
       expect(hasFlutter, isTrue);
+    });
+  });
+
+  group('convertToPackageUri', () {
+    test('reads package_config.json from the worker before it is mirrored locally', () async {
+      final localApi = MemoryWorkspaceResourceApi();
+      final remoteApi = MemoryWorkspaceResourceApi();
+      await remoteApi.root.getFile('example/.dart_tool/package_config.json').writeContent('''
+      {
+        "configVersion": 2,
+        "packages": [
+          {
+            "name": "provider_example",
+            "rootUri": "../",
+            "packageUri": "lib/",
+            "languageVersion": "3.0"
+          }
+        ]
+      }
+      ''');
+      final syncedApi = SyncedWorkspaceResourceApi(
+        localApi: localApi,
+        remoteApi: Future.value(remoteApi),
+      );
+      await syncedApi.apiReady;
+      final repository = WorkspaceRepository(
+        events: AppEventBus(),
+        taskStatus: TaskStatusController(),
+        workspaceResourceApi: syncedApi,
+        sdk: defaultSdk,
+        workspaceFuture: Completer<Workspace>().future,
+      );
+
+      expect(await localApi.fileExist('example/.dart_tool/package_config.json'), isFalse);
+      expect(
+        await repository.convertToPackageUri('example/lib/main.dart'),
+        Uri.parse('package:provider_example/main.dart'),
+      );
     });
   });
 }


### PR DESCRIPTION
Fixes #3724
Fixes #3800

**Problem**
In #3691, the editor was migrated to `SyncedWorkspaceResourceApi`, where the in-memory frontend filesystem (`localApi`) serves as the primary source of truth for reads, while file changes from the worker process are mirrored back to the frontend asynchronously.

Because `pub` runs inside the worker process, generated files like `.dart_tool/package_config.json` are created in the worker first. Prior to this change, `WorkspaceRepository.convertToPackageUri` and `WorkspaceRepository.hasFlutterDependency` queried `this.root` (the frontend's `localApi`), introducing a race condition immediately following initial project load and `pub get`:

- #3724:
  When loading packages with sub-projects (e.g. `?package=provider` where the entrypoint is `example/lib/main.dart` with package name `provider_example`), `convertToPackageUri` was called before the worker's `example/.dart_tool/package_config.json` was mirrored to `localApi`. Failing to find the package config, it fell back to the root package name, resulting in a mismatched `package:` URI. The sandbox module loader could not find the entrypoint module, leaving the preview blank until the user hit "Restart".

- #3800:
  On the initial run of a Flutter application, `hasFlutterDependency` checked `localApi` before `.dart_tool/package_config.json` had arrived from the worker. It returned `false`, causing the application to launch via `runMain()` rather than `runApp()`, which failed with a `"Starting preview failed"` / `"Failed to start"` error on the first attempt, but succeeded on the second attempt after the background sync completed.