### PR TITLE
Dartpad Preview: Add Command Palette

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -797,10 +797,7 @@ class AppState extends State<App> {
     if (isModifier && !event.altKey && !event.shiftKey && event.key == 'Enter') {
       event.preventDefault();
       _session.runOrHotReload();
-    } else if (isModifier &&
-        !event.altKey &&
-        event.shiftKey &&
-        (event.key == 'p' || event.key == 'P')) {
+    } else if (isModifier && !event.altKey && event.shiftKey && (event.key == 'p' || event.key == 'P')) {
       event.preventDefault();
       setState(() {
         _isCommandPaletteOpen = !_isCommandPaletteOpen;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -22,6 +22,7 @@ import 'features/preview/models/preview_state.dart';
 import 'features/preview/view/preview_container.dart';
 import 'features/shared/app_event_bus.dart';
 import 'features/shared/components/app_bar.dart';
+import 'features/shared/components/command_palette.dart';
 import 'features/shared/components/context_menu.dart';
 import 'features/shared/components/footer.dart';
 import 'features/shared/components/shortcut_definitions.dart';
@@ -109,6 +110,7 @@ class AppState extends State<App> {
   bool _isInitializingWorkspace = true;
   String _projectDir = '';
   String? _workspacePreparationFailure;
+  bool _isCommandPaletteOpen = false;
 
   GlobalStateKey<SplitPanelState> _previewSplitKey = GlobalStateKey<SplitPanelState>();
 
@@ -691,6 +693,17 @@ class AppState extends State<App> {
           onClose: session.contextMenu.hide,
         ),
       ),
+      if (_isCommandPaletteOpen)
+        CommandPalette.fromSession(
+          key: const ValueKey('active-command-palette'),
+          session: session,
+          projectDir: _projectDir,
+          onClose: () {
+            setState(() {
+              _isCommandPaletteOpen = false;
+            });
+          },
+        ),
     ]);
   }
 
@@ -777,13 +790,21 @@ class AppState extends State<App> {
   }
 
   void _handleGlobalKeyDown(web.KeyboardEvent event) {
-    if (event.defaultPrevented) {
+    if (event.defaultPrevented || event.repeat) {
       return;
     }
     final isModifier = isMac ? event.metaKey : event.ctrlKey;
     if (isModifier && !event.altKey && !event.shiftKey && event.key == 'Enter') {
       event.preventDefault();
       _session.runOrHotReload();
+    } else if (isModifier &&
+        !event.altKey &&
+        event.shiftKey &&
+        (event.key == 'p' || event.key == 'P')) {
+      event.preventDefault();
+      setState(() {
+        _isCommandPaletteOpen = !_isCommandPaletteOpen;
+      });
     }
   }
 
@@ -798,6 +819,7 @@ class AppState extends State<App> {
 
   static List<StyleRule> get styles => [
     ...ContextMenu.styles,
+    ...CommandPalette.styles,
     css('.app-shell').styles(
       display: .flex,
       width: 100.percent,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
@@ -27,6 +27,20 @@ final colorInfo = const ColorToken('info', Color('#208FFD'));
 final colorSuccess = const ColorToken('success', Color('#4CAF50'));
 
 /// Global styles that establish the document-level application layout.
+/// The default UI font family fallback chain used across the application.
+const defaultFontFamily = FontFamily.list([
+  FontFamily('Roboto'),
+  FontFamily('Inter'),
+  FontFamily('Segoe UI'),
+  FontFamilies.sansSerif,
+]);
+
+/// Monospace font family fallback chain used for code, shortcuts, and prompts.
+const monospaceFontFamily = FontFamily.list([
+  FontFamily('Consolas'),
+  FontFamilies.monospace,
+]);
+
 @css
 List<StyleRule> get appStyles => [
   css('html[data-theme="dark"]').styles(
@@ -42,12 +56,7 @@ List<StyleRule> get appStyles => [
     margin: .zero,
     overflow: .hidden,
     color: colorOnSurface,
-    fontFamily: const .list([
-      FontFamily('Roboto'),
-      FontFamily('Inter'),
-      FontFamily('Segoe UI'),
-      FontFamilies.sansSerif,
-    ]),
+    fontFamily: defaultFontFamily,
     backgroundColor: colorSurface,
   ),
   css('.material-symbols-outlined').styles(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
@@ -1,0 +1,504 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:jaspr/dom.dart' hide label;
+import 'package:jaspr/jaspr.dart';
+import 'package:logging/logging.dart';
+import 'package:web/web.dart' as web;
+
+import '../../../app_styles.dart';
+import '../../editor/codemirror/code_mirror_tab.dart';
+import '../../workspace/workspace_session.dart';
+import '../events/log_event.dart';
+import 'shortcut_definitions.dart';
+
+/// An executable command shown in the [CommandPalette].
+///
+/// Encapsulates command metadata and execution logic. If a command can be triggered
+/// by an existing keyboard shortcut, [shortcut] or [CommandPaletteAction.fromShortcut] links to that
+/// [ShortcutDefinition], ensuring display keys and labels are defined only once.
+class CommandPaletteAction {
+  const CommandPaletteAction({
+    required this.label,
+    this.shortcut,
+    this.category,
+    required this.onExecute,
+    this.isEnabled,
+  });
+
+  /// Creates a [CommandPaletteAction] from an existing [ShortcutDefinition].
+  ///
+  /// The [shortcut] provides the default [label], [category], and display key.
+  factory CommandPaletteAction.fromShortcut({
+    required ShortcutDefinition shortcut,
+    required FutureOr<void> Function() onExecute,
+    bool Function()? isEnabled,
+  }) => CommandPaletteAction(
+    label: shortcut.label,
+    shortcut: shortcut,
+    category: shortcut.category,
+    onExecute: onExecute,
+    isEnabled: isEnabled,
+  );
+
+  /// The human-readable name of the command shown in the palette.
+  final String label;
+
+  /// Optional keyboard shortcut associated with this command.
+  final ShortcutDefinition? shortcut;
+
+  /// Optional category used for grouping and search matching.
+  final ShortcutCategory? category;
+
+  /// Callback executed when this command is selected.
+  final FutureOr<void> Function() onExecute;
+
+  /// Optional predicate that determines whether this command can be executed.
+  final bool Function()? isEnabled;
+
+  /// The platform-resolved display key (e.g. `⌘ + Enter` on macOS, `Ctrl + Enter` on Windows),
+  /// or an empty string if this command has no shortcut.
+  String get resolvedDisplayKey => shortcut != null ? resolveDisplayKey(shortcut!.displayKey) : '';
+
+  /// Checks whether this action matches the search query against label, category, or shortcut.
+  bool matchesQuery(String query) {
+    final trimmed = query.trim().toLowerCase();
+    if (trimmed.isEmpty) {
+      return true;
+    }
+    if (label.toLowerCase().contains(trimmed)) {
+      return true;
+    }
+    if (category?.label.toLowerCase().contains(trimmed) ?? false) {
+      return true;
+    }
+    final currentShortcut = shortcut;
+    if (currentShortcut != null) {
+      if (currentShortcut.displayKey.toLowerCase().contains(trimmed) ||
+          resolvedDisplayKey.toLowerCase().contains(trimmed)) {
+        return true;
+      }
+    }
+    // Also match individual words in query
+    final tokens = trimmed.split(RegExp(r'\s+')).where((t) => t.isNotEmpty);
+    if (tokens.length > 1) {
+      final combined = '$label ${category?.label ?? ''} $resolvedDisplayKey'.toLowerCase();
+      if (tokens.every(combined.contains)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+/// A modal dialog for searching and executing application commands.
+///
+/// Displays all available actions immediately when opened, and dynamically
+/// filters them as the user types. Supports arrow navigation, Enter selection,
+/// and Escape / backdrop dismissal.
+class CommandPalette extends StatefulComponent {
+  /// Creates a [CommandPalette] with the given [actions].
+  const CommandPalette({
+    required this.actions,
+    required this.onClose,
+    super.key,
+  });
+
+  /// Creates a [CommandPalette] populated with default workspace actions from [session].
+  factory CommandPalette.fromSession({
+    required WorkspaceSession session,
+    String projectDir = '',
+    required VoidCallback onClose,
+    Key? key,
+  }) => CommandPalette(
+    key: key,
+    actions: CommandPalette.buildDefaultActions(
+      session: session,
+      projectDir: projectDir,
+    ),
+    onClose: onClose,
+  );
+
+  /// The list of actions available in the command palette.
+  final List<CommandPaletteAction> actions;
+
+  /// Called when the command palette is dismissed.
+  final VoidCallback onClose;
+
+  @override
+  State<CommandPalette> createState() => _CommandPaletteState();
+
+  @css
+  static List<StyleRule> get styles => _CommandPaletteState.styles;
+
+  /// Builds the default list of [CommandPaletteAction]s for the given [session].
+  static List<CommandPaletteAction> buildDefaultActions({
+    required WorkspaceSession session,
+    String projectDir = '',
+  }) {
+    return [
+      CommandPaletteAction(
+        label: 'Pub get',
+        onExecute: () => _executePubGet(session, projectDir),
+      ),
+      CommandPaletteAction(
+        label: 'Pub clean',
+        onExecute: () => _executePubClean(session, projectDir),
+      ),
+      CommandPaletteAction.fromShortcut(
+        shortcut: ShortcutDefinition.formatDocument,
+        onExecute: () async {
+          final tab = session.tabs.getTab(session.tabs.activeFile);
+          if (tab is CodeMirrorTab) {
+            await tab.editor.format();
+          }
+        },
+      ),
+      CommandPaletteAction.fromShortcut(
+        shortcut: ShortcutDefinition.runOrHotReload,
+        onExecute: session.runOrHotReload,
+      ),
+    ];
+  }
+
+  static Future<void> _executePubGet(WorkspaceSession session, String projectDir) async {
+    try {
+      await session.tabs.saveAllTabs();
+    } catch (_) {
+      return;
+    }
+    try {
+      await session.repository.pubGet(
+        path: projectDir,
+        projectRoot: projectDir,
+      );
+    } catch (error, stackTrace) {
+      session.events.dispatch(
+        LogEvent(
+          'Pub get failed.',
+          level: Level.SEVERE,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      );
+    }
+  }
+
+  static Future<void> _executePubClean(WorkspaceSession session, String projectDir) async {
+    try {
+      await session.repository.pubClean(
+        path: projectDir,
+      );
+    } catch (error, stackTrace) {
+      session.events.dispatch(
+        LogEvent(
+          'Pub clean failed.',
+          level: Level.SEVERE,
+          error: error,
+          stackTrace: stackTrace,
+        ),
+      );
+    }
+  }
+}
+
+class _CommandPaletteState extends State<CommandPalette> {
+  String _query = '';
+  int _selectedIndex = 0;
+  StreamSubscription<web.KeyboardEvent>? _keySubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _keySubscription = web.EventStreamProviders.keyDownEvent.forTarget(web.document).listen(_handleKeyDown);
+    Timer.run(() {
+      if (!mounted) {
+        return;
+      }
+      final input = web.document.querySelector('.command-palette-input') as web.HTMLInputElement?;
+      input?.focus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _keySubscription?.cancel();
+    _keySubscription = null;
+    super.dispose();
+  }
+
+  List<CommandPaletteAction> get _filteredActions {
+    return component.actions.where((action) {
+      if (action.isEnabled != null && !action.isEnabled!()) {
+        return false;
+      }
+      return action.matchesQuery(_query);
+    }).toList();
+  }
+
+  int _effectiveIndex(int length) => length == 0 ? 0 : _selectedIndex.clamp(0, length - 1);
+
+  void _handleKeyDown(web.KeyboardEvent event) {
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (event.key == 'Escape') {
+      event.preventDefault();
+      component.onClose();
+      return;
+    }
+
+    final filtered = _filteredActions;
+    final effectiveIndex = _effectiveIndex(filtered.length);
+    if (event.key == 'ArrowDown') {
+      event.preventDefault();
+      if (filtered.isNotEmpty) {
+        setState(() {
+          _selectedIndex = (effectiveIndex + 1) % filtered.length;
+        });
+        _scrollToSelected();
+      }
+      return;
+    } else if (event.key == 'ArrowUp') {
+      event.preventDefault();
+      if (filtered.isNotEmpty) {
+        setState(() {
+          _selectedIndex = (effectiveIndex - 1 + filtered.length) % filtered.length;
+        });
+        _scrollToSelected();
+      }
+      return;
+    } else if (event.key == 'Enter') {
+      event.preventDefault();
+      if (filtered.isNotEmpty) {
+        _executeAction(filtered[effectiveIndex]);
+      }
+      return;
+    } else if (event.key == 'Tab') {
+      // Prevent focus from leaving the command palette
+      event.preventDefault();
+    }
+  }
+
+  void _scrollToSelected() {
+    Timer.run(() {
+      final activeElem = web.document.querySelector('.command-palette-item.active') as web.HTMLElement?;
+      activeElem?.scrollIntoView();
+    });
+  }
+
+  void _executeAction(CommandPaletteAction action) {
+    component.onClose();
+    unawaited(Future.microtask(() => action.onExecute()));
+  }
+
+  @override
+  Component build(BuildContext context) {
+    final filtered = _filteredActions;
+    final selectedIndex = _effectiveIndex(filtered.length);
+
+    return div(
+      classes: 'command-palette-backdrop',
+      events: {
+        'click': (event) {
+          if (event.target == event.currentTarget) {
+            component.onClose();
+          }
+        },
+      },
+      attributes: const {
+        'role': 'dialog',
+        'aria-modal': 'true',
+        'aria-label': 'Command Palette',
+      },
+      [
+        div(classes: 'command-palette', [
+          div(classes: 'command-palette-input-container', [
+            const span(classes: 'command-palette-prompt', [.text('>')]),
+            input(
+              classes: 'command-palette-input',
+              attributes: {
+                'type': 'text',
+                'placeholder': 'Type a command or search...',
+                'value': _query,
+                'aria-autocomplete': 'list',
+                'aria-controls': 'command-palette-list',
+                'aria-activedescendant': filtered.isNotEmpty ? 'cmd-item-$selectedIndex' : '',
+                'spellcheck': 'false',
+                'autocomplete': 'off',
+              },
+              events: {
+                'input': (event) {
+                  final target = event.target as web.HTMLInputElement;
+                  setState(() {
+                    _query = target.value;
+                    _selectedIndex = 0;
+                  });
+                },
+              },
+            ),
+          ]),
+          div(
+            id: 'command-palette-list',
+            classes: 'command-palette-list',
+            attributes: const {
+              'role': 'listbox',
+            },
+            [
+              if (filtered.isEmpty)
+                const div(classes: 'command-palette-empty', [
+                  .text('No matching commands found'),
+                ])
+              else
+                for (var i = 0; i < filtered.length; i++)
+                  _buildItem(filtered[i], index: i, isSelected: i == selectedIndex),
+            ],
+          ),
+        ]),
+      ],
+    );
+  }
+
+  Component _buildItem(CommandPaletteAction action, {required int index, required bool isSelected}) {
+    final shortcut = action.resolvedDisplayKey;
+
+    return div(
+      id: 'cmd-item-$index',
+      classes: 'command-palette-item${isSelected ? ' active' : ''}',
+      attributes: {
+        'role': 'option',
+        'aria-selected': isSelected ? 'true' : 'false',
+      },
+      events: {
+        'mouseenter': (_) {
+          if (_selectedIndex != index) {
+            setState(() {
+              _selectedIndex = index;
+            });
+          }
+        },
+        'click': (_) => _executeAction(action),
+      },
+      [
+        span(classes: 'command-palette-item-title', [.text(action.label)]),
+        if (shortcut.isNotEmpty) span(classes: 'command-palette-item-shortcut', [.text(shortcut)]),
+      ],
+    );
+  }
+
+  static List<StyleRule> get styles => [
+    css('.command-palette-backdrop').styles(
+      display: .flex,
+      position: .fixed(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
+      zIndex: const ZIndex(10000),
+      justifyContent: .center,
+      backgroundColor: const Color('rgba(0, 0, 0, 0.45)'),
+    ),
+    css('.command-palette').styles(
+      display: .flex,
+      width: 580.px,
+      maxWidth: 92.percent,
+      maxHeight: 480.px,
+      padding: .zero,
+      margin: .only(top: 40.px),
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(6.px),
+      overflow: .hidden,
+      shadow: BoxShadow(
+        offsetX: 0.px,
+        offsetY: 10.px,
+        blur: 28.px,
+        color: const Color('rgba(0, 0, 0, 0.35)'),
+      ),
+      flexDirection: .column,
+      color: colorOnSurface,
+      backgroundColor: colorSurface,
+    ),
+    css('.command-palette-input-container').styles(
+      display: .flex,
+      padding: .symmetric(vertical: 8.px, horizontal: 12.px),
+      border: .only(
+        bottom: .solid(color: colorBorder, width: 1.px),
+      ),
+      alignItems: .center,
+      gap: Gap.all(8.px),
+      backgroundColor: colorSurface,
+    ),
+    css('.command-palette-prompt').styles(
+      userSelect: .none,
+      color: colorPrimary,
+      fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+      fontSize: 15.px,
+      fontWeight: .w700,
+    ),
+    css('.command-palette-input').styles(
+      padding: .symmetric(vertical: 4.px, horizontal: 2.px),
+      border: .unset,
+      outline: .unset,
+      flex: const .grow(1),
+      color: colorOnSurface,
+      fontFamily: const .list([
+        FontFamily('Roboto'),
+        FontFamily('Inter'),
+        FontFamily('Segoe UI'),
+        FontFamilies.sansSerif,
+      ]),
+      fontSize: 14.px,
+      backgroundColor: const Color('transparent'),
+    ),
+    css('.command-palette-input::placeholder').styles(
+      color: colorOnSurface.highlight(colorSurface, 0.4),
+    ),
+    css('.command-palette-list').styles(
+      display: .flex,
+      maxHeight: 340.px,
+      padding: .symmetric(vertical: 4.px),
+      overflow: const .only(y: .auto),
+      flexDirection: .column,
+    ),
+    css('.command-palette-item').styles(
+      display: .flex,
+      minHeight: 32.px,
+      padding: .symmetric(vertical: 6.px, horizontal: 14.px),
+      cursor: .pointer,
+      userSelect: .none,
+      justifyContent: .spaceBetween,
+      alignItems: .center,
+      gap: Gap.all(16.px),
+      color: colorOnSurface,
+      fontSize: 13.px,
+    ),
+    css('.command-palette-item.active').styles(
+      color: colorOnContainer,
+      backgroundColor: colorContainer,
+    ),
+    css('.command-palette-item-title').styles(
+      overflow: .hidden,
+      textOverflow: .ellipsis,
+      whiteSpace: .noWrap,
+    ),
+    css('.command-palette-item-shortcut').styles(
+      padding: .symmetric(vertical: 2.px, horizontal: 6.px),
+      border: .all(color: colorBorder, width: 1.px),
+      radius: .circular(3.px),
+      color: colorOnSurface.highlight(colorSurface, 0.2),
+      fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+      fontSize: 11.px,
+      whiteSpace: .noWrap,
+      backgroundColor: colorSurface,
+    ),
+    css('.command-palette-item.active .command-palette-item-shortcut').styles(
+      color: colorOnContainer,
+      backgroundColor: colorSurface,
+    ),
+    css('.command-palette-empty').styles(
+      padding: .symmetric(vertical: 20.px, horizontal: 16.px),
+      color: colorOnSurface.highlight(colorSurface, 0.35),
+      textAlign: .center,
+      fontSize: 13.px,
+    ),
+  ];
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
@@ -292,13 +292,14 @@ class _CommandPaletteState extends State<CommandPalette> {
       position: .fixed(top: 0.px, left: 0.px, right: 0.px, bottom: 0.px),
       zIndex: const ZIndex(10000),
       justifyContent: .center,
+      alignItems: .start,
       backgroundColor: const Color('rgba(0, 0, 0, 0.45)'),
     ),
     css('.command-palette').styles(
       display: .flex,
       width: 580.px,
       maxWidth: 92.percent,
-      maxHeight: 480.px,
+      maxHeight: 500.px,
       padding: .zero,
       margin: .only(top: 40.px),
       border: .all(color: colorBorder, width: 1.px),
@@ -322,6 +323,7 @@ class _CommandPaletteState extends State<CommandPalette> {
       ),
       alignItems: .center,
       gap: Gap.all(8.px),
+      flex: const .shrink(0),
       backgroundColor: colorSurface,
     ),
     css('.command-palette-prompt').styles(
@@ -346,7 +348,7 @@ class _CommandPaletteState extends State<CommandPalette> {
     ),
     css('.command-palette-list').styles(
       display: .flex,
-      maxHeight: 340.px,
+      minHeight: 0.px,
       padding: .symmetric(vertical: 4.px),
       overflow: const .only(y: .auto),
       flexDirection: .column,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette.dart
@@ -6,103 +6,24 @@ import 'dart:async';
 
 import 'package:jaspr/dom.dart' hide label;
 import 'package:jaspr/jaspr.dart';
-import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
-import '../../editor/codemirror/code_mirror_tab.dart';
 import '../../workspace/workspace_session.dart';
-import '../events/log_event.dart';
-import 'shortcut_definitions.dart';
+import 'command_palette_actions.dart';
 
-/// An executable command shown in the [CommandPalette].
-///
-/// Encapsulates command metadata and execution logic. If a command can be triggered
-/// by an existing keyboard shortcut, [shortcut] or [CommandPaletteAction.fromShortcut] links to that
-/// [ShortcutDefinition], ensuring display keys and labels are defined only once.
-class CommandPaletteAction {
-  const CommandPaletteAction({
-    required this.label,
-    this.shortcut,
-    this.category,
-    required this.onExecute,
-    this.isEnabled,
-  });
-
-  /// Creates a [CommandPaletteAction] from an existing [ShortcutDefinition].
-  ///
-  /// The [shortcut] provides the default [label], [category], and display key.
-  factory CommandPaletteAction.fromShortcut({
-    required ShortcutDefinition shortcut,
-    required FutureOr<void> Function() onExecute,
-    bool Function()? isEnabled,
-  }) => CommandPaletteAction(
-    label: shortcut.label,
-    shortcut: shortcut,
-    category: shortcut.category,
-    onExecute: onExecute,
-    isEnabled: isEnabled,
-  );
-
-  /// The human-readable name of the command shown in the palette.
-  final String label;
-
-  /// Optional keyboard shortcut associated with this command.
-  final ShortcutDefinition? shortcut;
-
-  /// Optional category used for grouping and search matching.
-  final ShortcutCategory? category;
-
-  /// Callback executed when this command is selected.
-  final FutureOr<void> Function() onExecute;
-
-  /// Optional predicate that determines whether this command can be executed.
-  final bool Function()? isEnabled;
-
-  /// The platform-resolved display key (e.g. `⌘ + Enter` on macOS, `Ctrl + Enter` on Windows),
-  /// or an empty string if this command has no shortcut.
-  String get resolvedDisplayKey => shortcut != null ? resolveDisplayKey(shortcut!.displayKey) : '';
-
-  /// Checks whether this action matches the search query against label, category, or shortcut.
-  bool matchesQuery(String query) {
-    final trimmed = query.trim().toLowerCase();
-    if (trimmed.isEmpty) {
-      return true;
-    }
-    if (label.toLowerCase().contains(trimmed)) {
-      return true;
-    }
-    if (category?.label.toLowerCase().contains(trimmed) ?? false) {
-      return true;
-    }
-    final currentShortcut = shortcut;
-    if (currentShortcut != null) {
-      if (currentShortcut.displayKey.toLowerCase().contains(trimmed) ||
-          resolvedDisplayKey.toLowerCase().contains(trimmed)) {
-        return true;
-      }
-    }
-    // Also match individual words in query
-    final tokens = trimmed.split(RegExp(r'\s+')).where((t) => t.isNotEmpty);
-    if (tokens.length > 1) {
-      final combined = '$label ${category?.label ?? ''} $resolvedDisplayKey'.toLowerCase();
-      if (tokens.every(combined.contains)) {
-        return true;
-      }
-    }
-    return false;
-  }
-}
+export 'command_palette_actions.dart';
 
 /// A modal dialog for searching and executing application commands.
 ///
 /// Displays all available actions immediately when opened, and dynamically
 /// filters them as the user types. Supports arrow navigation, Enter selection,
 /// and Escape / backdrop dismissal.
-class CommandPalette extends StatefulComponent {
-  /// Creates a [CommandPalette] with the given [actions].
+final class CommandPalette extends StatefulComponent {
+  /// Creates a [CommandPalette] with the given [actions] and execution [context].
   const CommandPalette({
-    required this.actions,
+    this.context = const CommandContext(),
+    this.actions = allCommandActions,
     required this.onClose,
     super.key,
   });
@@ -111,16 +32,21 @@ class CommandPalette extends StatefulComponent {
   factory CommandPalette.fromSession({
     required WorkspaceSession session,
     String projectDir = '',
+    List<CommandPaletteAction> actions = allCommandActions,
     required VoidCallback onClose,
     Key? key,
   }) => CommandPalette(
     key: key,
-    actions: CommandPalette.buildDefaultActions(
+    context: CommandContext(
       session: session,
       projectDir: projectDir,
     ),
+    actions: actions,
     onClose: onClose,
   );
+
+  /// The execution context passed to triggered command actions.
+  final CommandContext context;
 
   /// The list of actions available in the command palette.
   final List<CommandPaletteAction> actions;
@@ -134,74 +60,44 @@ class CommandPalette extends StatefulComponent {
   @css
   static List<StyleRule> get styles => _CommandPaletteState.styles;
 
-  /// Builds the default list of [CommandPaletteAction]s for the given [session].
-  static List<CommandPaletteAction> buildDefaultActions({
-    required WorkspaceSession session,
-    String projectDir = '',
-  }) {
-    return [
-      CommandPaletteAction(
-        label: 'Pub get',
-        onExecute: () => _executePubGet(session, projectDir),
-      ),
-      CommandPaletteAction(
-        label: 'Pub clean',
-        onExecute: () => _executePubClean(session, projectDir),
-      ),
-      CommandPaletteAction.fromShortcut(
-        shortcut: ShortcutDefinition.formatDocument,
-        onExecute: () async {
-          final tab = session.tabs.getTab(session.tabs.activeFile);
-          if (tab is CodeMirrorTab) {
-            await tab.editor.format();
-          }
-        },
-      ),
-      CommandPaletteAction.fromShortcut(
-        shortcut: ShortcutDefinition.runOrHotReload,
-        onExecute: session.runOrHotReload,
-      ),
-    ];
-  }
-
-  static Future<void> _executePubGet(WorkspaceSession session, String projectDir) async {
-    try {
-      await session.tabs.saveAllTabs();
-    } catch (_) {
-      return;
+  /// Checks whether [action] matches [query] against label, description, category, shortcut, or aliases.
+  static bool matchesCommand(CommandPaletteAction action, String query) {
+    final trimmed = query.trim().toLowerCase();
+    if (trimmed.isEmpty) {
+      return true;
     }
-    try {
-      await session.repository.pubGet(
-        path: projectDir,
-        projectRoot: projectDir,
-      );
-    } catch (error, stackTrace) {
-      session.events.dispatch(
-        LogEvent(
-          'Pub get failed.',
-          level: Level.SEVERE,
-          error: error,
-          stackTrace: stackTrace,
-        ),
-      );
+    if (action.label.toLowerCase().contains(trimmed)) {
+      return true;
     }
-  }
-
-  static Future<void> _executePubClean(WorkspaceSession session, String projectDir) async {
-    try {
-      await session.repository.pubClean(
-        path: projectDir,
-      );
-    } catch (error, stackTrace) {
-      session.events.dispatch(
-        LogEvent(
-          'Pub clean failed.',
-          level: Level.SEVERE,
-          error: error,
-          stackTrace: stackTrace,
-        ),
-      );
+    if (action.description.toLowerCase().contains(trimmed)) {
+      return true;
     }
+    if (action.category?.label.toLowerCase().contains(trimmed) ?? false) {
+      return true;
+    }
+    for (final alias in action.aliases) {
+      if (alias.toLowerCase().contains(trimmed)) {
+        return true;
+      }
+    }
+    final currentShortcut = action.shortcut;
+    if (currentShortcut != null) {
+      if (currentShortcut.displayKey.toLowerCase().contains(trimmed) ||
+          action.resolvedDisplayKey.toLowerCase().contains(trimmed)) {
+        return true;
+      }
+    }
+    // Also match individual words in query
+    final tokens = trimmed.split(RegExp(r'\s+')).where((t) => t.isNotEmpty);
+    if (tokens.length > 1) {
+      final combined =
+          '${action.label} ${action.description} ${action.category?.label ?? ''} ${action.resolvedDisplayKey} ${action.aliases.join(' ')}'
+              .toLowerCase();
+      if (tokens.every(combined.contains)) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 
@@ -232,10 +128,10 @@ class _CommandPaletteState extends State<CommandPalette> {
 
   List<CommandPaletteAction> get _filteredActions {
     return component.actions.where((action) {
-      if (action.isEnabled != null && !action.isEnabled!()) {
+      if (action.isEnabled != null && !action.isEnabled!(component.context)) {
         return false;
       }
-      return action.matchesQuery(_query);
+      return CommandPalette.matchesCommand(action, _query);
     }).toList();
   }
 
@@ -292,7 +188,7 @@ class _CommandPaletteState extends State<CommandPalette> {
 
   void _executeAction(CommandPaletteAction action) {
     component.onClose();
-    unawaited(Future.microtask(() => action.onExecute()));
+    unawaited(Future.microtask(() => action.onExecute(component.context)));
   }
 
   @override
@@ -371,6 +267,7 @@ class _CommandPaletteState extends State<CommandPalette> {
       attributes: {
         'role': 'option',
         'aria-selected': isSelected ? 'true' : 'false',
+        if (action.description.isNotEmpty) 'title': action.description,
       },
       events: {
         'mouseenter': (_) {
@@ -430,7 +327,7 @@ class _CommandPaletteState extends State<CommandPalette> {
     css('.command-palette-prompt').styles(
       userSelect: .none,
       color: colorPrimary,
-      fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+      fontFamily: monospaceFontFamily,
       fontSize: 15.px,
       fontWeight: .w700,
     ),
@@ -440,12 +337,7 @@ class _CommandPaletteState extends State<CommandPalette> {
       outline: .unset,
       flex: const .grow(1),
       color: colorOnSurface,
-      fontFamily: const .list([
-        FontFamily('Roboto'),
-        FontFamily('Inter'),
-        FontFamily('Segoe UI'),
-        FontFamilies.sansSerif,
-      ]),
+      fontFamily: defaultFontFamily,
       fontSize: 14.px,
       backgroundColor: const Color('transparent'),
     ),
@@ -485,7 +377,7 @@ class _CommandPaletteState extends State<CommandPalette> {
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(3.px),
       color: colorOnSurface.highlight(colorSurface, 0.2),
-      fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+      fontFamily: monospaceFontFamily,
       fontSize: 11.px,
       whiteSpace: .noWrap,
       backgroundColor: colorSurface,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
@@ -1,0 +1,343 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+
+import '../../bottom_panel/view_models/console_view_model.dart';
+import '../../bottom_panel/view_models/diagnostics_view_model.dart';
+import '../../editor/codemirror/code_mirror_tab.dart';
+import '../../editor/view_models/tabs_view_model.dart';
+import '../../filetree/file_tree_view_model.dart';
+import '../../preview/view_models/preview_view_model.dart';
+import '../../workspace/data/workspace_repository.dart';
+import '../../workspace/workspace_session.dart';
+import '../analyzer_status.dart';
+import '../app_event_bus.dart';
+import '../events/log_event.dart';
+import '../task_status.dart';
+import 'shortcut_definitions.dart';
+
+/// Execution context provided to commands executed from the command palette.
+///
+/// Encapsulates the active [session], the current [projectDir], and convenient
+/// accessors to common services.
+final class CommandContext {
+  const CommandContext({
+    this.session,
+    this.projectDir = '',
+  });
+
+  /// The active [WorkspaceSession], or `null` in headless/test environments where
+  /// actions do not interact with a workspace.
+  final WorkspaceSession? session;
+
+  /// The relative directory of the active project within the workspace.
+  final String projectDir;
+
+  WorkspaceRepository? get repository => session?.repository;
+
+  TabsViewModel? get tabs => session?.tabs;
+
+  AppEventBus? get events => session?.events;
+
+  PreviewViewModel? get preview => session?.preview;
+
+  ConsoleViewModel? get console => session?.console;
+
+  DiagnosticsViewModel? get diagnostics => session?.diagnostics;
+
+  FileTreeViewModel? get fileTree => session?.fileTree;
+
+  TaskStatusController? get taskStatus => session?.taskStatus;
+
+  AnalyzerStatusController? get analyzerStatus => session?.analyzerStatus;
+}
+
+/// An executable command shown in the command palette.
+///
+/// Encapsulates command metadata and execution logic. If a command can be triggered
+/// by an existing keyboard shortcut, [shortcut] or [CommandPaletteAction.fromShortcut] links to that
+/// [ShortcutDefinition], ensuring display keys and labels are defined only once.
+final class CommandPaletteAction {
+  const CommandPaletteAction({
+    required this.label,
+    this.description = '',
+    this.aliases = const [],
+    this.shortcut,
+    this.category,
+    required this.onExecute,
+    this.isEnabled,
+  });
+
+  /// Creates a [CommandPaletteAction] from an existing [ShortcutDefinition].
+  ///
+  /// The [shortcut] provides the default [label], [category], and display key.
+  factory CommandPaletteAction.fromShortcut({
+    required ShortcutDefinition shortcut,
+    String description = '',
+    List<String> aliases = const [],
+    required FutureOr<void> Function(CommandContext context) onExecute,
+    bool Function(CommandContext context)? isEnabled,
+  }) => CommandPaletteAction(
+    label: shortcut.label,
+    description: description,
+    aliases: aliases,
+    shortcut: shortcut,
+    category: shortcut.category,
+    onExecute: onExecute,
+    isEnabled: isEnabled,
+  );
+
+  /// The human-readable name of the command shown in the palette.
+  final String label;
+
+  /// One sentence human description of the command.
+  final String description;
+
+  /// Aliases for consideration in auto-complete and search matching.
+  final List<String> aliases;
+
+  /// Optional keyboard shortcut associated with this command.
+  final ShortcutDefinition? shortcut;
+
+  /// Optional category used for grouping and search matching.
+  final ShortcutCategory? category;
+
+  /// Callback executed when this command is selected.
+  final FutureOr<void> Function(CommandContext context) onExecute;
+
+  /// Optional predicate that determines whether this command can be executed.
+  final bool Function(CommandContext context)? isEnabled;
+
+  /// The platform-resolved display key (e.g. `⌘ + Enter` on macOS, `Ctrl + Enter` on Windows),
+  /// or an empty string if this command has no shortcut.
+  String get resolvedDisplayKey => shortcut != null ? resolveDisplayKey(shortcut!.displayKey) : '';
+}
+
+const pubGetAction = CommandPaletteAction(
+  label: 'Pub get',
+  description: 'Download and resolve package dependencies',
+  aliases: ['get', 'packages get', 'install'],
+  onExecute: _executePubGet,
+);
+
+const pubUpgradeAction = CommandPaletteAction(
+  label: 'Pub upgrade',
+  description: 'Upgrade package dependencies to their latest allowed versions',
+  aliases: ['upgrade', 'update', 'packages upgrade'],
+  onExecute: _executePubUpgrade,
+);
+
+const pubOutdatedAction = CommandPaletteAction(
+  label: 'Pub outdated',
+  description: 'Analyze dependencies to find which packages have newer versions',
+  aliases: ['outdated', 'check updates'],
+  onExecute: _executePubOutdated,
+);
+
+const pubDowngradeAction = CommandPaletteAction(
+  label: 'Pub downgrade',
+  description: 'Downgrade package dependencies to their lowest allowed versions',
+  aliases: ['downgrade'],
+  onExecute: _executePubDowngrade,
+);
+
+const pubCleanAction = CommandPaletteAction(
+  label: 'Pub clean',
+  description: 'Remove build and cache artifacts from the workspace',
+  aliases: ['clean'],
+  onExecute: _executePubClean,
+);
+
+const formatDocumentAction = CommandPaletteAction(
+  label: 'Format document',
+  description: 'Format the currently active document',
+  aliases: ['format', 'beautify', 'indent'],
+  shortcut: ShortcutDefinition.formatDocument,
+  category: ShortcutCategory.refactoring,
+  onExecute: _executeFormatDocument,
+);
+
+const runOrHotReloadAction = CommandPaletteAction(
+  label: 'Run / Hot reload',
+  description: 'Run the application or trigger a hot reload if already running',
+  aliases: ['run', 'reload', 'hot reload', 'restart'],
+  shortcut: ShortcutDefinition.runOrHotReload,
+  category: ShortcutCategory.execution,
+  onExecute: _executeRunOrHotReload,
+);
+
+const saveFileAction = CommandPaletteAction(
+  label: 'Save file',
+  description: 'Save changes in the currently open editor tab',
+  aliases: ['save', 'save file', 'write'],
+  shortcut: ShortcutDefinition.save,
+  onExecute: _executeSaveFile,
+);
+
+/// The complete default list of registered [CommandPaletteAction]s.
+const allCommandActions = <CommandPaletteAction>[
+  pubGetAction,
+  pubUpgradeAction,
+  pubOutdatedAction,
+  pubDowngradeAction,
+  pubCleanAction,
+  formatDocumentAction,
+  runOrHotReloadAction,
+  saveFileAction,
+];
+
+Future<void> _executePubGet(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  try {
+    await session.tabs.saveAllTabs();
+  } catch (_) {
+    return;
+  }
+  try {
+    await session.repository.pubGet(
+      path: context.projectDir,
+      projectRoot: context.projectDir,
+    );
+  } catch (error, stackTrace) {
+    session.events.dispatch(
+      LogEvent(
+        'Pub get failed.',
+        level: Level.SEVERE,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}
+
+Future<void> _executePubUpgrade(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  try {
+    await session.tabs.saveAllTabs();
+  } catch (_) {
+    return;
+  }
+  try {
+    await session.repository.pubUpgrade(
+      path: context.projectDir,
+      projectRoot: context.projectDir,
+    );
+  } catch (error, stackTrace) {
+    session.events.dispatch(
+      LogEvent(
+        'Pub upgrade failed.',
+        level: Level.SEVERE,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}
+
+Future<void> _executePubOutdated(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  try {
+    await session.repository.pubOutdated(
+      path: context.projectDir,
+      projectRoot: context.projectDir,
+    );
+  } catch (error, stackTrace) {
+    session.events.dispatch(
+      LogEvent(
+        'Pub outdated failed.',
+        level: Level.SEVERE,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}
+
+Future<void> _executePubDowngrade(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  try {
+    await session.tabs.saveAllTabs();
+  } catch (_) {
+    return;
+  }
+  try {
+    await session.repository.pubDowngrade(
+      path: context.projectDir,
+      projectRoot: context.projectDir,
+    );
+  } catch (error, stackTrace) {
+    session.events.dispatch(
+      LogEvent(
+        'Pub downgrade failed.',
+        level: Level.SEVERE,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}
+
+Future<void> _executePubClean(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  try {
+    await session.repository.pubClean(
+      path: context.projectDir,
+    );
+  } catch (error, stackTrace) {
+    session.events.dispatch(
+      LogEvent(
+        'Pub clean failed.',
+        level: Level.SEVERE,
+        error: error,
+        stackTrace: stackTrace,
+      ),
+    );
+  }
+}
+
+Future<void> _executeFormatDocument(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  final tab = session.tabs.getTab(session.tabs.activeFile);
+  if (tab is CodeMirrorTab) {
+    await tab.editor.format();
+  }
+}
+
+Future<void> _executeRunOrHotReload(CommandContext context) async {
+  context.session?.runOrHotReload();
+}
+
+Future<void> _executeSaveFile(CommandContext context) async {
+  final session = context.session;
+  if (session == null) {
+    return;
+  }
+  final activeFile = session.tabs.activeFile;
+  if (activeFile.isNotEmpty) {
+    await session.tabs.saveTab(activeFile);
+  } else {
+    await session.tabs.saveAllTabs();
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -16,6 +16,7 @@ String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'C
 
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
+  view('View'),
   execution('Execution'),
   refactoring('Refactoring & code intelligence'),
   editing('Editing'),
@@ -291,6 +292,13 @@ class ShortcutDefinition {
     label: 'Paste',
     displayKey: 'Mod + V',
   );
+
+  // ── Global & palette commands ───────────────────────────────────────────
+  static const commandPalette = ShortcutDefinition(
+    label: 'Open command palette',
+    displayKey: 'Mod + Shift + P',
+    category: ShortcutCategory.view,
+  );
 }
 
 /// The complete list of keyboard shortcuts displayed in the shortcuts dialog.
@@ -301,6 +309,9 @@ class ShortcutDefinition {
 /// Display keys use `Mod` as a platform-agnostic placeholder for the primary
 /// modifier key. Call [resolveDisplayKey] to get the platform-specific string.
 const shortcutDefinitions = <ShortcutDefinition>[
+  // ── View ─────────────────────────────────────────────────────────────────
+  ShortcutDefinition.commandPalette,
+
   // ── Execution ────────────────────────────────────────────────────────────
   ShortcutDefinition.runOrHotReload,
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -293,6 +293,13 @@ class ShortcutDefinition {
     displayKey: 'Mod + V',
   );
 
+  // ── File actions ─────────────────────────────────────────────────────────
+  static const save = ShortcutDefinition(
+    label: 'Save file',
+    displayKey: 'Mod + S',
+    codemirrorKeys: ['Mod-s'],
+  );
+
   // ── Global & palette commands ───────────────────────────────────────────
   static const commandPalette = ShortcutDefinition(
     label: 'Open command palette',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -12,6 +12,25 @@ enum TaskStatusOutcome { running, succeeded, failed }
 
 /// The typed identity and default display label of a tracked task.
 ///
+/// ### Task Tracking Guidelines: What Belongs in the Task Tracker
+///
+/// **Tracked (CLI-style operations and system lifecycle):**
+/// - **CLI tooling operations:** Commands typically invoked via CLI tools that
+///   run asynchronously and produce console output (e.g. [pubGet], [pubUpgrade],
+///   [pubDowngrade], [pubOutdated], [pubClean], [compilingApplication],
+///   [hotReload], [compilingChanges]). These tasks are always tracked unconditionally
+///   to provide predictable feedback to the user.
+/// - **System & runtime lifecycle:** Background environment preparations like
+///   [loadingCode], [initializingDartPadWorker], and [analyzingWorkspace].
+///
+/// **Not tracked (Editor interactions):**
+/// - Standard in-editor actions (e.g. formatting documents, saving files,
+///   renaming symbols, creating files, or applying quick fixes) are **not**
+///   tracked as tasks.
+/// - The user receives immediate visual feedback directly within the editor
+///   interface (text updates, tab indicators, or error toasts), so tracking them
+///   would only introduce UI noise and flicker.
+///
 /// ### Trade-offs of Merging Task Kinds
 ///
 /// **Pros of merging:**
@@ -27,17 +46,13 @@ enum TaskStatusOutcome { running, succeeded, failed }
 /// - **Coarser error & state attribution:** Code and UI widgets cannot distinguish
 ///   which specific phase failed (e.g. worker setup vs compilation) without inspecting
 ///   raw string labels.
-///
-/// The following [TaskKind]s provide 2 kinds for startup and worker initialization
-/// ([loadingCode], [initializingDartPadWorker]), specific kinds for Pub and
-/// analysis operations ([pubGet], [pubClean], [analyzingWorkspace]), and
-/// dedicated kinds for each compiling and preview action ([startingPreview],
-/// [restartingPreview], [stoppingPreview], [compilingApplication], [hotReload],
-/// [compilingChanges]).
 enum TaskKind {
   loadingCode('Loading code'),
   initializingDartPadWorker('Initializing DartPad worker'),
   pubGet('Pub get'),
+  pubUpgrade('Pub upgrade'),
+  pubDowngrade('Pub downgrade'),
+  pubOutdated('Pub outdated'),
   pubClean('Pub clean'),
   analyzingWorkspace('Analyzing workspace'),
   startingPreview('Starting preview'),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -109,16 +109,23 @@ class WorkspaceRepository {
     );
   }
 
-  Future<void> pubGet({String path = '', String projectRoot = ''}) {
+  Future<void> _runPubCommand({
+    required TaskKind kind,
+    required String commandName,
+    String path = '',
+    String projectRoot = '',
+    bool blocksPreview = false,
+  }) {
     final normalizedPath = workspaceContext.normalize(path);
     final pathLabel = workspaceContext.relativeDisplayPath(
       path: normalizedPath,
       projectRoot: projectRoot,
     );
     return taskStatus.runTask(
-      TaskKind.pubGet,
-      () => runWorkspacePubGet(
+      kind,
+      () => runWorkspacePubCommand(
         events: events,
+        commandName: commandName,
         path: path,
         projectRoot: projectRoot,
         command: (normalizedPath) async {
@@ -127,52 +134,46 @@ class WorkspaceRepository {
           if (api is SyncedWorkspaceResourceApi) {
             await api.flush();
           }
-          final result = await workspace.pub(uri: normalizedPath, command: 'get');
+          final result = await workspace.pub(uri: normalizedPath, command: commandName);
           return result.log;
         },
       ),
-      label: 'Pub get in $pathLabel',
+      label: '${kind.label} in $pathLabel',
       scope: normalizedPath.toString(),
-      blocksPreview: true,
+      blocksPreview: blocksPreview,
     );
   }
 
-  Future<void> _runPubCommand({
-    required String commandName,
-    String path = '',
-    String projectRoot = '',
-  }) => runWorkspacePubCommand(
-    events: events,
-    commandName: commandName,
+  Future<void> pubGet({String path = '', String projectRoot = ''}) => _runPubCommand(
+    kind: TaskKind.pubGet,
+    commandName: 'get',
     path: path,
     projectRoot: projectRoot,
-    command: (normalizedPath) async {
-      final workspace = await _workspaceFuture;
-      final api = workspaceResourceApi;
-      if (api is SyncedWorkspaceResourceApi) {
-        await api.flush();
-      }
-      final result = await workspace.pub(uri: normalizedPath, command: commandName);
-      return result.log;
-    },
+    blocksPreview: true,
   );
 
   Future<void> pubUpgrade({String path = '', String projectRoot = ''}) => _runPubCommand(
+    kind: TaskKind.pubUpgrade,
     commandName: 'upgrade',
     path: path,
     projectRoot: projectRoot,
+    blocksPreview: true,
   );
 
   Future<void> pubDowngrade({String path = '', String projectRoot = ''}) => _runPubCommand(
+    kind: TaskKind.pubDowngrade,
     commandName: 'downgrade',
     path: path,
     projectRoot: projectRoot,
+    blocksPreview: true,
   );
 
   Future<void> pubOutdated({String path = '', String projectRoot = ''}) => _runPubCommand(
+    kind: TaskKind.pubOutdated,
     commandName: 'outdated',
     path: path,
     projectRoot: projectRoot,
+    blocksPreview: false,
   );
 
   /// Removes generated Pub and build output from the workspace.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -137,6 +137,44 @@ class WorkspaceRepository {
     );
   }
 
+  Future<void> _runPubCommand({
+    required String commandName,
+    String path = '',
+    String projectRoot = '',
+  }) => runWorkspacePubCommand(
+    events: events,
+    commandName: commandName,
+    path: path,
+    projectRoot: projectRoot,
+    command: (normalizedPath) async {
+      final workspace = await _workspaceFuture;
+      final api = workspaceResourceApi;
+      if (api is SyncedWorkspaceResourceApi) {
+        await api.flush();
+      }
+      final result = await workspace.pub(uri: normalizedPath, command: commandName);
+      return result.log;
+    },
+  );
+
+  Future<void> pubUpgrade({String path = '', String projectRoot = ''}) => _runPubCommand(
+    commandName: 'upgrade',
+    path: path,
+    projectRoot: projectRoot,
+  );
+
+  Future<void> pubDowngrade({String path = '', String projectRoot = ''}) => _runPubCommand(
+    commandName: 'downgrade',
+    path: path,
+    projectRoot: projectRoot,
+  );
+
+  Future<void> pubOutdated({String path = '', String projectRoot = ''}) => _runPubCommand(
+    commandName: 'outdated',
+    path: path,
+    projectRoot: projectRoot,
+  );
+
   /// Removes generated Pub and build output from the workspace.
   Future<void> pubClean({String path = ''}) async {
     final normalizedPath = workspaceContext.normalize(path);
@@ -359,9 +397,10 @@ class WorkspaceRepository {
   }
 }
 
-/// Runs Pub Get and forwards its output to the application debug console.
-Future<void> runWorkspacePubGet({
+/// Runs a Pub command and forwards its output to the application debug console.
+Future<void> runWorkspacePubCommand({
   required AppEventBus events,
+  required String commandName,
   required String path,
   required String projectRoot,
   required Future<String> Function(String normalizedPath) command,
@@ -371,9 +410,23 @@ Future<void> runWorkspacePubGet({
     path: normalizedPath,
     projectRoot: projectRoot,
   );
-  events.dispatch(LogEvent('Running pub get in $pathLabel'));
+  events.dispatch(LogEvent('Running pub $commandName in $pathLabel'));
   final log = await command(normalizedPath);
   if (log.isNotEmpty) {
     events.dispatch(LogEvent(log));
   }
 }
+
+/// Runs Pub Get and forwards its output to the application debug console.
+Future<void> runWorkspacePubGet({
+  required AppEventBus events,
+  required String path,
+  required String projectRoot,
+  required Future<String> Function(String normalizedPath) command,
+}) => runWorkspacePubCommand(
+  events: events,
+  commandName: 'get',
+  path: path,
+  projectRoot: projectRoot,
+  command: command,
+);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/command_palette_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/command_palette_test.dart
@@ -1,0 +1,277 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/command_palette.dart';
+import 'package:dartpad_frontend/features/shared/components/shortcut_definitions.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  List<CommandPaletteAction> createTestActions({
+    void Function()? onPubGet,
+    void Function()? onPubClean,
+    void Function()? onFormat,
+    void Function()? onRun,
+  }) {
+    return [
+      CommandPaletteAction(
+        label: 'Pub get',
+        onExecute: onPubGet ?? () {},
+      ),
+      CommandPaletteAction(
+        label: 'Pub clean',
+        onExecute: onPubClean ?? () {},
+      ),
+      CommandPaletteAction.fromShortcut(
+        shortcut: ShortcutDefinition.formatDocument,
+        onExecute: onFormat ?? () {},
+      ),
+      CommandPaletteAction.fromShortcut(
+        shortcut: ShortcutDefinition.runOrHotReload,
+        onExecute: onRun ?? () {},
+      ),
+    ];
+  }
+
+  testClient('CommandPaletteAction.fromShortcut populates properties from shortcut', (tester) {
+    final action = CommandPaletteAction.fromShortcut(
+      shortcut: ShortcutDefinition.runOrHotReload,
+      onExecute: () {},
+    );
+    expect(action.shortcut, ShortcutDefinition.runOrHotReload);
+    expect(action.label, 'Run / Hot reload');
+    expect(action.category, ShortcutCategory.execution);
+    expect(action.resolvedDisplayKey, resolveDisplayKey('Mod + Enter'));
+  });
+
+  testClient('CommandPaletteAction can be constructed without shortcut', (tester) {
+    final action = CommandPaletteAction(
+      label: 'Pub get',
+      onExecute: () {},
+    );
+    expect(action.shortcut, isNull);
+    expect(action.label, 'Pub get');
+    expect(action.resolvedDisplayKey, isEmpty);
+  });
+
+  testClient('displays all available commands directly upon opening', (tester) async {
+    final actions = createTestActions();
+    tester.pumpComponent(CommandPalette(actions: actions, onClose: () {}));
+    await pumpEventQueue();
+
+    final palette = web.document.querySelector('.command-palette');
+    expect(palette, isNotNull);
+
+    final items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 4);
+
+    final itemTitles = [
+      for (var i = 0; i < items.length; i++)
+        (items.item(i) as web.HTMLElement).querySelector('.command-palette-item-title')?.textContent,
+    ];
+    expect(itemTitles, [
+      'Pub get',
+      'Pub clean',
+      'Format document',
+      'Run / Hot reload',
+    ]);
+
+    // The first item is active by default.
+    final firstItem = items.item(0) as web.HTMLElement;
+    expect(firstItem.className, contains('active'));
+  });
+
+  testClient('filters commands dynamically when typing into search input', (tester) async {
+    final actions = createTestActions();
+    tester.pumpComponent(CommandPalette(actions: actions, onClose: () {}));
+    await pumpEventQueue();
+
+    final input = web.document.querySelector('.command-palette-input') as web.HTMLInputElement?;
+    expect(input, isNotNull);
+
+    // Search for "clean"
+    input!.value = 'clean';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    var items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 1);
+    expect(items.item(0)!.textContent, contains('Pub clean'));
+
+    // Search for "format"
+    input.value = 'format';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 1);
+    expect(items.item(0)!.textContent, contains('Format document'));
+
+    // Search for "reload" (matching text from "Run / Hot reload")
+    input.value = 'reload';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 1);
+    expect(items.item(0)!.textContent, contains('Run / Hot reload'));
+  });
+
+  testClient('displays empty message when no commands match query', (tester) async {
+    final actions = createTestActions();
+    tester.pumpComponent(CommandPalette(actions: actions, onClose: () {}));
+    await pumpEventQueue();
+
+    final input = web.document.querySelector('.command-palette-input') as web.HTMLInputElement?;
+    input!.value = 'nonexistent command';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    final items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 0);
+
+    final emptyElem = web.document.querySelector('.command-palette-empty');
+    expect(emptyElem, isNotNull);
+    expect(emptyElem!.textContent, contains('No matching commands found'));
+  });
+
+  testClient('navigates with ArrowDown and ArrowUp', (tester) async {
+    final actions = createTestActions();
+    tester.pumpComponent(CommandPalette(actions: actions, onClose: () {}));
+    await pumpEventQueue();
+
+    final input = web.document.querySelector('.command-palette-input') as web.HTMLInputElement?;
+    expect(input, isNotNull);
+
+    // Initial state: item 0 is active
+    var activeItem = web.document.querySelector('.command-palette-item.active');
+    expect(activeItem?.textContent, contains('Pub get'));
+
+    // Press ArrowDown -> item 1 active
+    web.document.dispatchEvent(
+      web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true)),
+    );
+    await pumpEventQueue();
+
+    activeItem = web.document.querySelector('.command-palette-item.active');
+    expect(activeItem?.textContent, contains('Pub clean'));
+
+    // Press ArrowDown -> item 2 active
+    web.document.dispatchEvent(
+      web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowDown', bubbles: true, cancelable: true)),
+    );
+    await pumpEventQueue();
+
+    activeItem = web.document.querySelector('.command-palette-item.active');
+    expect(activeItem?.textContent, contains('Format document'));
+
+    // Press ArrowUp -> back to item 1
+    web.document.dispatchEvent(
+      web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'ArrowUp', bubbles: true, cancelable: true)),
+    );
+    await pumpEventQueue();
+
+    activeItem = web.document.querySelector('.command-palette-item.active');
+    expect(activeItem?.textContent, contains('Pub clean'));
+  });
+
+  testClient('executes selected command on Enter and closes palette', (tester) async {
+    var runExecuted = false;
+    var closed = false;
+
+    final actions = createTestActions(
+      onRun: () => runExecuted = true,
+    );
+    tester.pumpComponent(
+      CommandPalette(
+        actions: actions,
+        onClose: () => closed = true,
+      ),
+    );
+    await pumpEventQueue();
+
+    final input = web.document.querySelector('.command-palette-input') as web.HTMLInputElement?;
+    input!.value = 'run';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    web.document.dispatchEvent(
+      web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'Enter', bubbles: true, cancelable: true)),
+    );
+    await pumpEventQueue();
+
+    expect(closed, isTrue);
+    expect(runExecuted, isTrue);
+  });
+
+  testClient('executes command on item click and closes palette', (tester) async {
+    var formatExecuted = false;
+    var closed = false;
+
+    final actions = createTestActions(
+      onFormat: () => formatExecuted = true,
+    );
+    tester.pumpComponent(
+      CommandPalette(
+        actions: actions,
+        onClose: () => closed = true,
+      ),
+    );
+    await pumpEventQueue();
+
+    final items = web.document.querySelectorAll('.command-palette-item');
+    final formatItem = items.item(2) as web.HTMLElement?; // Format Document
+    formatItem?.click();
+    await pumpEventQueue();
+
+    expect(closed, isTrue);
+    expect(formatExecuted, isTrue);
+  });
+
+  testClient('closes on Escape key without executing actions', (tester) async {
+    var closed = false;
+    var executed = false;
+
+    final actions = createTestActions(
+      onPubGet: () => executed = true,
+    );
+    tester.pumpComponent(
+      CommandPalette(
+        actions: actions,
+        onClose: () => closed = true,
+      ),
+    );
+    await pumpEventQueue();
+
+    web.document.dispatchEvent(
+      web.KeyboardEvent('keydown', web.KeyboardEventInit(key: 'Escape', bubbles: true, cancelable: true)),
+    );
+    await pumpEventQueue();
+
+    expect(closed, isTrue);
+    expect(executed, isFalse);
+  });
+
+  testClient('closes on backdrop click', (tester) async {
+    var closed = false;
+
+    final actions = createTestActions();
+    tester.pumpComponent(
+      CommandPalette(
+        actions: actions,
+        onClose: () => closed = true,
+      ),
+    );
+    await pumpEventQueue();
+
+    final backdrop = web.document.querySelector('.command-palette-backdrop') as web.HTMLElement?;
+    backdrop?.click();
+    await pumpEventQueue();
+
+    expect(closed, isTrue);
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/command_palette_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/command_palette_test.dart
@@ -12,27 +12,35 @@ import 'package:web/web.dart' as web;
 
 void main() {
   List<CommandPaletteAction> createTestActions({
-    void Function()? onPubGet,
-    void Function()? onPubClean,
-    void Function()? onFormat,
-    void Function()? onRun,
+    void Function(CommandContext)? onPubGet,
+    void Function(CommandContext)? onPubClean,
+    void Function(CommandContext)? onFormat,
+    void Function(CommandContext)? onRun,
   }) {
     return [
       CommandPaletteAction(
         label: 'Pub get',
-        onExecute: onPubGet ?? () {},
+        description: 'Download and resolve dependencies',
+        aliases: const ['get', 'packages get'],
+        onExecute: onPubGet ?? (_) {},
       ),
       CommandPaletteAction(
         label: 'Pub clean',
-        onExecute: onPubClean ?? () {},
+        description: 'Remove build and cache artifacts',
+        aliases: const ['clean'],
+        onExecute: onPubClean ?? (_) {},
       ),
       CommandPaletteAction.fromShortcut(
         shortcut: ShortcutDefinition.formatDocument,
-        onExecute: onFormat ?? () {},
+        description: 'Format the currently active document',
+        aliases: const ['format', 'beautify'],
+        onExecute: onFormat ?? (_) {},
       ),
       CommandPaletteAction.fromShortcut(
         shortcut: ShortcutDefinition.runOrHotReload,
-        onExecute: onRun ?? () {},
+        description: 'Run the application or hot reload',
+        aliases: const ['run', 'reload'],
+        onExecute: onRun ?? (_) {},
       ),
     ];
   }
@@ -40,10 +48,14 @@ void main() {
   testClient('CommandPaletteAction.fromShortcut populates properties from shortcut', (tester) {
     final action = CommandPaletteAction.fromShortcut(
       shortcut: ShortcutDefinition.runOrHotReload,
-      onExecute: () {},
+      description: 'Run the app',
+      aliases: const ['run', 'reload'],
+      onExecute: (_) {},
     );
     expect(action.shortcut, ShortcutDefinition.runOrHotReload);
     expect(action.label, 'Run / Hot reload');
+    expect(action.description, 'Run the app');
+    expect(action.aliases, ['run', 'reload']);
     expect(action.category, ShortcutCategory.execution);
     expect(action.resolvedDisplayKey, resolveDisplayKey('Mod + Enter'));
   });
@@ -51,11 +63,29 @@ void main() {
   testClient('CommandPaletteAction can be constructed without shortcut', (tester) {
     final action = CommandPaletteAction(
       label: 'Pub get',
-      onExecute: () {},
+      description: 'Fetch packages',
+      aliases: const ['get'],
+      onExecute: (_) {},
     );
     expect(action.shortcut, isNull);
     expect(action.label, 'Pub get');
+    expect(action.description, 'Fetch packages');
+    expect(action.aliases, ['get']);
     expect(action.resolvedDisplayKey, isEmpty);
+  });
+
+  testClient('allCommandActions includes all expected default actions', (tester) {
+    final labels = allCommandActions.map((a) => a.label).toList();
+    expect(labels, [
+      'Pub get',
+      'Pub upgrade',
+      'Pub outdated',
+      'Pub downgrade',
+      'Pub clean',
+      'Format document',
+      'Run / Hot reload',
+      'Save file',
+    ]);
   });
 
   testClient('displays all available commands directly upon opening', (tester) async {
@@ -102,14 +132,23 @@ void main() {
     expect(items.length, 1);
     expect(items.item(0)!.textContent, contains('Pub clean'));
 
-    // Search for "format"
-    input.value = 'format';
+    // Search by alias "beautify" for format
+    input.value = 'beautify';
     input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
     await pumpEventQueue();
 
     items = web.document.querySelectorAll('.command-palette-item');
     expect(items.length, 1);
     expect(items.item(0)!.textContent, contains('Format document'));
+
+    // Search by alias "packages get" for pub get
+    input.value = 'packages get';
+    input.dispatchEvent(web.Event('input', web.EventInit(bubbles: true)));
+    await pumpEventQueue();
+
+    items = web.document.querySelectorAll('.command-palette-item');
+    expect(items.length, 1);
+    expect(items.item(0)!.textContent, contains('Pub get'));
 
     // Search for "reload" (matching text from "Run / Hot reload")
     input.value = 'reload';
@@ -179,15 +218,17 @@ void main() {
     expect(activeItem?.textContent, contains('Pub clean'));
   });
 
-  testClient('executes selected command on Enter and closes palette', (tester) async {
-    var runExecuted = false;
+  testClient('executes selected command on Enter, passes CommandContext, and closes palette', (tester) async {
+    CommandContext? capturedContext;
     var closed = false;
 
+    final testContext = const CommandContext(projectDir: 'my_project');
     final actions = createTestActions(
-      onRun: () => runExecuted = true,
+      onRun: (context) => capturedContext = context,
     );
     tester.pumpComponent(
       CommandPalette(
+        context: testContext,
         actions: actions,
         onClose: () => closed = true,
       ),
@@ -205,7 +246,7 @@ void main() {
     await pumpEventQueue();
 
     expect(closed, isTrue);
-    expect(runExecuted, isTrue);
+    expect(capturedContext, same(testContext));
   });
 
   testClient('executes command on item click and closes palette', (tester) async {
@@ -213,7 +254,7 @@ void main() {
     var closed = false;
 
     final actions = createTestActions(
-      onFormat: () => formatExecuted = true,
+      onFormat: (_) => formatExecuted = true,
     );
     tester.pumpComponent(
       CommandPalette(
@@ -237,7 +278,7 @@ void main() {
     var executed = false;
 
     final actions = createTestActions(
-      onPubGet: () => executed = true,
+      onPubGet: (_) => executed = true,
     );
     tester.pumpComponent(
       CommandPalette(

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
@@ -122,6 +122,11 @@ final undocumentedShortcutReasons = <String, String>{
     for (final key in group.value) key: group.key,
 };
 
+/// Documented shortcuts handled at the app/window level rather than inside CodeMirror.
+const _appLevelShortcuts = <ShortcutDefinition>{
+  ShortcutDefinition.commandPalette,
+};
+
 final class _TestLanguageServerClient implements LanguageServerClient {
   @override
   JSObject createCodeMirrorExtension(String file) => [
@@ -164,6 +169,15 @@ void main() {
     final documentedKeys = shortcutDefinitions.expand((shortcut) => shortcut.codemirrorKeys).toSet();
 
     for (final shortcut in shortcutDefinitions) {
+      if (_appLevelShortcuts.contains(shortcut)) {
+        continue;
+      }
+      expect(
+        shortcut.codemirrorKeys,
+        isNotEmpty,
+        reason:
+            '"${shortcut.label}" has no CodeMirror keys and is not listed in _appLevelShortcuts.',
+      );
       final hasKey = shortcut.codemirrorKeys.any(registeredKeys.contains);
       expect(
         hasKey,
@@ -172,6 +186,16 @@ void main() {
             '"${shortcut.label}" expects one of ${shortcut.codemirrorKeys} '
             'to be registered in CodeMirror, but none were found. '
             'Registered keys: $registeredKeys',
+      );
+    }
+
+    for (final shortcut in _appLevelShortcuts) {
+      expect(
+        shortcut.codemirrorKeys,
+        isEmpty,
+        reason:
+            '"${shortcut.label}" is listed in _appLevelShortcuts but defines CodeMirror keys: '
+            '${shortcut.codemirrorKeys}',
       );
     }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
@@ -175,8 +175,7 @@ void main() {
       expect(
         shortcut.codemirrorKeys,
         isNotEmpty,
-        reason:
-            '"${shortcut.label}" has no CodeMirror keys and is not listed in _appLevelShortcuts.',
+        reason: '"${shortcut.label}" has no CodeMirror keys and is not listed in _appLevelShortcuts.',
       );
       final hasKey = shortcut.codemirrorKeys.any(registeredKeys.contains);
       expect(

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
@@ -78,4 +78,21 @@ void main() {
     backdrop?.click();
     expect(closed, isTrue);
   });
+
+  testClient('renders View category with Open command palette shortcut', (tester) async {
+    tester.pumpComponent(ShortcutsDialog(onClose: () {}));
+
+    final categories = web.document.querySelectorAll('.shortcuts-dialog-category');
+    final categoryTexts = [
+      for (var i = 0; i < categories.length; i++) categories.item(i)?.textContent,
+    ];
+    expect(categoryTexts, contains('View'));
+
+    final rows = web.document.querySelectorAll('.shortcuts-dialog-row');
+    final rowLabels = [
+      for (var i = 0; i < rows.length; i++)
+        (rows.item(i) as web.HTMLElement).querySelector('.shortcuts-dialog-command')?.textContent,
+    ];
+    expect(rowLabels, contains('Open command palette'));
+  });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
@@ -101,6 +101,34 @@ void main() {
     await events.dispose();
   });
 
+  test('runWorkspacePubCommand logs its path and command output in order', () async {
+    final events = AppEventBus();
+    final logs = <LogEvent>[];
+    final subscription = events.on<LogEvent>().listen(logs.add);
+    String? commandPath;
+
+    await runWorkspacePubCommand(
+      events: events,
+      commandName: 'upgrade',
+      path: 'example/.',
+      projectRoot: 'example',
+      command: (path) async {
+        commandPath = path;
+        return 'Upgraded dependencies...';
+      },
+    );
+    await pumpEventQueue();
+
+    expect(commandPath, 'example');
+    expect(logs.map((event) => event.message), [
+      'Running pub upgrade in /',
+      'Upgraded dependencies...',
+    ]);
+
+    await subscription.cancel();
+    await events.dispose();
+  });
+
   test(
     'cleanGeneratedOutput removes build and .dart_tool when present',
     () async {
@@ -167,6 +195,84 @@ void main() {
     await future;
 
     expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+    taskStatus.dispose();
+    await repository.events.dispose();
+  });
+
+  test('Pub Upgrade exposes a blocking task status', () async {
+    final completer = Completer<Workspace>();
+    final taskStatus = TaskStatusController();
+    final repository = WorkspaceRepository(
+      events: AppEventBus(),
+      taskStatus: taskStatus,
+      workspaceResourceApi: _Workspace(),
+      sdk: defaultSdk,
+      workspaceFuture: completer.future,
+    );
+
+    final future = repository.pubUpgrade(path: 'example');
+    expect(taskStatus.current?.kind, TaskKind.pubUpgrade);
+    expect(taskStatus.current?.label, 'Pub upgrade in example');
+    expect(taskStatus.current?.scope, 'example');
+    expect(taskStatus.hasBlockingPreviewTask, isTrue);
+
+    completer.completeError(StateError('workspace not available'));
+    await expectLater(future, throwsA(isA<StateError>()));
+
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+    taskStatus.dispose();
+    await repository.events.dispose();
+  });
+
+  test('Pub Downgrade exposes a blocking task status', () async {
+    final completer = Completer<Workspace>();
+    final taskStatus = TaskStatusController();
+    final repository = WorkspaceRepository(
+      events: AppEventBus(),
+      taskStatus: taskStatus,
+      workspaceResourceApi: _Workspace(),
+      sdk: defaultSdk,
+      workspaceFuture: completer.future,
+    );
+
+    final future = repository.pubDowngrade(path: 'example');
+    expect(taskStatus.current?.kind, TaskKind.pubDowngrade);
+    expect(taskStatus.current?.label, 'Pub downgrade in example');
+    expect(taskStatus.current?.scope, 'example');
+    expect(taskStatus.hasBlockingPreviewTask, isTrue);
+
+    completer.completeError(StateError('workspace not available'));
+    await expectLater(future, throwsA(isA<StateError>()));
+
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+    taskStatus.dispose();
+    await repository.events.dispose();
+  });
+
+  test('Pub Outdated exposes a non-blocking task status', () async {
+    final completer = Completer<Workspace>();
+    final taskStatus = TaskStatusController();
+    final repository = WorkspaceRepository(
+      events: AppEventBus(),
+      taskStatus: taskStatus,
+      workspaceResourceApi: _Workspace(),
+      sdk: defaultSdk,
+      workspaceFuture: completer.future,
+    );
+
+    final future = repository.pubOutdated(path: 'example');
+    expect(taskStatus.current?.kind, TaskKind.pubOutdated);
+    expect(taskStatus.current?.label, 'Pub outdated in example');
+    expect(taskStatus.current?.scope, 'example');
+    expect(taskStatus.hasBlockingPreviewTask, isFalse);
+
+    completer.completeError(StateError('workspace not available'));
+    await expectLater(future, throwsA(isA<StateError>()));
+
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
     expect(taskStatus.hasBlockingPreviewTask, isFalse);
     taskStatus.dispose();
     await repository.events.dispose();


### PR DESCRIPTION
Adds a command palette which can be opened with
`cmd+shift+p`.

<img width="942" height="776" alt="grafik" src="https://github.com/user-attachments/assets/7c08c9de-a3ac-45de-98e4-76c7c3e42ac0" />

Fixes #3823 