### PR TITLE
[dartpad preview]: Implement collapsible panels

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -110,7 +110,7 @@ class AppState extends State<App> {
   String _projectDir = '';
   String? _workspacePreparationFailure;
 
-  final _previewSplitKey = GlobalStateKey<SplitPanelState>();
+  GlobalStateKey<SplitPanelState> _previewSplitKey = GlobalStateKey<SplitPanelState>();
 
   bool _isLargeScreen = true;
   SmallScreenTab _selectedSmallScreenTab = .code;
@@ -379,6 +379,7 @@ class AppState extends State<App> {
 
     setState(() {
       _workspaceGeneration++;
+      _previewSplitKey = GlobalStateKey<SplitPanelState>();
       _session = nextSession;
       _isInitializingWorkspace = true;
       _workspacePreparationFailure = null;
@@ -429,6 +430,7 @@ class AppState extends State<App> {
 
     setState(() {
       _workspaceGeneration++;
+      _previewSplitKey = GlobalStateKey<SplitPanelState>();
       _session = nextSession;
       _currentSdk = newSdk;
       _isInitializingWorkspace = true;

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -110,6 +110,8 @@ class AppState extends State<App> {
   String _projectDir = '';
   String? _workspacePreparationFailure;
 
+  final _previewSplitKey = GlobalStateKey<SplitPanelState>();
+
   bool _isLargeScreen = true;
   SmallScreenTab _selectedSmallScreenTab = .code;
   StreamSubscription<web.Event>? _resizeSubscription;
@@ -154,14 +156,16 @@ class AppState extends State<App> {
   }
 
   void _onPreviewStateChanged() {
-    if (!_isLargeScreen) {
-      final state = _session.preview.state;
-      if (state is PreviewStarting || state is PreviewRestarting || state is PreviewRunning) {
+    final state = _session.preview.state;
+    if (state is PreviewStarting || state is PreviewRestarting || state is PreviewRunning) {
+      if (!_isLargeScreen) {
         if (_selectedSmallScreenTab != .output) {
           setState(() {
             _selectedSmallScreenTab = .output;
           });
         }
+      } else if (_previewSplitKey.currentState?.isRightCollapsed ?? false) {
+        _previewSplitKey.currentState?.split();
       }
     }
   }
@@ -631,11 +635,15 @@ class AppState extends State<App> {
           div(classes: 'app-workspace', [
             if (_isLargeScreen)
               SplitPanel(
+                key: _previewSplitKey,
                 initialValue: 0.7,
+                canCollapseRight: true,
+                minValue: 0.3,
+                maxValue: 0.85,
                 left: EditorShell(
                   openTabs: session.tabs.openTabs,
                   activeFile: session.tabs.activeFile,
-                  fileTreeBuilder: (onCollapse) => _buildFileTree(session, onCollapse: onCollapse),
+                  fileTree: _buildFileTree(session),
                   editorOverlay: _buildEditorOverlay(session),
                   onSwitchFile: session.tabs.switchFile,
                   onCloseFile: session.tabs.closeFile,
@@ -649,7 +657,7 @@ class AppState extends State<App> {
               EditorShell(
                 openTabs: session.tabs.openTabs,
                 activeFile: session.tabs.activeFile,
-                fileTreeBuilder: (onCollapse) => _buildFileTree(session, onCollapse: onCollapse),
+                fileTree: _buildFileTree(session),
                 editorOverlay: _buildEditorOverlay(session),
                 onSwitchFile: session.tabs.switchFile,
                 onCloseFile: session.tabs.closeFile,
@@ -724,14 +732,13 @@ class AppState extends State<App> {
     ]);
   }
 
-  Component _buildFileTree(WorkspaceSession session, {VoidCallback? onCollapse}) {
+  Component _buildFileTree(WorkspaceSession session) {
     return ListenableBuilder(
       listenable: session.fileTree,
       builder: (context) => FileTreeView(
         state: session.fileTree.state,
         actions: session.fileTree.actions,
         contextMenu: session.contextMenu,
-        onCollapse: onCollapse,
       ),
     );
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -10,6 +10,7 @@ import 'package:jaspr/jaspr.dart';
 
 import '../../shared/app_event_bus.dart';
 import '../../shared/components/context_menu.dart';
+import '../../shared/components/split_panel.dart';
 import '../../shared/events/open_console_event.dart';
 import '../models/console_entry.dart';
 import 'bottom_panel_tabs.dart';
@@ -91,29 +92,49 @@ class _BottomPanelState extends State<BottomPanel> {
 
   void _listenForOpenConsole() {
     _openConsoleSubscription = component.events.on<OpenConsoleEvent>().listen((_) {
+      final panel = SplitPanel.of(context, listen: false);
+      if (panel != null && panel.isPanelCollapsed) {
+        panel.expand();
+      }
       if (mounted && _activeTab != BottomPanelTab.console) {
-        _selectTab(BottomPanelTab.console);
+        setState(() {
+          _activeTab = BottomPanelTab.console;
+        });
       }
     });
   }
 
-  void _selectTab(BottomPanelTab tab) {
-    setState(() {
-      _activeTab = tab;
-    });
+  @override
+  void dispose() {
+    unawaited(_openConsoleSubscription?.cancel());
+    super.dispose();
   }
 
   @override
   Component build(BuildContext context) {
-    return div(classes: 'bottom-panel', [
-      BottomPanelTabs(
-        problemsCount: component.diagnostics.length,
-        activeTab: _activeTab,
-        onSelectTab: _selectTab,
-        onClearConsole: component.onClearConsole,
-      ),
-      _buildContent(),
-    ]);
+    final panel = SplitPanel.of(context);
+    final isCollapsed = panel?.isPanelCollapsed ?? false;
+    return div(
+      classes: 'bottom-panel${isCollapsed ? ' collapsed' : ''}',
+      [
+        BottomPanelTabs(
+          problemsCount: component.diagnostics.length,
+          activeTab: _activeTab,
+          isCollapsed: isCollapsed,
+          onSelectTab: (tab) {
+            if (isCollapsed) {
+              panel?.expand();
+            }
+            setState(() {
+              _activeTab = tab;
+            });
+          },
+          onClearConsole: component.onClearConsole,
+          onCollapse: () => panel?.collapse(),
+        ),
+        if (!isCollapsed) _buildContent(),
+      ],
+    );
   }
 
   Component _buildContent() {
@@ -134,16 +155,9 @@ class _BottomPanelState extends State<BottomPanel> {
     ]);
   }
 
-  @override
-  void dispose() {
-    unawaited(_openConsoleSubscription?.cancel());
-    super.dispose();
-  }
-
   static List<StyleRule> get styles => [
     css('.bottom-panel').styles(
       display: .flex,
-      height: 100.percent,
       flexDirection: .column,
       flex: const .shrink(0),
     ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -130,7 +130,7 @@ class _BottomPanelState extends State<BottomPanel> {
             });
           },
           onClearConsole: component.onClearConsole,
-          onCollapse: () => panel?.collapse(),
+          onCollapse: panel != null && panel.canCollapse ? panel.collapse : null,
         ),
         if (!isCollapsed) _buildContent(),
       ],

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel_tabs.dart
@@ -16,6 +16,8 @@ class BottomPanelTabs extends StatelessComponent {
     required this.activeTab,
     required this.onSelectTab,
     required this.onClearConsole,
+    this.isCollapsed = false,
+    this.onCollapse,
     super.key,
   });
 
@@ -31,29 +33,44 @@ class BottomPanelTabs extends StatelessComponent {
   /// Clears the console's output.
   final void Function() onClearConsole;
 
+  /// Whether the bottom panel content is currently collapsed.
+  final bool isCollapsed;
+
+  /// An optional callback invoked to collapse the panel content.
+  final VoidCallback? onCollapse;
+
   @override
   Component build(BuildContext context) {
     return div(classes: 'bottom-panel-tabs', [
       _BottomPanelTabButton(
         label: 'Problems',
         countLabel: problemsCount.toString(),
-        active: activeTab == BottomPanelTab.problems,
+        active: !isCollapsed && activeTab == BottomPanelTab.problems,
         onClick: () => onSelectTab(BottomPanelTab.problems),
       ),
       _BottomPanelTabButton(
         label: 'Console',
-        active: activeTab == BottomPanelTab.console,
+        active: !isCollapsed && activeTab == BottomPanelTab.console,
         onClick: () => onSelectTab(BottomPanelTab.console),
       ),
       const div(classes: 'bottom-panel-tabs-spacer', []),
-      if (activeTab == BottomPanelTab.console)
+      if (!isCollapsed && activeTab == BottomPanelTab.console)
         IconButton(
           icon: 'playlist_remove',
           iconSize: 20,
           tooltip: 'Clear console',
           label: 'Clear console',
-          classes: 'bottom-panel-clear-btn',
+          classes: 'bottom-panel-btn',
           onClick: (_) => onClearConsole(),
+        ),
+      if (!isCollapsed && onCollapse != null)
+        IconButton(
+          tooltip: 'Hide bottom panel',
+          label: 'Hide bottom panel',
+          icon: 'expand_more',
+          iconSize: 20,
+          classes: 'bottom-panel-btn',
+          onClick: (_) => onCollapse!(),
         ),
     ]);
   }
@@ -109,8 +126,8 @@ class BottomPanelTabs extends StatelessComponent {
     css('.bottom-panel-tabs-spacer').styles(
       flex: const Flex(grow: 1),
     ),
-    css('.bottom-panel-clear-btn').styles(
-      margin: .only(right: 8.px),
+    css('.bottom-panel-btn').styles(
+      margin: .only(top: 2.px, bottom: 2.px, right: 8.px),
       alignSelf: .center,
     ),
   ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -125,13 +125,6 @@ class EditorShell extends StatelessComponent {
       flex: const Flex(grow: 1, basis: .zero),
       backgroundColor: colorContainer,
     ),
-    css('.file-tree-pane').styles(
-      display: .flex,
-      minWidth: 100.px,
-      minHeight: .zero,
-      overflow: .hidden,
-      flexDirection: .column,
-    ),
     css('.editor-host').styles(
       display: .flex,
       minWidth: .zero,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_shell.dart
@@ -9,18 +9,17 @@ import 'package:jaspr/jaspr.dart';
 import '../../../app_styles.dart';
 import '../../shared/components/context_menu.dart';
 import '../../shared/components/split_panel.dart';
-import '../../shared/icons.dart';
 import 'editor_breadcrumbs.dart';
 import 'editor_stack.dart';
 import 'editor_tab_bar.dart';
 
 /// Top-level layout shell that hosts the CodeMirror editor.
-class EditorShell extends StatefulComponent {
+class EditorShell extends StatelessComponent {
   /// Creates the top-level editor layout.
   const EditorShell({
     required this.openTabs,
     required this.activeFile,
-    required this.fileTreeBuilder,
+    required this.fileTree,
     required this.editorOverlay,
     required this.onSwitchFile,
     required this.onCloseFile,
@@ -46,8 +45,8 @@ class EditorShell extends StatefulComponent {
   /// Closes the editor tab at the provided path.
   final bool Function(String path, {bool discardChanges})? onCloseFile;
 
-  /// A builder function that creates the file tree component with a collapse callback.
-  final Component Function(VoidCallback onCollapse) fileTreeBuilder;
+  /// The file tree component to show in the side panel.
+  final Component fileTree;
 
   /// A component displayed above the active editor content.
   final Component editorOverlay;
@@ -69,96 +68,53 @@ class EditorShell extends StatefulComponent {
   final Component? smallScreenPreviewPanel;
 
   @override
-  State<EditorShell> createState() => _EditorShellState();
-
-  @css
-  static List<StyleRule> get styles => _EditorShellState.styles;
-}
-
-class _EditorShellState extends State<EditorShell> {
-  late bool _fileTreeCollapsed;
-
-  @override
-  void initState() {
-    super.initState();
-    _fileTreeCollapsed = component.isEmbedMode;
-  }
-
-  void _toggleFileTree() {
-    setState(() {
-      _fileTreeCollapsed = !_fileTreeCollapsed;
-    });
-  }
-
-  @override
   Component build(BuildContext context) {
-    final openTabs = component.openTabs;
-
+    final openTabs = this.openTabs;
     final editorContent = main_(classes: 'editor-host', [
       SplitPanel(
         isVertical: true,
         useRatio: true,
         initialValue: 0.75,
         minValue: 0.3,
-        maxValue: 0.9,
+        maxValue: 0.85,
+        canCollapseRight: true,
         left: div(classes: 'editor-area', [
           if (openTabs != null) ...[
             EditorTabBar(
               openTabs: openTabs,
-              activeFile: component.activeFile,
-              onSwitchFile: component.onSwitchFile!,
-              onCloseFile: component.onCloseFile!,
-              contextMenu: component.contextMenu,
+              activeFile: activeFile,
+              onSwitchFile: onSwitchFile!,
+              onCloseFile: onCloseFile!,
+              contextMenu: contextMenu,
             ),
-            if (component.activeFile.isNotEmpty) EditorBreadcrumbs(path: component.activeFile),
+            if (activeFile.isNotEmpty) EditorBreadcrumbs(path: activeFile),
             EditorStack(
               openTabs: openTabs,
-              activeFile: component.activeFile,
-              overlay: component.editorOverlay,
+              activeFile: activeFile,
+              overlay: editorOverlay,
             ),
           ],
         ]),
-        right: component.bottomPanel,
+        right: bottomPanel,
       ),
     ]);
-    final Component rightContent = component.smallScreenPreviewPanel ?? editorContent;
+    final Component rightContent = smallScreenPreviewPanel ?? editorContent;
 
-    final Component shellContent;
-    // Collapsed file tree: show a narrow rail with a toggle button.
-    if (_fileTreeCollapsed) {
-      shellContent = div(classes: 'editor-shell', [
-        aside(classes: 'file-tree-rail', [
-          button(
-            classes: 'file-tree-rail-button',
-            attributes: {
-              'title': 'Show file tree',
-              'aria-label': 'Show file tree',
-            },
-            onClick: _toggleFileTree,
-            [const Icon('folder_open', size: 18)],
-          ),
-        ]),
-        rightContent,
-      ]);
-    } else {
-      // Expanded file tree.
-      shellContent = div(classes: 'editor-shell', [
-        SplitPanel(
-          initialValue: 200,
-          useRatio: false,
-          minValue: 150,
-          maxValue: 300,
-          left: aside(classes: 'file-tree-pane', [
-            component.fileTreeBuilder(_toggleFileTree),
-          ]),
-          right: rightContent,
-        ),
-      ]);
-    }
-
-    return shellContent;
+    return div(classes: 'editor-shell', [
+      SplitPanel(
+        initialValue: 200,
+        initialState: isEmbedMode ? const LeftCollapsed(200) : null,
+        useRatio: false,
+        minValue: 150,
+        maxValue: 300,
+        canCollapseLeft: true,
+        left: fileTree,
+        right: rightContent,
+      ),
+    ]);
   }
 
+  @css
   static List<StyleRule> get styles => [
     css('.editor-shell').styles(
       display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -11,6 +11,8 @@ import 'package:web/web.dart' as web;
 
 import '../../app_styles.dart';
 import '../shared/components/context_menu.dart';
+import '../shared/components/icon_button.dart';
+import '../shared/components/split_panel.dart';
 import '../shared/icons.dart';
 import 'components/file_tree_file_item.dart';
 import 'components/file_tree_folder_item.dart';
@@ -28,7 +30,6 @@ final class FileTreeView extends StatefulComponent {
     required this.actions,
     this.confirmDelete,
     this.contextMenu,
-    this.onCollapse,
     super.key,
   });
 
@@ -43,9 +44,6 @@ final class FileTreeView extends StatefulComponent {
 
   /// The context menu controller used to show right-click menus.
   final ContextMenuController? contextMenu;
-
-  /// An optional callback invoked when the user clicks the collapse button in the header.
-  final VoidCallback? onCollapse;
 
   @override
   State<FileTreeView> createState() => _FileTreeViewInternalState();
@@ -73,20 +71,34 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
 
   @override
   Component build(BuildContext context) {
+    final panel = SplitPanel.of(context);
+    if (panel?.isPanelCollapsed ?? false) {
+      return aside(classes: 'file-tree-rail', [
+        IconButton(
+          tooltip: 'Show file tree',
+          label: 'Show file tree',
+          icon: 'folder_open',
+          iconSize: 18,
+          onClick: (_) => panel?.expand(),
+        ),
+      ]);
+    }
+
     final state = component.state;
     final actions = component.actions;
+    final showCollapse = panel != null && panel.canCollapse;
 
-    return div(classes: 'file-tree', [
+    return aside(classes: 'file-tree-pane file-tree', [
       div(classes: 'file-tree-header', [
         const span(classes: 'file-tree-title', [.text('Explorer')]),
-        if (component.onCollapse case final onCollapse?)
+        if (showCollapse)
           button(
             classes: 'file-tree-collapse-button',
             attributes: const {
               'title': 'Hide file tree',
               'aria-label': 'Hide file tree',
             },
-            onClick: onCollapse,
+            onClick: panel.collapse,
             [const Icon('chevron_left', size: 16)],
           ),
       ]),
@@ -317,6 +329,19 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
   }
 
   static List<StyleRule> get styles => [
+    css('.file-tree-rail').styles(
+      display: .flex,
+      width: 36.px,
+      minWidth: 36.px,
+      padding: .only(top: 8.px),
+      border: .only(
+        right: .solid(color: colorBorder, width: 1.px),
+      ),
+      flexDirection: .column,
+      alignItems: .center,
+      flex: const .shrink(0),
+      backgroundColor: colorSurface,
+    ),
     css('.file-tree', [
       css('&').styles(
         display: .flex,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view.dart
@@ -88,7 +88,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
     final actions = component.actions;
     final showCollapse = panel != null && panel.canCollapse;
 
-    return aside(classes: 'file-tree-pane file-tree', [
+    return aside(classes: 'file-tree', [
       div(classes: 'file-tree-header', [
         const span(classes: 'file-tree-title', [.text('Explorer')]),
         if (showCollapse)
@@ -346,6 +346,7 @@ final class _FileTreeViewInternalState extends State<FileTreeView> {
       css('&').styles(
         display: .flex,
         height: 100.percent,
+        minWidth: 100.px,
         minHeight: .zero,
         overflow: .hidden,
         flexDirection: .column,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -8,6 +8,8 @@ import 'package:jaspr/jaspr.dart';
 import '../../../app_styles.dart';
 import '../../bottom_panel/views/console_panel.dart';
 import '../../shared/components/button_group.dart';
+import '../../shared/components/icon_button.dart';
+import '../../shared/components/split_panel.dart';
 import '../../shared/components/task_status_indicator.dart';
 import '../../shared/node_container.dart';
 import '../../shared/task_status.dart';
@@ -52,6 +54,9 @@ class PreviewContainer extends StatefulComponent {
 class _PreviewContainerState extends State<PreviewContainer> {
   @override
   Component build(BuildContext context) {
+    final panel = SplitPanel.of(context);
+    final isCollapsed = panel?.isPanelCollapsed ?? false;
+
     final viewModel = component.preview;
     final state = viewModel.state;
     final isRunning = viewModel.isRunning;
@@ -70,29 +75,55 @@ class _PreviewContainerState extends State<PreviewContainer> {
       _ => null,
     };
 
-    return div(classes: 'preview-container', [
-      div(classes: 'preview-toolbar', [
-        div(classes: 'preview-controls', [
-          ListenableBuilder(
-            listenable: component.taskStatus,
-            builder: (context) => ButtonGroup(
-              children: [
-                if (isRunning)
-                  RuntimeButton.restart(previewViewModel: viewModel)
-                else
-                  RuntimeButton.start(
-                    previewViewModel: viewModel,
-                    activeFile: component.activeFile,
-                  ),
-                RuntimeButton.hotReload(previewViewModel: viewModel),
-                RuntimeButton.stop(previewViewModel: viewModel),
-              ],
-            ),
+    return div(classes: 'preview-container${isCollapsed ? ' collapsed' : ''}', [
+      aside(
+        key: const ValueKey('preview-rail'),
+        classes: 'preview-rail${isCollapsed ? '' : ' hidden'}',
+        [
+          IconButton(
+            tooltip: 'Show preview',
+            label: 'Show preview',
+            icon: 'play_arrow',
+            iconSize: 18,
+            onClick: (_) => panel?.expand(),
           ),
-        ]),
-      ]),
+        ],
+      ),
       div(
-        classes: 'preview-content ${!isRunning ? 'status-stopped' : ''} ${!viewModel.isFlutter ? 'is-dart' : ''}',
+        key: const ValueKey('preview-toolbar'),
+        classes: 'preview-toolbar${isCollapsed ? ' hidden' : ''}',
+        [
+          div(classes: 'preview-controls', [
+            ListenableBuilder(
+              listenable: component.taskStatus,
+              builder: (context) => ButtonGroup(
+                children: [
+                  if (isRunning)
+                    RuntimeButton.restart(previewViewModel: viewModel)
+                  else
+                    RuntimeButton.start(
+                      previewViewModel: viewModel,
+                      activeFile: component.activeFile,
+                    ),
+                  RuntimeButton.hotReload(previewViewModel: viewModel),
+                  RuntimeButton.stop(previewViewModel: viewModel),
+                ],
+              ),
+            ),
+          ]),
+          if (panel != null)
+            IconButton(
+              tooltip: 'Hide preview',
+              label: 'Hide preview',
+              icon: 'chevron_right',
+              onClick: (_) => panel.collapse(),
+            ),
+        ],
+      ),
+      div(
+        key: const ValueKey('preview-content'),
+        classes:
+            'preview-content ${!isRunning ? 'status-stopped' : ''} ${!viewModel.isFlutter ? 'is-dart' : ''}${isCollapsed ? ' collapsed' : ''}',
         [
           NodeContainer(viewModel.containerElement),
           if (taskStatusMode != null)
@@ -111,6 +142,21 @@ class _PreviewContainerState extends State<PreviewContainer> {
 
   static List<StyleRule> get styles => [
     ...PreviewTaskStatus.styles,
+    css('.preview-rail', [
+      css('&').styles(
+        display: .flex,
+        flexDirection: .column,
+        alignItems: .center,
+        width: 36.px,
+        height: 100.percent,
+        padding: .only(top: 8.px),
+        backgroundColor: colorSurface,
+        flex: const .shrink(0),
+      ),
+      css('&.hidden').styles(
+        display: .none,
+      ),
+    ]),
     css('.preview-container', [
       css('&').styles(
         display: .flex,
@@ -119,6 +165,13 @@ class _PreviewContainerState extends State<PreviewContainer> {
         flexDirection: .column,
         flex: const .grow(1),
         backgroundColor: colorContainer,
+      ),
+      css('&.collapsed').styles(
+        width: 36.px,
+        minWidth: 36.px,
+        maxWidth: 36.px,
+        flex: const .shrink(0),
+        backgroundColor: colorSurface,
       ),
       css('.active-icon-btn').styles(
         color: colorOnPrimary,
@@ -139,6 +192,9 @@ class _PreviewContainerState extends State<PreviewContainer> {
           flex: const .shrink(0),
           backgroundColor: colorSurface,
         ),
+        css('&.hidden').styles(
+          display: .none,
+        ),
         css('.preview-controls').styles(
           display: .flex,
           alignItems: .center,
@@ -155,6 +211,13 @@ class _PreviewContainerState extends State<PreviewContainer> {
           justifyContent: .center,
           alignItems: .center,
           flex: const .grow(1),
+        ),
+        css('&.collapsed').styles(
+          position: const .absolute(),
+          width: .zero,
+          height: .zero,
+          visibility: .hidden,
+          pointerEvents: .none,
         ),
         css('& .preview, & iframe').styles(
           width: 100.percent,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -254,13 +254,13 @@ class _PreviewContainerState extends State<PreviewContainer> {
     css('.preview-rail', [
       css('&').styles(
         display: .flex,
-        flexDirection: .column,
-        alignItems: .center,
         width: 36.px,
         height: 100.percent,
         padding: .only(top: 8.px),
-        backgroundColor: colorSurface,
+        flexDirection: .column,
+        alignItems: .center,
         flex: const .shrink(0),
+        backgroundColor: colorSurface,
       ),
       css('&.hidden').styles(
         display: .none,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -111,7 +111,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
               ),
             ),
           ]),
-          if (panel != null)
+          if (panel != null && panel.canCollapse)
             IconButton(
               tooltip: 'Hide preview',
               label: 'Hide preview',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
@@ -113,7 +113,7 @@ final class RightHidden extends SplitState {
   int get hashCode => Object.hash(RightHidden, lastSplitValue);
 }
 
-///// An inherited component that exposes [SplitPanelData] to descendants of a [SplitPanel].
+/// An inherited component that exposes [SplitPanelData] to descendants of a [SplitPanel].
 class _InheritedSplitPanel extends InheritedComponent {
   _InheritedSplitPanel({required this.data, required super.child});
 
@@ -314,7 +314,8 @@ class SplitPanelState extends State<SplitPanel> {
   }
 
   bool isDragging = false;
-  bool _dragStartedWhileCollapsed = false;
+  bool _dragStartedWhileLeftCollapsed = false;
+  bool _dragStartedWhileRightCollapsed = false;
   double _dragStartPos = 0;
   StreamSubscription<web.MouseEvent>? _mouseMoveSubscription;
   StreamSubscription<web.MouseEvent>? _mouseUpSubscription;
@@ -350,7 +351,8 @@ class SplitPanelState extends State<SplitPanel> {
 
     final startPos = component.isVertical ? event.clientY.toDouble() : event.clientX.toDouble();
     _dragStartPos = startPos;
-    _dragStartedWhileCollapsed = (canCollapseRight && isRightCollapsed) || (canCollapseLeft && isLeftCollapsed);
+    _dragStartedWhileRightCollapsed = canCollapseRight && isRightCollapsed;
+    _dragStartedWhileLeftCollapsed = canCollapseLeft && isLeftCollapsed;
 
     _mouseMoveSubscription?.cancel();
     _mouseMoveSubscription = web.EventStreamProviders.mouseMoveEvent.forTarget(web.window).listen((web.MouseEvent e) {
@@ -362,180 +364,121 @@ class SplitPanelState extends State<SplitPanel> {
       }
 
       final clientPos = (component.isVertical ? e.clientY : e.clientX).toDouble();
+      final currentFirstPos = clientPos - startOffset;
+      final currentSecondPos = totalSize - currentFirstPos;
 
-      if (canCollapseRight) {
-        final currentSecondPos = startOffset + totalSize - clientPos;
+      final double minFirst;
+      final double maxFirst;
+      if (component.useRatio) {
+        final minRatio = component.minValue ?? 0.15;
+        final maxRatio = component.maxValue ?? 0.85;
+        minFirst = totalSize * minRatio;
+        maxFirst = totalSize * maxRatio;
+      } else if (component.absoluteFirst) {
+        minFirst = component.minValue ?? 100.0;
+        maxFirst = component.maxValue ?? (totalSize - 100.0);
+      } else {
+        final minSecond = component.minValue ?? 100.0;
+        final maxSecond = component.maxValue ?? (totalSize - 100.0);
+        minFirst = totalSize - maxSecond;
+        maxFirst = totalSize - minSecond;
+      }
 
-        final double minSecond;
-        final double maxSecond;
-        if (component.useRatio) {
-          final minRatio = component.minValue ?? 0.15;
-          final maxRatio = component.maxValue ?? 0.85;
-          minSecond = totalSize * (1.0 - maxRatio);
-          maxSecond = totalSize * (1.0 - minRatio);
-        } else if (component.absoluteFirst) {
-          final minFirst = component.minValue ?? 100.0;
-          final maxFirst = component.maxValue ?? (totalSize - 100.0);
-          minSecond = totalSize - maxFirst;
-          maxSecond = totalSize - minFirst;
-        } else {
-          minSecond = component.minValue ?? 100.0;
-          maxSecond = component.maxValue ?? (totalSize - 100.0);
-        }
+      final minSecond = totalSize - maxFirst;
+      final maxSecond = totalSize - minFirst;
 
-        final effectiveMin = max(0.0, min(minSecond, totalSize * 0.5));
-        final effectiveMax = max(effectiveMin, maxSecond);
+      final effectiveMinFirst = max(0.0, min(minFirst, totalSize * 0.5));
+      final effectiveMaxFirst = max(effectiveMinFirst, maxFirst);
 
-        // Auto-collapse threshold when dragging smaller than effectiveMin
-        final collapseThreshold = effectiveMin - 30;
+      final effectiveMinSecond = max(0.0, min(minSecond, totalSize * 0.5));
+      final effectiveMaxSecond = max(effectiveMinSecond, maxSecond);
 
-        if (_dragStartedWhileCollapsed) {
-          // Drag started while collapsed: delta is how much the user dragged up/towards open
-          final delta = _dragStartPos - clientPos;
-          if (isRightCollapsed) {
-            if (delta > 10) {
-              final targetSize = max(effectiveMin, currentSecondPos).clamp(effectiveMin, effectiveMax);
-              final newValue = _valueFromSecondSize(targetSize, totalSize);
-              _updateFromDrag(Split(newValue));
-              if (currentSecondPos > collapseThreshold + 15) {
-                _dragStartedWhileCollapsed = false;
-              }
-            }
-          } else {
-            // Already auto-expanded during this drag gesture
-            if (delta < 5) {
-              _updateFromDrag(RightCollapsed(value));
-            } else {
-              final targetSize = max(effectiveMin, currentSecondPos).clamp(effectiveMin, effectiveMax);
-              final newValue = _valueFromSecondSize(targetSize, totalSize);
-              _updateFromDrag(Split(newValue));
-              if (currentSecondPos > collapseThreshold + 15) {
-                _dragStartedWhileCollapsed = false;
-              }
-            }
-          }
-          return;
-        }
+      final collapseThresholdRight = effectiveMinSecond - 30;
+      final collapseThresholdLeft = effectiveMinFirst - 30;
 
-        // Drag started while already expanded
+      if (_dragStartedWhileRightCollapsed) {
+        final delta = _dragStartPos - clientPos;
         if (isRightCollapsed) {
-          // If it auto-collapsed during this drag, can auto-expand if dragged back up
-          if (currentSecondPos > collapseThreshold + 15) {
-            final targetSize = currentSecondPos.clamp(effectiveMin, effectiveMax);
+          if (delta > 10) {
+            final targetSize = max(effectiveMinSecond, currentSecondPos).clamp(effectiveMinSecond, effectiveMaxSecond);
             final newValue = _valueFromSecondSize(targetSize, totalSize);
             _updateFromDrag(Split(newValue));
+            if (currentSecondPos > collapseThresholdRight + 15) {
+              _dragStartedWhileRightCollapsed = false;
+            }
           }
         } else {
-          // Expanded: if dragged too small (below collapseThreshold), auto-collapse
-          if (currentSecondPos < collapseThreshold) {
+          // Already auto-expanded during this drag gesture
+          if (delta < 5) {
             _updateFromDrag(RightCollapsed(value));
           } else {
-            final targetSize = currentSecondPos.clamp(effectiveMin, effectiveMax);
+            final targetSize = max(effectiveMinSecond, currentSecondPos).clamp(effectiveMinSecond, effectiveMaxSecond);
             final newValue = _valueFromSecondSize(targetSize, totalSize);
             _updateFromDrag(Split(newValue));
+            if (currentSecondPos > collapseThresholdRight + 15) {
+              _dragStartedWhileRightCollapsed = false;
+            }
           }
         }
         return;
       }
 
-      if (canCollapseLeft) {
-        final currentFirstPos = clientPos - startOffset;
-
-        final double minFirst;
-        final double maxFirst;
-        if (component.useRatio) {
-          final minRatio = component.minValue ?? 0.15;
-          final maxRatio = component.maxValue ?? 0.85;
-          minFirst = totalSize * minRatio;
-          maxFirst = totalSize * maxRatio;
-        } else if (component.absoluteFirst) {
-          minFirst = component.minValue ?? 100.0;
-          maxFirst = component.maxValue ?? (totalSize - 100.0);
-        } else {
-          final minSecond = component.minValue ?? 100.0;
-          final maxSecond = component.maxValue ?? (totalSize - 100.0);
-          minFirst = totalSize - maxSecond;
-          maxFirst = totalSize - minSecond;
-        }
-
-        final effectiveMin = max(0.0, min(minFirst, totalSize * 0.5));
-        final effectiveMax = max(effectiveMin, maxFirst);
-
-        // Auto-collapse threshold when dragging smaller than effectiveMin
-        final collapseThreshold = effectiveMin - 30;
-
-        if (_dragStartedWhileCollapsed) {
-          // Drag started while collapsed: delta is how much the user dragged right/down towards open
-          final delta = clientPos - _dragStartPos;
-          if (isLeftCollapsed) {
-            if (delta > 10) {
-              final targetSize = max(effectiveMin, currentFirstPos).clamp(effectiveMin, effectiveMax);
-              final newValue = _valueFromFirstSize(targetSize, totalSize);
-              _updateFromDrag(Split(newValue));
-              if (currentFirstPos > collapseThreshold + 15) {
-                _dragStartedWhileCollapsed = false;
-              }
-            }
-          } else {
-            // Already auto-expanded during this drag gesture
-            if (delta < 5) {
-              _updateFromDrag(LeftCollapsed(value));
-            } else {
-              final targetSize = max(effectiveMin, currentFirstPos).clamp(effectiveMin, effectiveMax);
-              final newValue = _valueFromFirstSize(targetSize, totalSize);
-              _updateFromDrag(Split(newValue));
-              if (currentFirstPos > collapseThreshold + 15) {
-                _dragStartedWhileCollapsed = false;
-              }
-            }
-          }
-          return;
-        }
-
-        // Drag started while already expanded
+      if (_dragStartedWhileLeftCollapsed) {
+        final delta = clientPos - _dragStartPos;
         if (isLeftCollapsed) {
-          // If it auto-collapsed during this drag, can auto-expand if dragged back right
-          if (currentFirstPos > collapseThreshold + 15) {
-            final targetSize = currentFirstPos.clamp(effectiveMin, effectiveMax);
+          if (delta > 10) {
+            final targetSize = max(effectiveMinFirst, currentFirstPos).clamp(effectiveMinFirst, effectiveMaxFirst);
             final newValue = _valueFromFirstSize(targetSize, totalSize);
             _updateFromDrag(Split(newValue));
+            if (currentFirstPos > collapseThresholdLeft + 15) {
+              _dragStartedWhileLeftCollapsed = false;
+            }
           }
         } else {
-          // Expanded: if dragged too small (below collapseThreshold), auto-collapse
-          if (currentFirstPos < collapseThreshold) {
+          // Already auto-expanded during this drag gesture
+          if (delta < 5) {
             _updateFromDrag(LeftCollapsed(value));
           } else {
-            final targetSize = currentFirstPos.clamp(effectiveMin, effectiveMax);
+            final targetSize = max(effectiveMinFirst, currentFirstPos).clamp(effectiveMinFirst, effectiveMaxFirst);
             final newValue = _valueFromFirstSize(targetSize, totalSize);
             _updateFromDrag(Split(newValue));
+            if (currentFirstPos > collapseThresholdLeft + 15) {
+              _dragStartedWhileLeftCollapsed = false;
+            }
           }
         }
         return;
       }
 
-      if (component.useRatio) {
-        var newRatio = (clientPos - startOffset) / totalSize;
+      // Drag started while already expanded
+      if (isRightCollapsed) {
+        // If it auto-collapsed during this drag, can auto-expand if dragged back up/left
+        if (currentSecondPos > collapseThresholdRight + 15) {
+          final targetSize = currentSecondPos.clamp(effectiveMinSecond, effectiveMaxSecond);
+          final newValue = _valueFromSecondSize(targetSize, totalSize);
+          _updateFromDrag(Split(newValue));
+        }
+        return;
+      }
 
-        final minR = component.minValue ?? 0.15;
-        final maxR = component.maxValue ?? 0.85;
-        if (newRatio < minR) {
-          newRatio = minR;
+      if (isLeftCollapsed) {
+        // If it auto-collapsed during this drag, can auto-expand if dragged back down/right
+        if (currentFirstPos > collapseThresholdLeft + 15) {
+          final targetSize = currentFirstPos.clamp(effectiveMinFirst, effectiveMaxFirst);
+          final newValue = _valueFromFirstSize(targetSize, totalSize);
+          _updateFromDrag(Split(newValue));
         }
-        if (newRatio > maxR) {
-          newRatio = maxR;
-        }
-        _updateFromDrag(Split(newRatio));
+        return;
+      }
+
+      // Expanded: check if dragged too small (below collapseThreshold), auto-collapse
+      if (canCollapseRight && currentSecondPos < collapseThresholdRight) {
+        _updateFromDrag(RightCollapsed(value));
+      } else if (canCollapseLeft && currentFirstPos < collapseThresholdLeft) {
+        _updateFromDrag(LeftCollapsed(value));
       } else {
-        var newValue = component.absoluteFirst ? (clientPos - startOffset) : (startOffset + totalSize - clientPos);
-
-        final minV = component.minValue ?? 100.0;
-        final maxV = component.maxValue ?? (totalSize - 100.0);
-        if (newValue < minV) {
-          newValue = minV;
-        }
-        if (newValue > maxV) {
-          newValue = maxV;
-        }
+        final targetSize = currentFirstPos.clamp(effectiveMinFirst, totalSize - effectiveMinSecond);
+        final newValue = _valueFromFirstSize(targetSize, totalSize);
         _updateFromDrag(Split(newValue));
       }
     });
@@ -551,7 +494,8 @@ class SplitPanelState extends State<SplitPanel> {
     _mouseMoveSubscription = null;
     _mouseUpSubscription?.cancel();
     _mouseUpSubscription = null;
-    _dragStartedWhileCollapsed = false;
+    _dragStartedWhileLeftCollapsed = false;
+    _dragStartedWhileRightCollapsed = false;
     setState(() {
       isDragging = false;
     });

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/split_panel.dart
@@ -3,10 +3,177 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
+
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
+
 import '../../../app_styles.dart';
+
+/// The collapse, hidden, and split state of a split panel.
+@immutable
+sealed class SplitState {
+  const SplitState();
+
+  /// Whether either panel is collapsed to its intrinsic/rail size.
+  bool get isCollapsed => this is LeftCollapsed || this is RightCollapsed;
+
+  /// Whether the left panel is collapsed.
+  bool get isLeftCollapsed => this is LeftCollapsed;
+
+  /// Whether the right panel is collapsed.
+  bool get isRightCollapsed => this is RightCollapsed;
+
+  /// Whether neither panel is collapsed or hidden.
+  bool get isSplit => this is Split;
+
+  /// Whether either panel is hidden completely.
+  bool get isHidden => this is LeftHidden || this is RightHidden;
+
+  /// Whether the left panel is hidden.
+  bool get isLeftHidden => this is LeftHidden;
+
+  /// Whether the right panel is hidden.
+  bool get isRightHidden => this is RightHidden;
+
+  /// The active split value or the last split value when collapsed or hidden.
+  double get value => switch (this) {
+    Split(:final value) => value,
+    LeftCollapsed(:final lastSplitValue) => lastSplitValue,
+    RightCollapsed(:final lastSplitValue) => lastSplitValue,
+    LeftHidden(:final lastSplitValue) => lastSplitValue,
+    RightHidden(:final lastSplitValue) => lastSplitValue,
+  };
+}
+
+/// The left (or top) panel is completely hidden (`display: none`) and the drag handle is hidden.
+final class LeftHidden extends SplitState {
+  const LeftHidden(this.lastSplitValue);
+  final double lastSplitValue;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is LeftHidden && other.lastSplitValue == lastSplitValue);
+
+  @override
+  int get hashCode => Object.hash(LeftHidden, lastSplitValue);
+}
+
+/// The left (or top) panel is collapsed to its intrinsic size with the drag handle visible.
+final class LeftCollapsed extends SplitState {
+  const LeftCollapsed(this.lastSplitValue);
+  final double lastSplitValue;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is LeftCollapsed && other.lastSplitValue == lastSplitValue);
+
+  @override
+  int get hashCode => Object.hash(LeftCollapsed, lastSplitValue);
+}
+
+/// Both panels are active and sized according to [value], with the drag handle visible.
+final class Split extends SplitState {
+  const Split(this.value);
+
+  @override
+  final double value;
+
+  @override
+  bool operator ==(Object other) => identical(this, other) || (other is Split && other.value == value);
+
+  @override
+  int get hashCode => Object.hash(Split, value);
+}
+
+/// The right (or bottom) panel is collapsed to its intrinsic size with the drag handle visible.
+final class RightCollapsed extends SplitState {
+  const RightCollapsed(this.lastSplitValue);
+  final double lastSplitValue;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is RightCollapsed && other.lastSplitValue == lastSplitValue);
+
+  @override
+  int get hashCode => Object.hash(RightCollapsed, lastSplitValue);
+}
+
+/// The right (or bottom) panel is completely hidden (`display: none`) and the drag handle is hidden.
+final class RightHidden extends SplitState {
+  const RightHidden(this.lastSplitValue);
+  final double lastSplitValue;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is RightHidden && other.lastSplitValue == lastSplitValue);
+
+  @override
+  int get hashCode => Object.hash(RightHidden, lastSplitValue);
+}
+
+///// An inherited component that exposes [SplitPanelData] to descendants of a [SplitPanel].
+class _InheritedSplitPanel extends InheritedComponent {
+  _InheritedSplitPanel({required this.data, required super.child});
+
+  final SplitPanelData data;
+
+  @override
+  bool updateShouldNotify(covariant _InheritedSplitPanel oldComponent) {
+    return data != oldComponent.data;
+  }
+}
+
+@immutable
+class SplitPanelData {
+  SplitPanelData({
+    required this._splitPanelState,
+    required this._isLeft,
+    required this.state,
+  });
+
+  /// The state of the enclosing [SplitPanel].
+  final SplitPanelState _splitPanelState;
+
+  /// Whether this inherited scope is for the left (or top) child panel.
+  final bool _isLeft;
+
+  /// The state of the split panel when this component was created.
+  final SplitState state;
+
+  /// Whether the panel on this side of the split can be collapsed.
+  bool get canCollapse => _isLeft ? _splitPanelState.canCollapseLeft : _splitPanelState.canCollapseRight;
+
+  /// Whether the panel on this side of the split is collapsed.
+  bool get isPanelCollapsed => _isLeft ? _splitPanelState.isLeftCollapsed : _splitPanelState.isRightCollapsed;
+
+  /// Whether the panel on this side of the split is hidden.
+  bool get isPanelHidden => _isLeft ? _splitPanelState.isLeftHidden : _splitPanelState.isRightHidden;
+
+  void expand([double? targetValue]) {
+    _splitPanelState.split(targetValue);
+  }
+
+  void collapse() {
+    if (_isLeft) {
+      _splitPanelState.collapseLeft();
+    } else {
+      _splitPanelState.collapseRight();
+    }
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is SplitPanelData &&
+          other._splitPanelState == _splitPanelState &&
+          other._isLeft == _isLeft &&
+          other.state == state);
+
+  @override
+  int get hashCode => Object.hash(_splitPanelState, _isLeft, state);
+}
 
 /// A component that divides its layout space between two sub-components,
 /// allowing the user to resize the boundary between them by dragging a splitter handle.
@@ -14,8 +181,9 @@ class SplitPanel extends StatefulComponent {
   const SplitPanel({
     required this.left,
     required this.right,
-    this.showLeft = true,
-    this.showRight = true,
+    this.canCollapseLeft,
+    this.canCollapseRight,
+    this.initialState,
     this.initialValue = 0.5,
     this.useRatio = true,
     this.isVertical = false,
@@ -31,14 +199,17 @@ class SplitPanel extends StatefulComponent {
   /// The right or bottom component in the split panel.
   final Component right;
 
+  /// Whether the left (or top) panel can be collapsed.
+  final bool? canCollapseLeft;
+
+  /// Whether the right (or bottom) panel can be collapsed.
+  final bool? canCollapseRight;
+
+  /// The initial collapse or split state. If null, defaults to [Split] with [initialValue].
+  final SplitState? initialState;
+
   /// The initial split value (either ratio or absolute pixels).
   final double initialValue;
-
-  /// Whether to display the left/top component.
-  final bool showLeft;
-
-  /// Whether to display the right/bottom component.
-  final bool showRight;
 
   /// Whether the split value represents a ratio (0.0 to 1.0) rather than absolute pixels.
   final bool useRatio;
@@ -56,30 +227,111 @@ class SplitPanel extends StatefulComponent {
   /// The maximum allowable split value (ratio or pixel limit).
   final double? maxValue;
 
-  @override
-  State<SplitPanel> createState() => _SplitPanelState();
+  /// Returns the [SplitPanelData] from the nearest ancestor.
+  static SplitPanelData? of(BuildContext context, {bool listen = true}) {
+    if (listen) {
+      return context.dependOnInheritedComponentOfExactType<_InheritedSplitPanel>()?.data;
+    }
+    return (context.getElementForInheritedComponentOfExactType<_InheritedSplitPanel>()?.component
+            as _InheritedSplitPanel?)
+        ?.data;
+  }
 
-  @css
-  static List<StyleRule> get styles => _SplitPanelState.styles;
+  @override
+  State<SplitPanel> createState() => SplitPanelState();
 }
 
-class _SplitPanelState extends State<SplitPanel> {
-  late double value;
+class SplitPanelState extends State<SplitPanel> {
+  late SplitState _state;
+
+  /// The current collapse, hidden, or split state.
+  SplitState get state => _state;
+
+  /// The current split value (ratio 0.0 to 1.0, or absolute pixels).
+  double get value => _state.value;
+
+  /// Whether the left (or top) panel can be collapsed.
+  bool get canCollapseLeft => component.canCollapseLeft ?? (_state is LeftCollapsed);
+
+  /// Whether the right (or bottom) panel can be collapsed.
+  bool get canCollapseRight => component.canCollapseRight ?? (_state is RightCollapsed);
+
+  /// Whether either panel is currently collapsed.
+  bool get isCollapsed => _state.isCollapsed;
+
+  /// Whether the left (or top) panel is collapsed.
+  bool get isLeftCollapsed => _state.isLeftCollapsed;
+
+  /// Whether the right (or bottom) panel is collapsed.
+  bool get isRightCollapsed => _state.isRightCollapsed;
+
+  /// Whether neither panel is collapsed or hidden.
+  bool get isSplit => _state.isSplit;
+
+  /// Backwards-compatible alias for [isSplit].
+  bool get isUncollapsed => _state.isSplit;
+
+  /// Whether either panel is hidden completely.
+  bool get isHidden => _state.isHidden;
+
+  /// Whether the left (or top) panel is hidden.
+  bool get isLeftHidden => _state.isLeftHidden;
+
+  /// Whether the right (or bottom) panel is hidden.
+  bool get isRightHidden => _state.isRightHidden;
+
+  /// Collapses the left (or top) panel.
+  void collapseLeft() {
+    setState(() => _state = LeftCollapsed(_state.value));
+  }
+
+  /// Collapses the right (or bottom) panel.
+  void collapseRight() {
+    setState(() => _state = RightCollapsed(_state.value));
+  }
+
+  /// Hides the left (or top) panel completely.
+  void hideLeft() {
+    setState(() => _state = LeftHidden(_state.value));
+  }
+
+  /// Hides the right (or bottom) panel completely.
+  void hideRight() {
+    setState(() => _state = RightHidden(_state.value));
+  }
+
+  /// Splits the panel to [targetValue] or restores the previous split size.
+  void split([double? targetValue]) {
+    setState(() => _state = Split(targetValue ?? _state.value));
+  }
+
+  void _updateFromDrag(SplitState newState) {
+    if (_state != newState) {
+      setState(() {
+        _state = newState;
+      });
+    }
+  }
+
   bool isDragging = false;
+  bool _dragStartedWhileCollapsed = false;
+  double _dragStartPos = 0;
   StreamSubscription<web.MouseEvent>? _mouseMoveSubscription;
   StreamSubscription<web.MouseEvent>? _mouseUpSubscription;
 
   @override
   void initState() {
     super.initState();
-    value = component.initialValue;
+    _state = component.initialState ?? Split(component.initialValue);
   }
 
   @override
   void didUpdateComponent(SplitPanel oldComponent) {
     super.didUpdateComponent(oldComponent);
-    if (oldComponent.initialValue != component.initialValue) {
-      value = component.initialValue;
+    if (component.initialState != null && component.initialState != oldComponent.initialState) {
+      _state = component.initialState!;
+    } else if (oldComponent.initialValue != component.initialValue) {
+      _state = Split(component.initialValue);
     }
   }
 
@@ -96,6 +348,10 @@ class _SplitPanelState extends State<SplitPanel> {
       isDragging = true;
     });
 
+    final startPos = component.isVertical ? event.clientY.toDouble() : event.clientX.toDouble();
+    _dragStartPos = startPos;
+    _dragStartedWhileCollapsed = (canCollapseRight && isRightCollapsed) || (canCollapseLeft && isLeftCollapsed);
+
     _mouseMoveSubscription?.cancel();
     _mouseMoveSubscription = web.EventStreamProviders.mouseMoveEvent.forTarget(web.window).listen((web.MouseEvent e) {
       final rect = container.getBoundingClientRect();
@@ -105,8 +361,159 @@ class _SplitPanelState extends State<SplitPanel> {
         return;
       }
 
+      final clientPos = (component.isVertical ? e.clientY : e.clientX).toDouble();
+
+      if (canCollapseRight) {
+        final currentSecondPos = startOffset + totalSize - clientPos;
+
+        final double minSecond;
+        final double maxSecond;
+        if (component.useRatio) {
+          final minRatio = component.minValue ?? 0.15;
+          final maxRatio = component.maxValue ?? 0.85;
+          minSecond = totalSize * (1.0 - maxRatio);
+          maxSecond = totalSize * (1.0 - minRatio);
+        } else if (component.absoluteFirst) {
+          final minFirst = component.minValue ?? 100.0;
+          final maxFirst = component.maxValue ?? (totalSize - 100.0);
+          minSecond = totalSize - maxFirst;
+          maxSecond = totalSize - minFirst;
+        } else {
+          minSecond = component.minValue ?? 100.0;
+          maxSecond = component.maxValue ?? (totalSize - 100.0);
+        }
+
+        final effectiveMin = max(0.0, min(minSecond, totalSize * 0.5));
+        final effectiveMax = max(effectiveMin, maxSecond);
+
+        // Auto-collapse threshold when dragging smaller than effectiveMin
+        final collapseThreshold = effectiveMin - 30;
+
+        if (_dragStartedWhileCollapsed) {
+          // Drag started while collapsed: delta is how much the user dragged up/towards open
+          final delta = _dragStartPos - clientPos;
+          if (isRightCollapsed) {
+            if (delta > 10) {
+              final targetSize = max(effectiveMin, currentSecondPos).clamp(effectiveMin, effectiveMax);
+              final newValue = _valueFromSecondSize(targetSize, totalSize);
+              _updateFromDrag(Split(newValue));
+              if (currentSecondPos > collapseThreshold + 15) {
+                _dragStartedWhileCollapsed = false;
+              }
+            }
+          } else {
+            // Already auto-expanded during this drag gesture
+            if (delta < 5) {
+              _updateFromDrag(RightCollapsed(value));
+            } else {
+              final targetSize = max(effectiveMin, currentSecondPos).clamp(effectiveMin, effectiveMax);
+              final newValue = _valueFromSecondSize(targetSize, totalSize);
+              _updateFromDrag(Split(newValue));
+              if (currentSecondPos > collapseThreshold + 15) {
+                _dragStartedWhileCollapsed = false;
+              }
+            }
+          }
+          return;
+        }
+
+        // Drag started while already expanded
+        if (isRightCollapsed) {
+          // If it auto-collapsed during this drag, can auto-expand if dragged back up
+          if (currentSecondPos > collapseThreshold + 15) {
+            final targetSize = currentSecondPos.clamp(effectiveMin, effectiveMax);
+            final newValue = _valueFromSecondSize(targetSize, totalSize);
+            _updateFromDrag(Split(newValue));
+          }
+        } else {
+          // Expanded: if dragged too small (below collapseThreshold), auto-collapse
+          if (currentSecondPos < collapseThreshold) {
+            _updateFromDrag(RightCollapsed(value));
+          } else {
+            final targetSize = currentSecondPos.clamp(effectiveMin, effectiveMax);
+            final newValue = _valueFromSecondSize(targetSize, totalSize);
+            _updateFromDrag(Split(newValue));
+          }
+        }
+        return;
+      }
+
+      if (canCollapseLeft) {
+        final currentFirstPos = clientPos - startOffset;
+
+        final double minFirst;
+        final double maxFirst;
+        if (component.useRatio) {
+          final minRatio = component.minValue ?? 0.15;
+          final maxRatio = component.maxValue ?? 0.85;
+          minFirst = totalSize * minRatio;
+          maxFirst = totalSize * maxRatio;
+        } else if (component.absoluteFirst) {
+          minFirst = component.minValue ?? 100.0;
+          maxFirst = component.maxValue ?? (totalSize - 100.0);
+        } else {
+          final minSecond = component.minValue ?? 100.0;
+          final maxSecond = component.maxValue ?? (totalSize - 100.0);
+          minFirst = totalSize - maxSecond;
+          maxFirst = totalSize - minSecond;
+        }
+
+        final effectiveMin = max(0.0, min(minFirst, totalSize * 0.5));
+        final effectiveMax = max(effectiveMin, maxFirst);
+
+        // Auto-collapse threshold when dragging smaller than effectiveMin
+        final collapseThreshold = effectiveMin - 30;
+
+        if (_dragStartedWhileCollapsed) {
+          // Drag started while collapsed: delta is how much the user dragged right/down towards open
+          final delta = clientPos - _dragStartPos;
+          if (isLeftCollapsed) {
+            if (delta > 10) {
+              final targetSize = max(effectiveMin, currentFirstPos).clamp(effectiveMin, effectiveMax);
+              final newValue = _valueFromFirstSize(targetSize, totalSize);
+              _updateFromDrag(Split(newValue));
+              if (currentFirstPos > collapseThreshold + 15) {
+                _dragStartedWhileCollapsed = false;
+              }
+            }
+          } else {
+            // Already auto-expanded during this drag gesture
+            if (delta < 5) {
+              _updateFromDrag(LeftCollapsed(value));
+            } else {
+              final targetSize = max(effectiveMin, currentFirstPos).clamp(effectiveMin, effectiveMax);
+              final newValue = _valueFromFirstSize(targetSize, totalSize);
+              _updateFromDrag(Split(newValue));
+              if (currentFirstPos > collapseThreshold + 15) {
+                _dragStartedWhileCollapsed = false;
+              }
+            }
+          }
+          return;
+        }
+
+        // Drag started while already expanded
+        if (isLeftCollapsed) {
+          // If it auto-collapsed during this drag, can auto-expand if dragged back right
+          if (currentFirstPos > collapseThreshold + 15) {
+            final targetSize = currentFirstPos.clamp(effectiveMin, effectiveMax);
+            final newValue = _valueFromFirstSize(targetSize, totalSize);
+            _updateFromDrag(Split(newValue));
+          }
+        } else {
+          // Expanded: if dragged too small (below collapseThreshold), auto-collapse
+          if (currentFirstPos < collapseThreshold) {
+            _updateFromDrag(LeftCollapsed(value));
+          } else {
+            final targetSize = currentFirstPos.clamp(effectiveMin, effectiveMax);
+            final newValue = _valueFromFirstSize(targetSize, totalSize);
+            _updateFromDrag(Split(newValue));
+          }
+        }
+        return;
+      }
+
       if (component.useRatio) {
-        final clientPos = component.isVertical ? e.clientY : e.clientX;
         var newRatio = (clientPos - startOffset) / totalSize;
 
         final minR = component.minValue ?? 0.15;
@@ -117,11 +524,8 @@ class _SplitPanelState extends State<SplitPanel> {
         if (newRatio > maxR) {
           newRatio = maxR;
         }
-        setState(() {
-          value = newRatio;
-        });
+        _updateFromDrag(Split(newRatio));
       } else {
-        final clientPos = component.isVertical ? e.clientY : e.clientX;
         var newValue = component.absoluteFirst ? (clientPos - startOffset) : (startOffset + totalSize - clientPos);
 
         final minV = component.minValue ?? 100.0;
@@ -132,9 +536,7 @@ class _SplitPanelState extends State<SplitPanel> {
         if (newValue > maxV) {
           newValue = maxV;
         }
-        setState(() {
-          value = newValue;
-        });
+        _updateFromDrag(Split(newValue));
       }
     });
 
@@ -149,9 +551,34 @@ class _SplitPanelState extends State<SplitPanel> {
     _mouseMoveSubscription = null;
     _mouseUpSubscription?.cancel();
     _mouseUpSubscription = null;
+    _dragStartedWhileCollapsed = false;
     setState(() {
       isDragging = false;
     });
+  }
+
+  double _valueFromFirstSize(double firstSize, double totalSize) {
+    if (component.useRatio) {
+      final ratio = firstSize / totalSize;
+      return ratio.clamp(component.minValue ?? 0.15, component.maxValue ?? 0.85);
+    } else if (component.absoluteFirst) {
+      return firstSize.clamp(component.minValue ?? 100.0, component.maxValue ?? (totalSize - 100.0));
+    } else {
+      final secondVal = totalSize - firstSize;
+      return secondVal.clamp(component.minValue ?? 100.0, component.maxValue ?? (totalSize - 100.0));
+    }
+  }
+
+  double _valueFromSecondSize(double secondSize, double totalSize) {
+    if (component.useRatio) {
+      final ratio = 1.0 - (secondSize / totalSize);
+      return ratio.clamp(component.minValue ?? 0.15, component.maxValue ?? 0.85);
+    } else if (component.absoluteFirst) {
+      final firstVal = totalSize - secondSize;
+      return firstVal.clamp(component.minValue ?? 100.0, component.maxValue ?? (totalSize - 100.0));
+    } else {
+      return secondSize.clamp(component.minValue ?? 100.0, component.maxValue ?? (totalSize - 100.0));
+    }
   }
 
   @override
@@ -165,29 +592,64 @@ class _SplitPanelState extends State<SplitPanel> {
   Component build(BuildContext context) {
     final leftChild = component.left;
     final rightChild = component.right;
+    final state = _state;
 
-    final leftFlex = component.useRatio
-        ? Flex(grow: component.showRight ? value : 1, basis: .zero)
-        : (component.showRight
-              ? (component.absoluteFirst ? Flex(grow: 0, basis: value.px) : const Flex(grow: 1, basis: .zero))
-              : const Flex(grow: 1, basis: .zero));
+    final Flex leftFlex;
+    final Flex rightFlex;
+    final Display? leftDisplay;
+    final Display? rightDisplay;
+    final bool showDragHandle;
 
-    final rightFlex = component.useRatio
-        ? Flex(grow: component.showLeft ? 1 - value : 1, basis: .zero)
-        : (component.showLeft
-              ? (component.absoluteFirst ? const Flex(grow: 1, basis: .zero) : Flex(grow: 0, basis: value.px))
-              : const Flex(grow: 1, basis: .zero));
+    switch (state) {
+      case LeftHidden():
+        leftFlex = const Flex.shrink(0);
+        rightFlex = const Flex(grow: 1, basis: .zero);
+        leftDisplay = .none;
+        rightDisplay = null;
+        showDragHandle = false;
+      case RightHidden():
+        leftFlex = const Flex(grow: 1, basis: .zero);
+        rightFlex = const Flex.shrink(0);
+        leftDisplay = null;
+        rightDisplay = .none;
+        showDragHandle = false;
+      case LeftCollapsed():
+        leftFlex = const Flex.shrink(0);
+        rightFlex = const Flex(grow: 1, basis: .zero);
+        leftDisplay = null;
+        rightDisplay = null;
+        showDragHandle = true;
+      case RightCollapsed():
+        leftFlex = const Flex(grow: 1, basis: .zero);
+        rightFlex = const Flex.shrink(0);
+        leftDisplay = null;
+        rightDisplay = null;
+        showDragHandle = true;
+      case Split(:final value):
+        leftFlex = component.useRatio
+            ? Flex(grow: value, basis: .zero)
+            : (component.absoluteFirst ? Flex(grow: 0, basis: value.px) : const Flex(grow: 1, basis: .zero));
+        rightFlex = component.useRatio
+            ? Flex(grow: 1 - value, basis: .zero)
+            : (component.absoluteFirst ? const Flex(grow: 1, basis: .zero) : Flex(grow: 0, basis: value.px));
+        leftDisplay = null;
+        rightDisplay = null;
+        showDragHandle = true;
+    }
 
     return Component.fragment([
-      Component.apply(
-        styles: Styles(
-          display: !component.showLeft ? .none : null,
-          pointerEvents: isDragging ? .none : null,
-          flex: leftFlex,
+      _InheritedSplitPanel(
+        data: SplitPanelData(splitPanelState: this, isLeft: true, state: state),
+        child: Component.apply(
+          styles: Styles(
+            display: leftDisplay,
+            pointerEvents: isDragging ? .none : null,
+            flex: leftFlex,
+          ),
+          child: leftChild,
         ),
-        child: leftChild,
       ),
-      if (component.showLeft && component.showRight)
+      if (showDragHandle)
         div(
           classes: 'drag-handle ${component.isVertical ? 'vertical' : 'horizontal'}${isDragging ? ' dragging' : ''}',
           events: {
@@ -195,19 +657,23 @@ class _SplitPanelState extends State<SplitPanel> {
           },
           [],
         ),
-      Component.apply(
-        styles: Styles(
-          display: !component.showRight ? .none : null,
-          pointerEvents: isDragging ? .none : null,
-          flex: rightFlex,
+      _InheritedSplitPanel(
+        data: SplitPanelData(splitPanelState: this, isLeft: false, state: state),
+        child: Component.apply(
+          styles: Styles(
+            display: rightDisplay,
+            pointerEvents: isDragging ? .none : null,
+            flex: rightFlex,
+          ),
+          child: rightChild,
         ),
-        child: rightChild,
       ),
     ]);
   }
 
-  static const width = 10;
+  static const width = 8;
 
+  @css
   static List<StyleRule> get styles => [
     css('.drag-handle').styles(
       position: const .relative(),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -39,8 +39,7 @@ void main() {
     await pumpEventQueue();
 
     expect(web.document.querySelector('.console-panel')!.textContent, contains('Running pub get in /'));
-    final clearButton =
-        web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
+    final clearButton = web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
     expect(clearButton.disabled, isFalse);
 
     clearButton.click();
@@ -67,8 +66,7 @@ void main() {
     consoleTab.click();
     await pumpEventQueue();
 
-    final clearButton =
-        web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
+    final clearButton = web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
     expect(clearButton.disabled, isFalse);
   });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -8,7 +8,9 @@ library;
 import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
 import 'package:dartpad_frontend/features/bottom_panel/views/bottom_panel.dart';
 import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
 import 'package:dartpad_frontend/features/shared/events/open_console_event.dart';
+import 'package:jaspr/dom.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:logging/logging.dart';
 import 'package:web/web.dart' as web;
@@ -30,18 +32,20 @@ void main() {
     );
 
     expect(web.document.querySelector('.console-panel'), isNull);
-    expect(web.document.querySelector('.bottom-panel-clear-btn'), isNull);
+    expect(web.document.querySelector('button[aria-label="Clear console"]'), isNull);
 
     final consoleTab = web.document.querySelector('.bottom-panel-tab:nth-child(2)')! as web.HTMLButtonElement;
     consoleTab.click();
     await pumpEventQueue();
 
     expect(web.document.querySelector('.console-panel')!.textContent, contains('Running pub get in /'));
-    final clearButton = web.document.querySelector('.bottom-panel-clear-btn')! as web.HTMLButtonElement;
+    final clearButton =
+        web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
     expect(clearButton.disabled, isFalse);
 
     clearButton.click();
     await pumpEventQueue();
+
     expect(clearCalls, 1);
   });
 
@@ -63,7 +67,8 @@ void main() {
     consoleTab.click();
     await pumpEventQueue();
 
-    final clearButton = web.document.querySelector('.bottom-panel-clear-btn')! as web.HTMLButtonElement;
+    final clearButton =
+        web.document.querySelector('button[aria-label="Clear console"]')! as web.HTMLButtonElement;
     expect(clearButton.disabled, isFalse);
   });
 
@@ -105,5 +110,29 @@ void main() {
     events.dispatch(const OpenConsoleEvent());
     await pumpEventQueue();
     expect(web.document.querySelector('.console-panel'), isNotNull);
+  });
+
+  testClient('hides content when collapsed in SplitPanel', (tester) {
+    final events = AppEventBus();
+    tester.pumpComponent(
+      SplitPanel(
+        initialState: const RightCollapsed(0.75),
+        canCollapseRight: true,
+        left: const div([]),
+        right: BottomPanel(
+          diagnostics: const [],
+          hasMoreDiagnostics: false,
+          activeFile: '',
+          logs: const [],
+          onOpenDiagnostic: (_, _) {},
+          onClearConsole: () {},
+          events: events,
+        ),
+      ),
+    );
+
+    expect(web.document.querySelector('.bottom-panel.collapsed'), isNotNull);
+    expect(web.document.querySelector('.bottom-panel-tabs'), isNotNull);
+    expect(web.document.querySelector('.bottom-panel-content'), isNull);
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
@@ -40,7 +40,7 @@ final class _FakeFileTree extends StatelessComponent {
         ),
       ]);
     }
-    return aside(classes: 'file-tree-pane', [
+    return aside(classes: 'file-tree', [
       div(id: 'file-tree', [
         const Component.text('tree'),
         button(
@@ -83,7 +83,7 @@ void main() {
       tester.pumpComponent(_createShell());
 
       expect(web.document.querySelector('.editor-shell'), isNotNull);
-      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree'), isNotNull);
       expect(web.document.querySelector('.editor-host'), isNotNull);
       expect(web.document.querySelector('#file-tree'), isNotNull);
     });
@@ -128,7 +128,7 @@ void main() {
 
       // Collapsed: rail is visible, full file-tree pane is not.
       expect(web.document.querySelector('.file-tree-rail'), isNotNull);
-      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree'), isNull);
     });
 
     testClient('collapsed rail has expand button with correct aria-label', (
@@ -155,7 +155,7 @@ void main() {
 
       // Initially collapsed – rail visible, pane not.
       expect(web.document.querySelector('.file-tree-rail'), isNotNull);
-      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree'), isNull);
 
       // Click expand button.
       final expandButton =
@@ -165,7 +165,7 @@ void main() {
 
       // Now expanded – pane visible, rail gone.
       expect(web.document.querySelector('.file-tree-rail'), isNull);
-      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree'), isNotNull);
       expect(web.document.querySelector('#file-tree'), isNotNull);
     });
 
@@ -190,7 +190,7 @@ void main() {
       // Expand.
       (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
       await pumpEventQueue();
-      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree'), isNotNull);
 
       // Collapse.
       (web.document.querySelector('.file-tree-collapse-button')! as web.HTMLButtonElement).click();
@@ -198,7 +198,7 @@ void main() {
 
       // Back to collapsed state.
       expect(web.document.querySelector('.file-tree-rail'), isNotNull);
-      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree'), isNull);
     });
 
     testClient('toggle cycle: collapse → expand → collapse', (tester) async {
@@ -212,7 +212,7 @@ void main() {
       await pumpEventQueue();
 
       // State 2: expanded.
-      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree'), isNotNull);
       expect(web.document.querySelector('.file-tree-rail'), isNull);
 
       // Collapse.
@@ -227,14 +227,14 @@ void main() {
       tester.pumpComponent(_createShell(isEmbedMode: true));
 
       // Collapsed: file tree is not rendered in the pane.
-      expect(web.document.querySelector('.file-tree-pane #file-tree'), isNull);
+      expect(web.document.querySelector('.file-tree #file-tree'), isNull);
 
       // Expand.
       (web.document.querySelector('.file-tree-rail-button')! as web.HTMLButtonElement).click();
       await pumpEventQueue();
 
       // File tree content is now visible inside the pane.
-      expect(web.document.querySelector('.file-tree-pane #file-tree'), isNotNull);
+      expect(web.document.querySelector('.file-tree #file-tree'), isNotNull);
     });
 
     testClient('editor host remains through toggle cycles', (tester) async {
@@ -259,14 +259,14 @@ void main() {
     testClient('standard mode shows file tree pane directly', (tester) {
       tester.pumpComponent(_createShell(isEmbedMode: false));
 
-      expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+      expect(web.document.querySelector('.file-tree'), isNotNull);
       expect(web.document.querySelector('.file-tree-rail'), isNull);
     });
 
     testClient('embed mode does not show file tree pane initially', (tester) {
       tester.pumpComponent(_createShell(isEmbedMode: true));
 
-      expect(web.document.querySelector('.file-tree-pane'), isNull);
+      expect(web.document.querySelector('.file-tree'), isNull);
       expect(web.document.querySelector('.file-tree-rail'), isNotNull);
     });
   });

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/components/editor_shell_test.dart
@@ -7,6 +7,7 @@ library;
 
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/editor/components/editor_shell.dart';
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
 import 'package:jaspr/dom.dart' hide path;
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_test/client_test.dart';
@@ -20,28 +21,54 @@ final class _FakeTab extends EditorTab<Component> {
   Component build() => div(id: 'editor-$path', [Component.text(path)]);
 }
 
+final class _FakeFileTree extends StatelessComponent {
+  const _FakeFileTree();
+
+  @override
+  Component build(BuildContext context) {
+    final panel = SplitPanel.of(context);
+    if (panel?.isPanelCollapsed ?? false) {
+      return aside(classes: 'file-tree-rail', [
+        button(
+          classes: 'file-tree-rail-button',
+          attributes: const {
+            'title': 'Show file tree',
+            'aria-label': 'Show file tree',
+          },
+          onClick: panel?.expand,
+          [const Component.text('expand')],
+        ),
+      ]);
+    }
+    return aside(classes: 'file-tree-pane', [
+      div(id: 'file-tree', [
+        const Component.text('tree'),
+        button(
+          classes: 'file-tree-collapse-button',
+          attributes: const {
+            'title': 'Hide file tree',
+            'aria-label': 'Hide file tree',
+          },
+          onClick: panel?.collapse,
+          [const Component.text('collapse')],
+        ),
+      ]),
+    ]);
+  }
+}
+
 /// Helper that creates an [EditorShell] with sensible defaults.
 EditorShell _createShell({
   List<EditorTab<Component>>? openTabs,
   String activeFile = 'main.dart',
   bool isEmbedMode = false,
+  Component? fileTree,
 }) {
   final tabs = openTabs ?? [_FakeTab('main.dart')];
   return EditorShell(
     openTabs: tabs,
     activeFile: activeFile,
-    fileTreeBuilder: (onCollapse) => div(id: 'file-tree', [
-      const Component.text('tree'),
-      button(
-        classes: 'file-tree-collapse-button',
-        attributes: const {
-          'title': 'Hide file tree',
-          'aria-label': 'Hide file tree',
-        },
-        onClick: onCollapse,
-        [const Component.text('collapse')],
-      ),
-    ]),
+    fileTree: fileTree ?? const _FakeFileTree(),
     editorOverlay: const div(id: 'editor-overlay', []),
     onSwitchFile: (_) {},
     onCloseFile: (_, {bool discardChanges = false}) => true,

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
@@ -80,7 +80,7 @@ void main() {
     collapseButton.click();
     await pumpEventQueue();
 
-    expect(web.document.querySelector('.file-tree-pane'), isNull);
+    expect(web.document.querySelector('.file-tree'), isNull);
     final railButton = web.document.querySelector('.file-tree-rail button') as web.HTMLButtonElement?;
     expect(railButton, isNotNull);
     expect(railButton!.getAttribute('aria-label'), 'Show file tree');
@@ -88,7 +88,7 @@ void main() {
     railButton.click();
     await pumpEventQueue();
 
-    expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+    expect(web.document.querySelector('.file-tree'), isNotNull);
     expect(web.document.querySelector('.file-tree-rail'), isNull);
   });
 

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_test.dart
@@ -11,6 +11,8 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/filetree/file_tree_models.dart';
 import 'package:dartpad_frontend/features/filetree/file_tree_view.dart';
 import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
+import 'package:jaspr/dom.dart' hide path;
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
 
@@ -47,13 +49,26 @@ void main() {
     expect(web.document.querySelector('.file-tree-toolbar'), isNull);
   });
 
-  testClient('renders collapse button in header when onCollapse is provided and invokes callback', (tester) async {
-    var collapseCalled = false;
+  testClient('does not render collapse button in header when not in a collapsible SplitPanel', (tester) {
     tester.pumpComponent(
       FileTreeView(
         state: _state(workspace),
         actions: _actions(),
-        onCollapse: () => collapseCalled = true,
+      ),
+    );
+
+    expect(web.document.querySelector('.file-tree-collapse-button'), isNull);
+  });
+
+  testClient('renders collapse button and collapses into rail when hosted in collapsible SplitPanel', (tester) async {
+    tester.pumpComponent(
+      SplitPanel(
+        canCollapseLeft: true,
+        left: FileTreeView(
+          state: _state(workspace),
+          actions: _actions(),
+        ),
+        right: const div([]),
       ),
     );
 
@@ -65,18 +80,16 @@ void main() {
     collapseButton.click();
     await pumpEventQueue();
 
-    expect(collapseCalled, isTrue);
-  });
+    expect(web.document.querySelector('.file-tree-pane'), isNull);
+    final railButton = web.document.querySelector('.file-tree-rail button') as web.HTMLButtonElement?;
+    expect(railButton, isNotNull);
+    expect(railButton!.getAttribute('aria-label'), 'Show file tree');
 
-  testClient('does not render collapse button in header when onCollapse is null', (tester) {
-    tester.pumpComponent(
-      FileTreeView(
-        state: _state(workspace),
-        actions: _actions(),
-      ),
-    );
+    railButton.click();
+    await pumpEventQueue();
 
-    expect(web.document.querySelector('.file-tree-collapse-button'), isNull);
+    expect(web.document.querySelector('.file-tree-pane'), isNotNull);
+    expect(web.document.querySelector('.file-tree-rail'), isNull);
   });
 
   testClient('single click on a folder selects it and toggles collapsed state', (tester) async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -437,8 +437,8 @@ void main() {
     expect(buttons[2].textContent, contains('stop'));
   });
 
-  testClient('hides all button and dropdown labels in narrow Flutter toolbar (< 250px)', (tester) async {
-    tester.pumpComponent(buildContainer(width: '240px'));
+  testClient('hides all button and dropdown labels in narrow Flutter toolbar (< 270px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '250px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -450,7 +450,7 @@ void main() {
   });
 
   testClient(
-    'expands only the first button label while hiding dropdown label in Flutter toolbar (250px - 299px)',
+    'expands only the first button label while hiding dropdown label in Flutter toolbar (270px - 319px)',
     (tester) async {
       tester.pumpComponent(buildContainer(width: '280px'));
       await pumpEventQueue();
@@ -467,7 +467,7 @@ void main() {
     },
   );
 
-  testClient('expands dropdown label and first button in medium-wide Flutter toolbar (300px - 379px)', (tester) async {
+  testClient('expands dropdown label and first button in medium-wide Flutter toolbar (320px - 409px)', (tester) async {
     tester.pumpComponent(buildContainer(width: '340px'));
     await pumpEventQueue();
 
@@ -482,8 +482,8 @@ void main() {
     expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
   });
 
-  testClient('expands all button labels and dropdown label in wide Flutter toolbar (>= 380px)', (tester) async {
-    tester.pumpComponent(buildContainer(width: '400px'));
+  testClient('expands all button labels and dropdown label in wide Flutter toolbar (>= 410px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '420px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -494,7 +494,7 @@ void main() {
     expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
   });
 
-  testClient('hides all button labels in narrow Dart toolbar (< 160px)', (tester) async {
+  testClient('hides all button labels in narrow Dart toolbar (< 180px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
     tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '140px'));
     await pumpEventQueue();
@@ -507,7 +507,7 @@ void main() {
     dartPreview.dispose();
   });
 
-  testClient('expands only the first button in medium Dart toolbar (160px - 249px)', (tester) async {
+  testClient('expands only the first button in medium Dart toolbar (180px - 269px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
     tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '200px'));
     await pumpEventQueue();
@@ -523,7 +523,7 @@ void main() {
     dartPreview.dispose();
   });
 
-  testClient('expands all buttons in wide Dart toolbar (>= 250px)', (tester) async {
+  testClient('expands all buttons in wide Dart toolbar (>= 270px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
     tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '300px'));
     await pumpEventQueue();

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -1,0 +1,132 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/preview/view/preview_container.dart';
+import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
+import 'package:dartpad_frontend/features/shared/task_status.dart';
+import 'package:dartpad_frontend/features/workspace/data/workspace_repository.dart';
+import 'package:dartpad_frontend/features/workspace/workspace_session.dart';
+import 'package:dartpad_frontend/sdks.g.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  group('PreviewContainer – collapse button', () {
+    late AppEventBus events;
+    late TaskStatusController taskStatus;
+    late WorkspaceSession session;
+
+    setUp(() {
+      events = AppEventBus();
+      taskStatus = TaskStatusController();
+      session = WorkspaceSession.create(
+        WorkspaceRepository.create(
+          events: events,
+          sdk: defaultSdk,
+          taskStatus: taskStatus,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await session.dispose(closeWorker: false);
+      await events.dispose();
+    });
+
+    testClient('does not render collapse button when not in a SplitPanel', (tester) {
+      tester.pumpComponent(
+        PreviewContainer(
+          preview: session.preview,
+          taskStatus: taskStatus,
+          activeFile: 'lib/main.dart',
+          onOpenConsole: () {},
+        ),
+      );
+
+      expect(web.document.querySelector('button[aria-label="Hide preview"]'), isNull);
+    });
+
+    testClient('renders collapse button when in SplitPanel', (tester) {
+      tester.pumpComponent(
+        SplitPanel(
+          canCollapseRight: true,
+          left: const div([]),
+          right: PreviewContainer(
+            preview: session.preview,
+            taskStatus: taskStatus,
+            activeFile: 'lib/main.dart',
+            onOpenConsole: () {},
+          ),
+        ),
+      );
+
+      final button = web.document.querySelector('button[aria-label="Hide preview"]') as web.HTMLButtonElement?;
+      expect(button, isNotNull);
+      expect(button!.getAttribute('aria-label'), 'Hide preview');
+    });
+
+    testClient('renders preview-rail and keeps container mounted when collapsed in SplitPanel', (tester) {
+      tester.pumpComponent(
+        SplitPanel(
+          initialState: const RightCollapsed(0.7),
+          canCollapseRight: true,
+          left: const div([]),
+          right: PreviewContainer(
+            preview: session.preview,
+            taskStatus: taskStatus,
+            activeFile: 'lib/main.dart',
+            onOpenConsole: () {},
+          ),
+        ),
+      );
+
+      expect(web.document.querySelector('.preview-container.collapsed'), isNotNull);
+      expect(web.document.querySelector('.preview-rail:not(.hidden)'), isNotNull);
+      expect(web.document.querySelector('.preview-rail button'), isNotNull);
+      expect(web.document.querySelector('.preview-toolbar.hidden'), isNotNull);
+      expect(web.document.querySelector('.preview-content.collapsed'), isNotNull);
+    });
+
+    testClient('collapsing and expanding preserves containerElement in the DOM', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        SplitPanel(
+          key: splitKey,
+          initialState: const Split(0.7),
+          canCollapseRight: true,
+          left: const div([]),
+          right: PreviewContainer(
+            preview: session.preview,
+            taskStatus: taskStatus,
+            activeFile: 'lib/main.dart',
+            onOpenConsole: () {},
+          ),
+        ),
+      );
+
+      final containerElement = session.preview.containerElement;
+      expect(containerElement.isConnected, isTrue);
+
+      // Collapse right panel
+      splitKey.currentState!.collapseRight();
+      await pumpEventQueue();
+
+      expect(containerElement.isConnected, isTrue);
+      expect(web.document.querySelector('.preview-container.collapsed'), isNotNull);
+
+      // Expand right panel
+      splitKey.currentState!.split();
+      await pumpEventQueue();
+
+      expect(containerElement.isConnected, isTrue);
+      expect(web.document.querySelector('.preview-container:not(.collapsed)'), isNotNull);
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/split_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/split_panel_test.dart
@@ -1,0 +1,435 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
+import 'package:jaspr/dom.dart';
+import 'package:jaspr/jaspr.dart';
+import 'package:jaspr_test/client_test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  group('SplitPanel', () {
+    testClient('renders left, right and drag handle', (tester) {
+      tester.pumpComponent(
+        const SplitPanel(
+          left: div(id: 'left-pane', [Component.text('left')]),
+          right: div(id: 'right-pane', [Component.text('right')]),
+        ),
+      );
+
+      expect(web.document.querySelector('#left-pane'), isNotNull);
+      expect(web.document.querySelector('#right-pane'), isNotNull);
+      expect(web.document.querySelector('.drag-handle'), isNotNull);
+    });
+
+    testClient('renders vertical drag handle when isVertical is true', (tester) {
+      tester.pumpComponent(
+        const SplitPanel(
+          isVertical: true,
+          left: div(id: 'top-pane', [Component.text('top')]),
+          right: div(id: 'bottom-pane', [Component.text('bottom')]),
+        ),
+      );
+
+      expect(web.document.querySelector('.drag-handle.vertical'), isNotNull);
+    });
+
+    testClient('renders collapsed second panel sizing to intrinsic size (no fixed basis)', (tester) {
+      tester.pumpComponent(
+        const SplitPanel(
+          initialState: RightCollapsed(0.5),
+          isVertical: true,
+          left: div(id: 'top-pane', [Component.text('top')]),
+          right: div(id: 'bottom-pane', [Component.text('bottom')]),
+        ),
+      );
+
+      final bottomPane = web.document.querySelector('#bottom-pane')! as web.HTMLElement;
+      expect(bottomPane.style.flexBasis, isEmpty);
+      expect(bottomPane.style.flexShrink, '0');
+    });
+
+    testClient('auto-expands when dragging collapsed handle up', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const RightCollapsed(0.75),
+              canCollapseRight: true,
+              isVertical: true,
+              useRatio: true,
+              maxValue: 0.8,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final handle = web.document.querySelector('.drag-handle')! as web.HTMLElement;
+      expect(handle, isNotNull);
+
+      // Start drag at Y=460 (collapsed handle near bottom)
+      handle.dispatchEvent(web.MouseEvent('mousedown', web.MouseEventInit(clientY: 460, clientX: 100)));
+      await pumpEventQueue();
+
+      // Drag up by 30px to Y=430 (delta = 30 > 10)
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 430, clientX: 100)));
+      await pumpEventQueue();
+
+      expect(splitKey.currentState!.isRightCollapsed, isFalse);
+
+      // Finish drag
+      web.window.dispatchEvent(web.MouseEvent('mouseup', web.MouseEventInit(clientY: 430, clientX: 100)));
+      await pumpEventQueue();
+    });
+
+    testClient('dragging collapsed handle does not flicker when expanding in small increments', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const RightCollapsed(0.75),
+              canCollapseRight: true,
+              isVertical: true,
+              useRatio: true,
+              maxValue: 0.8,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final handle = web.document.querySelector('.drag-handle')! as web.HTMLElement;
+      expect(handle, isNotNull);
+
+      // Start drag at Y=460 (collapsed handle near bottom)
+      handle.dispatchEvent(web.MouseEvent('mousedown', web.MouseEventInit(clientY: 460, clientX: 100)));
+      await pumpEventQueue();
+
+      // Drag up past initial expand delta (Y=445, delta = 15 > 10)
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 445, clientX: 100)));
+      await pumpEventQueue();
+      expect(splitKey.currentState!.isRightCollapsed, isFalse);
+
+      // Move in small 1px increments (currentSecondPos is still below collapseThreshold):
+      // Must NOT flicker back to collapsed!
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 444, clientX: 100)));
+      await pumpEventQueue();
+      expect(splitKey.currentState!.isRightCollapsed, isFalse);
+
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 440, clientX: 100)));
+      await pumpEventQueue();
+      expect(splitKey.currentState!.isRightCollapsed, isFalse);
+
+      // Finish drag
+      web.window.dispatchEvent(web.MouseEvent('mouseup', web.MouseEventInit(clientY: 440, clientX: 100)));
+      await pumpEventQueue();
+    });
+
+    testClient('auto-collapses when dragging expanded handle down too small', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const Split(0.75),
+              canCollapseRight: true,
+              isVertical: true,
+              maxValue: 0.8,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final handle = web.document.querySelector('.drag-handle')! as web.HTMLElement;
+      expect(handle, isNotNull);
+
+      // Start drag at Y=375 (expanded position)
+      handle.dispatchEvent(web.MouseEvent('mousedown', web.MouseEventInit(clientY: 375, clientX: 100)));
+      await pumpEventQueue();
+
+      // Drag down towards bottom: Y=470 (currentSecondPos = 500 - 470 = 30, which is < collapseThreshold 70)
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 470, clientX: 100)));
+      await pumpEventQueue();
+
+      expect(splitKey.currentState!.isRightCollapsed, isTrue);
+
+      // Finish drag
+      web.window.dispatchEvent(web.MouseEvent('mouseup', web.MouseEventInit(clientY: 470, clientX: 100)));
+      await pumpEventQueue();
+    });
+
+    testClient('SplitPanelState manages SplitViewState transitions', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        SplitPanel(
+          key: splitKey,
+          initialValue: 0.75,
+          left: const div([]),
+          right: const div([]),
+        ),
+      );
+
+      final state = splitKey.currentState!;
+      expect(state.state, const Split(0.75));
+      expect(state.isSplit, isTrue);
+      expect(state.isUncollapsed, isTrue);
+      expect(state.isCollapsed, isFalse);
+      expect(state.isLeftCollapsed, isFalse);
+      expect(state.isRightCollapsed, isFalse);
+
+      state.collapseLeft();
+      await pumpEventQueue();
+      expect(state.state, const LeftCollapsed(0.75));
+      expect(state.isLeftCollapsed, isTrue);
+      expect(state.isCollapsed, isTrue);
+
+      state.collapseRight();
+      await pumpEventQueue();
+      expect(state.state, const RightCollapsed(0.75));
+      expect(state.isRightCollapsed, isTrue);
+      expect(state.isCollapsed, isTrue);
+
+      state.hideLeft();
+      await pumpEventQueue();
+      expect(state.state, const LeftHidden(0.75));
+      expect(state.isLeftHidden, isTrue);
+      expect(state.isHidden, isTrue);
+
+      state.hideRight();
+      await pumpEventQueue();
+      expect(state.state, const RightHidden(0.75));
+      expect(state.isRightHidden, isTrue);
+      expect(state.isHidden, isTrue);
+
+      state.split();
+      await pumpEventQueue();
+      expect(state.state, const Split(0.75));
+      expect(state.isSplit, isTrue);
+      expect(state.isCollapsed, isFalse);
+      expect(state.value, 0.75);
+    });
+
+    testClient('SplitPanelState toggles and updates sizes by code', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        SplitPanel(
+          key: splitKey,
+          initialValue: 0.75,
+          left: const div([]),
+          right: const div([]),
+        ),
+      );
+
+      final state = splitKey.currentState!;
+      expect(state.value, 0.75);
+      expect(state.isCollapsed, isFalse);
+
+      state.collapseRight();
+      await pumpEventQueue();
+      expect(state.state, const RightCollapsed(0.75));
+      expect(state.isCollapsed, isTrue);
+
+      state.split();
+      await pumpEventQueue();
+      expect(state.state, const Split(0.75));
+      expect(state.isCollapsed, isFalse);
+      expect(state.value, 0.75);
+
+      state.split(0.6);
+      await pumpEventQueue();
+      expect(state.value, 0.6);
+    });
+
+    testClient('SplitPanelState leftCollapsed and rightCollapsed layout in SplitPanel', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialValue: 0.5,
+              isVertical: true,
+              useRatio: true,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final topPane = web.document.querySelector('#top-pane')! as web.HTMLElement;
+      final bottomPane = web.document.querySelector('#bottom-pane')! as web.HTMLElement;
+
+      // Uncollapsed: both have ratio flex basis 0
+      expect(topPane.style.flexGrow, '0.5');
+      expect(bottomPane.style.flexGrow, '0.5');
+
+      // Collapse left: top pane shrinks to 0, bottom pane grows to 1
+      splitKey.currentState!.collapseLeft();
+      await pumpEventQueue();
+
+      expect(topPane.style.flexShrink, '0');
+      expect(bottomPane.style.flexGrow, '1');
+
+      // Collapse right: top pane grows to 1, bottom pane shrinks to 0
+      splitKey.currentState!.collapseRight();
+      await pumpEventQueue();
+
+      expect(topPane.style.flexGrow, '1');
+      expect(bottomPane.style.flexShrink, '0');
+
+      // Hide right: right pane display none, drag handle removed
+      splitKey.currentState!.hideRight();
+      await pumpEventQueue();
+
+      expect(web.document.querySelector('.drag-handle'), isNull);
+      expect(bottomPane.style.display, 'none');
+
+      // Expand: restored to ratio
+      splitKey.currentState!.split();
+      await pumpEventQueue();
+
+      expect(web.document.querySelector('.drag-handle'), isNotNull);
+      expect(topPane.style.flexGrow, '0.5');
+      expect(bottomPane.style.flexGrow, '0.5');
+    });
+
+    testClient('SplitPanelState expands and restores value when attached to SplitPanel', (tester) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const RightCollapsed(0.75),
+              isVertical: true,
+              useRatio: true,
+              minValue: 0.1,
+              maxValue: 0.9,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final state = splitKey.currentState!;
+      expect(state.isCollapsed, isTrue);
+
+      state.split();
+      await pumpEventQueue();
+
+      expect(state.isCollapsed, isFalse);
+      expect(state.value, 0.75);
+
+      // Can expand to explicit targetValue
+      state.collapseRight();
+      await pumpEventQueue();
+      expect(state.isCollapsed, isTrue);
+
+      state.split(0.6);
+      await pumpEventQueue();
+      expect(state.isCollapsed, isFalse);
+      expect(state.value, 0.6);
+    });
+
+    testClient('SplitPanel.of(context) exposes SplitPanelData to descendants', (tester) async {
+      SplitPanelData? leftData;
+      SplitPanelData? rightData;
+      SplitPanelData? noListenRightData;
+
+      tester.pumpComponent(
+        SplitPanel(
+          canCollapseLeft: true,
+          canCollapseRight: true,
+          left: _ContextInspector(onBuild: (ctx) => leftData = SplitPanel.of(ctx)),
+          right: _ContextInspector(
+            onBuild: (ctx) {
+              rightData = SplitPanel.of(ctx);
+              noListenRightData = SplitPanel.of(ctx, listen: false);
+            },
+          ),
+        ),
+      );
+
+      expect(leftData, isNotNull);
+      expect(leftData!.canCollapse, isTrue);
+      expect(leftData!.isPanelCollapsed, isFalse);
+
+      expect(rightData, isNotNull);
+      expect(rightData!.canCollapse, isTrue);
+      expect(rightData!.isPanelCollapsed, isFalse);
+      expect(noListenRightData, isNotNull);
+
+      // Collapse right panel via SplitPanelData
+      rightData!.collapse();
+      await pumpEventQueue();
+
+      expect(rightData!.isPanelCollapsed, isTrue);
+      expect(leftData!.isPanelCollapsed, isFalse);
+
+      // Expand right panel
+      rightData!.expand();
+      await pumpEventQueue();
+
+      expect(rightData!.isPanelCollapsed, isFalse);
+
+      // Collapse left panel via SplitPanelData
+      leftData!.collapse();
+      await pumpEventQueue();
+
+      expect(leftData!.isPanelCollapsed, isTrue);
+    });
+  });
+}
+
+class _ContextInspector extends StatelessComponent {
+  const _ContextInspector({this.onBuild});
+
+  final void Function(BuildContext context)? onBuild;
+
+  @override
+  Component build(BuildContext context) {
+    onBuild?.call(context);
+    return const div([]);
+  }
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/split_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/split_panel_test.dart
@@ -187,6 +187,93 @@ void main() {
       await pumpEventQueue();
     });
 
+    testClient('auto-collapses left when dragging handle too small with both canCollapseLeft and canCollapseRight', (
+      tester,
+    ) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const Split(0.5),
+              canCollapseLeft: true,
+              canCollapseRight: true,
+              isVertical: true,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final handle = web.document.querySelector('.drag-handle')! as web.HTMLElement;
+      expect(handle, isNotNull);
+
+      // Start drag at Y=250 (expanded position)
+      handle.dispatchEvent(web.MouseEvent('mousedown', web.MouseEventInit(clientY: 250, clientX: 100)));
+      await pumpEventQueue();
+
+      // Drag up towards top: Y=30 (currentFirstPos = 30 < collapseThresholdLeft 45)
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 30, clientX: 100)));
+      await pumpEventQueue();
+
+      expect(splitKey.currentState!.isLeftCollapsed, isTrue);
+
+      // Finish drag
+      web.window.dispatchEvent(web.MouseEvent('mouseup', web.MouseEventInit(clientY: 30, clientX: 100)));
+      await pumpEventQueue();
+    });
+
+    testClient('auto-expands left-collapsed handle when both canCollapseLeft and canCollapseRight are enabled', (
+      tester,
+    ) async {
+      final splitKey = GlobalStateKey<SplitPanelState>();
+      tester.pumpComponent(
+        div(
+          styles: Styles(
+            display: .flex,
+            height: 500.px,
+            flexDirection: .column,
+          ),
+          [
+            SplitPanel(
+              key: splitKey,
+              initialState: const LeftCollapsed(0.25),
+              canCollapseLeft: true,
+              canCollapseRight: true,
+              isVertical: true,
+              left: const div(id: 'top-pane', [Component.text('top')]),
+              right: const div(id: 'bottom-pane', [Component.text('bottom')]),
+            ),
+          ],
+        ),
+      );
+
+      final handle = web.document.querySelector('.drag-handle')! as web.HTMLElement;
+      expect(handle, isNotNull);
+
+      // Start drag at Y=40 (collapsed handle near top)
+      handle.dispatchEvent(web.MouseEvent('mousedown', web.MouseEventInit(clientY: 40, clientX: 100)));
+      await pumpEventQueue();
+
+      // Drag down by 30px to Y=70 (delta = 30 > 10)
+      web.window.dispatchEvent(web.MouseEvent('mousemove', web.MouseEventInit(clientY: 70, clientX: 100)));
+      await pumpEventQueue();
+
+      expect(splitKey.currentState!.isLeftCollapsed, isFalse);
+      expect(splitKey.currentState!.isRightCollapsed, isFalse);
+
+      // Finish drag
+      web.window.dispatchEvent(web.MouseEvent('mouseup', web.MouseEventInit(clientY: 70, clientX: 100)));
+      await pumpEventQueue();
+    });
+
     testClient('SplitPanelState manages SplitViewState transitions', (tester) async {
       final splitKey = GlobalStateKey<SplitPanelState>();
       tester.pumpComponent(

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_lifecycle_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_lifecycle_test.dart
@@ -7,6 +7,7 @@ library;
 
 import 'dart:async';
 
+import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
 import 'package:dartpad_frontend/features/workspace/workspace_lifecycle.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
@@ -42,6 +43,18 @@ void main() {
   ) async {
     final operations = <String>[];
     tester.pumpComponent(_ResetHarness(operations));
+
+    (web.document.querySelector('button')! as web.HTMLButtonElement).click();
+    await pumpEventQueue();
+
+    expect(operations, ['unmount:0', 'dispose:0', 'create:1']);
+  });
+
+  testClient('unmounts SplitPanel subtree when GlobalStateKey is refreshed on reset', (
+    tester,
+  ) async {
+    final operations = <String>[];
+    tester.pumpComponent(_SplitPanelResetHarness(operations));
 
     (web.document.querySelector('button')! as web.HTMLButtonElement).click();
     await pumpEventQueue();
@@ -114,5 +127,57 @@ final class _TrackedWorkspaceState extends State<_TrackedWorkspace> {
   void dispose() {
     component.operations.add('unmount:${component.generation}');
     super.dispose();
+  }
+}
+
+final class _SplitPanelResetHarness extends StatefulComponent {
+  const _SplitPanelResetHarness(this.operations);
+
+  final List<String> operations;
+
+  @override
+  State<_SplitPanelResetHarness> createState() => _SplitPanelResetHarnessState();
+}
+
+final class _SplitPanelResetHarnessState extends State<_SplitPanelResetHarness> {
+  int generation = 0;
+  GlobalStateKey<SplitPanelState> previewSplitKey = GlobalStateKey<SplitPanelState>();
+
+  void reset() {
+    final oldGeneration = generation;
+    final previousWorkspaceDisposed = Completer<void>();
+    unawaited(
+      previousWorkspaceDisposed.future.then((_) {
+        component.operations.add('create:${oldGeneration + 1}');
+      }),
+    );
+    setState(() {
+      generation++;
+      previewSplitKey = GlobalStateKey<SplitPanelState>();
+    });
+    disposeAfterWorkspaceUnmount(context, () async {
+      component.operations.add('dispose:$oldGeneration');
+      previousWorkspaceDisposed.complete();
+    });
+  }
+
+  @override
+  Component build(BuildContext context) {
+    return div([
+      button(onClick: reset, const [.text('Reset')]),
+      div(
+        key: ValueKey(generation),
+        [
+          SplitPanel(
+            key: previewSplitKey,
+            left: _TrackedWorkspace(
+              generation: generation,
+              operations: component.operations,
+            ),
+            right: const div([]),
+          ),
+        ],
+      ),
+    ]);
   }
 }


### PR DESCRIPTION
Closes #3715 

Makes the Preview panel, bottom panel and file tree panel collabsible.
- Panels can be collabsed via pressing a button, or dragging them beyond their minimal threshold
- Panels can be expanded via pressing a button, or dragging them out
- Filetree and preview panel show a siderail when collapsed, bottom panels simply shows the same tabs as when expanded.

All collapsed:
<img width="1264" height="731" alt="Bildschirmfoto 2026-09-08 um 09 16 51" src="https://github.com/user-attachments/assets/4989b833-8590-4cfe-819e-78f43a76a376" />


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
