### PR TITLE
Fix dartpad preview dart console controls

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -19,7 +19,7 @@ persistent project storage.
 - Dependency resolution with `pub get`, plus `Pub get` and `Pub clean` actions
   when `pubspec.yaml` or `pubspec.lock` is active.
 - Compilation and execution in an isolated preview sandbox, with start, stop,
-  restart, and hot reload controls.
+  restart, and Flutter-only hot reload controls.
 - Built-in Dart, Flutter, and Flame examples, as well as projects loaded from
   pub.dev packages, GitHub Gists, and remote tar archives.
 - Responsive desktop and small-screen layouts, light and dark themes, and an
@@ -232,11 +232,15 @@ it opens `README.md` when available. Otherwise no initial file is opened. Gist
 and sample URLs do not currently support a `main` override.
 
 After dependency resolution, the frontend automatically runs the resolved
-entrypoint only if its path ends in `.dart`. The Start button is independent
+entrypoint only if its path ends in `.dart`. The Run button is independent
 of that startup choice: it runs the currently active editor file, or
 `lib/main.dart` if no file is active. It does not replace an active non-Dart
 file with `lib/main.dart`. Restart recompiles the entrypoint of the current run;
-Hot Reload recompiles changes for that same running entrypoint.
+Hot Reload is only offered for Flutter applications and recompiles changes for
+that same running entrypoint. For Dart console programs, a successful launch
+immediately restores Run and disables Stop. Execution is not tracked: an async
+`main()`, timers, and other background work may continue producing console
+output until the next run replaces the sandbox.
 
 Whether that entrypoint is presented as a Flutter application or a console
 program is determined as described in [SDK detection](#sdk-detection).

--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -238,10 +238,7 @@ of that startup choice: it runs the currently active editor file, or
 file with `lib/main.dart`. Restart recompiles the entrypoint of the current run;
 Hot Reload is only offered for Flutter applications and recompiles changes for
 that same running entrypoint. For Dart console programs, a successful launch
-immediately restores Run and disables Stop. Execution is not tracked: an async
-`main()`, timers, and other background work may continue producing console
-output until the next run replaces the sandbox.
-
+immediately restores Run and disables Stop.
 Whether that entrypoint is presented as a Flutter application or a console
 program is determined as described in [SDK detection](#sdk-detection).
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -12,7 +12,7 @@ import '../../shared/icons.dart';
 import '../view_models/preview_view_model.dart';
 
 /// A button component used to trigger preview runtime actions
-/// (Start, Restart, Reload, Stop).
+/// (Run, Restart, Reload, Stop).
 class RuntimeButton extends StatelessComponent {
   /// Creates a runtime button with direct configurations.
   const RuntimeButton({
@@ -25,7 +25,7 @@ class RuntimeButton extends StatelessComponent {
 
   /// Factory constructor for a 'Run' button that runs the [activeFile]
   /// or falls back to 'lib/main.dart' if no active file is present.
-  factory RuntimeButton.start({
+  factory RuntimeButton.run({
     required PreviewViewModel previewViewModel,
     required String activeFile,
   }) {

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -23,14 +23,14 @@ class RuntimeButton extends StatelessComponent {
     super.key,
   });
 
-  /// Factory constructor for a 'Start' button that runs the [activeFile]
+  /// Factory constructor for a 'Run' button that runs the [activeFile]
   /// or falls back to 'lib/main.dart' if no active file is present.
   factory RuntimeButton.start({
     required PreviewViewModel previewViewModel,
     required String activeFile,
   }) {
     return RuntimeButton(
-      title: 'Start',
+      title: 'Run',
       icon: 'play_arrow',
       isEnabled: previewViewModel.canStart,
       onClick: () => previewViewModel.runCode(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/preview_state.dart
@@ -33,6 +33,13 @@ class PreviewRunning extends _ActivePreviewState {
   PreviewRunning(super.entrypoint);
 }
 
+/// State after successfully launching a Dart console program.
+///
+/// The UI is ready for another run; async main and timers may still be running.
+class PreviewDartReady extends _ActivePreviewState {
+  PreviewDartReady(super.entrypoint);
+}
+
 /// State representing an application restart after recompiling current sources.
 class PreviewRestarting extends _ActivePreviewState {
   PreviewRestarting(super.entrypoint);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -184,8 +184,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
                       previewViewModel: viewModel,
                       activeFile: component.activeFile,
                     ),
-                  if (viewModel.isFlutter)
-                    RuntimeButton.restart(previewViewModel: viewModel),
+                  if (viewModel.isFlutter) RuntimeButton.restart(previewViewModel: viewModel),
                   RuntimeButton.stop(previewViewModel: viewModel),
                 ],
               ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -180,7 +180,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
                   if (isRunning && viewModel.isFlutter)
                     RuntimeButton.reload(previewViewModel: viewModel)
                   else
-                    RuntimeButton.start(
+                    RuntimeButton.run(
                       previewViewModel: viewModel,
                       activeFile: component.activeFile,
                     ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -177,14 +177,15 @@ class _PreviewContainerState extends State<PreviewContainer> {
               listenable: component.taskStatus,
               builder: (context) => ButtonGroup(
                 children: [
-                  if (isRunning)
+                  if (isRunning && viewModel.isFlutter)
                     RuntimeButton.reload(previewViewModel: viewModel)
                   else
                     RuntimeButton.start(
                       previewViewModel: viewModel,
                       activeFile: component.activeFile,
                     ),
-                  RuntimeButton.restart(previewViewModel: viewModel),
+                  if (viewModel.isFlutter)
+                    RuntimeButton.restart(previewViewModel: viewModel),
                   RuntimeButton.stop(previewViewModel: viewModel),
                 ],
               ),
@@ -244,7 +245,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
               persistentFailureMessage: failureMessage,
               onOpenConsole: component.onOpenConsole,
             ),
-          if (isRunning && !viewModel.isFlutter) ConsolePanel(logs: viewModel.appLogs),
+          if ((isRunning || state is PreviewDartReady) && !viewModel.isFlutter) ConsolePanel(logs: viewModel.appLogs),
         ],
       ),
     ]);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -74,19 +74,19 @@ class PreviewViewModel extends ChangeNotifier {
   bool get canStart =>
       !_busy &&
       !workspaceRepository.taskStatus.hasBlockingPreviewTask &&
-      (_state is PreviewInitial || _state is PreviewCompileError);
+      (_state is PreviewInitial || _state is PreviewDartReady || _state is PreviewCompileError);
 
   /// Whether the running preview can be restarted.
   bool get canRestart => _canReloadOrRestart;
 
-  /// Whether the running preview can accept a hot reload.
-  bool get canHotReload => _canReloadOrRestart;
+  /// Whether the running Flutter preview can accept a hot reload.
+  bool get canHotReload => _isFlutter && _canReloadOrRestart;
 
   bool get _canReloadOrRestart =>
       !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
 
   /// Whether the preview run process can be stopped.
-  bool get canStop => _state is! PreviewStopping && (_busy || _sandbox != null);
+  bool get canStop => _state is! PreviewStopping && _state is! PreviewDartReady && (_busy || _sandbox != null);
 
   /// Whether the application preview is currently running or executing restarts/reloads.
   bool get isRunning => _state is PreviewRunning || state is PreviewRestarting || state is PreviewHotReloading;
@@ -232,7 +232,7 @@ class PreviewViewModel extends ChangeNotifier {
       }
       eventBus.dispatch(const LogEvent('App is running.'));
 
-      _state = PreviewRunning(entrypoint);
+      _state = _isFlutter ? PreviewRunning(entrypoint) : PreviewDartReady(entrypoint);
     } on CompilationFailedException catch (e, st) {
       if (_isCurrentOperation(operationId)) {
         eventBus.dispatch(
@@ -258,7 +258,7 @@ class PreviewViewModel extends ChangeNotifier {
     } finally {
       if (!_isCurrentOperation(operationId)) {
         statusTask.cancel();
-      } else if (_state is PreviewRunning) {
+      } else if (_state is PreviewRunning || _state is PreviewDartReady) {
         statusTask.succeed();
       } else if (_state is PreviewCompileError) {
         statusTask.fail();
@@ -274,11 +274,11 @@ class PreviewViewModel extends ChangeNotifier {
   /// Hot reloads the currently active execution session compiler changes into
   /// the sandbox.
   Future<void> hotReloadCode() async {
-    final entry = state.entrypoint;
-    if (entry == null) {
+    if (!canHotReload) {
       return;
     }
-    if (_busy || workspaceRepository.taskStatus.hasBlockingPreviewTask) {
+    final entry = state.entrypoint;
+    if (entry == null) {
       return;
     }
     final operationId = _beginOperation();

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view_models/preview_view_model.dart
@@ -86,10 +86,13 @@ class PreviewViewModel extends ChangeNotifier {
       !_busy && !workspaceRepository.taskStatus.hasBlockingPreviewTask && _state is PreviewRunning;
 
   /// Whether the preview run process can be stopped.
+  ///
+  /// For pure Dart console programs, once launched ([PreviewDartReady]), execution
+  /// is untracked and cannot be stopped; [canStart] is restored immediately instead.
   bool get canStop => _state is! PreviewStopping && _state is! PreviewDartReady && (_busy || _sandbox != null);
 
   /// Whether the application preview is currently running or executing restarts/reloads.
-  bool get isRunning => _state is PreviewRunning || state is PreviewRestarting || state is PreviewHotReloading;
+  bool get isRunning => _state is PreviewRunning || _state is PreviewRestarting || _state is PreviewHotReloading;
 
   bool get _busy =>
       _state is PreviewStarting ||

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -5,17 +5,22 @@
 @TestOn('browser')
 library;
 
+import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
 import 'package:dartpad_frontend/features/preview/components/runtime_button.dart';
 import 'package:dartpad_frontend/features/preview/models/preview_state.dart';
 import 'package:dartpad_frontend/features/preview/view/preview_container.dart';
 import 'package:dartpad_frontend/features/preview/view_models/preview_view_model.dart';
+import 'package:dartpad_frontend/features/shared/app_event_bus.dart';
 import 'package:dartpad_frontend/features/shared/components/split_panel.dart';
 import 'package:dartpad_frontend/features/shared/task_status.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
+
+import '../view_models/preview_view_model_test.dart'
+    show FakePreviewSandbox, FakeWorkspaceRepository, FakeWorkspaceResourceApi;
 
 class FakePreviewViewModel extends ChangeNotifier implements PreviewViewModel {
   @override
@@ -419,7 +424,7 @@ void main() {
     expect(buttons[2].textContent, contains('stop'));
   });
 
-  testClient('shows Start button when preview is stopped', (tester) async {
+  testClient('shows Run button when preview is stopped', (tester) async {
     preview.setRunning(value: false);
     tester.pumpComponent(buildContainer());
     await pumpEventQueue();
@@ -427,7 +432,7 @@ void main() {
     final buttons = findRuntimeButtons();
     expect(buttons, hasLength(3));
 
-    expect(buttons[0].querySelector('.runtime-button-label')?.textContent, 'Start');
+    expect(buttons[0].querySelector('.runtime-button-label')?.textContent, 'Run');
     expect(buttons[0].textContent, contains('play_arrow'));
 
     expect(buttons[1].querySelector('.runtime-button-label')?.textContent, 'Restart');
@@ -515,11 +520,9 @@ void main() {
     final buttons = findRuntimeButtons();
     final firstLabel = buttons[0].querySelector('.runtime-button-label') as web.HTMLElement;
     final secondLabel = buttons[1].querySelector('.runtime-button-label') as web.HTMLElement;
-    final thirdLabel = buttons[2].querySelector('.runtime-button-label') as web.HTMLElement;
 
     expect(web.window.getComputedStyle(firstLabel).display, isNot('none'));
     expect(web.window.getComputedStyle(secondLabel).display, 'none');
-    expect(web.window.getComputedStyle(thirdLabel).display, 'none');
     dartPreview.dispose();
   });
 
@@ -534,5 +537,71 @@ void main() {
       expect(web.window.getComputedStyle(label).display, isNot('none'));
     }
     dartPreview.dispose();
+  });
+
+  group('runtime controls', () {
+    late AppEventBus events;
+    late FakeWorkspaceRepository repository;
+    late FakePreviewSandbox sandbox;
+    late PreviewViewModel preview;
+
+    setUp(() {
+      events = AppEventBus();
+      repository = FakeWorkspaceRepository(events, FakeWorkspaceResourceApi());
+      sandbox = FakePreviewSandbox();
+      preview = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => sandbox,
+      );
+    });
+
+    tearDown(() async {
+      preview.dispose();
+      repository.taskStatus.dispose();
+      await events.dispose();
+    });
+
+    Component buildPreview() => ListenableBuilder(
+      listenable: preview,
+      builder: (_) => PreviewContainer(
+        preview: preview,
+        taskStatus: repository.taskStatus,
+        activeFile: 'lib/main.dart',
+        onOpenConsole: () {},
+      ),
+    );
+
+    web.HTMLButtonElement? button(String label) =>
+        web.document.querySelector('.preview-toolbar [aria-label="$label"]') as web.HTMLButtonElement?;
+
+    testClient('Dart hides Hot Reload and restores Run immediately after launch', (tester) async {
+      repository.flutterDependency = false;
+      await preview.runCode('lib/main.dart');
+      tester.pumpComponent(buildPreview());
+
+      expect(button('Reload'), isNull);
+      expect(button('Restart'), isNull);
+      expect(button('Run')?.disabled, isFalse);
+      expect(button('Stop')?.disabled, isTrue);
+
+      sandbox.consoleController.add((level: ConsoleLevel.log, message: 'timer is still running'));
+      await pumpEventQueue();
+
+      expect(web.document.querySelector('.console-panel')?.textContent, contains('timer is still running'));
+      expect(button('Run')?.disabled, isFalse);
+      expect(button('Stop')?.disabled, isTrue);
+      expect(sandbox.disposeCount, 0);
+    });
+
+    testClient('Flutter keeps Hot Reload and running controls after launch', (tester) async {
+      await preview.runCode('lib/main.dart');
+      tester.pumpComponent(buildPreview());
+
+      expect(button('Reload')?.disabled, isFalse);
+      expect(button('Restart')?.disabled, isFalse);
+      expect(button('Stop')?.disabled, isFalse);
+      expect(button('Run'), isNull);
+    });
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view_models/preview_view_model_test.dart
@@ -326,16 +326,19 @@ void main() {
 
       expect(stateChanges, [
         isA<PreviewStarting>(),
-        isA<PreviewRunning>(),
+        isA<PreviewDartReady>(),
       ]);
 
-      expect(viewModel.state, isA<PreviewRunning>());
-      expect(viewModel.canStart, isFalse);
-      expect(viewModel.canRestart, isTrue);
-      expect(viewModel.canHotReload, isTrue);
-      expect(viewModel.canStop, isTrue);
-      expect(viewModel.isRunning, isTrue);
+      expect(viewModel.state, isA<PreviewDartReady>());
+      expect(viewModel.canStart, isTrue);
+      expect(viewModel.canRestart, isFalse);
+      expect(viewModel.canStop, isFalse);
+      expect(viewModel.isRunning, isFalse);
       expect(viewModel.isFlutter, isFalse);
+
+      expect(viewModel.canHotReload, isFalse);
+      await viewModel.hotReloadCode();
+      expect(fakeSandbox.hotReloadCount, 0);
 
       expect(fakeCompiler.compileCount, 1);
       expect(fakeSandbox.loadModuleCount, 1);
@@ -371,14 +374,123 @@ void main() {
       await viewModel.runCode('lib/main.dart');
       await pump();
 
-      expect(viewModel.state, isA<PreviewRunning>());
+      expect(viewModel.state, isA<PreviewDartReady>());
       expect(fakeSandbox.runAppCount, 0);
       expect(fakeSandbox.runMainCount, 1);
       expect(fakeSandbox.runUri, Uri.parse('package:app/main.dart'));
       expect(viewModel.isFlutter, isFalse);
+      expect(viewModel.canHotReload, isFalse);
+
+      await viewModel.hotReloadCode();
+      expect(fakeCompiler.compileCount, 1);
+      expect(fakeSandbox.hotReloadCount, 0);
 
       viewModel.dispose();
       dartRepository.taskStatus.dispose();
+    });
+
+    test('Dart launch restores controls without waiting for execution to finish', () async {
+      repository.flutterDependency = false;
+      final fakeSandbox = FakePreviewSandbox();
+      repository.onStartHotReloadCompiler = (_) => FakeCompilerSession();
+
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      fakeSandbox.consoleController.add((level: ConsoleLevel.log, message: 'done'));
+      await pump();
+
+      expect(viewModel.state, isA<PreviewDartReady>());
+      expect(viewModel.state.entrypoint, 'lib/main.dart');
+      expect(viewModel.canStart, isTrue);
+      expect(viewModel.canRestart, isFalse);
+      expect(viewModel.canHotReload, isFalse);
+      expect(viewModel.canStop, isFalse);
+      expect(viewModel.isRunning, isFalse);
+      expect(viewModel.appLogs.single.message, 'done');
+
+      // Background work can still print, but must not revive the running UI.
+      fakeSandbox.consoleController.add((level: ConsoleLevel.log, message: 'timer tick'));
+      await pump();
+      expect(viewModel.appLogs.last.message, 'timer tick');
+      expect(viewModel.canStart, isTrue);
+      expect(viewModel.canStop, isFalse);
+      expect(viewModel.isRunning, isFalse);
+      expect(fakeSandbox.disposeCount, 0);
+
+      await viewModel.hotReloadCode();
+      expect(fakeSandbox.hotReloadCount, 0);
+
+      viewModel.dispose();
+    });
+
+    test('Dart controls stay busy until the launch request succeeds', () async {
+      repository.flutterDependency = false;
+      final launchCompleted = Completer<void>();
+      final fakeSandbox = FakePreviewSandbox()..onRunApp = (_) => launchCompleted.future;
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => fakeSandbox,
+      );
+
+      final run = viewModel.runCode('lib/main.dart');
+      await pump();
+
+      expect(viewModel.state, isA<PreviewStarting>());
+      expect(viewModel.canStart, isFalse);
+      expect(viewModel.canHotReload, isFalse);
+      expect(viewModel.canStop, isTrue);
+
+      launchCompleted.complete();
+      await run;
+
+      expect(viewModel.state, isA<PreviewDartReady>());
+      expect(viewModel.canStart, isTrue);
+      expect(viewModel.canStop, isFalse);
+      expect(
+        repository.taskStatus.entries.where((entry) => entry.kind == TaskKind.startingPreview).single.outcome,
+        TaskStatusOutcome.succeeded,
+      );
+
+      viewModel.dispose();
+    });
+
+    test('another Dart run replaces the old sandbox and compiler', () async {
+      repository.flutterDependency = false;
+      final firstSandbox = FakePreviewSandbox();
+      final secondSandbox = FakePreviewSandbox();
+      final firstCompiler = FakeCompilerSession();
+      final secondCompiler = FakeCompilerSession();
+      var compilerIndex = 0;
+      repository.onStartHotReloadCompiler = (_) => compilerIndex++ == 0 ? firstCompiler : secondCompiler;
+      var sandboxIndex = 0;
+      final viewModel = PreviewViewModel(
+        workspaceRepository: repository,
+        eventBus: events,
+        createSandbox: (_, {required assetBaseUrl}) async => sandboxIndex++ == 0 ? firstSandbox : secondSandbox,
+      );
+
+      await viewModel.runCode('lib/main.dart');
+      firstSandbox.consoleController.add((level: ConsoleLevel.log, message: 'old timer tick'));
+      await pump();
+      expect(viewModel.appLogs, hasLength(1));
+
+      await viewModel.runCode('lib/main.dart');
+
+      expect(firstSandbox.disposeCount, 1);
+      expect(firstCompiler.closeCount, 1);
+      expect(secondCompiler.compileCount, 1);
+      expect(secondSandbox.runAppCount, 1);
+      expect(viewModel.appLogs, isEmpty);
+      expect(viewModel.state, isA<PreviewDartReady>());
+      expect(viewModel.canStart, isTrue);
+
+      viewModel.dispose();
     });
 
     test('runCode fails compilation with CompilationFailedException', () async {
@@ -431,6 +543,7 @@ void main() {
       expect(errState.message, contains('load crash'));
       expect(errState.action, PreviewLaunchAction.start);
       expect(errState.failedTask, TaskKind.startingPreview);
+      expect(viewModel.canStop, isTrue);
 
       expect(loggedEvents.any((e) => e.message == 'Run failed' && e.level == Level.SEVERE), isTrue);
 


### PR DESCRIPTION

Refines runtime controls and lifecycle handling for Dart console applications in `dartpad_preview`:
- **Button update:** Renamed the "Start" button to "Run" to better match user expectations.
- **Flutter-only Hot Reload:** Hid and disabled the Hot Reload button when running standalone Dart console code.
- **Immediate readiness (`PreviewDartReady`):** Dart apps now transition to a ready state immediately after launch. This re-enables the "Run" button right away and disables "Stop" once the app is running.

Fixes #3818 
