### PR TITLE
[dartpad preview]: improve toolbar ux by showing button labels when possible

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app_styles.dart
@@ -69,6 +69,7 @@ List<StyleRule> get appStyles => [
       '-webkit-font-feature-settings': "'liga'",
       'font-feature-settings': "'liga'",
       '-webkit-font-smoothing': 'antialiased',
+      'font-variation-settings': "'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24",
     },
   ),
   ...[

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/device_mode_dropdown.dart
@@ -29,7 +29,11 @@ class DeviceModeDropdown extends StatelessComponent {
       disabled: disabled,
       trigger: button(
         classes: 'device-dropdown-trigger${disabled ? ' disabled' : ''}',
-        attributes: disabled ? {'disabled': 'true'} : {},
+        attributes: {
+          'title': mode.title,
+          'aria-label': mode.title,
+          if (disabled) 'disabled': 'true',
+        },
         [
           Icon(mode.icon, size: 18.0),
           span(classes: 'device-dropdown-label', [.text(mode.title)]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -132,14 +132,14 @@ class RuntimeButton extends StatelessComponent {
         backgroundColor: colorSurface.highlight(colorOnSurface, 0.1),
       ),
       css('&:disabled').styles(
-        cursor: .notAllowed,
         opacity: 0.5,
+        cursor: .notAllowed,
       ),
       css('.runtime-button-label').styles(
         display: .none,
+        color: colorOnSurface,
         fontSize: 13.px,
         fontWeight: .w500,
-        color: colorOnSurface,
         whiteSpace: .noWrap,
       ),
     ]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -4,9 +4,11 @@
 
 import 'dart:async';
 
+import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
-import '../../shared/components/icon_button.dart';
+import '../../../app_styles.dart';
+import '../../shared/icons.dart';
 import '../view_models/preview_view_model.dart';
 
 /// A button component used to trigger preview runtime actions
@@ -54,7 +56,7 @@ class RuntimeButton extends StatelessComponent {
   /// in the currently running entrypoint.
   factory RuntimeButton.hotReload({required PreviewViewModel previewViewModel}) {
     return RuntimeButton(
-      title: 'Hot Reload',
+      title: 'Reload',
       icon: 'bolt',
       isEnabled: previewViewModel.canHotReload,
       onClick: () => previewViewModel.hotReloadCode(),
@@ -86,12 +88,60 @@ class RuntimeButton extends StatelessComponent {
 
   @override
   Component build(BuildContext context) {
-    return IconButton(
-      label: title,
-      icon: icon,
+    return button(
+      classes: [
+        'runtime-button',
+        if (!isEnabled) 'disabled',
+      ].join(' '),
       disabled: !isEnabled,
-      tooltip: title,
-      onClick: (_) => onClick(),
+      attributes: {
+        'title': title,
+        'aria-label': title,
+      },
+      onClick: isEnabled ? () => unawaited(onClick()) : null,
+      [
+        Icon(icon, size: 18.0),
+        span(classes: 'runtime-button-label', [.text(title)]),
+      ],
     );
   }
+
+  @css
+  static List<StyleRule> get styles => [
+    css('.runtime-button', [
+      css('&').styles(
+        display: .flex,
+        position: const .relative(),
+        width: 28.px,
+        height: 28.px,
+        padding: .zero,
+        border: .none,
+        radius: .circular(4.px),
+        cursor: .pointer,
+        transition: Transition('background-color', duration: 150.ms, curve: .ease),
+        justifyContent: .center,
+        alignItems: .center,
+        color: colorOnSurface,
+        whiteSpace: .noWrap,
+        backgroundColor: Colors.transparent,
+      ),
+      css('& > *').styles(
+        raw: {'flex-shrink': '0'},
+      ),
+      css('&:not(:disabled):hover').styles(
+        backgroundColor: colorSurface.highlight(colorOnSurface, 0.1),
+      ),
+      css('&:disabled').styles(
+        cursor: .notAllowed,
+        opacity: 0.5,
+      ),
+      css('.runtime-button-label').styles(
+        display: .none,
+        fontSize: 13.px,
+        fontWeight: .w500,
+        color: colorOnSurface,
+        whiteSpace: .noWrap,
+      ),
+    ]),
+  ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -12,7 +12,7 @@ import '../../shared/icons.dart';
 import '../view_models/preview_view_model.dart';
 
 /// A button component used to trigger preview runtime actions
-/// (Start, Restart, Hot Reload, Stop).
+/// (Start, Restart, Reload, Stop).
 class RuntimeButton extends StatelessComponent {
   /// Creates a runtime button with direct configurations.
   const RuntimeButton({
@@ -52,9 +52,9 @@ class RuntimeButton extends StatelessComponent {
     );
   }
 
-  /// Factory constructor for a 'Hot Reload' button that hot reloads changes
+  /// Factory constructor for a 'Reload' button that hot reloads changes
   /// in the currently running entrypoint.
-  factory RuntimeButton.hotReload({required PreviewViewModel previewViewModel}) {
+  factory RuntimeButton.reload({required PreviewViewModel previewViewModel}) {
     return RuntimeButton(
       title: 'Reload',
       icon: 'bolt',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/device_mode.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/models/device_mode.dart
@@ -19,7 +19,7 @@ enum DeviceMode {
   final (int, int)? size;
 
   String get title => switch (this) {
-    DeviceMode.current => 'Current screen size',
+    DeviceMode.current => 'Full size',
     DeviceMode.mobile => 'Mobile',
     DeviceMode.tablet => 'Tablet',
   };

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -163,7 +163,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
               builder: (context) => ButtonGroup(
                 children: [
                   if (isRunning)
-                    RuntimeButton.hotReload(previewViewModel: viewModel)
+                    RuntimeButton.reload(previewViewModel: viewModel)
                   else
                     RuntimeButton.start(
                       previewViewModel: viewModel,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -151,52 +151,58 @@ class _PreviewContainerState extends State<PreviewContainer> {
     };
 
     return div(classes: 'preview-container', [
-      div(classes: 'preview-toolbar', [
-        div(classes: 'preview-controls', [
-          ListenableBuilder(
-            listenable: component.taskStatus,
-            builder: (context) => ButtonGroup(
-              children: [
-                if (isRunning)
-                  RuntimeButton.restart(previewViewModel: viewModel)
-                else
-                  RuntimeButton.start(
-                    previewViewModel: viewModel,
-                    activeFile: component.activeFile,
-                  ),
-                RuntimeButton.hotReload(previewViewModel: viewModel),
-                RuntimeButton.stop(previewViewModel: viewModel),
-              ],
+      div(
+        classes: [
+          'preview-toolbar',
+          if (viewModel.isFlutter) 'has-device-mode',
+        ].join(' '),
+        [
+          div(classes: 'preview-controls', [
+            ListenableBuilder(
+              listenable: component.taskStatus,
+              builder: (context) => ButtonGroup(
+                children: [
+                  if (isRunning)
+                    RuntimeButton.hotReload(previewViewModel: viewModel)
+                  else
+                    RuntimeButton.start(
+                      previewViewModel: viewModel,
+                      activeFile: component.activeFile,
+                    ),
+                  RuntimeButton.restart(previewViewModel: viewModel),
+                  RuntimeButton.stop(previewViewModel: viewModel),
+                ],
+              ),
             ),
-          ),
-          if (viewModel.isFlutter)
-            ButtonGroup(
-              children: [
-                DeviceModeDropdown(
-                  mode: mode,
-                  disabled: !isRunning,
-                  onModeSelected: (m) {
-                    setState(() {
-                      mode = m;
-                      isRotated = false;
-                    });
-                    context.binding.addPostFrameCallback(_updateScale);
-                  },
-                ),
-                if (mode.size != null)
-                  IconButton(
-                    icon: 'screen_rotation',
-                    tooltip: 'Rotate orientation',
+            if (viewModel.isFlutter)
+              ButtonGroup(
+                children: [
+                  DeviceModeDropdown(
+                    mode: mode,
                     disabled: !isRunning,
-                    onClick: (_) {
-                      setState(() => isRotated = !isRotated);
+                    onModeSelected: (m) {
+                      setState(() {
+                        mode = m;
+                        isRotated = false;
+                      });
                       context.binding.addPostFrameCallback(_updateScale);
                     },
                   ),
-              ],
-            ),
-        ]),
-      ]),
+                  if (mode.size != null)
+                    IconButton(
+                      icon: 'screen_rotation',
+                      tooltip: 'Rotate orientation',
+                      disabled: !isRunning,
+                      onClick: (_) {
+                        setState(() => isRotated = !isRotated);
+                        context.binding.addPostFrameCallback(_updateScale);
+                      },
+                    ),
+                ],
+              ),
+          ]),
+        ],
+      ),
       div(
         key: _contentKey,
         classes: [
@@ -222,7 +228,9 @@ class _PreviewContainerState extends State<PreviewContainer> {
   }
 
   static List<StyleRule> get styles => [
-    ...PreviewTaskStatus.styles,
+    css('.preview-toolbar.has-device-mode .device-dropdown-label').styles(
+      display: .none,
+    ),
     css('.preview-container', [
       css('&').styles(
         display: .flex,
@@ -231,6 +239,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
         flexDirection: .column,
         flex: const .grow(1),
         backgroundColor: colorContainer,
+        raw: {'container-type': 'inline-size'},
       ),
       css('.active-icon-btn').styles(
         color: colorOnPrimary,
@@ -242,7 +251,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
       css('.preview-toolbar', [
         css('&').styles(
           display: .flex,
-          padding: .symmetric(vertical: 4.px, horizontal: 12.px),
+          padding: .symmetric(vertical: 4.px, horizontal: 4.px),
           border: .only(
             bottom: .solid(color: colorBorder, width: 1.px),
           ),
@@ -253,7 +262,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
         ),
         css('.preview-controls').styles(
           display: .flex,
-          flexWrap: .wrap,
+          flexWrap: .nowrap,
           justifyContent: .center,
           alignItems: .center,
           flex: const .grow(1),
@@ -338,5 +347,54 @@ class _PreviewContainerState extends State<PreviewContainer> {
         ),
       ]),
     ]),
+    // Flutter: first button expands at >= 250px
+    ContainerStyleRule('(min-width: 250px)', [
+      css('.preview-toolbar.has-device-mode .runtime-button:first-child', expandedRuntimeButtonStyles),
+    ]),
+    // Flutter: device dropdown label expands at >= 300px
+    ContainerStyleRule('(min-width: 300px)', [
+      css('.preview-toolbar.has-device-mode .device-dropdown-label').styles(
+        display: .inline,
+      ),
+    ]),
+    // Flutter: all 3 buttons expand at >= 380px
+    ContainerStyleRule('(min-width: 380px)', [
+      css('.preview-toolbar.has-device-mode .runtime-button', expandedRuntimeButtonStyles),
+    ]),
+    // Dart (no device dropdown): first button expands at >= 160px
+    ContainerStyleRule('(min-width: 160px)', [
+      css('.preview-toolbar:not(.has-device-mode) .runtime-button:first-child', expandedRuntimeButtonStyles),
+    ]),
+    // Dart (no device dropdown): all 3 buttons expand at >= 250px
+    ContainerStyleRule('(min-width: 250px)', [
+      css('.preview-toolbar:not(.has-device-mode) .runtime-button', expandedRuntimeButtonStyles),
+    ]),
   ];
+
+  static List<StyleRule> get expandedRuntimeButtonStyles => [
+    css('&').styles(
+      width: .auto,
+      padding: .only(left: 5.px, right: 8.px),
+      gap: .all(6.px),
+    ),
+    css('.runtime-button-label').styles(
+      display: .inline,
+    ),
+  ];
+}
+
+/// Style rule that renders a CSS `@container` query.
+class ContainerStyleRule implements StyleRule {
+  const ContainerStyleRule(this.query, this.styles);
+
+  final String query;
+  final List<StyleRule> styles;
+
+  @override
+  String toCss([String indent = '']) {
+    const blockInset = '  ';
+    return '$indent@container $query {\n'
+        '${styles.map((r) => '${r.toCss('$indent$blockInset')}\n').join()}'
+        '$indent}';
+  }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/button_group.dart
@@ -46,17 +46,17 @@ class ButtonGroup extends StatelessComponent {
         alignItems: .center,
         backgroundColor: colorContainer,
       ),
-      css('& > *, & .icon-button, & .text-button, & .device-dropdown-trigger').styles(
+      css('& > *, & .icon-button, & .text-button, & .device-dropdown-trigger, & .runtime-button').styles(
         border: .none,
         radius: .circular(0.px),
       ),
       css(
-        '& > *:first-child, & > *:first-child .icon-button, & > *:first-child .text-button, & > *:first-child .device-dropdown-trigger',
+        '& > *:first-child, & > *:first-child .icon-button, & > *:first-child .text-button, & > *:first-child .device-dropdown-trigger, & > *:first-child .runtime-button',
       ).styles(
         radius: .only(topLeft: .circular(5.px), bottomLeft: .circular(5.px)),
       ),
       css(
-        '& > *:last-child, & > *:last-child .icon-button, & > *:last-child .text-button, & > *:last-child .device-dropdown-trigger',
+        '& > *:last-child, & > *:last-child .icon-button, & > *:last-child .text-button, & > *:last-child .device-dropdown-trigger, & > *:last-child .runtime-button',
       ).styles(
         radius: .only(topRight: .circular(5.px), bottomRight: .circular(5.px)),
       ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/dropdown_menu.dart
@@ -217,7 +217,7 @@ class _DropdownMenuState extends State<DropdownMenu> {
     css('.dropdown-menu-panel').styles(
       position: .absolute(top: 100.percent),
       zIndex: const ZIndex(99),
-      minWidth: 180.px,
+      minWidth: 120.px,
       padding: .symmetric(vertical: 4.px),
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(8.px),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -67,7 +67,8 @@ void main() {
 
     final style = web.document.createElement('style') as web.HTMLStyleElement;
     style.id = 'test-preview-style';
-    style.textContent = '''
+    style.textContent =
+        '''
       .preview-container {
         display: flex;
         flex-direction: column;
@@ -79,6 +80,7 @@ void main() {
         width: 100%;
         height: 100%;
       }
+      ${PreviewContainer.styles.map((rule) => rule.toCss()).join('\n')}
     ''';
     web.document.head!.appendChild(style);
   });
@@ -95,6 +97,7 @@ void main() {
     String height = '1000px',
   }) {
     return div(
+      key: ValueKey('container-$width-$height-${customPreview?.isFlutter ?? preview.isFlutter}'),
       attributes: {
         'style': 'display: flex; flex-direction: column; width: $width; height: $height;',
       },
@@ -120,8 +123,21 @@ void main() {
     return null;
   }
 
+  List<web.HTMLButtonElement> findRuntimeButtons() {
+    final list = <web.HTMLButtonElement>[];
+    final buttons = web.document.querySelectorAll('.preview-controls .runtime-button');
+    for (var i = 0; i < buttons.length; i++) {
+      list.add(buttons.item(i) as web.HTMLButtonElement);
+    }
+    return list;
+  }
+
   web.HTMLButtonElement findDropdownTrigger() {
     return web.document.querySelector('.device-dropdown-trigger')! as web.HTMLButtonElement;
+  }
+
+  web.HTMLElement findDropdownLabel() {
+    return web.document.querySelector('.device-dropdown-label')! as web.HTMLElement;
   }
 
   Future<void> selectDropdownOption(String title) async {
@@ -285,5 +301,140 @@ void main() {
     await pumpEventQueue();
 
     expect(web.document.querySelector('.preview-container'), isNull);
+  });
+
+  testClient('renders runtime buttons with icons and labels', (tester) async {
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    expect(buttons, hasLength(3));
+
+    // Running mode shows Reload first, Restart second, Stop third
+    expect(buttons[0].querySelector('.runtime-button-label')?.textContent, 'Reload');
+    expect(buttons[0].textContent, contains('bolt'));
+
+    expect(buttons[1].querySelector('.runtime-button-label')?.textContent, 'Restart');
+    expect(buttons[1].textContent, contains('restart_alt'));
+
+    expect(buttons[2].querySelector('.runtime-button-label')?.textContent, 'Stop');
+    expect(buttons[2].textContent, contains('stop'));
+  });
+
+  testClient('shows Start button when preview is stopped', (tester) async {
+    preview.setRunning(value: false);
+    tester.pumpComponent(buildContainer());
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    expect(buttons, hasLength(3));
+
+    expect(buttons[0].querySelector('.runtime-button-label')?.textContent, 'Start');
+    expect(buttons[0].textContent, contains('play_arrow'));
+
+    expect(buttons[1].querySelector('.runtime-button-label')?.textContent, 'Restart');
+    expect(buttons[1].textContent, contains('restart_alt'));
+
+    expect(buttons[2].querySelector('.runtime-button-label')?.textContent, 'Stop');
+    expect(buttons[2].textContent, contains('stop'));
+  });
+
+  testClient('hides all button and dropdown labels in narrow Flutter toolbar (< 260px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '240px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    for (final btn in buttons) {
+      final label = btn.querySelector('.runtime-button-label') as web.HTMLElement;
+      expect(web.window.getComputedStyle(label).display, 'none');
+    }
+    expect(web.window.getComputedStyle(findDropdownLabel()).display, 'none');
+  });
+
+  testClient(
+    'expands only the first button label while hiding dropdown label in Flutter toolbar (260px - 379px)',
+    (tester) async {
+      tester.pumpComponent(buildContainer(width: '300px'));
+      await pumpEventQueue();
+
+      final buttons = findRuntimeButtons();
+      final firstLabel = buttons[0].querySelector('.runtime-button-label') as web.HTMLElement;
+      final secondLabel = buttons[1].querySelector('.runtime-button-label') as web.HTMLElement;
+      final thirdLabel = buttons[2].querySelector('.runtime-button-label') as web.HTMLElement;
+
+      expect(web.window.getComputedStyle(firstLabel).display, isNot('none'));
+      expect(web.window.getComputedStyle(secondLabel).display, 'none');
+      expect(web.window.getComputedStyle(thirdLabel).display, 'none');
+      expect(web.window.getComputedStyle(findDropdownLabel()).display, 'none');
+    },
+  );
+
+  testClient('expands dropdown label and first button in medium-wide Flutter toolbar (380px - 479px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '400px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    final firstLabel = buttons[0].querySelector('.runtime-button-label') as web.HTMLElement;
+    final secondLabel = buttons[1].querySelector('.runtime-button-label') as web.HTMLElement;
+    final thirdLabel = buttons[2].querySelector('.runtime-button-label') as web.HTMLElement;
+
+    expect(web.window.getComputedStyle(firstLabel).display, isNot('none'));
+    expect(web.window.getComputedStyle(secondLabel).display, 'none');
+    expect(web.window.getComputedStyle(thirdLabel).display, 'none');
+    expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
+  });
+
+  testClient('expands all button labels and dropdown label in wide Flutter toolbar (>= 480px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '500px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    for (final btn in buttons) {
+      final label = btn.querySelector('.runtime-button-label') as web.HTMLElement;
+      expect(web.window.getComputedStyle(label).display, isNot('none'));
+    }
+    expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
+  });
+
+  testClient('hides all button labels in narrow Dart toolbar (< 200px)', (tester) async {
+    final dartPreview = FakePreviewViewModel()..isFlutter = false;
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '180px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    for (final btn in buttons) {
+      final label = btn.querySelector('.runtime-button-label') as web.HTMLElement;
+      expect(web.window.getComputedStyle(label).display, 'none');
+    }
+    dartPreview.dispose();
+  });
+
+  testClient('expands only the first button in medium Dart toolbar (200px - 329px)', (tester) async {
+    final dartPreview = FakePreviewViewModel()..isFlutter = false;
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '260px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    final firstLabel = buttons[0].querySelector('.runtime-button-label') as web.HTMLElement;
+    final secondLabel = buttons[1].querySelector('.runtime-button-label') as web.HTMLElement;
+    final thirdLabel = buttons[2].querySelector('.runtime-button-label') as web.HTMLElement;
+
+    expect(web.window.getComputedStyle(firstLabel).display, isNot('none'));
+    expect(web.window.getComputedStyle(secondLabel).display, 'none');
+    expect(web.window.getComputedStyle(thirdLabel).display, 'none');
+    dartPreview.dispose();
+  });
+
+  testClient('expands all buttons in wide Dart toolbar (>= 330px)', (tester) async {
+    final dartPreview = FakePreviewViewModel()..isFlutter = false;
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '380px'));
+    await pumpEventQueue();
+
+    final buttons = findRuntimeButtons();
+    for (final btn in buttons) {
+      final label = btn.querySelector('.runtime-button-label') as web.HTMLElement;
+      expect(web.window.getComputedStyle(label).display, isNot('none'));
+    }
+    dartPreview.dispose();
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'package:dartpad_frontend/features/bottom_panel/models/console_entry.dart';
+import 'package:dartpad_frontend/features/preview/components/runtime_button.dart';
 import 'package:dartpad_frontend/features/preview/models/preview_state.dart';
 import 'package:dartpad_frontend/features/preview/view/preview_container.dart';
 import 'package:dartpad_frontend/features/preview/view_models/preview_view_model.dart';
@@ -41,17 +42,26 @@ class FakePreviewViewModel extends ChangeNotifier implements PreviewViewModel {
   bool canStop = true;
 
   @override
-  List<ConsoleEntry> appLogs = const [];
+  final List<ConsoleEntry> appLogs = [];
 
   void setRunning({required bool value}) {
     isRunning = value;
-    state = value ? PreviewRunning('lib/main.dart') : PreviewInitial();
     canStart = !value;
     canRestart = value;
     canHotReload = value;
     canStop = value;
+    state = value ? PreviewRunning('lib/main.dart') : PreviewInitial();
     notifyListeners();
   }
+
+  @override
+  Future<void> runCode(String activeFile) async {}
+
+  @override
+  Future<void> hotReloadCode() async {}
+
+  @override
+  Future<void> stopCode() async {}
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -81,6 +91,7 @@ void main() {
         height: 100%;
       }
       ${PreviewContainer.styles.map((rule) => rule.toCss()).join('\n')}
+      ${RuntimeButton.styles.map((rule) => rule.toCss()).join('\n')}
     ''';
     web.document.head!.appendChild(style);
   });
@@ -191,16 +202,16 @@ void main() {
     expect(rotateBtn!.disabled, isFalse);
   });
 
-  testClient('switches mode to current screen size and removes rotation button', (tester) async {
+  testClient('switches mode to full size and removes rotation button', (tester) async {
     tester.pumpComponent(buildContainer());
     await pumpEventQueue();
 
     expect(findRotateButton(), isNotNull);
 
-    await selectDropdownOption('Current screen size');
+    await selectDropdownOption('Full size');
 
     final trigger = findDropdownTrigger();
-    expect(trigger.textContent, contains('Current screen size'));
+    expect(trigger.textContent, contains('Full size'));
     expect(trigger.textContent, contains('devices'));
 
     final content = web.document.querySelector('.preview-content') as web.HTMLElement;
@@ -234,14 +245,14 @@ void main() {
     expect(content.style.getPropertyValue('--device-height'), '576px');
   });
 
-  testClient('removes device CSS variables in current screen size mode', (tester) async {
+  testClient('removes device CSS variables in full size mode', (tester) async {
     tester.pumpComponent(buildContainer());
     await pumpEventQueue();
 
     final content = web.document.querySelector('.preview-content') as web.HTMLElement;
     expect(content.style.getPropertyValue('--device-width'), '390px');
 
-    await selectDropdownOption('Current screen size');
+    await selectDropdownOption('Full size');
 
     expect(content.style.getPropertyValue('--device-width'), isEmpty);
     expect(content.style.getPropertyValue('--device-height'), isEmpty);
@@ -339,7 +350,7 @@ void main() {
     expect(buttons[2].textContent, contains('stop'));
   });
 
-  testClient('hides all button and dropdown labels in narrow Flutter toolbar (< 260px)', (tester) async {
+  testClient('hides all button and dropdown labels in narrow Flutter toolbar (< 250px)', (tester) async {
     tester.pumpComponent(buildContainer(width: '240px'));
     await pumpEventQueue();
 
@@ -352,9 +363,9 @@ void main() {
   });
 
   testClient(
-    'expands only the first button label while hiding dropdown label in Flutter toolbar (260px - 379px)',
+    'expands only the first button label while hiding dropdown label in Flutter toolbar (250px - 299px)',
     (tester) async {
-      tester.pumpComponent(buildContainer(width: '300px'));
+      tester.pumpComponent(buildContainer(width: '280px'));
       await pumpEventQueue();
 
       final buttons = findRuntimeButtons();
@@ -369,8 +380,8 @@ void main() {
     },
   );
 
-  testClient('expands dropdown label and first button in medium-wide Flutter toolbar (380px - 479px)', (tester) async {
-    tester.pumpComponent(buildContainer(width: '400px'));
+  testClient('expands dropdown label and first button in medium-wide Flutter toolbar (300px - 379px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '340px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -384,8 +395,8 @@ void main() {
     expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
   });
 
-  testClient('expands all button labels and dropdown label in wide Flutter toolbar (>= 480px)', (tester) async {
-    tester.pumpComponent(buildContainer(width: '500px'));
+  testClient('expands all button labels and dropdown label in wide Flutter toolbar (>= 380px)', (tester) async {
+    tester.pumpComponent(buildContainer(width: '400px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -396,9 +407,9 @@ void main() {
     expect(web.window.getComputedStyle(findDropdownLabel()).display, isNot('none'));
   });
 
-  testClient('hides all button labels in narrow Dart toolbar (< 200px)', (tester) async {
+  testClient('hides all button labels in narrow Dart toolbar (< 160px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
-    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '180px'));
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '140px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -409,9 +420,9 @@ void main() {
     dartPreview.dispose();
   });
 
-  testClient('expands only the first button in medium Dart toolbar (200px - 329px)', (tester) async {
+  testClient('expands only the first button in medium Dart toolbar (160px - 249px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
-    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '260px'));
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '200px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();
@@ -425,9 +436,9 @@ void main() {
     dartPreview.dispose();
   });
 
-  testClient('expands all buttons in wide Dart toolbar (>= 330px)', (tester) async {
+  testClient('expands all buttons in wide Dart toolbar (>= 250px)', (tester) async {
     final dartPreview = FakePreviewViewModel()..isFlutter = false;
-    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '380px'));
+    tester.pumpComponent(buildContainer(customPreview: dartPreview, width: '300px'));
     await pumpEventQueue();
 
     final buttons = findRuntimeButtons();


### PR DESCRIPTION
Improves the toolbar ux by showing labels for the start/restart/stop buttons, and only collapsing to icon-only when there is not enough space in three steps:

[From: Wide toolbar]
1. All buttons have icons + labels
2. Only first button has icon+label (start / reload), others have icons only
3. The device mode dropdown is icon only
4. All buttons are icon only
[To: Small toolbar]

I also made all icons filled, which imo looks better.

Fixes #3858 

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
