### PR TITLE
refactor(dartpad-preview) consolidate analyzer status in task list

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -674,7 +674,6 @@ class AppState extends State<App> {
           if (!isEmbedMode)
             Footer(
               taskStatus: session.taskStatus,
-              analyzerStatus: session.analyzerStatus,
               statusMessage: session.tabs.errorMessage ?? session.tabs.warningMessage,
               isSmallScreen: !_isLargeScreen,
               currentSdk: _currentSdk,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
@@ -9,11 +9,16 @@ import 'task_status.dart';
 /// The session-scoped lifecycle of the Dart analyzer.
 enum AnalyzerStatusPhase { waiting, analyzing, ready, unavailable }
 
-/// Tracks analyzer readiness separately from user-visible application tasks.
+/// Tracks analyzer readiness and translates LSP analysis activity into
+/// application tasks.
 ///
-/// Analyzer startup and the first complete analysis are represented by one
-/// normal task. Later analysis cycles only toggle [AnalyzerStatusPhase.analyzing]
-/// and never replace or restart that initialization task.
+/// Analyzer startup and the first complete analysis are represented by a
+/// [TaskKind.startingAnalyzer] task. Later analysis cycles trigger a
+/// [TaskKind.analyzing] task which reuses the same task key, replacing earlier
+/// analysis entries in recent task history.
+///
+/// [phase] reflects the current analyzer lifecycle state and notifies
+/// listeners of state transitions.
 final class AnalyzerStatusController extends ChangeNotifier {
   AnalyzerStatusController(this._taskStatus);
 
@@ -21,17 +26,18 @@ final class AnalyzerStatusController extends ChangeNotifier {
 
   AnalyzerStatusPhase _phase = AnalyzerStatusPhase.waiting;
   TaskStatusHandle? _initializationTask;
+  TaskStatusHandle? _currentTask;
   bool _initializationFinished = false;
   bool _disposed = false;
 
   AnalyzerStatusPhase get phase => _phase;
 
-  /// Starts the single task spanning analyzer startup and initial analysis.
+  /// Starts the task spanning analyzer startup and initial analysis.
   void beginInitialization() {
     if (_disposed || _initializationTask != null || _initializationFinished) {
       return;
     }
-    _initializationTask = _taskStatus.startTask(TaskKind.analyzingWorkspace);
+    _initializationTask = _taskStatus.startTask(TaskKind.startingAnalyzer);
     _setPhase(AnalyzerStatusPhase.analyzing);
   }
 
@@ -42,13 +48,34 @@ final class AnalyzerStatusController extends ChangeNotifier {
     }
     if (isAnalyzing) {
       _setPhase(AnalyzerStatusPhase.analyzing);
+      if (_initializationTask != null) {
+        return;
+      }
+      if (!_initializationFinished) {
+        _initializationTask = _taskStatus.startTask(TaskKind.startingAnalyzer);
+        return;
+      }
+      _currentTask ??= _taskStatus.startTask(TaskKind.analyzing);
       return;
     }
 
-    _initializationTask?.succeed();
-    _initializationTask = null;
-    _initializationFinished = true;
-    _setPhase(AnalyzerStatusPhase.ready);
+    if (_phase == AnalyzerStatusPhase.unavailable) {
+      return;
+    }
+
+    final hadActiveTask = _initializationTask != null || _currentTask != null;
+    if (_initializationTask case final task?) {
+      task.succeed();
+      _initializationTask = null;
+      _initializationFinished = true;
+    }
+    if (_currentTask case final task?) {
+      task.succeed();
+      _currentTask = null;
+    }
+    if (hadActiveTask || _initializationFinished) {
+      _setPhase(AnalyzerStatusPhase.ready);
+    }
   }
 
   /// Marks the analyzer as unavailable after startup or stream failure.
@@ -56,8 +83,19 @@ final class AnalyzerStatusController extends ChangeNotifier {
     if (_disposed) {
       return;
     }
-    _initializationTask?.fail();
-    _initializationTask = null;
+    final hadActiveTask = _initializationTask != null || _currentTask != null;
+    if (_initializationTask case final task?) {
+      task.fail();
+      _initializationTask = null;
+    }
+    if (_currentTask case final task?) {
+      task.fail();
+      _currentTask = null;
+    }
+    if (!hadActiveTask) {
+      final kind = _initializationFinished ? TaskKind.analyzing : TaskKind.startingAnalyzer;
+      _taskStatus.startTask(kind).fail();
+    }
     _initializationFinished = true;
     _setPhase(AnalyzerStatusPhase.unavailable);
   }
@@ -76,8 +114,14 @@ final class AnalyzerStatusController extends ChangeNotifier {
       return;
     }
     _disposed = true;
-    _initializationTask?.cancel();
-    _initializationTask = null;
+    if (_initializationTask case final task?) {
+      task.cancel();
+      _initializationTask = null;
+    }
+    if (_currentTask case final task?) {
+      task.cancel();
+      _currentTask = null;
+    }
     super.dispose();
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/analyzer_status.dart
@@ -2,12 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:jaspr/jaspr.dart';
-
 import 'task_status.dart';
-
-/// The session-scoped lifecycle of the Dart analyzer.
-enum AnalyzerStatusPhase { waiting, analyzing, ready, unavailable }
 
 /// Tracks analyzer readiness and translates LSP analysis activity into
 /// application tasks.
@@ -16,21 +11,16 @@ enum AnalyzerStatusPhase { waiting, analyzing, ready, unavailable }
 /// [TaskKind.startingAnalyzer] task. Later analysis cycles trigger a
 /// [TaskKind.analyzing] task which reuses the same task key, replacing earlier
 /// analysis entries in recent task history.
-///
-/// [phase] reflects the current analyzer lifecycle state and notifies
-/// listeners of state transitions.
-final class AnalyzerStatusController extends ChangeNotifier {
+final class AnalyzerStatusController {
   AnalyzerStatusController(this._taskStatus);
 
   final TaskStatusController _taskStatus;
 
-  AnalyzerStatusPhase _phase = AnalyzerStatusPhase.waiting;
   TaskStatusHandle? _initializationTask;
   TaskStatusHandle? _currentTask;
   bool _initializationFinished = false;
+  bool _unavailable = false;
   bool _disposed = false;
-
-  AnalyzerStatusPhase get phase => _phase;
 
   /// Starts the task spanning analyzer startup and initial analysis.
   void beginInitialization() {
@@ -38,7 +28,6 @@ final class AnalyzerStatusController extends ChangeNotifier {
       return;
     }
     _initializationTask = _taskStatus.startTask(TaskKind.startingAnalyzer);
-    _setPhase(AnalyzerStatusPhase.analyzing);
   }
 
   /// Applies an analyzer busy/idle notification.
@@ -47,7 +36,7 @@ final class AnalyzerStatusController extends ChangeNotifier {
       return;
     }
     if (isAnalyzing) {
-      _setPhase(AnalyzerStatusPhase.analyzing);
+      _unavailable = false;
       if (_initializationTask != null) {
         return;
       }
@@ -59,11 +48,10 @@ final class AnalyzerStatusController extends ChangeNotifier {
       return;
     }
 
-    if (_phase == AnalyzerStatusPhase.unavailable) {
+    if (_unavailable) {
       return;
     }
 
-    final hadActiveTask = _initializationTask != null || _currentTask != null;
     if (_initializationTask case final task?) {
       task.succeed();
       _initializationTask = null;
@@ -72,9 +60,6 @@ final class AnalyzerStatusController extends ChangeNotifier {
     if (_currentTask case final task?) {
       task.succeed();
       _currentTask = null;
-    }
-    if (hadActiveTask || _initializationFinished) {
-      _setPhase(AnalyzerStatusPhase.ready);
     }
   }
 
@@ -97,18 +82,23 @@ final class AnalyzerStatusController extends ChangeNotifier {
       _taskStatus.startTask(kind).fail();
     }
     _initializationFinished = true;
-    _setPhase(AnalyzerStatusPhase.unavailable);
+    _unavailable = true;
   }
 
-  void _setPhase(AnalyzerStatusPhase phase) {
-    if (_phase == phase) {
+  /// Resets the controller state and cancels any pending analysis tasks.
+  void reset() {
+    if (_disposed) {
       return;
     }
-    _phase = phase;
-    notifyListeners();
+    _initializationTask?.cancel();
+    _initializationTask = null;
+    _currentTask?.cancel();
+    _currentTask = null;
+    _initializationFinished = false;
+    _unavailable = false;
   }
 
-  @override
+  /// Cancels any active tasks and disposes the controller.
   void dispose() {
     if (_disposed) {
       return;
@@ -122,6 +112,5 @@ final class AnalyzerStatusController extends ChangeNotifier {
       task.cancel();
       _currentTask = null;
     }
-    super.dispose();
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
@@ -14,7 +14,6 @@ import '../../filetree/file_tree_view_model.dart';
 import '../../preview/view_models/preview_view_model.dart';
 import '../../workspace/data/workspace_repository.dart';
 import '../../workspace/workspace_session.dart';
-import '../analyzer_status.dart';
 import '../app_event_bus.dart';
 import '../events/log_event.dart';
 import '../task_status.dart';
@@ -52,8 +51,6 @@ final class CommandContext {
   FileTreeViewModel? get fileTree => session?.fileTree;
 
   TaskStatusController? get taskStatus => session?.taskStatus;
-
-  AnalyzerStatusController? get analyzerStatus => session?.analyzerStatus;
 }
 
 /// An executable command shown in the command palette.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/footer.dart
@@ -7,7 +7,6 @@ import 'package:jaspr/jaspr.dart';
 
 import '../../../app_styles.dart';
 import '../../../sdks.g.dart';
-import '../analyzer_status.dart';
 import '../icons.dart';
 import '../sdk_info.dart';
 import '../task_status.dart';
@@ -21,7 +20,6 @@ final class Footer extends StatefulComponent {
   /// Creates the application footer.
   const Footer({
     required this.taskStatus,
-    required this.analyzerStatus,
     this.statusMessage,
     this.isSmallScreen = false,
     this.currentSdk,
@@ -31,9 +29,6 @@ final class Footer extends StatefulComponent {
 
   /// Recent application task activity.
   final TaskStatusController taskStatus;
-
-  /// Readiness and background activity of the session analyzer.
-  final AnalyzerStatusController analyzerStatus;
 
   /// An optional editor error or warning shown alongside task activity.
   final String? statusMessage;
@@ -93,7 +88,6 @@ class _FooterState extends State<Footer> {
         else
           const div(classes: 'app-footer-spacer', []),
         TaskStatusIndicator(controller: component.taskStatus),
-        AnalyzerStatusIndicator(controller: component.analyzerStatus),
         _buildRuntimeVersions(),
       ]),
       if (_showShortcuts)
@@ -174,7 +168,6 @@ class _FooterState extends State<Footer> {
 
   static List<StyleRule> get styles => [
     ...TaskStatusIndicator.styles,
-    ...AnalyzerStatusIndicator.styles,
     css('.app-footer').styles(
       display: .flex,
       minHeight: 34.px,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/task_status_indicator.dart
@@ -9,7 +9,6 @@ import 'package:jaspr/jaspr.dart';
 import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
-import '../analyzer_status.dart';
 import '../icons.dart';
 import '../task_status.dart';
 
@@ -344,100 +343,6 @@ class _TaskStatusIndicatorState extends State<TaskStatusIndicator> {
         raw: {'max-width': 'none'},
       ),
     ]),
-  ];
-}
-
-/// Stable analyzer readiness indicator with a non-timed update pulse.
-final class AnalyzerStatusIndicator extends StatefulComponent {
-  const AnalyzerStatusIndicator({required this.controller, super.key});
-
-  final AnalyzerStatusController controller;
-
-  @override
-  State<AnalyzerStatusIndicator> createState() => _AnalyzerStatusIndicatorState();
-
-  @css
-  static List<StyleRule> get styles => _AnalyzerStatusIndicatorState.styles;
-}
-
-class _AnalyzerStatusIndicatorState extends State<AnalyzerStatusIndicator> {
-  @override
-  void initState() {
-    super.initState();
-    component.controller.addListener(_onStatusChanged);
-  }
-
-  @override
-  void didUpdateComponent(AnalyzerStatusIndicator oldComponent) {
-    super.didUpdateComponent(oldComponent);
-    if (!identical(oldComponent.controller, component.controller)) {
-      oldComponent.controller.removeListener(_onStatusChanged);
-      component.controller.addListener(_onStatusChanged);
-    }
-  }
-
-  void _onStatusChanged() {
-    if (!mounted) {
-      return;
-    }
-    setState(() {});
-  }
-
-  @override
-  void dispose() {
-    component.controller.removeListener(_onStatusChanged);
-    super.dispose();
-  }
-
-  @override
-  Component build(BuildContext context) {
-    final phase = component.controller.phase;
-    final unavailable = phase == AnalyzerStatusPhase.unavailable;
-    final running = phase == AnalyzerStatusPhase.waiting || phase == AnalyzerStatusPhase.analyzing;
-
-    return div(
-      classes: 'analyzer-status ${phase.name}',
-      attributes: {'aria-label': 'Analyzer: ${phase.name}'},
-      [
-        _TaskStatusIcon.outcome(
-          outcome: running
-              ? TaskStatusOutcome.running
-              : unavailable
-              ? TaskStatusOutcome.failed
-              : TaskStatusOutcome.succeeded,
-          size: 16,
-        ),
-        const span(classes: 'analyzer-status-label', [.text('Analyzer')]),
-      ],
-    );
-  }
-
-  static List<StyleRule> get styles => [
-    css('.analyzer-status').styles(
-      display: .flex,
-      height: 28.px,
-      minWidth: .zero,
-      padding: .symmetric(horizontal: 6.px),
-      alignItems: .center,
-      gap: Gap.all(6.px),
-      fontSize: 11.px,
-      whiteSpace: .noWrap,
-    ),
-    css('.analyzer-status-label').styles(
-      minWidth: .zero,
-      overflow: .hidden,
-      textOverflow: .ellipsis,
-    ),
-    css('.analyzer-status .task-status-icon.running').styles(
-      width: 10.px,
-      height: 10.px,
-      border: .only(
-        top: .solid(color: colorPrimary, width: 2.px),
-        right: .solid(color: colorBorder, width: 2.px),
-        bottom: .solid(color: colorBorder, width: 2.px),
-        left: .solid(color: colorBorder, width: 2.px),
-      ),
-    ),
   ];
 }
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -54,6 +54,7 @@ enum TaskKind {
   pubDowngrade('Pub downgrade'),
   pubOutdated('Pub outdated'),
   pubClean('Pub clean'),
+
   /// Initial analyzer startup and baseline workspace analysis.
   startingAnalyzer('Starting analyzer'),
 

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/task_status.dart
@@ -21,7 +21,7 @@ enum TaskStatusOutcome { running, succeeded, failed }
 ///   [hotReload], [compilingChanges]). These tasks are always tracked unconditionally
 ///   to provide predictable feedback to the user.
 /// - **System & runtime lifecycle:** Background environment preparations like
-///   [loadingCode], [initializingDartPadWorker], and [analyzingWorkspace].
+///   [loadingCode], [initializingDartPadWorker], and [startingAnalyzer].
 ///
 /// **Not tracked (Editor interactions):**
 /// - Standard in-editor actions (e.g. formatting documents, saving files,
@@ -54,7 +54,11 @@ enum TaskKind {
   pubDowngrade('Pub downgrade'),
   pubOutdated('Pub outdated'),
   pubClean('Pub clean'),
-  analyzingWorkspace('Analyzing workspace'),
+  /// Initial analyzer startup and baseline workspace analysis.
+  startingAnalyzer('Starting analyzer'),
+
+  /// An incremental background re-analysis cycle.
+  analyzing('Analyzing'),
   startingPreview('Starting preview'),
   restartingPreview('Restarting preview'),
   stoppingPreview('Stopping preview'),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_task_status_test.dart
@@ -30,7 +30,7 @@ void main() {
       ),
     );
 
-    controller.startTask(TaskKind.analyzingWorkspace);
+    controller.startTask(TaskKind.startingAnalyzer);
     controller.startTask(
       TaskKind.pubClean,
       label: 'Pub clean in /',

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
@@ -18,8 +18,8 @@ void main() {
       controller.beginInitialization();
       expect(controller.phase, AnalyzerStatusPhase.analyzing);
       expect(taskStatus.entries, hasLength(1));
-      expect(taskStatus.current?.kind, TaskKind.analyzingWorkspace);
-      expect(taskStatus.current?.label, 'Analyzing workspace');
+      expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+      expect(taskStatus.current?.label, 'Starting analyzer');
       expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
       expect(taskStatus.hasBlockingPreviewTask, isFalse);
 
@@ -37,7 +37,7 @@ void main() {
     });
   });
 
-  test('later analysis cycles do not replace or restart the initial task', () {
+  test('later analysis cycles track an analyzing task and replace earlier runs', () {
     var now = DateTime.utc(2026, 8, 31, 12);
     withClock(Clock(() => now), () {
       final taskStatus = TaskStatusController();
@@ -47,17 +47,38 @@ void main() {
       now = now.add(const Duration(seconds: 2));
       controller.update(isAnalyzing: false);
       final initialTask = taskStatus.current!;
+      expect(initialTask.kind, TaskKind.startingAnalyzer);
 
       now = now.add(const Duration(minutes: 1));
       controller.update(isAnalyzing: true);
       expect(controller.phase, AnalyzerStatusPhase.analyzing);
-      expect(taskStatus.entries, [same(initialTask)]);
+      expect(taskStatus.entries, hasLength(2));
+      expect(taskStatus.current?.kind, TaskKind.analyzing);
+      expect(taskStatus.current?.label, 'Analyzing');
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
 
       now = now.add(const Duration(seconds: 1));
       controller.update(isAnalyzing: false);
       expect(controller.phase, AnalyzerStatusPhase.ready);
-      expect(taskStatus.entries, [same(initialTask)]);
-      expect(initialTask.durationAt(now), const Duration(seconds: 2));
+      expect(taskStatus.entries, hasLength(2));
+      final firstCycle = taskStatus.entries.firstWhere((e) => e.kind == TaskKind.analyzing);
+      expect(firstCycle.outcome, TaskStatusOutcome.succeeded);
+      expect(firstCycle.durationAt(now), const Duration(seconds: 1));
+
+      // Starting another analysis cycle replaces the previous analyzing entry.
+      now = now.add(const Duration(minutes: 1));
+      controller.update(isAnalyzing: true);
+      expect(taskStatus.entries, hasLength(2));
+      expect(taskStatus.current?.kind, TaskKind.analyzing);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+      expect(taskStatus.entries, contains(initialTask));
+
+      now = now.add(const Duration(seconds: 2));
+      controller.update(isAnalyzing: false);
+      expect(taskStatus.entries, hasLength(2));
+      final secondCycle = taskStatus.entries.firstWhere((e) => e.kind == TaskKind.analyzing);
+      expect(secondCycle.outcome, TaskStatusOutcome.succeeded);
+      expect(secondCycle.durationAt(now), const Duration(seconds: 2));
 
       controller.dispose();
       taskStatus.dispose();
@@ -72,13 +93,18 @@ void main() {
     controller.markUnavailable();
     expect(controller.phase, AnalyzerStatusPhase.unavailable);
     expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
 
     controller.update(isAnalyzing: true);
     expect(controller.phase, AnalyzerStatusPhase.analyzing);
+    expect(taskStatus.current?.kind, TaskKind.analyzing);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
     controller.update(isAnalyzing: false);
     expect(controller.phase, AnalyzerStatusPhase.ready);
-    expect(taskStatus.entries, hasLength(1));
-    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+    expect(taskStatus.entries, hasLength(2));
+    expect(taskStatus.entries.firstWhere((e) => e.kind == TaskKind.analyzing).outcome, TaskStatusOutcome.succeeded);
+    expect(taskStatus.entries.firstWhere((e) => e.kind == TaskKind.startingAnalyzer).outcome, TaskStatusOutcome.failed);
 
     controller.dispose();
     taskStatus.dispose();
@@ -92,6 +118,64 @@ void main() {
     controller.dispose();
 
     expect(taskStatus.entries, isEmpty);
+    taskStatus.dispose();
+  });
+
+  test('dispose cancels a pending analyzing task', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+    controller.beginInitialization();
+    controller.update(isAnalyzing: false);
+    controller.update(isAnalyzing: true);
+    expect(taskStatus.current?.kind, TaskKind.analyzing);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
+    controller.dispose();
+
+    expect(taskStatus.entries.where((e) => e.kind == TaskKind.analyzing), isEmpty);
+    taskStatus.dispose();
+  });
+
+  test('markUnavailable while idle records a failed analyzing task', () {
+    var now = DateTime.utc(2026, 8, 31, 12);
+    withClock(Clock(() => now), () {
+      final taskStatus = TaskStatusController();
+      final controller = AnalyzerStatusController(taskStatus);
+      controller.beginInitialization();
+      now = now.add(const Duration(seconds: 1));
+      controller.update(isAnalyzing: false);
+      expect(controller.phase, AnalyzerStatusPhase.ready);
+      expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
+
+      now = now.add(const Duration(seconds: 1));
+      controller.markUnavailable();
+      expect(controller.phase, AnalyzerStatusPhase.unavailable);
+      expect(taskStatus.current?.kind, TaskKind.analyzing);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+      // Trailing isAnalyzing: false updates must not revert phase to ready.
+      controller.update(isAnalyzing: false);
+      expect(controller.phase, AnalyzerStatusPhase.unavailable);
+
+      controller.dispose();
+      taskStatus.dispose();
+    });
+  });
+
+  test('markUnavailable before beginInitialization records a failed startingAnalyzer task', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.markUnavailable();
+    expect(controller.phase, AnalyzerStatusPhase.unavailable);
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+    controller.update(isAnalyzing: false);
+    expect(controller.phase, AnalyzerStatusPhase.unavailable);
+
+    controller.dispose();
     taskStatus.dispose();
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/analyzer_status_test.dart
@@ -16,7 +16,6 @@ void main() {
 
       controller.beginInitialization();
       controller.beginInitialization();
-      expect(controller.phase, AnalyzerStatusPhase.analyzing);
       expect(taskStatus.entries, hasLength(1));
       expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
       expect(taskStatus.current?.label, 'Starting analyzer');
@@ -28,7 +27,6 @@ void main() {
       expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
 
       controller.update(isAnalyzing: false);
-      expect(controller.phase, AnalyzerStatusPhase.ready);
       expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
       expect(taskStatus.current?.durationAt(now), const Duration(seconds: 3));
 
@@ -51,7 +49,6 @@ void main() {
 
       now = now.add(const Duration(minutes: 1));
       controller.update(isAnalyzing: true);
-      expect(controller.phase, AnalyzerStatusPhase.analyzing);
       expect(taskStatus.entries, hasLength(2));
       expect(taskStatus.current?.kind, TaskKind.analyzing);
       expect(taskStatus.current?.label, 'Analyzing');
@@ -59,7 +56,6 @@ void main() {
 
       now = now.add(const Duration(seconds: 1));
       controller.update(isAnalyzing: false);
-      expect(controller.phase, AnalyzerStatusPhase.ready);
       expect(taskStatus.entries, hasLength(2));
       final firstCycle = taskStatus.entries.firstWhere((e) => e.kind == TaskKind.analyzing);
       expect(firstCycle.outcome, TaskStatusOutcome.succeeded);
@@ -91,17 +87,14 @@ void main() {
 
     controller.beginInitialization();
     controller.markUnavailable();
-    expect(controller.phase, AnalyzerStatusPhase.unavailable);
     expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
     expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
 
     controller.update(isAnalyzing: true);
-    expect(controller.phase, AnalyzerStatusPhase.analyzing);
     expect(taskStatus.current?.kind, TaskKind.analyzing);
     expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
 
     controller.update(isAnalyzing: false);
-    expect(controller.phase, AnalyzerStatusPhase.ready);
     expect(taskStatus.entries, hasLength(2));
     expect(taskStatus.entries.firstWhere((e) => e.kind == TaskKind.analyzing).outcome, TaskStatusOutcome.succeeded);
     expect(taskStatus.entries.firstWhere((e) => e.kind == TaskKind.startingAnalyzer).outcome, TaskStatusOutcome.failed);
@@ -144,19 +137,17 @@ void main() {
       controller.beginInitialization();
       now = now.add(const Duration(seconds: 1));
       controller.update(isAnalyzing: false);
-      expect(controller.phase, AnalyzerStatusPhase.ready);
       expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
       expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
 
       now = now.add(const Duration(seconds: 1));
       controller.markUnavailable();
-      expect(controller.phase, AnalyzerStatusPhase.unavailable);
       expect(taskStatus.current?.kind, TaskKind.analyzing);
       expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
 
-      // Trailing isAnalyzing: false updates must not revert phase to ready.
+      // Trailing isAnalyzing: false updates must not create or succeed tasks.
       controller.update(isAnalyzing: false);
-      expect(controller.phase, AnalyzerStatusPhase.unavailable);
+      expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
 
       controller.dispose();
       taskStatus.dispose();
@@ -168,12 +159,53 @@ void main() {
     final controller = AnalyzerStatusController(taskStatus);
 
     controller.markUnavailable();
-    expect(controller.phase, AnalyzerStatusPhase.unavailable);
     expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
     expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
 
     controller.update(isAnalyzing: false);
-    expect(controller.phase, AnalyzerStatusPhase.unavailable);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+    controller.dispose();
+    taskStatus.dispose();
+  });
+
+  test('reset cancels active tasks and clears initialization state', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.beginInitialization();
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
+    controller.reset();
+    expect(taskStatus.entries, isEmpty);
+
+    // After reset, initialization can begin anew.
+    controller.beginInitialization();
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
+    controller.dispose();
+    taskStatus.dispose();
+  });
+
+  test('reset after markUnavailable clears unavailable state', () {
+    final taskStatus = TaskStatusController();
+    final controller = AnalyzerStatusController(taskStatus);
+
+    controller.markUnavailable();
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.failed);
+
+    controller.reset();
+
+    // After reset, initialization begins with a fresh startingAnalyzer task.
+    controller.beginInitialization();
+    expect(taskStatus.current?.kind, TaskKind.startingAnalyzer);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.running);
+
+    controller.update(isAnalyzing: false);
+    expect(taskStatus.current?.outcome, TaskStatusOutcome.succeeded);
 
     controller.dispose();
     taskStatus.dispose();

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/footer_test.dart
@@ -14,15 +14,12 @@ import 'package:web/web.dart' as web;
 
 void main() {
   late TaskStatusController taskStatus;
-  late AnalyzerStatusController analyzerStatus;
 
   setUp(() {
     taskStatus = TaskStatusController();
-    analyzerStatus = AnalyzerStatusController(taskStatus);
   });
 
   tearDown(() {
-    analyzerStatus.dispose();
     taskStatus.dispose();
   });
 
@@ -30,7 +27,6 @@ void main() {
     tester.pumpComponent(
       Footer(
         taskStatus: taskStatus,
-        analyzerStatus: analyzerStatus,
         isSmallScreen: false,
       ),
     );
@@ -46,7 +42,6 @@ void main() {
     tester.pumpComponent(
       Footer(
         taskStatus: taskStatus,
-        analyzerStatus: analyzerStatus,
         isSmallScreen: true,
       ),
     );
@@ -62,7 +57,6 @@ void main() {
     tester.pumpComponent(
       Footer(
         taskStatus: taskStatus,
-        analyzerStatus: analyzerStatus,
         isSmallScreen: false,
       ),
     );
@@ -112,7 +106,6 @@ void main() {
     tester.pumpComponent(
       Footer(
         taskStatus: taskStatus,
-        analyzerStatus: analyzerStatus,
         isSmallScreen: false,
       ),
     );
@@ -147,7 +140,6 @@ void main() {
     tester.pumpComponent(
       Footer(
         taskStatus: taskStatus,
-        analyzerStatus: analyzerStatus,
         statusMessage: 'Could not save all files.',
       ),
     );
@@ -163,43 +155,42 @@ void main() {
     expect(web.document.querySelector('.app-footer-message')?.textContent, 'Could not save all files.');
   });
 
-  testClient('shows a fixed analyzer label with activity, ready, and failure icons', (tester) async {
+  testClient('shows analyzer startup and change analysis in the task status bar', (tester) async {
+    final analyzerStatus = AnalyzerStatusController(taskStatus);
     tester.pumpComponent(
-      Footer(taskStatus: taskStatus, analyzerStatus: analyzerStatus),
+      Footer(taskStatus: taskStatus),
     );
 
-    expect(web.document.querySelector('.analyzer-status.waiting'), isNotNull);
-    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
-    expect(web.document.querySelector('.analyzer-status .task-status-icon.running'), isNotNull);
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Ready'));
 
     analyzerStatus.beginInitialization();
-    analyzerStatus.update(isAnalyzing: true);
     await pumpEventQueue();
-    expect(web.document.querySelector('.analyzer-status.analyzing'), isNotNull);
-    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
-    expect(web.document.querySelector('.analyzer-status-duration'), isNull);
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Starting analyzer'));
 
     analyzerStatus.update(isAnalyzing: false);
     await pumpEventQueue();
-    expect(web.document.querySelector('.analyzer-status.ready'), isNotNull);
-    expect(web.document.querySelector('.analyzer-status .task-status-icon.succeeded'), isNotNull);
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Starting analyzer'));
 
     analyzerStatus.update(isAnalyzing: true);
     await pumpEventQueue();
-    expect(web.document.querySelector('.analyzer-status.analyzing'), isNotNull);
-    expect(web.document.querySelector('.analyzer-status')?.textContent?.trim(), 'Analyzer');
-    expect(taskStatus.entries, hasLength(1));
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Analyzing'));
+
+    analyzerStatus.update(isAnalyzing: false);
+    await pumpEventQueue();
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Analyzing'));
 
     analyzerStatus.markUnavailable();
     await pumpEventQueue();
-    expect(web.document.querySelector('.analyzer-status.unavailable'), isNotNull);
-    expect(web.document.querySelector('.analyzer-status .task-status-icon.failed'), isNotNull);
+    expect(web.document.querySelector('.task-status-trigger')?.textContent, contains('Analyzing'));
+    expect(web.document.querySelector('.task-status-trigger .task-status-icon.failed'), isNotNull);
+
+    analyzerStatus.dispose();
   });
 
   testClient('opens by focus or click and closes with Escape', (tester) async {
-    taskStatus.startTask(TaskKind.analyzingWorkspace);
+    taskStatus.startTask(TaskKind.startingAnalyzer);
     tester.pumpComponent(
-      Footer(taskStatus: taskStatus, analyzerStatus: analyzerStatus),
+      Footer(taskStatus: taskStatus),
     );
 
     final trigger = web.document.querySelector('.task-status-trigger') as web.HTMLButtonElement;

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/task_status_test.dart
@@ -135,7 +135,7 @@ void main() {
 
     test('tracks whether a running task blocks preview compilation', () {
       withClock(Clock(() => now), () {
-        final passive = controller.startTask(TaskKind.analyzingWorkspace);
+        final passive = controller.startTask(TaskKind.startingAnalyzer);
         expect(controller.hasBlockingPreviewTask, isFalse);
 
         final blocking = controller.startTask(
@@ -154,12 +154,12 @@ void main() {
     test('removes completed tasks after retention but keeps running tasks', () {
       withClock(Clock(() => now), () {
         controller.startTask(TaskKind.loadingCode, scope: 'completed').succeed();
-        controller.startTask(TaskKind.analyzingWorkspace);
+        controller.startTask(TaskKind.startingAnalyzer);
 
         now = now.add(const Duration(minutes: 5, milliseconds: 1));
         controller.startTask(TaskKind.pubClean, scope: '/').cancel();
 
-        expect(controller.entries.map((entry) => entry.kind), [TaskKind.analyzingWorkspace]);
+        expect(controller.entries.map((entry) => entry.kind), [TaskKind.startingAnalyzer]);
       });
     });
 
@@ -185,7 +185,7 @@ void main() {
 
     test('dispose clears tasks and makes existing handles inert', () {
       withClock(Clock(() => now), () {
-        final handle = controller.startTask(TaskKind.analyzingWorkspace);
+        final handle = controller.startTask(TaskKind.startingAnalyzer);
 
         controller.dispose();
         handle.succeed();

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     expect(workspace.disposeCount, 1);
     expect(
-      () => session.taskStatus.startTask(TaskKind.analyzingWorkspace),
+      () => session.taskStatus.startTask(TaskKind.startingAnalyzer),
       throwsStateError,
     );
     await expectLater(


### PR DESCRIPTION
Consolidates the task tracker and analyzer status in the footer:

<img width="383" height="318" alt="grafik" src="https://github.com/user-attachments/assets/1f1e3b27-0bd4-4a05-b89c-dd2f4ae694bd" />

Fixes #3859