### PR TITLE
Dartpad preview small UI fixes

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/README.md
+++ b/pkgs/dartpad_preview/dartpad_frontend/README.md
@@ -16,8 +16,8 @@ persistent project storage.
   other project files.
 - Dart analysis, diagnostics, completion, formatting, code actions, and
   navigation through the language server running in the browser worker.
-- Dependency resolution with `pub get`, plus `Pub get` and `Pub clean` actions
-  when `pubspec.yaml` or `pubspec.lock` is active.
+- Dependency resolution with `pub get`, plus a `Pub get` action when
+  `pubspec.yaml` or `pubspec.lock` is active.
 - Compilation and execution in an isolated preview sandbox, with start, stop,
   restart, and Flutter-only hot reload controls.
 - Built-in Dart, Flutter, and Flame examples, as well as projects loaded from
@@ -180,8 +180,8 @@ source:
 Before invoking `pub get`, pending in-memory changes are flushed to the worker.
 Pub output is streamed to the Console panel. Once this step finishes, or fails
 and is reported, startup continues with automatic execution and language-server
-initialization. Opening `pubspec.yaml` or `pubspec.lock` exposes manual `Pub
-get` and `Pub clean` actions for that file's directory.
+initialization. Opening `pubspec.yaml` or `pubspec.lock` exposes a manual
+`Pub get` action for that file's directory.
 
 When the frontend maps the executed Dart file to its library URI, it searches
 upward for `.dart_tool/package_config.json`, then for `pubspec.yaml`. Files

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -739,7 +739,6 @@ class AppState extends State<App> {
           path: workspacePath,
           projectRoot: _projectDir,
         ),
-        onPubClean: (workspacePath) => session.repository.pubClean(path: workspacePath),
       ),
       ErrorToast(
         key: const ValueKey('editor-error-toast'),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -716,7 +716,6 @@ class AppState extends State<App> {
         builder: (context) => BottomPanel(
           diagnostics: session.diagnostics.diagnostics,
           hasMoreDiagnostics: session.diagnostics.hasMoreDiagnostics,
-          activeFile: session.tabs.activeFile,
           logs: session.console.logs,
           onClearConsole: session.console.clear,
           events: session.events,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/bottom_panel.dart
@@ -26,11 +26,10 @@ enum BottomPanelTab {
 }
 
 /// The bottom panel showing tabs with associated content panes.
-class BottomPanel extends StatefulComponent {
+final class BottomPanel extends StatefulComponent {
   const BottomPanel({
     required this.diagnostics,
     required this.hasMoreDiagnostics,
-    required this.activeFile,
     required this.onOpenDiagnostic,
     required this.logs,
     required this.onClearConsole,
@@ -44,9 +43,6 @@ class BottomPanel extends StatefulComponent {
 
   /// Whether diagnostics are omitted from the problems panel.
   final bool hasMoreDiagnostics;
-
-  /// The currently active editor file path, used to highlight matching rows.
-  final String activeFile;
 
   /// Called when the user clicks a diagnostic row.
   final void Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
@@ -122,7 +118,6 @@ class _BottomPanelState extends State<BottomPanel> {
         BottomPanelTab.problems => ProblemsPanel(
           diagnostics: component.diagnostics,
           hasMoreDiagnostics: component.hasMoreDiagnostics,
-          activeFile: component.activeFile,
           onOpenDiagnostic: component.onOpenDiagnostic,
         ),
         BottomPanelTab.console => ConsolePanel(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -11,11 +11,10 @@ import 'package:web/web.dart' as web;
 
 import '../../../app_styles.dart';
 
-class ProblemsPanel extends StatelessComponent {
+final class ProblemsPanel extends StatelessComponent {
   const ProblemsPanel({
     required this.diagnostics,
     required this.hasMoreDiagnostics,
-    required this.activeFile,
     required this.onOpenDiagnostic,
     super.key,
   });
@@ -24,7 +23,6 @@ class ProblemsPanel extends StatelessComponent {
 
   /// Whether diagnostics are omitted from the problems panel.
   final bool hasMoreDiagnostics;
-  final String activeFile;
   final FutureOr<void> Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
 
   @override
@@ -42,7 +40,6 @@ class ProblemsPanel extends StatelessComponent {
             _ProblemRow(
               fileName: entry.fileName,
               diagnostic: entry.diagnostic,
-              activeFile: activeFile,
               onOpenDiagnostic: onOpenDiagnostic,
             ),
       ]),
@@ -169,17 +166,15 @@ class ProblemsPanel extends StatelessComponent {
   ];
 }
 
-class _ProblemRow extends StatelessComponent {
+final class _ProblemRow extends StatelessComponent {
   const _ProblemRow({
     required this.fileName,
     required this.diagnostic,
-    required this.activeFile,
     required this.onOpenDiagnostic,
   });
 
   final String fileName;
   final Diagnostic diagnostic;
-  final String activeFile;
   final FutureOr<void> Function(String fileName, Diagnostic diagnostic) onOpenDiagnostic;
 
   @override
@@ -189,11 +184,10 @@ class _ProblemRow extends StatelessComponent {
     final line = diagnostic.line + 1;
     final character = diagnostic.character + 1;
     final location = '$fileName:$line:$character';
-    final activeClass = fileName == activeFile ? ' active-file' : '';
 
     return div(
       key: ValueKey('problem-$location-${diagnostic.message}'),
-      classes: 'problem-row $severityClass$activeClass',
+      classes: 'problem-row $severityClass',
       attributes: {
         'title': '$severityLabel: ${diagnostic.message} ($location)',
         'tabindex': '0',

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/views/problems_panel.dart
@@ -123,9 +123,6 @@ class ProblemsPanel extends StatelessComponent {
           left: .solid(color: colorInfo, width: 2.px),
         ),
       ),
-      css('& .problem-row.active-file').styles(
-        backgroundColor: colorContainer.highlight(colorOnContainer, 0.2),
-      ),
       css('& .problem-severity-badge').styles(
         display: .inlineFlex,
         width: 18.px,
@@ -168,9 +165,6 @@ class ProblemsPanel extends StatelessComponent {
         ]),
         fontSize: 11.px,
       ),
-      css(
-        '& .problem-row:hover .problem-location, & .problem-row:focus-within .problem-location',
-      ).styles(display: .none),
     ]),
   ];
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_breadcrumbs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_breadcrumbs.dart
@@ -71,7 +71,7 @@ final class EditorBreadcrumbs extends StatelessComponent {
         gap: .all(4.px),
         flex: const .shrink(0),
         color: colorOnSurface,
-        fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+        fontFamily: monospaceFontFamily,
         fontSize: 11.px,
         backgroundColor: colorSurface,
       ),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_breadcrumbs.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/editor_breadcrumbs.dart
@@ -4,7 +4,6 @@
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
-import 'package:jaspr_content/components/file_icon.dart';
 
 import '../../../app_styles.dart';
 import '../../shared/icons.dart';
@@ -48,30 +47,10 @@ final class EditorBreadcrumbs extends StatelessComponent {
           else
             span(
               classes: 'editor-breadcrumb-item editor-breadcrumb-file',
-              [
-                _fileIcon(segments[i]),
-                span(
-                  classes: 'editor-breadcrumb-name',
-                  [.text(segments[i])],
-                ),
-              ],
+              [.text(segments[i])],
             ),
         ],
       ],
-    );
-  }
-
-  Component _fileIcon(String fileName) {
-    final lowerName = fileName.toLowerCase();
-    final colorClass = switch (lowerName) {
-      final path when path.endsWith('.dart') => 'file-icon-dart',
-      final path when path.endsWith('.yaml') || path.endsWith('.yml') => 'file-icon-yaml',
-      _ => 'file-icon',
-    };
-    return FileIcon.forFile(
-      fileName,
-      classes: 'editor-breadcrumb-icon $colorClass',
-      attributes: const {'aria-hidden': 'true', 'width': '14', 'height': '14'},
     );
   }
 
@@ -108,16 +87,10 @@ final class EditorBreadcrumbs extends StatelessComponent {
       css('.editor-breadcrumb-file').styles(
         color: colorOnContainer,
       ),
-      css('.editor-breadcrumb-name').styles(
-        whiteSpace: .noWrap,
-      ),
       css('.editor-breadcrumb-separator').styles(
         display: .inlineFlex,
         alignItems: .center,
         color: colorOnSurface.highlight(colorSurface, 0.4),
-      ),
-      css('.editor-breadcrumb-icon').styles(
-        flex: const .shrink(0),
       ),
     ]),
   ];

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
@@ -13,9 +13,9 @@ import '../../shared/app_event_bus.dart';
 import '../../shared/components/button.dart';
 import '../../shared/events/log_event.dart';
 
-/// Displays path-aware Pub actions for an active Pub metadata file.
+/// Displays a path-aware Pub get action for an active Pub metadata file.
 ///
-/// Manages its own busy state internally, disabling the action buttons while
+/// Manages its own busy state internally, disabling the action button while
 /// a Pub operation is in progress.
 final class PubspecEditorActions extends StatefulComponent {
   /// Creates the floating Pub actions for [activeFile].
@@ -24,7 +24,6 @@ final class PubspecEditorActions extends StatefulComponent {
     required this.saveAllFiles,
     required this.events,
     required this.onPubGet,
-    required this.onPubClean,
     super.key,
   });
 
@@ -39,9 +38,6 @@ final class PubspecEditorActions extends StatefulComponent {
 
   /// Runs Pub Get in the supplied workspace-relative directory.
   final Future<void> Function(String path) onPubGet;
-
-  /// Runs Pub Clean in the supplied workspace-relative directory.
-  final Future<void> Function(String path) onPubClean;
 
   @override
   State<PubspecEditorActions> createState() => _PubspecEditorActionsState();
@@ -85,11 +81,6 @@ class _PubspecEditorActionsState extends State<PubspecEditorActions> {
       }
       await component.onPubGet(path);
     });
-  }
-
-  /// Runs Pub Clean in [path] without saving files first.
-  Future<void> _pubClean(String path) async {
-    await _run('Pub clean failed.', () => component.onPubClean(path));
   }
 
   Future<void> _run(
@@ -138,11 +129,6 @@ class _PubspecEditorActionsState extends State<PubspecEditorActions> {
             label: 'Pub get',
             disabled: _busy,
             onClick: () => unawaited(_pubGet(directory)),
-          ),
-          Button(
-            label: 'Pub clean',
-            disabled: _busy,
-            onClick: () => unawaited(_pubClean(directory)),
           ),
         ]),
     ]);

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
@@ -18,7 +18,7 @@ import '../../shared/events/log_event.dart';
 /// Manages its own busy state internally, disabling the action button while
 /// a Pub operation is in progress.
 final class PubspecEditorActions extends StatefulComponent {
-  /// Creates the floating Pub actions for [activeFile].
+  /// Creates the floating Pub get action for [activeFile].
   const PubspecEditorActions({
     required this.activeFile,
     required this.saveAllFiles,
@@ -50,7 +50,6 @@ final class PubspecEditorActions extends StatefulComponent {
         position: .absolute(right: 32.px, top: 16.px),
         zIndex: const ZIndex(20),
         alignItems: .center,
-        gap: .all(8.px),
       ),
       css('.dp-button').styles(
         shadow: BoxShadow(
@@ -124,13 +123,17 @@ class _PubspecEditorActionsState extends State<PubspecEditorActions> {
     // with an element when this component is nested in the editor overlay.
     return div(classes: 'pubspec-editor-actions-host', [
       if (isPubspecFile)
-        div(classes: 'pubspec-editor-actions', [
-          Button(
-            label: 'Pub get',
-            disabled: _busy,
-            onClick: () => unawaited(_pubGet(directory)),
-          ),
-        ]),
+        div(
+          classes: 'pubspec-editor-actions',
+          attributes: {'aria-busy': _busy ? 'true' : 'false'},
+          [
+            Button(
+              label: 'Pub get',
+              disabled: _busy,
+              onClick: () => unawaited(_pubGet(directory)),
+            ),
+          ],
+        ),
     ]);
   }
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/command_palette_actions.dart
@@ -111,7 +111,7 @@ final class CommandPaletteAction {
 
   /// The platform-resolved display key (e.g. `⌘ + Enter` on macOS, `Ctrl + Enter` on Windows),
   /// or an empty string if this command has no shortcut.
-  String get resolvedDisplayKey => shortcut != null ? resolveDisplayKey(shortcut!.displayKey) : '';
+  String get resolvedDisplayKey => shortcut?.resolvedDisplayKey ?? '';
 }
 
 const pubGetAction = CommandPaletteAction(

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
@@ -41,7 +41,7 @@ class ContextMenuItem extends ContextMenuEntry {
   }) => ContextMenuItem(
     label: shortcut.label,
     onPressed: onPressed,
-    shortcut: resolveDisplayKey(shortcut.displayKey),
+    shortcut: shortcut.resolvedDisplayKey,
   );
 
   /// The text label displayed for this menu item.

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/context_menu.dart
@@ -17,12 +17,12 @@ sealed class ContextMenuEntry {
 }
 
 /// A non-interactive separator line.
-class ContextMenuDivider extends ContextMenuEntry {
+final class ContextMenuDivider extends ContextMenuEntry {
   const ContextMenuDivider();
 }
 
 /// An interactive item in a [ContextMenu].
-class ContextMenuItem extends ContextMenuEntry {
+final class ContextMenuItem extends ContextMenuEntry {
   const ContextMenuItem({
     required this.label,
     required this.onPressed,
@@ -34,7 +34,7 @@ class ContextMenuItem extends ContextMenuEntry {
   /// Creates a context menu item from a [ShortcutDefinition].
   ///
   /// The [shortcut] definition provides the default [label] and [shortcut] string
-  /// (resolved via [resolveDisplayKey]).
+  /// (resolved via [ShortcutDefinition.resolvedDisplayKey]).
   factory ContextMenuItem.fromShortcut({
     required ShortcutDefinition shortcut,
     required VoidCallback onPressed,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -14,6 +14,9 @@ final isMac =
 /// - `Mod` → `⌘` on macOS, `Ctrl` on other platforms.
 String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'Ctrl');
 
+/// Resolves platform-agnostic modifier placeholders in [keys] using [resolveDisplayKey].
+List<String> resolveDisplayKeys(Iterable<String> keys) => keys.map(resolveDisplayKey).toList();
+
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
   view('View'),
@@ -37,23 +40,65 @@ enum ShortcutCategory {
 /// Shortcuts without a [category] (such as native clipboard actions) are not
 /// listed in the general shortcuts dialog and are only used for menus or
 /// toolbars.
-class ShortcutDefinition {
+final class ShortcutDefinition {
+  /// Creates a shortcut definition.
+  ///
+  /// Exactly one of [displayKey] (for a single key combination) or
+  /// [displayKeys] (for multiple alternative key combinations) must be
+  /// provided.
   const ShortcutDefinition({
     required this.label,
-    required this.displayKey,
+    String? displayKey,
+    List<String>? displayKeys,
     this.codemirrorKeys = const [],
     this.category,
     this.isPrimary = true,
-  });
+  }) : assert(
+         (displayKey != null) == (displayKeys == null),
+         'Provide exactly one of displayKey or displayKeys',
+       ),
+       _displayKey = displayKey,
+       _displayKeys = displayKeys;
 
   /// Human-readable command name, e.g. `'Quick fix'`.
   final String label;
 
-  /// Display string shown in the dialog or context menus.
+  final String? _displayKey;
+  final List<String>? _displayKeys;
+
+  /// List of alternative display key combinations shown in the shortcuts dialog.
   ///
-  /// May contain the placeholder `Mod` which is resolved at render time
-  /// via [resolveDisplayKey] to `⌘` on macOS or `Ctrl` on other platforms.
-  final String displayKey;
+  /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKeys] for UI rendering.
+  List<String> get displayKeys {
+    if (_displayKeys != null) {
+      return _displayKeys;
+    }
+    final key = _displayKey;
+    if (key != null) {
+      return [key];
+    }
+    return const [];
+  }
+
+  /// Display string shown in single-string contexts (e.g. context menus).
+  ///
+  /// When multiple display keys are defined, they are joined with `' or '`.
+  /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKey] for UI rendering.
+  String get displayKey {
+    if (_displayKey != null) {
+      return _displayKey;
+    }
+    if (_displayKeys != null) {
+      return _displayKeys.join(' or ');
+    }
+    return '';
+  }
+
+  /// Resolves platform-agnostic modifier placeholders in [displayKeys] using [resolveDisplayKey].
+  List<String> get resolvedDisplayKeys => resolveDisplayKeys(displayKeys);
+
+  /// Resolves platform-agnostic modifier placeholders in [displayKey] using [resolveDisplayKey].
+  String get resolvedDisplayKey => resolveDisplayKey(displayKey);
 
   /// CodeMirror key notation(s) for this shortcut.
   ///
@@ -183,7 +228,7 @@ class ShortcutDefinition {
 
   static const jumpToMatchingBracket = ShortcutDefinition(
     label: 'Jump to matching bracket',
-    displayKey: r'Mod + Shift + \ / Alt + M',
+    displayKeys: [r'Mod + Shift + \', 'Alt + M'],
     codemirrorKeys: [r'Shift-Mod-\', 'Alt-m'],
     category: ShortcutCategory.editing,
     isPrimary: false,
@@ -206,7 +251,7 @@ class ShortcutDefinition {
 
   static const findNext = ShortcutDefinition(
     label: 'Find next',
-    displayKey: 'F3 / Mod + G',
+    displayKeys: ['F3', 'Mod + G'],
     codemirrorKeys: ['F3', 'Mod-g'],
     category: ShortcutCategory.search,
     isPrimary: false,
@@ -214,7 +259,7 @@ class ShortcutDefinition {
 
   static const findPrevious = ShortcutDefinition(
     label: 'Find previous',
-    displayKey: 'Shift + F3 / Mod + Shift + G',
+    displayKeys: ['Shift + F3', 'Mod + Shift + G'],
     codemirrorKeys: ['Shift-F3', 'Mod-Shift-g'],
     category: ShortcutCategory.search,
     isPrimary: false,
@@ -247,7 +292,7 @@ class ShortcutDefinition {
 
   static const foldCode = ShortcutDefinition(
     label: 'Fold code',
-    displayKey: 'Ctrl + Shift + [ / Alt + -',
+    displayKeys: ['Ctrl + Shift + [', 'Alt + -'],
     codemirrorKeys: ['Ctrl-Shift-[', 'Alt--'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
@@ -255,7 +300,7 @@ class ShortcutDefinition {
 
   static const unfoldCode = ShortcutDefinition(
     label: 'Unfold code',
-    displayKey: 'Ctrl + Shift + ] / Alt + +',
+    displayKeys: ['Ctrl + Shift + ]', 'Alt + +'],
     codemirrorKeys: ['Ctrl-Shift-]', 'Alt-+', 'Alt-='],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
@@ -263,7 +308,7 @@ class ShortcutDefinition {
 
   static const foldAll = ShortcutDefinition(
     label: 'Fold all',
-    displayKey: 'Ctrl + Alt + [ / Alt + 0',
+    displayKeys: ['Ctrl + Alt + [', 'Alt + 0'],
     codemirrorKeys: ['Ctrl-Alt-[', 'Alt-0'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
@@ -271,7 +316,7 @@ class ShortcutDefinition {
 
   static const unfoldAll = ShortcutDefinition(
     label: 'Unfold all',
-    displayKey: 'Ctrl + Alt + ] / Alt + 9',
+    displayKeys: ['Ctrl + Alt + ]', 'Alt + 9'],
     codemirrorKeys: ['Ctrl-Alt-]', 'Alt-9'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -14,9 +14,6 @@ final isMac =
 /// - `Mod` → `⌘` on macOS, `Ctrl` on other platforms.
 String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'Ctrl');
 
-/// Resolves platform-agnostic modifier placeholders in [keys] using [resolveDisplayKey].
-List<String> resolveDisplayKeys(Iterable<String> keys) => keys.map(resolveDisplayKey).toList();
-
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
   view('View'),
@@ -41,64 +38,50 @@ enum ShortcutCategory {
 /// listed in the general shortcuts dialog and are only used for menus or
 /// toolbars.
 final class ShortcutDefinition {
-  /// Creates a shortcut definition.
-  ///
-  /// Exactly one of [displayKey] (for a single key combination) or
-  /// [displayKeys] (for multiple alternative key combinations) must be
-  /// provided.
+  /// Creates a shortcut definition for a single key combination.
   const ShortcutDefinition({
     required this.label,
-    String? displayKey,
-    List<String>? displayKeys,
+    required String displayKey,
     this.codemirrorKeys = const [],
     this.category,
     this.isPrimary = true,
-  }) : assert(
-         (displayKey != null) == (displayKeys == null),
-         'Provide exactly one of displayKey or displayKeys',
-       ),
-       _displayKey = displayKey,
-       _displayKeys = displayKeys;
+  })  : _singleDisplayKey = displayKey,
+        _alternativeDisplayKeys = null;
+
+  /// Creates a shortcut definition with multiple alternative key combinations.
+  const ShortcutDefinition.alternatives({
+    required this.label,
+    required List<String> displayKeys,
+    this.codemirrorKeys = const [],
+    this.category,
+    this.isPrimary = true,
+  })  : _singleDisplayKey = null,
+        _alternativeDisplayKeys = displayKeys;
 
   /// Human-readable command name, e.g. `'Quick fix'`.
   final String label;
 
-  final String? _displayKey;
-  final List<String>? _displayKeys;
+  final String? _singleDisplayKey;
+  final List<String>? _alternativeDisplayKeys;
 
-  /// List of alternative display key combinations shown in the shortcuts dialog.
+  /// List of display key combination(s) shown in the shortcuts dialog.
   ///
+  /// Returns a single-element list if defined via [displayKey], or the alternative
+  /// key combinations if defined via [displayKeys].
   /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKeys] for UI rendering.
-  List<String> get displayKeys {
-    if (_displayKeys != null) {
-      return _displayKeys;
-    }
-    final key = _displayKey;
-    if (key != null) {
-      return [key];
-    }
-    return const [];
-  }
+  List<String> get displayKeys => _alternativeDisplayKeys ?? [_singleDisplayKey!];
 
   /// Display string shown in single-string contexts (e.g. context menus).
   ///
   /// When multiple display keys are defined, they are joined with `' or '`.
   /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKey] for UI rendering.
-  String get displayKey {
-    if (_displayKey != null) {
-      return _displayKey;
-    }
-    if (_displayKeys != null) {
-      return _displayKeys.join(' or ');
-    }
-    return '';
-  }
+  String get displayKey => _singleDisplayKey ?? _alternativeDisplayKeys!.join(' or ');
 
   /// Resolves platform-agnostic modifier placeholders in [displayKeys] using [resolveDisplayKey].
-  List<String> get resolvedDisplayKeys => resolveDisplayKeys(displayKeys);
+  List<String> get resolvedDisplayKeys => displayKeys.map(resolveDisplayKey).toList();
 
   /// Resolves platform-agnostic modifier placeholders in [displayKey] using [resolveDisplayKey].
-  String get resolvedDisplayKey => resolveDisplayKey(displayKey);
+  String get resolvedDisplayKey => resolvedDisplayKeys.join(' or ');
 
   /// CodeMirror key notation(s) for this shortcut.
   ///
@@ -226,7 +209,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const jumpToMatchingBracket = ShortcutDefinition(
+  static const jumpToMatchingBracket = ShortcutDefinition.alternatives(
     label: 'Jump to matching bracket',
     displayKeys: [r'Mod + Shift + \', 'Alt + M'],
     codemirrorKeys: [r'Shift-Mod-\', 'Alt-m'],
@@ -249,7 +232,7 @@ final class ShortcutDefinition {
     category: ShortcutCategory.search,
   );
 
-  static const findNext = ShortcutDefinition(
+  static const findNext = ShortcutDefinition.alternatives(
     label: 'Find next',
     displayKeys: ['F3', 'Mod + G'],
     codemirrorKeys: ['F3', 'Mod-g'],
@@ -257,7 +240,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const findPrevious = ShortcutDefinition(
+  static const findPrevious = ShortcutDefinition.alternatives(
     label: 'Find previous',
     displayKeys: ['Shift + F3', 'Mod + Shift + G'],
     codemirrorKeys: ['Shift-F3', 'Mod-Shift-g'],
@@ -290,7 +273,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const foldCode = ShortcutDefinition(
+  static const foldCode = ShortcutDefinition.alternatives(
     label: 'Fold code',
     displayKeys: ['Ctrl + Shift + [', 'Alt + -'],
     codemirrorKeys: ['Ctrl-Shift-[', 'Alt--'],
@@ -298,7 +281,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const unfoldCode = ShortcutDefinition(
+  static const unfoldCode = ShortcutDefinition.alternatives(
     label: 'Unfold code',
     displayKeys: ['Ctrl + Shift + ]', 'Alt + +'],
     codemirrorKeys: ['Ctrl-Shift-]', 'Alt-+', 'Alt-='],
@@ -306,7 +289,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const foldAll = ShortcutDefinition(
+  static const foldAll = ShortcutDefinition.alternatives(
     label: 'Fold all',
     displayKeys: ['Ctrl + Alt + [', 'Alt + 0'],
     codemirrorKeys: ['Ctrl-Alt-[', 'Alt-0'],
@@ -314,7 +297,7 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const unfoldAll = ShortcutDefinition(
+  static const unfoldAll = ShortcutDefinition.alternatives(
     label: 'Unfold all',
     displayKeys: ['Ctrl + Alt + ]', 'Alt + 9'],
     codemirrorKeys: ['Ctrl-Alt-]', 'Alt-9'],

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
@@ -298,7 +298,7 @@ class _ShortcutsDialogState extends State<ShortcutsDialog> {
       border: .all(color: colorBorder, width: 1.px),
       radius: .circular(4.px),
       color: colorOnContainer,
-      fontFamily: const .list([FontFamily('Consolas'), FontFamilies.monospace]),
+      fontFamily: monospaceFontFamily,
       fontSize: 11.px,
       whiteSpace: .noWrap,
       backgroundColor: colorContainer,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcuts_dialog.dart
@@ -119,11 +119,11 @@ class _ShortcutsDialogState extends State<ShortcutsDialog> {
         shortcutRows.add(_categoryHeader(category.label));
       }
       for (final shortcut in primary) {
-        shortcutRows.add(_shortcutRow(shortcut.label, resolveDisplayKey(shortcut.displayKey)));
+        shortcutRows.add(_shortcutRow(shortcut));
       }
       if (_showMoreShortcuts) {
         for (final shortcut in extended) {
-          shortcutRows.add(_shortcutRow(shortcut.label, resolveDisplayKey(shortcut.displayKey)));
+          shortcutRows.add(_shortcutRow(shortcut));
         }
       }
     }
@@ -185,10 +185,20 @@ class _ShortcutsDialogState extends State<ShortcutsDialog> {
     ]);
   }
 
-  Component _shortcutRow(String command, String shortcut) {
+  Component _shortcutRow(ShortcutDefinition shortcut) {
+    final keys = shortcut.resolvedDisplayKeys;
     return div(classes: 'shortcuts-dialog-row', [
-      span(classes: 'shortcuts-dialog-command', [.text(command)]),
-      span(classes: 'shortcuts-dialog-key', [.text(shortcut)]),
+      span(classes: 'shortcuts-dialog-command', [.text(shortcut.label)]),
+      span(classes: 'shortcuts-dialog-keys', [
+        for (var i = 0; i < keys.length; i++)
+          if (i == 0)
+            span(classes: 'shortcuts-dialog-key', [.text(keys[i])])
+          else
+            span(classes: 'shortcuts-dialog-alternative', [
+              const span(classes: 'shortcuts-dialog-separator', [Component.text('or')]),
+              span(classes: 'shortcuts-dialog-key', [.text(keys[i])]),
+            ]),
+      ]),
     ]);
   }
 
@@ -266,6 +276,22 @@ class _ShortcutsDialogState extends State<ShortcutsDialog> {
     css('.shortcuts-dialog-command').styles(
       color: colorOnSurface,
       fontSize: 12.px,
+    ),
+    css('.shortcuts-dialog-keys').styles(
+      display: .flex,
+      flexWrap: .wrap,
+      justifyContent: .end,
+      alignItems: .center,
+      gap: Gap.all(6.px),
+    ),
+    css('.shortcuts-dialog-alternative').styles(
+      display: .inlineFlex,
+      alignItems: .center,
+      gap: Gap.all(6.px),
+    ),
+    css('.shortcuts-dialog-separator').styles(
+      color: colorOnSurface.highlight(colorSurface, 0.25),
+      fontSize: 11.px,
     ),
     css('.shortcuts-dialog-key').styles(
       padding: .symmetric(vertical: 2.px, horizontal: 6.px),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/bottom_panel/views/bottom_panel_test.dart
@@ -21,7 +21,6 @@ void main() {
       BottomPanel(
         diagnostics: const [],
         hasMoreDiagnostics: false,
-        activeFile: '',
         logs: const [ConsoleEntry(message: 'Running pub get in /', level: Level.INFO)],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () => clearCalls++,
@@ -51,7 +50,6 @@ void main() {
       BottomPanel(
         diagnostics: const [],
         hasMoreDiagnostics: false,
-        activeFile: '',
         logs: const [],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () {},
@@ -73,7 +71,6 @@ void main() {
       BottomPanel(
         diagnostics: const [],
         hasMoreDiagnostics: true,
-        activeFile: '',
         logs: const [],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () {},
@@ -93,7 +90,6 @@ void main() {
       BottomPanel(
         diagnostics: const [],
         hasMoreDiagnostics: false,
-        activeFile: '',
         logs: const [],
         onOpenDiagnostic: (_, _) {},
         onClearConsole: () {},

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
@@ -161,6 +161,9 @@ void main() {
 
     expect(operations, ['save-all']);
     expect(logs, isEmpty);
+
+    final pubGet = web.document.querySelector('[aria-label="Pub get"]')! as web.HTMLButtonElement;
+    expect(pubGet.disabled, isFalse);
   });
 
   testClient('disables action while busy', (tester) async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/pubspec_editor_actions_test.dart
@@ -25,26 +25,20 @@ void main() {
     await events.dispose();
   });
 
-  testClient('runs root pubspec actions in the workspace root', (tester) async {
+  testClient('runs root pubspec action in the workspace root', (tester) async {
     String? pubGetPath;
-    String? pubCleanPath;
     tester.pumpComponent(
       PubspecEditorActions(
         activeFile: 'pubspec.yaml',
         saveAllFiles: () async {},
         events: events,
         onPubGet: (path) async => pubGetPath = path,
-        onPubClean: (path) async => pubCleanPath = path,
       ),
     );
 
     (web.document.querySelector('[aria-label="Pub get"]')! as web.HTMLButtonElement).click();
     await pumpEventQueue();
     expect(pubGetPath, '');
-
-    (web.document.querySelector('[aria-label="Pub clean"]')! as web.HTMLButtonElement).click();
-    await pumpEventQueue();
-    expect(pubCleanPath, '');
   });
 
   testClient('uses the directory of a nested pubspec lock', (tester) async {
@@ -55,7 +49,6 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (path) async => pubGetPath = path,
-        onPubClean: (_) async {},
       ),
     );
 
@@ -72,7 +65,6 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (_) async {},
-        onPubClean: (_) async {},
       ),
     );
 
@@ -86,7 +78,6 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (_) async {},
-        onPubClean: (_) async {},
       ),
     );
     await pumpEventQueue();
@@ -98,13 +89,11 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (_) async {},
-        onPubClean: (_) async {},
       ),
     );
     await pumpEventQueue();
 
     expect(web.document.querySelector('[aria-label="Pub get"]'), isNotNull);
-    expect(web.document.querySelector('[aria-label="Pub clean"]'), isNotNull);
   });
 
   testClient('saves all files before running Pub Get', (tester) async {
@@ -115,7 +104,6 @@ void main() {
         saveAllFiles: () async => operations.add('save-all'),
         events: events,
         onPubGet: (path) async => operations.add('pub-get:$path'),
-        onPubClean: (_) async {},
       ),
     );
 
@@ -123,24 +111,6 @@ void main() {
     await pumpEventQueue();
 
     expect(operations, ['save-all', 'pub-get:']);
-  });
-
-  testClient('runs Pub Clean without saving files', (tester) async {
-    final operations = <String>[];
-    tester.pumpComponent(
-      PubspecEditorActions(
-        activeFile: 'pubspec.yaml',
-        saveAllFiles: () async => operations.add('save-all'),
-        events: events,
-        onPubGet: (_) async {},
-        onPubClean: (path) async => operations.add('pub-clean:$path'),
-      ),
-    );
-
-    (web.document.querySelector('[aria-label="Pub clean"]')! as web.HTMLButtonElement).click();
-    await pumpEventQueue();
-
-    expect(operations, ['pub-clean:']);
   });
 
   testClient('logs failures and resets busy state', (tester) async {
@@ -154,7 +124,6 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (_) async => throw StateError('pub failed'),
-        onPubClean: (_) async {},
       ),
     );
 
@@ -184,7 +153,6 @@ void main() {
         },
         events: events,
         onPubGet: (path) async => operations.add('pub-get:$path'),
-        onPubClean: (_) async {},
       ),
     );
 
@@ -195,7 +163,7 @@ void main() {
     expect(logs, isEmpty);
   });
 
-  testClient('disables both actions while busy', (tester) async {
+  testClient('disables action while busy', (tester) async {
     final completer = Completer<void>();
     tester.pumpComponent(
       PubspecEditorActions(
@@ -203,7 +171,6 @@ void main() {
         saveAllFiles: () async {},
         events: events,
         onPubGet: (_) => completer.future,
-        onPubClean: (_) async {},
       ),
     );
 
@@ -211,15 +178,12 @@ void main() {
     await pumpEventQueue();
 
     final pubGet = web.document.querySelector('[aria-label="Pub get"]')! as web.HTMLButtonElement;
-    final pubClean = web.document.querySelector('[aria-label="Pub clean"]')! as web.HTMLButtonElement;
     expect(pubGet.disabled, isTrue);
-    expect(pubClean.disabled, isTrue);
 
     completer.complete();
     await pumpEventQueue();
 
     expect(pubGet.disabled, isFalse);
-    expect(pubClean.disabled, isFalse);
   });
 
   testClient('ignores another Pub action while one is running', (tester) async {
@@ -234,13 +198,13 @@ void main() {
           operations.add('pub-get:$path');
           await completer.future;
         },
-        onPubClean: (path) async => operations.add('pub-clean:$path'),
       ),
     );
 
-    (web.document.querySelector('[aria-label="Pub get"]')! as web.HTMLButtonElement).click();
+    final pubGet = web.document.querySelector('[aria-label="Pub get"]')! as web.HTMLButtonElement;
+    pubGet.click();
     await pumpEventQueue();
-    (web.document.querySelector('[aria-label="Pub clean"]')! as web.HTMLButtonElement).click();
+    pubGet.click();
     await pumpEventQueue();
 
     expect(operations, ['save-all', 'pub-get:']);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
@@ -160,7 +160,7 @@ void main() {
       expect(single.resolvedDisplayKeys, [resolveDisplayKey('Mod + S')]);
       expect(single.resolvedDisplayKey, resolveDisplayKey('Mod + S'));
 
-      const multiple = ShortcutDefinition(
+      const multiple = ShortcutDefinition.alternatives(
         label: 'Multiple',
         displayKeys: ['F3', 'Mod + G'],
       );
@@ -168,17 +168,6 @@ void main() {
       expect(multiple.displayKey, 'F3 or Mod + G');
       expect(multiple.resolvedDisplayKeys, ['F3', resolveDisplayKey('Mod + G')]);
       expect(multiple.resolvedDisplayKey, 'F3 or ${resolveDisplayKey('Mod + G')}');
-    });
-
-    test('enforces mutual exclusivity between displayKey and displayKeys', () {
-      expect(
-        () => ShortcutDefinition(label: 'Invalid', displayKey: 'A', displayKeys: ['B']),
-        throwsA(isA<AssertionError>()),
-      );
-      expect(
-        () => ShortcutDefinition(label: 'Invalid'),
-        throwsA(isA<AssertionError>()),
-      );
     });
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
@@ -95,4 +95,90 @@ void main() {
     ];
     expect(rowLabels, contains('Open command palette'));
   });
+
+  testClient('renders multiple key badges with "or" separator for alternative shortcuts', (tester) async {
+    tester.pumpComponent(ShortcutsDialog(onClose: () {}));
+
+    // Expand to see all shortcuts including findNext and foldCode.
+    final toggleBtn = web.document.querySelector('.shortcuts-dialog-toggle-btn') as web.HTMLButtonElement?;
+    expect(toggleBtn, isNotNull);
+    toggleBtn?.click();
+    await pumpEventQueue();
+
+    final rows = web.document.querySelectorAll('.shortcuts-dialog-row');
+    web.HTMLElement? findRow(String command) {
+      for (var i = 0; i < rows.length; i++) {
+        final row = rows.item(i) as web.HTMLElement;
+        if (row.querySelector('.shortcuts-dialog-command')?.textContent == command) {
+          return row;
+        }
+      }
+      return null;
+    }
+
+    // Command with multiple key combos (Find next)
+    final findNextRow = findRow('Find next');
+    expect(findNextRow, isNotNull);
+    final findNextKeys = findNextRow!.querySelectorAll('.shortcuts-dialog-key');
+    expect(findNextKeys.length, 2);
+    expect(findNextKeys.item(0)?.textContent, 'F3');
+    expect(findNextKeys.item(1)?.textContent, resolveDisplayKey('Mod + G'));
+    final findNextSeparator = findNextRow.querySelectorAll('.shortcuts-dialog-separator');
+    expect(findNextSeparator.length, 1);
+    expect(findNextSeparator.item(0)?.textContent, 'or');
+    final findNextAlternatives = findNextRow.querySelectorAll('.shortcuts-dialog-alternative');
+    expect(findNextAlternatives.length, 1);
+
+    // Command with multiple key combos (Fold code)
+    final foldCodeRow = findRow('Fold code');
+    expect(foldCodeRow, isNotNull);
+    final foldCodeKeys = foldCodeRow!.querySelectorAll('.shortcuts-dialog-key');
+    expect(foldCodeKeys.length, 2);
+    expect(foldCodeKeys.item(0)?.textContent, 'Ctrl + Shift + [');
+    expect(foldCodeKeys.item(1)?.textContent, 'Alt + -');
+    final foldCodeSeparator = foldCodeRow.querySelectorAll('.shortcuts-dialog-separator');
+    expect(foldCodeSeparator.length, 1);
+    expect(foldCodeSeparator.item(0)?.textContent, 'or');
+    final foldCodeAlternatives = foldCodeRow.querySelectorAll('.shortcuts-dialog-alternative');
+    expect(foldCodeAlternatives.length, 1);
+
+    // Single combo command (Open command palette)
+    final commandPaletteRow = findRow('Open command palette');
+    expect(commandPaletteRow, isNotNull);
+    final commandPaletteKeys = commandPaletteRow!.querySelectorAll('.shortcuts-dialog-key');
+    expect(commandPaletteKeys.length, 1);
+    expect(commandPaletteKeys.item(0)?.textContent, resolveDisplayKey('Mod + Shift + P'));
+    final commandPaletteSeparator = commandPaletteRow.querySelectorAll('.shortcuts-dialog-separator');
+    expect(commandPaletteSeparator.length, 0);
+  });
+
+  group('ShortcutDefinition', () {
+    test('resolves display keys and joins them in displayKey', () {
+      const single = ShortcutDefinition(label: 'Single', displayKey: 'Mod + S');
+      expect(single.displayKeys, ['Mod + S']);
+      expect(single.displayKey, 'Mod + S');
+      expect(single.resolvedDisplayKeys, [resolveDisplayKey('Mod + S')]);
+      expect(single.resolvedDisplayKey, resolveDisplayKey('Mod + S'));
+
+      const multiple = ShortcutDefinition(
+        label: 'Multiple',
+        displayKeys: ['F3', 'Mod + G'],
+      );
+      expect(multiple.displayKeys, ['F3', 'Mod + G']);
+      expect(multiple.displayKey, 'F3 or Mod + G');
+      expect(multiple.resolvedDisplayKeys, ['F3', resolveDisplayKey('Mod + G')]);
+      expect(multiple.resolvedDisplayKey, 'F3 or ${resolveDisplayKey('Mod + G')}');
+    });
+
+    test('enforces mutual exclusivity between displayKey and displayKeys', () {
+      expect(
+        () => ShortcutDefinition(label: 'Invalid', displayKey: 'A', displayKeys: ['B']),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => ShortcutDefinition(label: 'Invalid'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
 }


### PR DESCRIPTION
This PR addresses several UI refinements and fixes across the DartPad preview frontend:

### Changes

* **Remove file icon from editor breadcrumbs** (Fixes #3846)
  Removes the redundant and visually distorted file icon from the breadcrumb bar above the editor

* **Fix disappearing problem locations on hover and active row background** (Fixes #3845)
  Prevents the file path and line number from disappearing when hovering or focusing a problem row, and removes the gray background on active file items.
  <details open>
  <summary>Screenshot</summary>

  <img width="710" height="161" alt="Problems panel hover and styling fix" src="https://github.com/user-attachments/assets/38e5872b-6d01-45ed-8a31-50706426815f" />
  </details>

* **Remove "Pub clean" action from pubspec editor** (Fixes #3796)
  Removes the unnecessary "Pub clean" button when viewing pubspec files, leaving only "Pub get".

* **Visually separate alternative keyboard shortcuts with "or"** (Fixes #3842)
  Splits multiple shortcut key combinations into distinct badges separated by an "or" label in the shortcuts dialog rather than joining them with a slash inside a single badge.
  <details open>
  <summary>Screenshot</summary>

  <img width="380" height="197" alt="Shortcuts dialog with separated key combos" src="https://github.com/user-attachments/assets/ec65b305-0886-419b-9a7a-3f1cf83405f9" />
  </details>

---

Fixes #3846
Fixes #3845
Fixes #3796
Fixes #3842