### PR TITLE
feat(dartpad-preview): add beforeunload warning dialog

### DIFF
--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -98,6 +98,14 @@ final class ExampleProjectSource extends ProjectSource {
   Map<String, String> get queryParameters => sampleId == null ? const <String, String>{} : {'sample': sampleId!};
 }
 
+/// Prompts the browser's native confirmation dialog before unloading the page
+/// to prevent accidental data loss, as workspace changes are currently held in memory.
+@visibleForTesting
+void handleBeforeUnload(web.BeforeUnloadEvent event) {
+  event.preventDefault();
+  event.returnValue = '';
+}
+
 /// Composition root – wires all services and drives the startup lifecycle.
 class AppState extends State<App> {
   late WorkspaceSession _session;
@@ -118,6 +126,7 @@ class AppState extends State<App> {
   SmallScreenTab _selectedSmallScreenTab = .code;
   StreamSubscription<web.Event>? _resizeSubscription;
   StreamSubscription<web.KeyboardEvent>? _keySubscription;
+  StreamSubscription<web.BeforeUnloadEvent>? _beforeUnloadSubscription;
 
   SdkInfo _currentSdk = defaultSdk;
 
@@ -129,6 +138,9 @@ class AppState extends State<App> {
       _updateScreenSize();
     });
     _keySubscription = web.EventStreamProviders.keyDownEvent.forTarget(web.document).listen(_handleGlobalKeyDown);
+    _beforeUnloadSubscription = web.EventStreamProviders.beforeUnloadEvent
+        .forTarget(web.window)
+        .listen(handleBeforeUnload);
 
     final events = AppEventBus();
     final taskStatus = TaskStatusController();
@@ -806,6 +818,7 @@ class AppState extends State<App> {
   void dispose() {
     _resizeSubscription?.cancel();
     _keySubscription?.cancel();
+    _beforeUnloadSubscription?.cancel();
     _session.preview.removeListener(_onPreviewStateChanged);
     unawaited(_session.dispose(closeWorker: true));
     super.dispose();

--- a/pkgs/dartpad_preview/dartpad_frontend/test/app_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/app_test.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('browser')
+library;
+
+import 'dart:async';
+
+import 'package:dartpad_frontend/app.dart';
+import 'package:test/test.dart';
+import 'package:web/web.dart' as web;
+
+void main() {
+  test('handleBeforeUnload prevents default', () {
+    final event =
+        web.Event(
+              'beforeunload',
+              web.EventInit(cancelable: true),
+            )
+            as web.BeforeUnloadEvent;
+
+    expect(event.defaultPrevented, isFalse);
+
+    handleBeforeUnload(event);
+
+    expect(event.defaultPrevented, isTrue);
+  });
+
+  test('beforeunload listener on window invokes handleBeforeUnload', () async {
+    final completer = Completer<web.BeforeUnloadEvent>();
+    final subscription = web.EventStreamProviders.beforeUnloadEvent.forTarget(web.window).listen((event) {
+      handleBeforeUnload(event);
+      completer.complete(event);
+    });
+    addTearDown(subscription.cancel);
+
+    final event = web.Event(
+      'beforeunload',
+      web.EventInit(cancelable: true),
+    );
+    web.window.dispatchEvent(event);
+
+    final handledEvent = await completer.future;
+    expect(handledEvent.defaultPrevented, isTrue);
+  });
+}


### PR DESCRIPTION
Adds a `beforeunload` event listener to `window` in `AppState` to trigger the browser's native exit confirmation dialog. This prevents accidental data loss when users reload or navigate away from the page while working with in-memory workspace edits.

Fixes #3827



