### PR TITLE
[dartpad preview]: check if entrypoint has main method before starting preview

### DIFF
--- a/pkgs/dartpad_preview/codemirror-lang-dart/lib/codemirror_lang_dart.dart
+++ b/pkgs/dartpad_preview/codemirror-lang-dart/lib/codemirror_lang_dart.dart
@@ -13,6 +13,8 @@ import 'package:analyzer/src/dart/scanner/scanner.dart';
 // ignore: implementation_imports  // TODO: remove when https://github.com/dart-lang/sdk/issues/63822 is fixed
 import 'package:analyzer/src/string_source.dart';
 
+export 'src/has_main_method.dart';
+
 @JS('window._codemirror')
 external _CodemirrorNamespace get _codemirrorModule;
 

--- a/pkgs/dartpad_preview/codemirror-lang-dart/lib/src/has_main_method.dart
+++ b/pkgs/dartpad_preview/codemirror-lang-dart/lib/src/has_main_method.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/analysis/features.dart';
+import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/error/listener.dart';
+// ignore: implementation_imports  // TODO: remove when https://github.com/dart-lang/sdk/issues/63822 is fixed
+import 'package:analyzer/src/dart/scanner/scanner.dart';
+// ignore: implementation_imports  // TODO: remove when https://github.com/dart-lang/sdk/issues/63822 is fixed
+import 'package:analyzer/src/string_source.dart';
+
+/// Checks whether the given Dart source [code] defines a top-level `main()` function.
+bool hasMainMethod(String code) {
+  final source = StringSource(code, '');
+  final diagnosticCollector = RecordingDiagnosticListener();
+  final diagnosticReporter = DiagnosticReporter(diagnosticCollector, source);
+
+  final scanner = Scanner(code, diagnosticReporter)
+    ..configureFeatures(
+      featureSetForOverriding: FeatureSet.latestLanguageVersion(),
+      featureSet: FeatureSet.latestLanguageVersion(),
+    );
+  var token = scanner.tokenize();
+
+  var braceDepth = 0;
+  while (token.type != TokenType.EOF) {
+    if (token.type == TokenType.OPEN_CURLY_BRACKET) {
+      braceDepth++;
+    } else if (token.type == TokenType.CLOSE_CURLY_BRACKET) {
+      if (braceDepth > 0) {
+        braceDepth--;
+      }
+    } else if (braceDepth == 0 && token.type == TokenType.IDENTIFIER && token.lexeme == 'main') {
+      if (token.next?.type == TokenType.OPEN_PAREN) {
+        return true;
+      }
+    }
+    token = token.next!;
+  }
+  return false;
+}

--- a/pkgs/dartpad_preview/codemirror-lang-dart/pubspec.yaml
+++ b/pkgs/dartpad_preview/codemirror-lang-dart/pubspec.yaml
@@ -11,3 +11,6 @@ resolution: workspace
 dependencies:
   analyzer: ^12.1.0
   web: ^1.1.1
+
+dev_dependencies:
+  test: any

--- a/pkgs/dartpad_preview/codemirror-lang-dart/test/has_main_method_test.dart
+++ b/pkgs/dartpad_preview/codemirror-lang-dart/test/has_main_method_test.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:codemirror_lang_dart/src/has_main_method.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('hasMainMethod', () {
+    test('detects standard void main()', () {
+      expect(hasMainMethod('void main() {}'), isTrue);
+    });
+
+    test('detects main() with arguments', () {
+      expect(hasMainMethod('void main(List<String> args) {}'), isTrue);
+      expect(hasMainMethod('void main([List<String>? args]) {}'), isTrue);
+      expect(hasMainMethod('void main({List<String>? args}) {}'), isTrue);
+    });
+
+    test('detects main() without return type', () {
+      expect(hasMainMethod('main() {}'), isTrue);
+      expect(hasMainMethod("main() => print('hello');"), isTrue);
+    });
+
+    test('detects async Future<void> main()', () {
+      expect(hasMainMethod('Future<void> main() async {}'), isTrue);
+      expect(hasMainMethod('Future main() async {}'), isTrue);
+    });
+
+    test('detects main() with preceding annotations and comments', () {
+      const code = '''
+/// The main application entrypoint.
+@pragma('vm:entry-point')
+void main() {
+  runApp();
+}
+''';
+      expect(hasMainMethod(code), isTrue);
+    });
+
+    test('ignores main inside a class', () {
+      const code = '''
+class App {
+  void main() {}
+}
+''';
+      expect(hasMainMethod(code), isFalse);
+    });
+
+    test('ignores main inside an enum, mixin, or extension', () {
+      expect(
+        hasMainMethod('''
+enum Colors {
+  red;
+  void main() {}
+}
+'''),
+        isFalse,
+      );
+
+      expect(
+        hasMainMethod('''
+mixin Runner {
+  void main() {}
+}
+'''),
+        isFalse,
+      );
+
+      expect(
+        hasMainMethod('''
+extension Ext on int {
+  void main() {}
+}
+'''),
+        isFalse,
+      );
+    });
+
+    test('ignores top-level variables and getters named main', () {
+      expect(hasMainMethod('var main = 42;'), isFalse);
+      expect(hasMainMethod('final int main = 10;'), isFalse);
+      expect(hasMainMethod('int get main => 42;'), isFalse);
+      expect(hasMainMethod('class main {}'), isFalse);
+    });
+
+    test('ignores main inside comments', () {
+      expect(hasMainMethod('// void main() {}'), isFalse);
+      expect(hasMainMethod('/* void main() {} */'), isFalse);
+      expect(hasMainMethod('/// void main() {}'), isFalse);
+    });
+
+    test('ignores main inside string literals', () {
+      expect(hasMainMethod("var s = 'void main() {}';"), isFalse);
+      expect(hasMainMethod('var s = "void main() {}";'), isFalse);
+      expect(hasMainMethod("var s = '''void main() {}''';"), isFalse);
+    });
+
+    test('returns false for files without main', () {
+      expect(hasMainMethod(''), isFalse);
+      expect(hasMainMethod('void foo() {}'), isFalse);
+      expect(hasMainMethod('class Widget {}'), isFalse);
+    });
+
+    test('correctly identifies main even if preceded by other declarations', () {
+      const code = '''
+import 'package:flutter/material.dart';
+
+class MyWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => const Placeholder();
+}
+
+void main() {
+  runApp(const MyWidget());
+}
+''';
+      expect(hasMainMethod(code), isTrue);
+    });
+  });
+}

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/app.dart
@@ -760,9 +760,9 @@ class AppState extends State<App> {
       builder: (context) => PreviewContainer(
         preview: session.preview,
         taskStatus: session.taskStatus,
-        activeFile: session.tabs.activeFile,
         workspacePreparationFailure: _workspacePreparationFailure,
         onOpenConsole: () => _openConsole(session),
+        onStart: session.startPreview,
       ),
     );
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/components/runtime_button.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 
@@ -23,19 +21,16 @@ class RuntimeButton extends StatelessComponent {
     super.key,
   });
 
-  /// Factory constructor for a 'Run' button that runs the [activeFile]
-  /// or falls back to 'lib/main.dart' if no active file is present.
+  /// Factory constructor for a 'Run' button that triggers [onRun].
   factory RuntimeButton.run({
     required PreviewViewModel previewViewModel,
-    required String activeFile,
+    required void Function() onRun,
   }) {
     return RuntimeButton(
       title: 'Run',
       icon: 'play_arrow',
       isEnabled: previewViewModel.canStart,
-      onClick: () => previewViewModel.runCode(
-        activeFile.isNotEmpty ? activeFile : 'lib/main.dart',
-      ),
+      onClick: onRun,
     );
   }
 
@@ -59,7 +54,7 @@ class RuntimeButton extends StatelessComponent {
       title: 'Reload',
       icon: 'bolt',
       isEnabled: previewViewModel.canHotReload,
-      onClick: () => previewViewModel.hotReloadCode(),
+      onClick: previewViewModel.hotReloadCode,
     );
   }
 
@@ -70,7 +65,7 @@ class RuntimeButton extends StatelessComponent {
       title: 'Stop',
       icon: 'stop',
       isEnabled: previewViewModel.canStop,
-      onClick: () => previewViewModel.stopCode(),
+      onClick: previewViewModel.stopCode,
     );
   }
 
@@ -84,7 +79,7 @@ class RuntimeButton extends StatelessComponent {
   final bool isEnabled;
 
   /// Callback executed when the button is clicked.
-  final Future<void> Function() onClick;
+  final void Function() onClick;
 
   @override
   Component build(BuildContext context) {
@@ -98,7 +93,7 @@ class RuntimeButton extends StatelessComponent {
         'title': title,
         'aria-label': title,
       },
-      onClick: isEnabled ? () => unawaited(onClick()) : null,
+      onClick: isEnabled ? onClick : null,
       [
         Icon(icon, size: 18.0),
         span(classes: 'runtime-button-label', [.text(title)]),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/preview/view/preview_container.dart
@@ -29,7 +29,7 @@ class PreviewContainer extends StatefulComponent {
   const PreviewContainer({
     required this.preview,
     required this.taskStatus,
-    required this.activeFile,
+    required this.onStart,
     required this.onOpenConsole,
     this.workspacePreparationFailure,
     super.key,
@@ -41,8 +41,8 @@ class PreviewContainer extends StatefulComponent {
   /// Tracks prerequisite and runtime tasks shown in an empty preview.
   final TaskStatusController taskStatus;
 
-  /// The path of the currently active file in the editor workspace.
-  final String activeFile;
+  /// Callback invoked when the user starts the preview.
+  final void Function() onStart;
 
   /// A persistent failure from the one-time workspace preparation lifecycle.
   final String? workspacePreparationFailure;
@@ -182,7 +182,7 @@ class _PreviewContainerState extends State<PreviewContainer> {
                   else
                     RuntimeButton.run(
                       previewViewModel: viewModel,
-                      activeFile: component.activeFile,
+                      onRun: component.onStart,
                     ),
                   if (viewModel.isFlutter) RuntimeButton.restart(previewViewModel: viewModel),
                   RuntimeButton.stop(previewViewModel: viewModel),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/workspace_session.dart
@@ -4,12 +4,14 @@
 
 import 'dart:async';
 
+import 'package:codemirror_dart/codemirror_dart.dart';
 import 'package:dartpad/dartpad.dart';
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/jaspr.dart' show kDebugMode;
 
 import '../bottom_panel/view_models/console_view_model.dart';
 import '../bottom_panel/view_models/diagnostics_view_model.dart';
+import '../editor/codemirror/code_mirror_tab.dart';
 import '../editor/codemirror/code_mirror_tab_adapter.dart';
 import '../editor/image/image_tab.dart';
 import '../editor/view_models/tabs_view_model.dart';
@@ -98,18 +100,51 @@ final class WorkspaceSession {
     if (preview.canHotReload) {
       unawaited(preview.hotReloadCode());
     } else if (preview.canStart) {
-      final activeFile = tabs.activeFile;
-      unawaited(
-        preview.runCode(
-          activeFile.isNotEmpty ? activeFile : (preview.state.entrypoint ?? 'lib/main.dart'),
-        ),
-      );
+      unawaited(startPreview());
     }
+  }
+
+  /// Starts the preview using the resolved runnable entrypoint.
+  Future<void> startPreview() async {
+    final entrypoint = await resolveRunnableEntrypoint();
+    await preview.runCode(entrypoint);
+  }
+
+  /// Resolves the entrypoint to run when starting the preview.
+  ///
+  /// If the current active file is a Dart file containing a `main()` method,
+  /// it is used as the entrypoint. Otherwise, falls back to `lib/main.dart`
+  /// (prefixed by [_projectRoot] if present).
+  Future<String> resolveRunnableEntrypoint([String? targetFile]) async {
+    final active = targetFile ?? tabs.activeFile;
+    final fallbackPath = _projectRoot != null && _projectRoot!.isNotEmpty
+        ? '$_projectRoot/lib/main.dart'
+        : 'lib/main.dart';
+
+    if (active.isNotEmpty && active.endsWith('.dart')) {
+      final tab = tabs.activeTab;
+      String? content;
+      if (tab is CodeMirrorTab && tab.path == active) {
+        content = tab.content;
+      } else {
+        final file = repository.root.getFile(active);
+        if (await file.exists()) {
+          content = await file.readContent();
+        }
+      }
+
+      if (content != null && hasMainMethod(content)) {
+        return active;
+      }
+    }
+
+    return fallbackPath;
   }
 
   LanguageServer? _languageServer;
   LanguageServerClient? _languageServerClient;
   StreamSubscription<AnalyzerActivity>? _analyzerSubscription;
+  String? _projectRoot;
   bool _disposed = false;
 
   /// Attaches language-server resources to this session's consumers.
@@ -127,6 +162,7 @@ final class WorkspaceSession {
 
     _languageServer = server;
     _languageServerClient = client;
+    _projectRoot = projectRoot;
     _analyzerSubscription = client.analyzerActivityStream.listen(
       _onAnalyzerActivity,
       onError: (_) => analyzerStatus.markUnavailable(),

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/preview/view/preview_container_test.dart
@@ -122,7 +122,7 @@ void main() {
         PreviewContainer(
           preview: customPreview ?? preview,
           taskStatus: taskStatus,
-          activeFile: 'lib/main.dart',
+          onStart: () {},
           onOpenConsole: () {},
         ),
       ],
@@ -189,7 +189,7 @@ void main() {
           right: PreviewContainer(
             preview: preview,
             taskStatus: taskStatus,
-            activeFile: 'lib/main.dart',
+            onStart: () {},
             onOpenConsole: () {},
           ),
         ),
@@ -209,7 +209,7 @@ void main() {
           right: PreviewContainer(
             preview: preview,
             taskStatus: taskStatus,
-            activeFile: 'lib/main.dart',
+            onStart: () {},
             onOpenConsole: () {},
           ),
         ),
@@ -233,7 +233,7 @@ void main() {
           right: PreviewContainer(
             preview: preview,
             taskStatus: taskStatus,
-            activeFile: 'lib/main.dart',
+            onStart: () {},
             onOpenConsole: () {},
           ),
         ),
@@ -567,7 +567,7 @@ void main() {
       builder: (_) => PreviewContainer(
         preview: preview,
         taskStatus: repository.taskStatus,
-        activeFile: 'lib/main.dart',
+        onStart: () {},
         onOpenConsole: () {},
       ),
     );

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_session_test.dart
@@ -118,7 +118,38 @@ void main() {
 
     // runOrHotReload starts runCode
     session.runOrHotReload();
+    await Future<void>.delayed(Duration.zero);
     expect(session.preview.state, isA<PreviewStarting>());
+
+    await session.dispose(closeWorker: false);
+  });
+
+  test('resolves runnable entrypoint based on main() presence', () async {
+    final events = AppEventBus();
+    final workspace = _Workspace();
+    await workspace.writeFileFromText('lib/main.dart', 'void main() {}');
+    await workspace.writeFileFromText('lib/other.dart', 'void other() {}');
+    await workspace.writeFileFromText('lib/custom.dart', 'void main() {}');
+
+    final repository = WorkspaceRepository(
+      events: events,
+      taskStatus: TaskStatusController(),
+      workspaceResourceApi: workspace,
+      sdk: defaultSdk,
+      workspaceFuture: Completer<Workspace>().future,
+    );
+    final session = WorkspaceSession.create(repository);
+
+    // canStart is immediately true without waiting on LSP
+    expect(session.preview.canStart, isTrue);
+
+    // 1. Custom file with main() becomes the runnable entrypoint
+    final customEntrypoint = await session.resolveRunnableEntrypoint('lib/custom.dart');
+    expect(customEntrypoint, 'lib/custom.dart');
+
+    // 2. File without main() falls back to lib/main.dart
+    final otherEntrypoint = await session.resolveRunnableEntrypoint('lib/other.dart');
+    expect(otherEntrypoint, 'lib/main.dart');
 
     await session.dispose(closeWorker: false);
   });


### PR DESCRIPTION
Fixes #3704

When starting the preview, the active file is checked first and if it doesn't contain a main() method, it falls back to lib/main.dart

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
