### PR TITLE
Dartpad-Preview: replace context with focused path helpers

### DIFF
--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/tabs_controller.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/tabs_controller.dart
@@ -34,7 +34,7 @@ abstract mixin class TabsController<T> {
 
   final List<EditorTab<T>> _tabs = [];
   final Map<String, EditorTab<T>> _keepAliveTabs = {};
-  final Map<String, Future<void>> _loadingTabs = {};
+  final Map<String, _PendingTabLoad> _loadingTabs = {};
   final Map<String, StreamSubscription<void>> _tabUpdateSubscriptions = {};
   String _activeTabPath = '';
   StreamSubscription<WorkspaceChangeEvent>? _workspaceSubscription;
@@ -98,33 +98,42 @@ abstract mixin class TabsController<T> {
       return;
     }
 
-    Future<void>? loadFuture = _loadingTabs[fileName];
-    if (loadFuture == null) {
-      loadFuture = _loadTab(fileName);
-      _loadingTabs[fileName] = loadFuture;
+    var pendingLoad = _loadingTabs[fileName];
+    if (pendingLoad == null) {
+      pendingLoad = _PendingTabLoad();
+      _loadingTabs[fileName] = pendingLoad;
+      pendingLoad.future = _loadTab(fileName, pendingLoad);
     }
 
-    await loadFuture;
+    await pendingLoad.future;
     if (_tabs.any((tab) => tab.path == fileName)) {
       _setActivePath(fileName);
     }
   }
 
-  Future<void> _loadTab(String fileName) async {
+  Future<void> _loadTab(String fileName, _PendingTabLoad pendingLoad) async {
     try {
       final tab = await _createTab(fileName);
-      // Check if it got cancelled or deleted while loading
-      if (!_loadingTabs.containsKey(fileName)) {
+      // Check whether this specific load was cancelled or superseded.
+      if (!identical(_loadingTabs[fileName], pendingLoad)) {
         tab.dispose();
-        await _tabUpdateSubscriptions.remove(fileName)?.cancel();
         return;
       }
 
-      if (!_tabs.any((t) => t.path == fileName)) {
-        _tabs.add(tab);
+      if (_tabs.any((t) => t.path == fileName)) {
+        tab.dispose();
+        return;
       }
+
+      unawaited(_tabUpdateSubscriptions[fileName]?.cancel());
+      _tabUpdateSubscriptions[fileName] = tab.onUpdate.listen((_) {
+        didUpdate();
+      });
+      _tabs.add(tab);
     } finally {
-      unawaited(_loadingTabs.remove(fileName));
+      if (identical(_loadingTabs[fileName], pendingLoad)) {
+        _loadingTabs.remove(fileName);
+      }
     }
   }
 
@@ -132,10 +141,6 @@ abstract mixin class TabsController<T> {
     for (final adapter in adapters) {
       final tab = await adapter.createTab(fileName);
       if (tab != null) {
-        unawaited(_tabUpdateSubscriptions[fileName]?.cancel());
-        _tabUpdateSubscriptions[fileName] = tab.onUpdate.listen((_) {
-          didUpdate();
-        });
         return tab;
       }
     }
@@ -297,13 +302,13 @@ abstract mixin class TabsController<T> {
   }
 
   void _handleFileMoved(String oldPath, String newPath) {
-    final normalizedOldPath = workspaceContext.normalize(oldPath);
-    final normalizedNewPath = workspaceContext.normalize(newPath);
+    final normalizedOldPath = normalizeWorkspacePath(oldPath);
+    final normalizedNewPath = normalizeWorkspacePath(newPath);
     _cancelLoadsAtOrBelow(normalizedOldPath);
 
-    final openTabs = _tabs.where((tab) => workspaceContext.isWithinFolder(tab.path, normalizedOldPath)).toList();
+    final openTabs = _tabs.where((tab) => isWithinWorkspaceFolder(tab.path, normalizedOldPath)).toList();
     final keptTabs = _keepAliveTabs.entries
-        .where((entry) => workspaceContext.isWithinFolder(entry.key, normalizedOldPath))
+        .where((entry) => isWithinWorkspaceFolder(entry.key, normalizedOldPath))
         .toList();
     if (openTabs.isEmpty && keptTabs.isEmpty) {
       return;
@@ -311,7 +316,7 @@ abstract mixin class TabsController<T> {
 
     for (final tab in openTabs) {
       final previousPath = tab.path;
-      final rebasedPath = workspaceContext.rebasePath(
+      final rebasedPath = rebaseWorkspacePath(
         previousPath,
         normalizedOldPath,
         normalizedNewPath,
@@ -321,7 +326,7 @@ abstract mixin class TabsController<T> {
     }
     for (final entry in keptTabs) {
       final previousPath = entry.key;
-      final rebasedPath = workspaceContext.rebasePath(
+      final rebasedPath = rebaseWorkspacePath(
         previousPath,
         normalizedOldPath,
         normalizedNewPath,
@@ -331,8 +336,8 @@ abstract mixin class TabsController<T> {
       _moveTabUpdateSubscription(previousPath, rebasedPath);
       _keepAliveTabs[rebasedPath] = entry.value;
     }
-    if (workspaceContext.isWithinFolder(_activeTabPath, normalizedOldPath)) {
-      _activeTabPath = workspaceContext.rebasePath(
+    if (isWithinWorkspaceFolder(_activeTabPath, normalizedOldPath)) {
+      _activeTabPath = rebaseWorkspacePath(
         _activeTabPath,
         normalizedOldPath,
         normalizedNewPath,
@@ -351,24 +356,24 @@ abstract mixin class TabsController<T> {
   }
 
   void _handleDeletedFile(String path) {
-    final normalizedPath = workspaceContext.normalize(path);
+    final normalizedPath = normalizeWorkspacePath(path);
     _cancelLoadsAtOrBelow(normalizedPath);
 
-    final openTabs = _tabs.where((tab) => workspaceContext.isWithinFolder(tab.path, normalizedPath)).toList();
+    final openTabs = _tabs.where((tab) => isWithinWorkspaceFolder(tab.path, normalizedPath)).toList();
     final keptTabs = _keepAliveTabs.entries
-        .where((entry) => workspaceContext.isWithinFolder(entry.key, normalizedPath))
+        .where((entry) => isWithinWorkspaceFolder(entry.key, normalizedPath))
         .toList();
     if (openTabs.isEmpty && keptTabs.isEmpty) {
       return;
     }
 
     final activeIndex = _tabs.indexWhere((tab) => tab.path == _activeTabPath);
-    final activeWasDeleted = activeIndex != -1 && workspaceContext.isWithinFolder(_activeTabPath, normalizedPath);
+    final activeWasDeleted = activeIndex != -1 && isWithinWorkspaceFolder(_activeTabPath, normalizedPath);
     String? nextActivePath;
     if (activeWasDeleted) {
       for (var index = activeIndex + 1; index < _tabs.length; index++) {
         final candidate = _tabs[index];
-        if (!workspaceContext.isWithinFolder(candidate.path, normalizedPath)) {
+        if (!isWithinWorkspaceFolder(candidate.path, normalizedPath)) {
           nextActivePath = candidate.path;
           break;
         }
@@ -376,7 +381,7 @@ abstract mixin class TabsController<T> {
       if (nextActivePath == null) {
         for (var index = activeIndex - 1; index >= 0; index--) {
           final candidate = _tabs[index];
-          if (!workspaceContext.isWithinFolder(candidate.path, normalizedPath)) {
+          if (!isWithinWorkspaceFolder(candidate.path, normalizedPath)) {
             nextActivePath = candidate.path;
             break;
           }
@@ -407,11 +412,9 @@ abstract mixin class TabsController<T> {
   }
 
   void _cancelLoadsAtOrBelow(String path) {
-    final matchingPaths = _loadingTabs.keys
-        .where((candidate) => workspaceContext.isWithinFolder(candidate, path))
-        .toList();
+    final matchingPaths = _loadingTabs.keys.where((candidate) => isWithinWorkspaceFolder(candidate, path)).toList();
     for (final matchingPath in matchingPaths) {
-      unawaited(_loadingTabs.remove(matchingPath));
+      _loadingTabs.remove(matchingPath);
     }
   }
 
@@ -452,4 +455,8 @@ abstract mixin class TabsController<T> {
     _loadingTabs.clear();
     _activeTabPath = '';
   }
+}
+
+final class _PendingTabLoad {
+  late final Future<void> future;
 }

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/diagnostic_uri_resolver.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/lsp/diagnostic_uri_resolver.dart
@@ -9,9 +9,9 @@ import '../workspace/workspace_path.dart';
 /// If [workspaceFolder] is provided, the URI is resolved relative to it.
 /// Otherwise, the last path segment is returned as a fallback.
 String pathFromDiagnosticUri(String uri, {Uri? workspaceFolder}) {
-  final workspacePath = _pathWithinWorkspace(uri, workspaceFolder);
-  if (workspacePath != null) {
-    return workspacePath;
+  final resolvedPath = _pathWithinWorkspace(uri, workspaceFolder);
+  if (resolvedPath != null) {
+    return resolvedPath;
   }
 
   return Uri.decodeFull(uri.split('/').last);
@@ -27,11 +27,11 @@ String? _pathWithinWorkspace(String uri, Uri? workspaceFolder) {
     return null;
   }
 
-  final workspacePath = workspaceFolder.path.endsWith('/') ? workspaceFolder.path : '${workspaceFolder.path}/';
+  final folderPrefix = workspaceFolder.path.endsWith('/') ? workspaceFolder.path : '${workspaceFolder.path}/';
   final isSameLocation = parsedUri.scheme == workspaceFolder.scheme && parsedUri.authority == workspaceFolder.authority;
-  if (isSameLocation && parsedUri.path.startsWith(workspacePath)) {
-    final relativePath = parsedUri.path.substring(workspacePath.length);
-    return workspaceContext.normalize(Uri.decodeFull(relativePath));
+  if (isSameLocation && parsedUri.path.startsWith(folderPrefix)) {
+    final relativePath = parsedUri.path.substring(folderPrefix.length);
+    return normalizeWorkspacePath(Uri.decodeFull(relativePath));
   }
 
   return null;

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/workspace/workspace_path.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/workspace/workspace_path.dart
@@ -7,101 +7,70 @@ import 'package:path/path.dart' as p;
 /// The path context for virtual workspace paths, which always use `/`.
 final p.Context workspacePath = p.posix;
 
-/// The singleton [WorkspaceContext] instance for workspace path manipulation.
-final WorkspaceContext workspaceContext = WorkspaceContext._();
-
-/// Utility class for working with virtual workspace paths.
+/// Normalizes a workspace [path].
 ///
-/// Provides path manipulation functions such as normalization, joining, rebase,
-/// parent directory detection, and visibility filtering for virtual workspace resources.
-class WorkspaceContext {
-  WorkspaceContext._();
+/// The workspace root is represented by an empty string instead of `.`.
+String normalizeWorkspacePath(String path) {
+  final normalized = workspacePath.normalize(path);
+  return normalized == '.' ? '' : normalized;
+}
 
-  /// Normalizes a workspace [path], returning an empty string for the current directory (`.`).
-  String normalize(String path) {
-    final normalized = workspacePath.normalize(path);
-    return normalized == '.' ? '' : normalized;
+/// Returns the final path segment of a workspace [path].
+String basenameWorkspacePath(String path) {
+  return workspacePath.basename(normalizeWorkspacePath(path));
+}
+
+/// Returns the workspace-relative parent folder of [path].
+///
+/// The workspace root is represented by an empty string.
+String parentWorkspacePath(String path) {
+  return normalizeWorkspacePath(
+    workspacePath.dirname(normalizeWorkspacePath(path)),
+  );
+}
+
+/// Joins [folder] and [child] into a normalized workspace path.
+String joinWorkspacePath(String folder, String child) {
+  return normalizeWorkspacePath(
+    workspacePath.join(normalizeWorkspacePath(folder), child),
+  );
+}
+
+/// Whether [path] identifies [folder] itself or one of its descendants.
+bool isWithinWorkspaceFolder(String path, String folder) {
+  final normalizedPath = normalizeWorkspacePath(path);
+  final normalizedFolder = normalizeWorkspacePath(folder);
+  if (!_isWorkspaceRelativePath(normalizedPath) || !_isWorkspaceRelativePath(normalizedFolder)) {
+    return false;
   }
+  return normalizedFolder.isEmpty ||
+      normalizedPath == normalizedFolder ||
+      workspacePath.isWithin(normalizedFolder, normalizedPath);
+}
 
-  /// Returns the final path segment of [value].
-  String basename(String value) => workspacePath.basename(normalize(value));
+bool _isWorkspaceRelativePath(String path) {
+  return !workspacePath.isAbsolute(path) && !workspacePath.split(path).contains('..');
+}
 
-  /// Returns the workspace-relative parent folder of [value].
-  ///
-  /// The workspace root is represented by an empty string.
-  String dirname(String value) {
-    final result = workspacePath.dirname(normalize(value));
-    return result == '.' ? '' : result;
+/// Replaces the [sourceFolder] prefix of [path] with [destinationFolder].
+///
+/// Returns the normalized [path] unchanged when it is outside [sourceFolder].
+String rebaseWorkspacePath(
+  String path,
+  String sourceFolder,
+  String destinationFolder,
+) {
+  final normalizedPath = normalizeWorkspacePath(path);
+  final normalizedSource = normalizeWorkspacePath(sourceFolder);
+  final normalizedDestination = normalizeWorkspacePath(destinationFolder);
+  if (!isWithinWorkspaceFolder(normalizedPath, normalizedSource)) {
+    return normalizedPath;
   }
-
-  /// Joins [folder] and [name] into a normalized workspace path.
-  String join(String folder, String name) {
-    return normalize(
-      workspacePath.join(normalize(folder), name),
-    );
+  if (normalizedPath == normalizedSource) {
+    return normalizedDestination;
   }
-
-  /// Whether [value] identifies [folder] itself or one of its descendants.
-  bool isWithinFolder(String value, String folder) {
-    final normalizedValue = normalize(value);
-    final normalizedFolder = normalize(folder);
-    return normalizedFolder.isEmpty ||
-        normalizedValue == normalizedFolder ||
-        workspacePath.isWithin(normalizedFolder, normalizedValue);
-  }
-
-  /// Replaces the [sourceFolder] prefix of [value] with [destinationFolder].
-  ///
-  /// Returns the normalized [value] unchanged when it is outside
-  /// [sourceFolder].
-  String rebasePath(String value, String sourceFolder, String destinationFolder) {
-    final normalizedValue = normalize(value);
-    final normalizedOldRoot = normalize(sourceFolder);
-    final normalizedNewRoot = normalize(destinationFolder);
-    if (normalizedValue == normalizedOldRoot) {
-      return normalizedNewRoot;
-    }
-    return workspacePath.join(
-      normalizedNewRoot,
-      workspacePath.relative(normalizedValue, from: normalizedOldRoot),
-    );
-  }
-
-  /// Whether [value] should be shown in the workspace file tree.
-  ///
-  /// The workspace root and generated `.dart_tool` and `build` subtrees are
-  /// hidden.
-  bool isVisiblePath(String value) {
-    final normalized = normalize(value);
-    if (normalized.isEmpty) {
-      return false;
-    }
-    return normalized
-        .split('/')
-        .every(
-          (segment) => segment.isNotEmpty && segment != '.dart_tool' && segment != 'build',
-        );
-  }
-
-  /// Returns [path] relative to [projectRoot] for display to the user.
-  ///
-  /// The project root itself is displayed as `/`.
-  String relativeDisplayPath({
-    required String path,
-    required String projectRoot,
-  }) {
-    final normalizedPath = normalize(path);
-    final normalizedRoot = normalize(projectRoot);
-
-    if (normalizedPath == normalizedRoot) {
-      return '/';
-    }
-    if (normalizedRoot.isNotEmpty && normalizedPath.startsWith('$normalizedRoot/')) {
-      return normalizedPath.substring(normalizedRoot.length + 1);
-    }
-    if (normalizedRoot.isNotEmpty) {
-      return workspacePath.relative(normalizedPath, from: normalizedRoot);
-    }
-    return normalizedPath.isEmpty ? '/' : normalizedPath;
-  }
+  return joinWorkspacePath(
+    normalizedDestination,
+    workspacePath.relative(normalizedPath, from: normalizedSource),
+  );
 }

--- a/pkgs/dartpad_preview/dartpad_editor/test/editor/tabs_controller_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/editor/tabs_controller_test.dart
@@ -151,6 +151,7 @@ class TestTabAdapter extends EditorTabAdapter<String> {
 
   /// Tabs created by this adapter, keyed by path.
   final Map<String, TestTab> createdTabs = {};
+  final List<TestTab> _allCreatedTabs = [];
 
   @override
   Future<EditorTab<String>?> createTab(String path) async {
@@ -168,6 +169,7 @@ class TestTabAdapter extends EditorTabAdapter<String> {
       onDiscard: () => onDiscard?.call(path),
     );
     createdTabs[path] = tab;
+    _allCreatedTabs.add(tab);
     return tab;
   }
 }
@@ -311,6 +313,43 @@ void main() {
       tabs.updateLog.clear();
       deletedTab.notifyUpdate();
       expect(tabs.updateLog, isEmpty);
+    });
+
+    test('a cancelled load cannot replace a newer load for the same file', () async {
+      final firstGate = Completer<void>();
+      adapter.creationGate = firstGate;
+      workspace.addFile('reopened.dart');
+
+      final firstOpen = tabs.openFile('reopened.dart');
+      await adapter.creationStarted.future;
+      workspace.removeFile('reopened.dart');
+      await emitWorkspaceEvent(
+        {'type': 'remove', 'path': 'reopened.dart'},
+      );
+
+      final secondGate = Completer<void>();
+      adapter.creationGate = secondGate;
+      workspace.addFile('reopened.dart');
+      final secondOpen = tabs.openFile('reopened.dart');
+      while (adapter.creationCount < 2) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      firstGate.complete();
+      await firstOpen;
+      expect(tabs.openTabs, isEmpty);
+
+      secondGate.complete();
+      await secondOpen;
+
+      expect(tabs.openTabs, hasLength(1));
+      expect(tabs.activeFile, 'reopened.dart');
+      expect(adapter._allCreatedTabs.first.lifecycleLog, contains('dispose'));
+      expect(adapter._allCreatedTabs.last.lifecycleLog, isNot(contains('dispose')));
+
+      tabs.updateLog.clear();
+      adapter._allCreatedTabs.last.notifyUpdate();
+      expect(tabs.updateLog, [null]);
     });
   });
 

--- a/pkgs/dartpad_preview/dartpad_editor/test/lsp/diagnostic_uri_resolver_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/lsp/diagnostic_uri_resolver_test.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:dartpad_editor/src/lsp/diagnostic_uri_resolver.dart';
-import 'package:dartpad_editor/src/workspace/workspace_path.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -68,21 +67,5 @@ void main() {
         );
       }
     });
-  });
-
-  test('normalizeWorkspacePath canonicalizes POSIX paths', () {
-    final cases = {
-      'lib/main.dart': 'lib/main.dart',
-      '.': '',
-      '': '',
-      'lib//src///main.dart': 'lib/src/main.dart',
-      'lib/../src/main.dart': 'src/main.dart',
-      'lib/./src/./main.dart': 'lib/src/main.dart',
-      '/absolute/path.dart': '/absolute/path.dart',
-    };
-
-    for (final MapEntry(key: input, value: expected) in cases.entries) {
-      expect(workspaceContext.normalize(input), expected, reason: 'input: $input');
-    }
   });
 }

--- a/pkgs/dartpad_preview/dartpad_editor/test/workspace/workspace_path_test.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/test/workspace/workspace_path_test.dart
@@ -6,33 +6,63 @@ import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('WorkspaceContext.relativeDisplayPath', () {
-    test('displays the workspace root as a slash', () {
-      expect(workspaceContext.relativeDisplayPath(path: '', projectRoot: ''), '/');
-    });
+  test('normalizeWorkspacePath canonicalizes POSIX paths and the root', () {
+    final cases = {
+      'lib/main.dart': 'lib/main.dart',
+      '.': '',
+      '': '',
+      'lib//src///main.dart': 'lib/src/main.dart',
+      'lib/../src/main.dart': 'src/main.dart',
+      'lib/./src/./main.dart': 'lib/src/main.dart',
+      '/absolute/path.dart': '/absolute/path.dart',
+    };
 
-    test('displays a focused archive directory as the project root', () {
-      expect(
-        workspaceContext.relativeDisplayPath(path: 'example', projectRoot: 'example'),
-        '/',
-      );
-    });
+    for (final MapEntry(key: input, value: expected) in cases.entries) {
+      expect(normalizeWorkspacePath(input), expected, reason: 'input: $input');
+    }
+  });
 
-    test('displays nested paths relative to the focused project root', () {
-      expect(
-        workspaceContext.relativeDisplayPath(
-          path: 'packages/demo/example',
-          projectRoot: 'packages/demo',
-        ),
-        'example',
-      );
-    });
+  test('parentWorkspacePath preserves the empty workspace root', () {
+    expect(parentWorkspacePath(''), '');
+    expect(parentWorkspacePath('.'), '');
+    expect(parentWorkspacePath('lib'), '');
+    expect(parentWorkspacePath('lib/src/main.dart'), 'lib/src');
+  });
 
-    test('displays paths above the focused project root with parent segments', () {
-      expect(
-        workspaceContext.relativeDisplayPath(path: '', projectRoot: 'example'),
-        '..',
-      );
-    });
+  test('basenameWorkspacePath normalizes before returning the final segment', () {
+    expect(basenameWorkspacePath('lib/../web/main.dart'), 'main.dart');
+    expect(basenameWorkspacePath('packages/example/.'), 'example');
+  });
+
+  test('joinWorkspacePath returns a normalized workspace path', () {
+    expect(joinWorkspacePath('', 'lib/main.dart'), 'lib/main.dart');
+    expect(joinWorkspacePath('.', 'lib/../web/main.dart'), 'web/main.dart');
+    expect(joinWorkspacePath('packages/example/.', 'lib/main.dart'), 'packages/example/lib/main.dart');
+  });
+
+  test('isWithinWorkspaceFolder includes the folder and descendants', () {
+    expect(isWithinWorkspaceFolder('', ''), isTrue);
+    expect(isWithinWorkspaceFolder('lib/main.dart', ''), isTrue);
+    expect(isWithinWorkspaceFolder('lib', 'lib'), isTrue);
+    expect(isWithinWorkspaceFolder('lib/src/main.dart', 'lib'), isTrue);
+    expect(isWithinWorkspaceFolder('library/main.dart', 'lib'), isFalse);
+    expect(isWithinWorkspaceFolder('lib', 'lib/src'), isFalse);
+  });
+
+  test('isWithinWorkspaceFolder rejects paths outside the workspace', () {
+    expect(isWithinWorkspaceFolder('../outside.dart', ''), isFalse);
+    expect(isWithinWorkspaceFolder('lib/../../outside.dart', ''), isFalse);
+    expect(isWithinWorkspaceFolder('/sdk/lib/core.dart', ''), isFalse);
+    expect(isWithinWorkspaceFolder('..hidden/file.dart', ''), isTrue);
+    expect(isWithinWorkspaceFolder('../outside/file.dart', '../outside'), isFalse);
+  });
+
+  test('rebaseWorkspacePath rebases the folder and its descendants', () {
+    expect(rebaseWorkspacePath('lib', 'lib', 'src'), 'src');
+    expect(rebaseWorkspacePath('lib/nested/main.dart', 'lib', 'src'), 'src/nested/main.dart');
+  });
+
+  test('rebaseWorkspacePath leaves paths outside the source folder unchanged', () {
+    expect(rebaseWorkspacePath('library/main.dart', 'lib', 'src'), 'library/main.dart');
   });
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/bottom_panel/view_models/diagnostics_view_model.dart
@@ -12,7 +12,7 @@ import '../../editor/view_models/tabs_view_model.dart';
 
 /// Manages diagnostics from the language server and navigation to their source
 /// locations.
-class DiagnosticsViewModel extends ChangeNotifier {
+final class DiagnosticsViewModel extends ChangeNotifier {
   DiagnosticsViewModel({required this.tabs});
 
   /// The maximum number of diagnostics rendered in the problems panel.
@@ -24,7 +24,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
   List<DiagnosticEntry> _diagnostics = const [];
   String? _projectRoot;
 
-  StreamSubscription<Map<String, dynamic>>? _diagnosticsSubscription;
+  StreamSubscription<Map<String, Object?>>? _diagnosticsSubscription;
 
   /// The first [maxDisplayedDiagnostics] diagnostics, sorted by severity then
   /// location.
@@ -53,7 +53,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
     String? projectRoot,
   }) {
     _diagnosticsSubscription?.cancel();
-    _projectRoot = projectRoot == null ? null : workspaceContext.normalize(projectRoot);
+    _projectRoot = projectRoot == null ? null : normalizeWorkspacePath(projectRoot);
     _updateDiagnostics(lsc);
     _diagnosticsSubscription = lsc.diagnosticsStream.listen((_) {
       _updateDiagnostics(lsc);
@@ -65,7 +65,7 @@ class DiagnosticsViewModel extends ChangeNotifier {
   void _updateDiagnostics(LanguageServerClient lsc) {
     _diagnostics = lsc.allDiagnostics
         .where(
-          (entry) => _projectRoot == null || workspaceContext.isWithinFolder(entry.fileName, _projectRoot!),
+          (entry) => _projectRoot == null || isWithinWorkspaceFolder(entry.fileName, _projectRoot!),
         )
         .toList(growable: false);
   }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/editor/components/pubspec_editor_actions.dart
@@ -114,8 +114,8 @@ class _PubspecEditorActionsState extends State<PubspecEditorActions> {
 
   @override
   Component build(BuildContext context) {
-    final fileName = workspaceContext.basename(component.activeFile);
-    final directory = workspaceContext.dirname(component.activeFile);
+    final fileName = basenameWorkspacePath(component.activeFile);
+    final directory = parentWorkspacePath(component.activeFile);
     final isPubspecFile = fileName == 'pubspec.yaml' || fileName == 'pubspec.lock';
 
     // Keep the stateful component's root render object stable while switching

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_file_item.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:js_interop';
 
+import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
 import 'package:jaspr_content/components/file_icon.dart';
@@ -127,8 +128,7 @@ class _FileTreeFileItemState extends State<FileTreeFileItem> {
           setState(() {
             _isRenaming = false;
           });
-          final parentPath = path.contains('/') ? path.substring(0, path.lastIndexOf('/')) : '';
-          final newPath = parentPath.isEmpty ? newName : '$parentPath/$newName';
+          final newPath = joinWorkspacePath(parentWorkspacePath(path), newName);
           await component.actions.renameFile(path, newName);
           component.onSelect(newPath);
         },

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/components/file_tree_folder_item.dart
@@ -88,11 +88,11 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
   @override
   void initState() {
     super.initState();
-    final expectedLibPath = workspaceContext.join(component.state.focusedPath, 'lib');
+    final expectedLibPath = joinWorkspacePath(component.state.focusedPath, 'lib');
     final activeFile = component.state.activeFile;
     final folderPath = component.node.resource.path;
     final isActiveParent =
-        folderPath.isNotEmpty && workspaceContext.isWithinFolder(activeFile, folderPath) && activeFile != folderPath;
+        folderPath.isNotEmpty && isWithinWorkspaceFolder(activeFile, folderPath) && activeFile != folderPath;
 
     if (folderPath == expectedLibPath || isActiveParent) {
       _isCollapsed = false;
@@ -121,7 +121,7 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
     final activeFile = component.state.activeFile;
     final folderPath = component.node.resource.path;
     final isActiveParent =
-        folderPath.isNotEmpty && workspaceContext.isWithinFolder(activeFile, folderPath) && activeFile != folderPath;
+        folderPath.isNotEmpty && isWithinWorkspaceFolder(activeFile, folderPath) && activeFile != folderPath;
 
     if (isActiveParent && activeFile != oldComponent.state.activeFile) {
       _isCollapsed = false;
@@ -174,8 +174,7 @@ class _FileTreeFolderItemState extends State<FileTreeFolderItem> {
           setState(() {
             _isRenaming = false;
           });
-          final parentPath = path.contains('/') ? path.substring(0, path.lastIndexOf('/')) : '';
-          final newPath = parentPath.isEmpty ? newName : '$parentPath/$newName';
+          final newPath = joinWorkspacePath(parentWorkspacePath(path), newName);
           await component.actions.renameFolder(path, newName);
           component.onSelect(newPath);
         },

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_models.dart
@@ -146,8 +146,7 @@ final class FileTreeState {
     required String currentPath,
     required String newName,
   }) {
-    final parentPath = currentPath.contains('/') ? currentPath.substring(0, currentPath.lastIndexOf('/')) : '';
-    final newPath = parentPath.isEmpty ? newName : '$parentPath/$newName';
+    final newPath = joinWorkspacePath(parentWorkspacePath(currentPath), newName);
     if (newPath != currentPath && root.exists(newPath)) {
       return 'A file or folder already exists at "$newPath".';
     }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/filetree/file_tree_view_model.dart
@@ -85,27 +85,27 @@ final class FileTreeViewModel extends ChangeNotifier {
   );
 
   /// Whether the file at [path] is required by DartPad Preview.
-  bool isProtectedFile(String path) => protectedPaths.contains(workspaceContext.normalize(path));
+  bool isProtectedFile(String path) => protectedPaths.contains(normalizeWorkspacePath(path));
 
   /// Whether [path] is or contains a file required by DartPad Preview.
   bool isProtectedFolder(String path) {
-    final normalized = workspaceContext.normalize(path);
-    return protectedPaths.any((protectedPath) => workspaceContext.isWithinFolder(protectedPath, normalized));
+    final normalized = normalizeWorkspacePath(path);
+    return protectedPaths.any((protectedPath) => isWithinWorkspaceFolder(protectedPath, normalized));
   }
 
   /// Whether [path] has unsaved changes.
   ///
   /// When [folder] is true, descendants of [path] are checked as well.
   bool hasDirtyEntry(String path, {required bool folder}) {
-    final normalized = workspaceContext.normalize(path);
+    final normalized = normalizeWorkspacePath(path);
     return tabs.dirtyFiles.any(
-      (dirtyPath) => folder ? workspaceContext.isWithinFolder(dirtyPath, normalized) : dirtyPath == normalized,
+      (dirtyPath) => folder ? isWithinWorkspaceFolder(dirtyPath, normalized) : dirtyPath == normalized,
     );
   }
 
   /// Creates a file in the target folder.
   Future<void> createFile(String parentPath, String name) async {
-    final targetPath = workspaceContext.join(parentPath, name);
+    final targetPath = joinWorkspacePath(parentPath, name);
     await _runMutation(() async {
       await workspace.ensureTargetAvailable(
         sourcePath: '',
@@ -120,7 +120,7 @@ final class FileTreeViewModel extends ChangeNotifier {
 
   /// Creates a folder in the target folder.
   Future<void> createFolder(String parentPath, String name) async {
-    final targetPath = workspaceContext.join(parentPath, name);
+    final targetPath = joinWorkspacePath(parentPath, name);
     await _runMutation(() async {
       await workspace.ensureTargetAvailable(
         sourcePath: '',
@@ -134,7 +134,7 @@ final class FileTreeViewModel extends ChangeNotifier {
 
   /// Renames the file at [oldPath].
   Future<void> renameFile(String oldPath, String newName) async {
-    final newPath = workspaceContext.join(workspaceContext.dirname(oldPath), newName);
+    final newPath = joinWorkspacePath(parentWorkspacePath(oldPath), newName);
     if (newPath == oldPath) {
       return;
     }
@@ -148,7 +148,7 @@ final class FileTreeViewModel extends ChangeNotifier {
 
   /// Renames the folder at [oldPath].
   Future<void> renameFolder(String oldPath, String newName) async {
-    final newPath = workspaceContext.join(workspaceContext.dirname(oldPath), newName);
+    final newPath = joinWorkspacePath(parentWorkspacePath(oldPath), newName);
     if (newPath == oldPath) {
       return;
     }
@@ -192,16 +192,19 @@ final class FileTreeViewModel extends ChangeNotifier {
 
   /// Moves the entry into [targetFolderPath].
   Future<void> moveEntry(String sourcePath, String targetFolderPath) async {
-    final isFolder = await workspace.folderExist(sourcePath);
-    if (isFolder && !_canMoveFolder(sourcePath, targetFolderPath)) {
-      throw ArgumentError('A folder cannot be moved into itself.');
-    }
-    final newPath = workspaceContext.join(targetFolderPath, workspaceContext.basename(sourcePath));
+    final newPath = joinWorkspacePath(
+      targetFolderPath,
+      basenameWorkspacePath(sourcePath),
+    );
     if (newPath == sourcePath) {
       return;
     }
 
     await _runMutation(() async {
+      final isFolder = await workspace.folderExist(sourcePath);
+      if (isFolder && !_canMoveFolder(sourcePath, targetFolderPath)) {
+        throw ArgumentError('A folder cannot be moved into itself.');
+      }
       await _prepareRenameOrMove(sourcePath, newPath);
       final targetFolder = workspace.root.getFolder(targetFolderPath);
       if (!isFolder) {
@@ -237,9 +240,9 @@ final class FileTreeViewModel extends ChangeNotifier {
   }
 
   bool _canMoveFolder(String folder, String targetFolder) {
-    final source = workspaceContext.normalize(folder);
-    final target = workspaceContext.normalize(targetFolder);
-    return source.isNotEmpty && !workspaceContext.isWithinFolder(target, source);
+    final source = normalizeWorkspacePath(folder);
+    final target = normalizeWorkspacePath(targetFolder);
+    return source.isNotEmpty && !isWithinWorkspaceFolder(target, source);
   }
 
   void clearOperationError() {
@@ -248,13 +251,13 @@ final class FileTreeViewModel extends ChangeNotifier {
   }
 
   void focusPath(String path) {
-    _focusedPath = workspaceContext.normalize(path);
+    _focusedPath = normalizeWorkspacePath(path);
     _notify();
   }
 
   void navigateUp() {
     if (_focusedPath.isNotEmpty) {
-      focusPath(workspaceContext.dirname(_focusedPath));
+      focusPath(parentWorkspacePath(_focusedPath));
     }
   }
 
@@ -304,7 +307,7 @@ final class FileTreeViewModel extends ChangeNotifier {
       if (resource is WorkspaceFolder) {
         folders[resource.path] = resource;
       } else if (resource is WorkspaceFile) {
-        final isIgnored = !workspaceContext.isVisiblePath(resource.path);
+        final isIgnored = !_isVisibleFileTreePath(resource.path);
         children
             .putIfAbsent(resource.parent.path, () => [])
             .add(
@@ -330,7 +333,7 @@ final class FileTreeViewModel extends ChangeNotifier {
       builtFolders[folderPath] = FileTreeFolderNode(
         folder,
         children: folderChildren,
-        isIgnored: !workspaceContext.isVisiblePath(folderPath),
+        isIgnored: !_isVisibleFileTreePath(folderPath),
       );
     }
 
@@ -339,7 +342,7 @@ final class FileTreeViewModel extends ChangeNotifier {
       builtFolders.values.where((node) => node.resource.parent.path == root.path),
     );
     _sortNodes(rootChildren);
-    return FileTreeFolderNode(root, children: rootChildren, isIgnored: !workspaceContext.isVisiblePath(root.path));
+    return FileTreeFolderNode(root, children: rootChildren, isIgnored: !_isVisibleFileTreePath(root.path));
   }
 
   void _sortNodes(List<FileTreeNode> nodes) {
@@ -394,11 +397,23 @@ final class FileTreeViewModel extends ChangeNotifier {
 Set<String> _pathsWithAncestors(Iterable<String> paths) {
   final result = <String>{};
   for (final path in paths) {
-    var current = workspaceContext.normalize(path);
+    var current = normalizeWorkspacePath(path);
     while (current.isNotEmpty) {
       result.add(current);
-      current = workspaceContext.dirname(current);
+      current = parentWorkspacePath(current);
     }
   }
   return result;
+}
+
+/// Whether [path] should be presented as a regular file-tree entry.
+///
+/// Top-level dotfiles and dotfolders, including their descendants, are marked
+/// as ignored. Nested dot entries remain visible.
+bool _isVisibleFileTreePath(String path) {
+  final normalized = normalizeWorkspacePath(path);
+  if (normalized.isEmpty) {
+    return false;
+  }
+  return !normalized.split('/').first.startsWith('.');
 }

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/archive_loader.dart
@@ -15,7 +15,7 @@ import 'project_loader.dart';
 /// A loader that downloads a (gzipped) tar archive from a remote URL,
 /// extracts all of its files into a virtual workspace folder, and opens a
 /// target file.
-class ArchiveLoader {
+final class ArchiveLoader {
   /// Creates an archive loader.
   const ArchiveLoader({
     required this.archiveUrl,
@@ -119,10 +119,10 @@ class ArchiveLoader {
   /// `pubspec_overrides.yaml` file.
   void _disableWorkspaceResolution(Project project) {
     for (final path in project.paths.toList()) {
-      if (workspaceContext.basename(path) == 'pubspec.yaml') {
+      if (basenameWorkspacePath(path) == 'pubspec.yaml') {
         _disableWorkspaceResolutionForPackage(
           project,
-          workspaceContext.dirname(path),
+          parentWorkspacePath(path),
         );
       }
     }
@@ -132,7 +132,7 @@ class ArchiveLoader {
     Project project,
     String projectDir,
   ) {
-    final pubspecPath = workspaceContext.join(projectDir, 'pubspec.yaml');
+    final pubspecPath = joinWorkspacePath(projectDir, 'pubspec.yaml');
     final pubspecBytes = project.readFile(pubspecPath);
     if (pubspecBytes == null) {
       return;
@@ -149,7 +149,7 @@ class ArchiveLoader {
       return;
     }
 
-    final overridesPath = workspaceContext.join(projectDir, 'pubspec_overrides.yaml');
+    final overridesPath = joinWorkspacePath(projectDir, 'pubspec_overrides.yaml');
     project.writeFile(
       overridesPath,
       Uint8List.fromList(utf8.encode(jsonEncode({'resolution': null}))),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/gist_loader.dart
@@ -11,7 +11,7 @@ import 'package:http/http.dart' as http;
 import 'project_loader.dart';
 
 /// Loads all files of a GitHub gist into a virtual workspace.
-class GistLoader {
+final class GistLoader {
   const GistLoader({required this.gistId});
 
   /// The GitHub gist identifier.
@@ -34,8 +34,8 @@ class GistLoader {
       throw Exception('Failed to load gist $gistId (${response.statusCode})');
     }
 
-    final json = jsonDecode(response.body);
-    if (json is! Map<String, dynamic>) {
+    final Object? json = jsonDecode(response.body);
+    if (json is! Map<String, Object?>) {
       throw const FormatException('Unexpected gist response.');
     }
     if (json['truncated'] == true) {
@@ -43,7 +43,7 @@ class GistLoader {
     }
 
     final filesJson = json['files'];
-    if (filesJson is! Map<String, dynamic>) {
+    if (filesJson is! Map<String, Object?>) {
       throw const FormatException('Unexpected gist files response.');
     }
 
@@ -63,8 +63,8 @@ class GistLoader {
     );
   }
 
-  Future<ProjectFile> _loadFile(dynamic value) async {
-    if (value is! Map<String, dynamic>) {
+  Future<ProjectFile> _loadFile(Object? value) async {
+    if (value is! Map<String, Object?>) {
       throw const FormatException('Unexpected gist file response.');
     }
 
@@ -105,7 +105,7 @@ class GistLoader {
   List<ProjectFile> _moveRootDartFilesIntoLib(List<ProjectFile> files) {
     return [
       for (final file in files)
-        if (workspaceContext.dirname(file.path).isEmpty && file.path.endsWith('.dart'))
+        if (parentWorkspacePath(file.path).isEmpty && file.path.endsWith('.dart'))
           ProjectFile(path: 'lib/${file.path}', bytes: file.bytes)
         else
           file,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/startup/project_loader.dart
@@ -91,7 +91,7 @@ Uri resolveEditorRootUri(Uri rootWorkspaceUri, String? packageRoot) {
     return rootWorkspaceUri;
   }
 
-  final normalizedPackageRoot = workspaceContext.normalize(packageRoot);
+  final normalizedPackageRoot = normalizeWorkspacePath(packageRoot);
   return rootWorkspaceUri.resolveUri(
     Uri(path: '$normalizedPackageRoot/'),
   );
@@ -110,7 +110,7 @@ final class ProjectLoader {
 
     for (var i = segments.length - 1; i >= 0; i--) {
       final parentDirectory = segments.sublist(0, i).join('/');
-      final pubspecPath = workspaceContext.join(parentDirectory, 'pubspec.yaml');
+      final pubspecPath = joinWorkspacePath(parentDirectory, 'pubspec.yaml');
       if (project.containsFile(pubspecPath)) {
         return parentDirectory;
       }
@@ -126,10 +126,10 @@ final class ProjectLoader {
   ) async {
     final folders = <String>{};
     for (final file in project.files) {
-      var directory = workspaceContext.dirname(file.path);
+      var directory = parentWorkspacePath(file.path);
       while (directory.isNotEmpty) {
         folders.add(directory);
-        directory = workspaceContext.dirname(directory);
+        directory = parentWorkspacePath(directory);
       }
     }
 
@@ -148,7 +148,7 @@ final class ProjectLoader {
 
   /// Normalizes [path] and verifies that it remains inside the workspace.
   static String normalizePath(String path) {
-    final normalized = workspaceContext.normalize(path);
+    final normalized = normalizeWorkspacePath(path);
     if (normalized.isEmpty ||
         workspacePath.isAbsolute(normalized) ||
         normalized == '..' ||

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/workspace/data/workspace_repository.dart
@@ -116,8 +116,8 @@ class WorkspaceRepository {
     String projectRoot = '',
     bool blocksPreview = false,
   }) {
-    final normalizedPath = workspaceContext.normalize(path);
-    final pathLabel = workspaceContext.relativeDisplayPath(
+    final normalizedPath = normalizeWorkspacePath(path);
+    final pathLabel = _displayPathRelativeToProject(
       path: normalizedPath,
       projectRoot: projectRoot,
     );
@@ -178,8 +178,8 @@ class WorkspaceRepository {
 
   /// Removes generated Pub and build output from the workspace.
   Future<void> pubClean({String path = ''}) async {
-    final normalizedPath = workspaceContext.normalize(path);
-    final pathLabel = workspaceContext.relativeDisplayPath(
+    final normalizedPath = normalizeWorkspacePath(path);
+    final pathLabel = _displayPathRelativeToProject(
       path: normalizedPath,
       projectRoot: '',
     );
@@ -205,8 +205,8 @@ class WorkspaceRepository {
     WorkspaceResourceApi workspace, {
     String path = '',
   }) async {
-    final buildPath = workspaceContext.join(path, 'build');
-    final dartToolPath = workspaceContext.join(path, '.dart_tool');
+    final buildPath = joinWorkspacePath(path, 'build');
+    final dartToolPath = joinWorkspacePath(path, '.dart_tool');
     if (await workspace.folderExist(buildPath)) {
       await workspace.deleteFileSystemEntity(buildPath);
     }
@@ -351,7 +351,7 @@ class WorkspaceRepository {
     final packageName = resolvedPackageName ?? 'app';
     final packageFolder = resolvedFolder ?? metadataRoot;
 
-    final libFolder = workspaceContext.join(packageFolder.path, 'lib');
+    final libFolder = joinWorkspacePath(packageFolder.path, 'lib');
     if (workspacePath.isWithin(libFolder, filePath)) {
       final relativePath = workspacePath.relative(filePath, from: libFolder);
       return Uri(
@@ -398,6 +398,28 @@ class WorkspaceRepository {
   }
 }
 
+/// Returns a user-facing path relative to the active [projectRoot].
+///
+/// The project root itself is displayed as `/`.
+String _displayPathRelativeToProject({
+  required String path,
+  required String projectRoot,
+}) {
+  final normalizedPath = normalizeWorkspacePath(path);
+  final normalizedRoot = normalizeWorkspacePath(projectRoot);
+
+  if (normalizedPath == normalizedRoot) {
+    return '/';
+  }
+  if (normalizedRoot.isNotEmpty && normalizedPath.startsWith('$normalizedRoot/')) {
+    return normalizedPath.substring(normalizedRoot.length + 1);
+  }
+  if (normalizedRoot.isNotEmpty) {
+    return workspacePath.relative(normalizedPath, from: normalizedRoot);
+  }
+  return normalizedPath.isEmpty ? '/' : normalizedPath;
+}
+
 /// Runs a Pub command and forwards its output to the application debug console.
 Future<void> runWorkspacePubCommand({
   required AppEventBus events,
@@ -406,8 +428,8 @@ Future<void> runWorkspacePubCommand({
   required String projectRoot,
   required Future<String> Function(String normalizedPath) command,
 }) async {
-  final normalizedPath = workspaceContext.normalize(path);
-  final pathLabel = workspaceContext.relativeDisplayPath(
+  final normalizedPath = normalizeWorkspacePath(path);
+  final pathLabel = _displayPathRelativeToProject(
     path: normalizedPath,
     projectRoot: projectRoot,
   );

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/filetree/file_tree_view_model_test.dart
@@ -206,17 +206,35 @@ void main() {
     await workspace.changeEventsController.close();
   });
 
-  test('builds a folders-first tree and marks generated workspace entries as ignored', () {
+  test('builds a folders-first tree and marks top-level dot entries as ignored', () async {
     final rootChildren = viewModel.state.root.children;
 
     final folders = rootChildren.whereType<FileTreeFolderNode>().toList();
     expect(folders.map((node) => node.resource.path), ['.dart_tool', 'build', 'lib']);
     expect(folders.firstWhere((node) => node.resource.path == '.dart_tool').isIgnored, isTrue);
-    expect(folders.firstWhere((node) => node.resource.path == 'build').isIgnored, isTrue);
+    expect(folders.firstWhere((node) => node.resource.path == 'build').isIgnored, isFalse);
     expect(folders.firstWhere((node) => node.resource.path == 'lib').isIgnored, isFalse);
 
     final files = rootChildren.whereType<FileTreeFileNode>().toList();
     expect(files.map((node) => node.resource.path), ['pubspec.yaml']);
+
+    workspace
+      ..addTextFile('.env', '')
+      ..addTextFile('packages/example/.dart_tool/package_config.json', '{}')
+      ..addTextFile('packages/example/build/output.js', '');
+    await viewModel.refresh();
+
+    final refreshedRoot = viewModel.state.root;
+    final hiddenFile = refreshedRoot.children.whereType<FileTreeFileNode>().firstWhere(
+      (node) => node.resource.path == '.env',
+    );
+    final hiddenFolder = refreshedRoot.findFolder('.dart_tool')!;
+    expect(hiddenFile.isIgnored, isTrue);
+    expect(hiddenFolder.isIgnored, isTrue);
+    expect(hiddenFolder.children.single.isIgnored, isTrue);
+    expect(refreshedRoot.findFolder('packages/example/.dart_tool')?.isIgnored, isFalse);
+    expect(refreshedRoot.findFolder('packages/example/build')?.isIgnored, isFalse);
+    expect(viewModel.state.root.findFolder('packages/example')?.isIgnored, isFalse);
   });
 
   test('marks text files and supported images as openable', () async {
@@ -354,18 +372,18 @@ void main() {
     expect(viewModel.state.operationError, contains('required project file'));
   });
 
-  test('refuses moving a folder into itself or a descendant', () async {
+  test('reports moving a folder into itself or a descendant as an operation error', () async {
     workspace
       ..folders.add('assets')
       ..folders.add('assets/images');
     await viewModel.refresh();
 
-    expect(
-      () => viewModel.moveEntry('assets', 'assets/images'),
-      throwsArgumentError,
-    );
+    await viewModel.moveEntry('assets', 'assets/images');
+
     expect(workspace.folders, contains('assets'));
     expect(operationLog, isEmpty);
+    expect(viewModel.state.operationError, 'Workspace operation failed.');
+    expect(viewModel.state.busy, isFalse);
   });
 
   test('focuses on a subfolder and exposes it as the root of the tree', () async {

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/workspace/workspace_repository_test.dart
@@ -129,6 +129,38 @@ void main() {
     await events.dispose();
   });
 
+  for (final testCase in [
+    (name: 'workspace root', path: '', projectRoot: '', expected: '/'),
+    (name: 'project root', path: 'example', projectRoot: 'example', expected: '/'),
+    (
+      name: 'project descendant',
+      path: 'packages/demo/example',
+      projectRoot: 'packages/demo',
+      expected: 'example',
+    ),
+    (name: 'above project root', path: '', projectRoot: 'example', expected: '..'),
+  ]) {
+    test('runWorkspacePubCommand displays ${testCase.name}', () async {
+      final events = AppEventBus();
+      final logs = <LogEvent>[];
+      final subscription = events.on<LogEvent>().listen(logs.add);
+
+      await runWorkspacePubCommand(
+        events: events,
+        commandName: 'get',
+        path: testCase.path,
+        projectRoot: testCase.projectRoot,
+        command: (_) async => '',
+      );
+      await pumpEventQueue();
+
+      expect(logs.map((event) => event.message), ['Running pub get in ${testCase.expected}']);
+
+      await subscription.cancel();
+      await events.dispose();
+    });
+  }
+
   test(
     'cleanGeneratedOutput removes build and .dart_tool when present',
     () async {


### PR DESCRIPTION
## Summary

- Remove the stateless `WorkspaceContext` abstraction and replace it with focused workspace path helpers.
- Keep `workspacePath` as the shared POSIX path context.
- Move file-tree visibility and display-path behavior closer to their owning frontend features.
- Hide top-level dotfiles and dotfolders in the file tree while keeping entries such as `build` visible.
- Reject absolute and escaping paths in workspace containment checks.
- Fix stale tab loads being able to interfere with newer loads for the same path.
- Ensure invalid folder moves are handled by the file-tree mutation state instead of producing unhandled async errors.

Fixes #3887 