### PR TITLE
[dartpad preview]: adjust shortcuts to work on mac

### DIFF
--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -40537,6 +40537,9 @@ ${text}</tr>
         });
     }
 
+    // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+    // for details. All rights reserved. Use of this source code is governed by a
+    // BSD-style license that can be found in the LICENSE file.
     /**
      * Selects all occurrences of the currently selected text or surrounding word.
      *

--- a/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/assets/codemirror-dart.bundle.js
@@ -40537,6 +40537,57 @@ ${text}</tr>
         });
     }
 
+    /**
+     * Selects all occurrences of the currently selected text or surrounding word.
+     *
+     * Unlike CodeMirror's default `selectSelectionMatches`, this:
+     * 1. Automatically expands to the surrounding word when the selection is empty (like `selectNextOccurrence` / VS Code).
+     * 2. Works when multiple occurrences are already selected.
+     */
+    const selectAllOccurrences = ({ state, dispatch }) => {
+        let { main } = state.selection;
+        let from = main.from;
+        let to = main.to;
+        let fullWord = false;
+        if (main.empty) {
+            let word = state.wordAt(main.head);
+            if (!word)
+                return false;
+            from = word.from;
+            to = word.to;
+            fullWord = true;
+        }
+        else {
+            let word = state.wordAt(main.head);
+            fullWord = Boolean(word && word.from === main.from && word.to === main.to);
+        }
+        let text = state.sliceDoc(from, to);
+        if (!text)
+            return false;
+        let matches = [];
+        let mainIndex = 0;
+        for (let cur = new SearchCursor(state.doc, text); !cur.next().done;) {
+            if (matches.length > 1000)
+                return false;
+            if (fullWord) {
+                let w = state.wordAt(cur.value.from);
+                if (!w || w.from !== cur.value.from || w.to !== cur.value.to)
+                    continue;
+            }
+            if (cur.value.from <= from && cur.value.to >= to) {
+                mainIndex = matches.length;
+            }
+            matches.push(EditorSelection.range(cur.value.from, cur.value.to));
+        }
+        if (!matches.length)
+            return false;
+        dispatch(state.update({
+            selection: EditorSelection.create(matches, mainIndex),
+            userEvent: "select.search.matches",
+        }));
+        return true;
+    };
+
     // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
@@ -40652,13 +40703,23 @@ ${text}</tr>
     // for details. All rights reserved. Use of this source code is governed by a
     // BSD-style license that can be found in the LICENSE file.
     const extraKeymap = [
+        { key: "Mod-Shift-l", run: selectAllOccurrences, preventDefault: true },
+        { key: "Mod-Shift-L", run: selectAllOccurrences, preventDefault: true },
         { key: "Shift-Mod-\\", run: cursorMatchingBracket },
         { key: "Alt-m", run: cursorMatchingBracket },
-        { key: "Alt--", run: foldCode },
-        { key: "Alt-+", run: unfoldCode },
-        { key: "Alt-=", run: unfoldCode },
-        { key: "Alt-0", run: foldAll },
-        { key: "Alt-9", run: unfoldAll },
+        // macOS may report Option+M as "µ" in KeyboardEvent.key.
+        { key: "Alt-µ", run: cursorMatchingBracket, preventDefault: true },
+        { key: "Shift-Alt-f", run: formatDocument, preventDefault: true },
+        { key: "Shift-Alt-F", run: formatDocument, preventDefault: true },
+        // macOS may report Option+Shift+F as "Ï" in KeyboardEvent.key.
+        { key: "Shift-Alt-Ï", run: formatDocument, preventDefault: true },
+        { key: "Mod-Shift-7", run: toggleLineComment },
+        { key: "Mod-Shift-/", run: toggleLineComment },
+        { key: "Mod-Shift-Digit7", run: toggleLineComment },
+        { key: "Shift-Alt-a", run: toggleBlockComment, preventDefault: true },
+        { key: "Shift-Alt-A", run: toggleBlockComment, preventDefault: true },
+        // macOS may report Option+Shift+A as "Å" in KeyboardEvent.key.
+        { key: "Shift-Alt-Å", run: toggleBlockComment, preventDefault: true },
     ];
     /**
      * Returns all key binding strings registered in the given editor state.
@@ -40699,12 +40760,10 @@ ${text}</tr>
         lintGutter,
         linter,
         LSPPlugin,
-        formatDocument,
         formatDocumentAsync,
         dartpadTheme: dartpad,
         showPanel,
         syntaxHighlighting,
-        toggleLineComment,
         // custom extensions
         dartLanguage,
         yaml,

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/extensions.dart
@@ -45,12 +45,6 @@ external JSAny get indentWithTab;
 @JS('keymap.of')
 external JSAny keymapOf(JSArray<KeyBinding> bindings);
 
-@JS()
-external JSFunction get toggleLineComment;
-
-@JS()
-external JSFunction get formatDocument;
-
 /// Formats [view] and resolves after the returned edits have been applied.
 @JS()
 external JSPromise<JSBoolean> formatDocumentAsync(EditorView view);

--- a/pkgs/dartpad_preview/codemirror-dart/lib/src/languages.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/lib/src/languages.dart
@@ -9,7 +9,6 @@ import 'dart:js_interop';
 
 import 'package:codemirror_lang_dart/codemirror_lang_dart.dart' show dartLanguage;
 
-import 'extensions.dart';
 import 'types.dart';
 
 @JS()
@@ -40,7 +39,7 @@ external JSAny sass();
 external JSAny sql();
 
 /// Returns the full Dart editor extension bundle as a jsified array:
-/// `[LanguageSupport, languageData (commentTokens), keymap (toggle comment)]`.
+/// `[LanguageSupport, languageData (commentTokens)]`.
 ///
 /// **Not to be confused with [dartLanguage]**, which returns a single
 /// `LanguageSupport` object. Use [dartLanguage] when only the language
@@ -67,26 +66,6 @@ JSObject dart() {
   return [
         language,
         EditorState.languageData.of(languageDataProvider),
-        keymapOf(
-          [
-            KeyBinding(
-              key: 'Mod-/'.toJS,
-              run: toggleLineComment,
-            ),
-            KeyBinding(
-              key: 'Mod-Shift-7'.toJS,
-              run: toggleLineComment,
-            ),
-            KeyBinding(
-              key: 'Mod-Shift-/'.toJS,
-              run: toggleLineComment,
-            ),
-            KeyBinding(
-              key: 'Mod-Shift-Digit7'.toJS,
-              run: toggleLineComment,
-            ),
-          ].toJS,
-        ),
       ].jsify()
       as JSObject;
 }

--- a/pkgs/dartpad_preview/codemirror-dart/src/index.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/index.ts
@@ -30,6 +30,7 @@ import { dartpad as dartpadTheme } from "./theme";
 import {
   indentWithTab,
   toggleLineComment,
+  toggleBlockComment,
   cursorMatchingBracket,
 } from "@codemirror/commands";
 import {
@@ -37,10 +38,6 @@ import {
   defaultHighlightStyle,
   HighlightStyle,
   indentUnit,
-  foldCode,
-  unfoldCode,
-  foldAll,
-  unfoldAll,
 } from "@codemirror/language";
 import { lintGutter, linter } from "@codemirror/lint";
 import { LSPPlugin } from "@codemirror/lsp-client";
@@ -49,17 +46,28 @@ import { gotoDefinitionOnClick } from "./gotoDefinition";
 import { diagnosticHoverToolbar } from "./diagnosticHoverToolbar";
 import { forceSemanticTokensRefresh } from "./semanticHighlighting";
 import { formatDocument, formatDocumentAsync } from "./formatting";
+import { selectAllOccurrences } from "./search";
 import { selectionAction } from "./selectionAction";
 import { renameTooltipField, showRenameMessage, startRename } from "./rename";
 
 export const extraKeymap: readonly KeyBinding[] = [
+  { key: "Mod-Shift-l", run: selectAllOccurrences, preventDefault: true },
+  { key: "Mod-Shift-L", run: selectAllOccurrences, preventDefault: true },
   { key: "Shift-Mod-\\", run: cursorMatchingBracket },
   { key: "Alt-m", run: cursorMatchingBracket },
-  { key: "Alt--", run: foldCode },
-  { key: "Alt-+", run: unfoldCode },
-  { key: "Alt-=", run: unfoldCode },
-  { key: "Alt-0", run: foldAll },
-  { key: "Alt-9", run: unfoldAll },
+  // macOS may report Option+M as "µ" in KeyboardEvent.key.
+  { key: "Alt-µ", run: cursorMatchingBracket, preventDefault: true },
+  { key: "Shift-Alt-f", run: formatDocument, preventDefault: true },
+  { key: "Shift-Alt-F", run: formatDocument, preventDefault: true },
+  // macOS may report Option+Shift+F as "Ï" in KeyboardEvent.key.
+  { key: "Shift-Alt-Ï", run: formatDocument, preventDefault: true },
+  { key: "Mod-Shift-7", run: toggleLineComment },
+  { key: "Mod-Shift-/", run: toggleLineComment },
+  { key: "Mod-Shift-Digit7", run: toggleLineComment },
+  { key: "Shift-Alt-a", run: toggleBlockComment, preventDefault: true },
+  { key: "Shift-Alt-A", run: toggleBlockComment, preventDefault: true },
+  // macOS may report Option+Shift+A as "Å" in KeyboardEvent.key.
+  { key: "Shift-Alt-Å", run: toggleBlockComment, preventDefault: true },
 ];
 
 declare global {
@@ -80,12 +88,10 @@ declare global {
       lintGutter: () => Extension;
       linter: (source: any, config?: any) => Extension;
       LSPPlugin: typeof LSPPlugin;
-      formatDocument: typeof formatDocument;
       formatDocumentAsync: typeof formatDocumentAsync;
       dartpadTheme: Extension;
       showPanel: typeof showPanel;
       syntaxHighlighting: (style: any, options?: any) => Extension;
-      toggleLineComment: any;
 
       // custom extensions
       dartLanguage: typeof dartLanguage;
@@ -161,12 +167,10 @@ window._codemirror = {
   lintGutter,
   linter,
   LSPPlugin,
-  formatDocument,
   formatDocumentAsync,
   dartpadTheme,
   showPanel,
   syntaxHighlighting,
-  toggleLineComment,
 
   // custom extensions
   dartLanguage,

--- a/pkgs/dartpad_preview/codemirror-dart/src/search.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/search.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import { StateCommand, EditorSelection, SelectionRange } from "@codemirror/state";
+import { SearchCursor } from "@codemirror/search";
+
+/**
+ * Selects all occurrences of the currently selected text or surrounding word.
+ *
+ * Unlike CodeMirror's default `selectSelectionMatches`, this:
+ * 1. Automatically expands to the surrounding word when the selection is empty (like `selectNextOccurrence` / VS Code).
+ * 2. Works when multiple occurrences are already selected.
+ */
+export const selectAllOccurrences: StateCommand = ({ state, dispatch }) => {
+  let { main } = state.selection;
+  let from = main.from;
+  let to = main.to;
+  let fullWord = false;
+
+  if (main.empty) {
+    let word = state.wordAt(main.head);
+    if (!word) return false;
+    from = word.from;
+    to = word.to;
+    fullWord = true;
+  } else {
+    let word = state.wordAt(main.head);
+    fullWord = Boolean(word && word.from === main.from && word.to === main.to);
+  }
+
+  let text = state.sliceDoc(from, to);
+  if (!text) return false;
+
+  let matches: SelectionRange[] = [];
+  let mainIndex = 0;
+  for (let cur = new SearchCursor(state.doc, text); !cur.next().done;) {
+    if (matches.length > 1000) return false;
+    if (fullWord) {
+      let w = state.wordAt(cur.value.from);
+      if (!w || w.from !== cur.value.from || w.to !== cur.value.to) continue;
+    }
+    if (cur.value.from <= from && cur.value.to >= to) {
+      mainIndex = matches.length;
+    }
+    matches.push(EditorSelection.range(cur.value.from, cur.value.to));
+  }
+
+  if (!matches.length) return false;
+
+  dispatch(
+    state.update({
+      selection: EditorSelection.create(matches, mainIndex),
+      userEvent: "select.search.matches",
+    }),
+  );
+  return true;
+};

--- a/pkgs/dartpad_preview/codemirror-dart/src/search.ts
+++ b/pkgs/dartpad_preview/codemirror-dart/src/search.ts
@@ -2,7 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import { StateCommand, EditorSelection, SelectionRange } from "@codemirror/state";
+import {
+  StateCommand,
+  EditorSelection,
+  SelectionRange,
+} from "@codemirror/state";
 import { SearchCursor } from "@codemirror/search";
 
 /**

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -31,11 +31,10 @@ void main() {
       'lintGutter',
       'linter',
       'LSPPlugin',
-      'formatDocument',
+      'formatDocumentAsync',
       'dartpadTheme',
       'showPanel',
       'syntaxHighlighting',
-      'toggleLineComment',
       'dartLanguage',
       'yaml',
       'markdown',
@@ -340,5 +339,208 @@ void main() {
 
     // Cursor should have jumped to matching '}' (index 14 / after '}')
     expect(view.state.selection.main.head, 14);
+  });
+
+  test('extraKeymap Shift-Alt-Å toggles block comment', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(
+          EditorStateConfig(
+            doc: 'print("hello");'.toJS,
+            selection: EditorSelection.single(0, 15),
+            extensions: <JSAny>[
+              keymapOf(extraKeymap),
+              basicSetup,
+              dart(),
+            ].toJS,
+          ),
+        ),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    final content = view.dom.querySelector('.cm-content')!;
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: 'Å',
+          altKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    expect(view.state.doc.toJsString().toDart, '/* print("hello"); */');
+  });
+
+  test('extraKeymap Alt-µ jumps cursor to matching bracket', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(
+          EditorStateConfig(
+            doc: 'void main() {}'.toJS,
+            selection: EditorSelection.single(12), // at '{'
+            extensions: <JSAny>[
+              keymapOf(extraKeymap),
+              basicSetup,
+              dart(),
+            ].toJS,
+          ),
+        ),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    expect(view.state.selection.main.head, 12);
+
+    final content = view.dom.querySelector('.cm-content')!;
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: 'µ',
+          altKey: true,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    expect(view.state.selection.main.head, 14);
+  });
+
+  test('extraKeymap Mod-Shift-l selects all occurrences from cursor inside a word', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(
+          EditorStateConfig(
+            doc: 'int count = 0; count++; print(count);'.toJS,
+            selection: EditorSelection.single(6), // inside first "count"
+            extensions: <JSAny>[
+              keymapOf(extraKeymap),
+              basicSetup,
+              dart(),
+            ].toJS,
+          ),
+        ),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    final isMac = web.window.navigator.platform.toLowerCase().contains('mac');
+    final content = view.dom.querySelector('.cm-content')!;
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: 'L',
+          metaKey: isMac,
+          ctrlKey: !isMac,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    expect(view.state.selection.ranges.length, 3);
+    for (int i = 0; i < view.state.selection.ranges.length; i++) {
+      final range = view.state.selection.ranges[i];
+      final text = view.state.sliceDoc(range.from, range.to).toDart;
+      expect(text, 'count');
+    }
+  });
+
+  test('foldCode and unfoldCode fold and unfold line with bracket shortcuts', () {
+    final parent = web.HTMLDivElement();
+    web.document.body!.append(parent);
+
+    final view = EditorView(
+      EditorViewConfig(
+        parent: parent,
+        state: EditorState.create(
+          EditorStateConfig(
+            doc: 'void main() {\n  print("hello");\n}\n'.toJS,
+            selection: EditorSelection.single(0), // line 1
+            extensions: <JSAny>[
+              basicSetup,
+              dart(),
+            ].toJS,
+          ),
+        ),
+      ),
+    );
+
+    addTearDown(() {
+      view.destroy();
+      parent.remove();
+    });
+
+    final isMac = web.window.navigator.platform.toLowerCase().contains('mac');
+    final content = view.dom.querySelector('.cm-content')!;
+
+    // Dispatch fold shortcut: Cmd-Alt-[ on macOS, Ctrl-Shift-[ on others
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: '[',
+          metaKey: isMac,
+          altKey: isMac,
+          ctrlKey: !isMac,
+          shiftKey: !isMac,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    // A fold widget (.cm-foldPlaceholder) should appear in the DOM
+    expect(view.dom.querySelector('.cm-foldPlaceholder'), isNotNull);
+
+    // Dispatch unfold shortcut: Cmd-Alt-] on macOS, Ctrl-Shift-] on others
+    content.dispatchEvent(
+      web.KeyboardEvent(
+        'keydown',
+        web.KeyboardEventInit(
+          key: ']',
+          metaKey: isMac,
+          altKey: isMac,
+          ctrlKey: !isMac,
+          shiftKey: !isMac,
+          bubbles: true,
+          cancelable: true,
+        ),
+      ),
+    );
+
+    expect(view.dom.querySelector('.cm-foldPlaceholder'), isNull);
   });
 }

--- a/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
+++ b/pkgs/dartpad_preview/codemirror-dart/test/bindings_test.dart
@@ -506,12 +506,15 @@ void main() {
     final isMac = web.window.navigator.platform.toLowerCase().contains('mac');
     final content = view.dom.querySelector('.cm-content')!;
 
-    // Dispatch fold shortcut: Cmd-Alt-[ on macOS, Ctrl-Shift-[ on others
+    // Dispatch fold shortcut: Cmd-Alt-[ on macOS, Ctrl-Shift-[ on others.
+    // On non-Mac keyboards, Shift+[ produces '{' with keyCode 219.
     content.dispatchEvent(
       web.KeyboardEvent(
         'keydown',
         web.KeyboardEventInit(
-          key: '[',
+          key: isMac ? '[' : '{',
+          code: 'BracketLeft',
+          keyCode: 219,
           metaKey: isMac,
           altKey: isMac,
           ctrlKey: !isMac,
@@ -525,12 +528,15 @@ void main() {
     // A fold widget (.cm-foldPlaceholder) should appear in the DOM
     expect(view.dom.querySelector('.cm-foldPlaceholder'), isNotNull);
 
-    // Dispatch unfold shortcut: Cmd-Alt-] on macOS, Ctrl-Shift-] on others
+    // Dispatch unfold shortcut: Cmd-Alt-] on macOS, Ctrl-Shift-] on others.
+    // On non-Mac keyboards, Shift+] produces '}' with keyCode 221.
     content.dispatchEvent(
       web.KeyboardEvent(
         'keydown',
         web.KeyboardEventInit(
-          key: ']',
+          key: isMac ? ']' : '}',
+          code: 'BracketRight',
+          keyCode: 221,
           metaKey: isMac,
           altKey: isMac,
           ctrlKey: !isMac,

--- a/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
+++ b/pkgs/dartpad_preview/dartpad_editor/lib/src/editor/codemirror_editor.dart
@@ -356,26 +356,6 @@ JSAny _languageExtension(String fileName, [LanguageServerClient? languageServerC
     'dart' => [
       cm.dart(),
       if (languageServerClient case final lsc?) lsc.createCodeMirrorExtension(fileName),
-      cm.keymapOf(
-        [
-          cm.KeyBinding(
-            key: 'Shift-Alt-f'.toJS,
-            run: cm.formatDocument,
-            preventDefault: true,
-          ),
-          cm.KeyBinding(
-            key: 'Shift-Alt-F'.toJS,
-            run: cm.formatDocument,
-            preventDefault: true,
-          ),
-          // macOS may report Option+Shift+F as "Ï" in KeyboardEvent.key.
-          cm.KeyBinding(
-            key: 'Shift-Alt-Ï'.toJS,
-            run: cm.formatDocument,
-            preventDefault: true,
-          ),
-        ].toJS,
-      ),
     ].toJS,
     'yaml' || 'yml' || 'lock' => cm.yaml(),
     'md' => cm.markdown(),

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -9,10 +9,23 @@ final isMac =
     web.window.navigator.platform.toLowerCase().contains('mac') ||
     web.window.navigator.userAgent.toLowerCase().contains('mac');
 
-/// Resolves platform-agnostic modifier placeholders in a display key string.
+final _platformPattern = RegExp(r'<mac:\s*(.*?)\s*\|\s*other:\s*(.*?)>');
+
+/// Resolves platform-agnostic modifier placeholders and platform conditionals
+/// in a display key string.
 ///
+/// - `<mac: A | other: B>` → `A` on macOS, `B` on other platforms.
 /// - `Mod` → `⌘` on macOS, `Ctrl` on other platforms.
-String resolveDisplayKey(String key) => key.replaceAll('Mod', isMac ? '⌘' : 'Ctrl');
+/// - `Alt` → `⌥` on macOS, `Alt` on other platforms.
+String resolveDisplayKey(String key, {bool? onMac}) {
+  final mac = onMac ?? isMac;
+  final platformResolved = key.replaceAllMapped(_platformPattern, (m) {
+    return mac ? m[1]! : m[2]!;
+  });
+  return platformResolved
+      .replaceAll('Mod', mac ? '⌘' : 'Ctrl')
+      .replaceAll('Alt', mac ? '⌥' : 'Alt');
+}
 
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.
 enum ShortcutCategory {
@@ -68,13 +81,15 @@ final class ShortcutDefinition {
   ///
   /// Returns a single-element list if defined via [displayKey], or the alternative
   /// key combinations if defined via [displayKeys].
-  /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKeys] for UI rendering.
+  /// May contain unresolved `Mod` placeholders or `<mac: ... | other: ...>` syntax.
+  /// Use [resolvedDisplayKeys] for UI rendering.
   List<String> get displayKeys => _alternativeDisplayKeys ?? [_singleDisplayKey!];
 
   /// Display string shown in single-string contexts (e.g. context menus).
   ///
   /// When multiple display keys are defined, they are joined with `' or '`.
-  /// May contain unresolved `Mod` placeholders. Use [resolvedDisplayKey] for UI rendering.
+  /// May contain unresolved `Mod` placeholders or `<mac: ... | other: ...>` syntax.
+  /// Use [resolvedDisplayKey] for UI rendering.
   String get displayKey => _singleDisplayKey ?? _alternativeDisplayKeys!.join(' or ');
 
   /// Resolves platform-agnostic modifier placeholders in [displayKeys] using [resolveDisplayKey].
@@ -143,7 +158,7 @@ final class ShortcutDefinition {
 
   static const formatDocument = ShortcutDefinition(
     label: 'Format document',
-    displayKey: 'Shift + Alt + F',
+    displayKey: 'Alt + Shift + F',
     codemirrorKeys: ['Shift-Alt-f', 'Shift-Alt-F'],
     category: ShortcutCategory.refactoring,
   );
@@ -166,8 +181,8 @@ final class ShortcutDefinition {
 
   static const toggleBlockComment = ShortcutDefinition(
     label: 'Toggle block comment',
-    displayKey: 'Shift + Alt + A',
-    codemirrorKeys: ['Alt-A'],
+    displayKey: 'Alt + Shift + A',
+    codemirrorKeys: ['Alt-A', 'Shift-Alt-a', 'Shift-Alt-A'],
     category: ShortcutCategory.editing,
   );
 
@@ -203,7 +218,7 @@ final class ShortcutDefinition {
 
   static const copyLine = ShortcutDefinition(
     label: 'Copy line up / down',
-    displayKey: 'Shift + Alt + ↑ / ↓',
+    displayKey: 'Alt + Shift + ↑ / ↓',
     codemirrorKeys: ['Shift-Alt-ArrowUp', 'Shift-Alt-ArrowDown'],
     category: ShortcutCategory.editing,
     isPrimary: false,
@@ -251,7 +266,7 @@ final class ShortcutDefinition {
   static const selectAllOccurrences = ShortcutDefinition(
     label: 'Select all occurrences',
     displayKey: 'Mod + Shift + L',
-    codemirrorKeys: ['Mod-Shift-l'],
+    codemirrorKeys: ['Mod-Shift-l', 'Mod-Shift-L'],
     category: ShortcutCategory.search,
     isPrimary: false,
   );
@@ -273,34 +288,34 @@ final class ShortcutDefinition {
     isPrimary: false,
   );
 
-  static const foldCode = ShortcutDefinition.alternatives(
+  static const foldCode = ShortcutDefinition(
     label: 'Fold code',
-    displayKeys: ['Ctrl + Shift + [', 'Alt + -'],
-    codemirrorKeys: ['Ctrl-Shift-[', 'Alt--'],
+    displayKey: '<mac: Mod + Alt + [ | other: Ctrl + Shift + [>',
+    codemirrorKeys: ['Ctrl-Shift-[', 'Cmd-Alt-['],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
-  static const unfoldCode = ShortcutDefinition.alternatives(
+  static const unfoldCode = ShortcutDefinition(
     label: 'Unfold code',
-    displayKeys: ['Ctrl + Shift + ]', 'Alt + +'],
-    codemirrorKeys: ['Ctrl-Shift-]', 'Alt-+', 'Alt-='],
+    displayKey: '<mac: Mod + Alt + ] | other: Ctrl + Shift + ]>',
+    codemirrorKeys: ['Ctrl-Shift-]', 'Cmd-Alt-]'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
-  static const foldAll = ShortcutDefinition.alternatives(
+  static const foldAll = ShortcutDefinition(
     label: 'Fold all',
-    displayKeys: ['Ctrl + Alt + [', 'Alt + 0'],
-    codemirrorKeys: ['Ctrl-Alt-[', 'Alt-0'],
+    displayKey: 'Ctrl + Alt + [',
+    codemirrorKeys: ['Ctrl-Alt-['],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
 
-  static const unfoldAll = ShortcutDefinition.alternatives(
+  static const unfoldAll = ShortcutDefinition(
     label: 'Unfold all',
-    displayKeys: ['Ctrl + Alt + ]', 'Alt + 9'],
-    codemirrorKeys: ['Ctrl-Alt-]', 'Alt-9'],
+    displayKey: 'Ctrl + Alt + ]',
+    codemirrorKeys: ['Ctrl-Alt-]'],
     category: ShortcutCategory.autocompleteFolding,
     isPrimary: false,
   );
@@ -341,8 +356,8 @@ final class ShortcutDefinition {
 /// This list is the **single source of truth** for both the dialog UI and the
 /// automated test that validates shortcuts against CodeMirror's keymap.
 ///
-/// Display keys use `Mod` as a platform-agnostic placeholder for the primary
-/// modifier key. Call [resolveDisplayKey] to get the platform-specific string.
+/// Display keys use `Mod` and `Alt` as platform-agnostic placeholders for modifier
+/// keys. Call [resolveDisplayKey] to get the platform-specific string.
 const shortcutDefinitions = <ShortcutDefinition>[
   // ── View ─────────────────────────────────────────────────────────────────
   ShortcutDefinition.commandPalette,

--- a/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/lib/features/shared/components/shortcut_definitions.dart
@@ -22,9 +22,7 @@ String resolveDisplayKey(String key, {bool? onMac}) {
   final platformResolved = key.replaceAllMapped(_platformPattern, (m) {
     return mac ? m[1]! : m[2]!;
   });
-  return platformResolved
-      .replaceAll('Mod', mac ? '⌘' : 'Ctrl')
-      .replaceAll('Alt', mac ? '⌥' : 'Alt');
+  return platformResolved.replaceAll('Mod', mac ? '⌘' : 'Ctrl').replaceAll('Alt', mac ? '⌥' : 'Alt');
 }
 
 /// Categories for grouping keyboard shortcuts in the shortcuts dialog.

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/codemirror/editor_context_menu_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/editor/codemirror/editor_context_menu_test.dart
@@ -11,6 +11,7 @@ import 'package:codemirror_dart/codemirror_dart.dart' as cm;
 import 'package:dartpad_editor/dartpad_editor.dart';
 import 'package:dartpad_frontend/features/editor/codemirror/editor_context_menu.dart';
 import 'package:dartpad_frontend/features/shared/components/context_menu.dart';
+import 'package:dartpad_frontend/features/shared/components/shortcut_definitions.dart';
 import 'package:jaspr_test/client_test.dart';
 import 'package:web/web.dart' as web;
 
@@ -76,7 +77,7 @@ void main() {
       expect(items[4], isA<ContextMenuItem>());
       final item4 = items[4] as ContextMenuItem;
       expect(item4.label, 'Format document');
-      expect(item4.shortcut, 'Shift + Alt + F');
+      expect(item4.shortcut, resolveDisplayKey('Alt + Shift + F'));
 
       // Divider
       expect(items[5], isA<ContextMenuDivider>());

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcut_registration_test.dart
@@ -105,15 +105,15 @@ const _undocumentedShortcutGroups = <String, List<String>>{
     'Mod-u',
     'Alt-u',
     'Mod-Shift-u',
-    'Cmd-Alt-[',
-    'Cmd-Alt-]',
   ],
   'DartPad save command, which is intentionally not shown in the shortcuts dialog.': ['Mod-s'],
-  'Alternative browser and keyboard-layout bindings for documented comment commands.': [
+  'Alternative browser and keyboard-layout bindings for documented commands.': [
     'Mod-Shift-7',
     'Mod-Shift-/',
     'Mod-Shift-Digit7',
     'Shift-Alt-Ï',
+    'Shift-Alt-Å',
+    'Alt-µ',
   ],
 };
 
@@ -143,6 +143,7 @@ final class _TestLanguageServerClient implements LanguageServerClient {
 void main() {
   setUpAll(() async {
     final script = web.document.createElement('script') as web.HTMLScriptElement;
+    script.charset = 'utf-8';
     final loaded = web.EventStreamProviders.loadEvent.forTarget(script).first;
     script.src = 'packages/codemirror_dart/assets/codemirror-dart.bundle.js';
     web.document.head!.appendChild(script);

--- a/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
+++ b/pkgs/dartpad_preview/dartpad_frontend/test/features/shared/components/shortcuts_dialog_test.dart
@@ -129,18 +129,14 @@ void main() {
     final findNextAlternatives = findNextRow.querySelectorAll('.shortcuts-dialog-alternative');
     expect(findNextAlternatives.length, 1);
 
-    // Command with multiple key combos (Fold code)
+    // Single combo command with platform-specific key (Fold code)
     final foldCodeRow = findRow('Fold code');
     expect(foldCodeRow, isNotNull);
     final foldCodeKeys = foldCodeRow!.querySelectorAll('.shortcuts-dialog-key');
-    expect(foldCodeKeys.length, 2);
-    expect(foldCodeKeys.item(0)?.textContent, 'Ctrl + Shift + [');
-    expect(foldCodeKeys.item(1)?.textContent, 'Alt + -');
+    expect(foldCodeKeys.length, 1);
+    expect(foldCodeKeys.item(0)?.textContent, ShortcutDefinition.foldCode.resolvedDisplayKey);
     final foldCodeSeparator = foldCodeRow.querySelectorAll('.shortcuts-dialog-separator');
-    expect(foldCodeSeparator.length, 1);
-    expect(foldCodeSeparator.item(0)?.textContent, 'or');
-    final foldCodeAlternatives = foldCodeRow.querySelectorAll('.shortcuts-dialog-alternative');
-    expect(foldCodeAlternatives.length, 1);
+    expect(foldCodeSeparator.length, 0);
 
     // Single combo command (Open command palette)
     final commandPaletteRow = findRow('Open command palette');
@@ -168,6 +164,29 @@ void main() {
       expect(multiple.displayKey, 'F3 or Mod + G');
       expect(multiple.resolvedDisplayKeys, ['F3', resolveDisplayKey('Mod + G')]);
       expect(multiple.resolvedDisplayKey, 'F3 or ${resolveDisplayKey('Mod + G')}');
+
+      const altShortcut = ShortcutDefinition(label: 'Format', displayKey: 'Alt + Shift + F');
+      expect(altShortcut.resolvedDisplayKeys, [resolveDisplayKey('Alt + Shift + F')]);
+      expect(altShortcut.resolvedDisplayKey, resolveDisplayKey('Alt + Shift + F'));
+    });
+
+    test('resolves Alt to ⌥ on macOS and Alt on other platforms', () {
+      expect(resolveDisplayKey('Alt + F', onMac: true), '⌥ + F');
+      expect(resolveDisplayKey('Alt + F', onMac: false), 'Alt + F');
+      expect(resolveDisplayKey('Alt + Shift + ↑ / ↓', onMac: true), '⌥ + Shift + ↑ / ↓');
+      expect(resolveDisplayKey('Alt + Shift + ↑ / ↓', onMac: false), 'Alt + Shift + ↑ / ↓');
+      expect(resolveDisplayKey('Mod + Alt + G', onMac: true), '⌘ + ⌥ + G');
+      expect(resolveDisplayKey('Mod + Alt + G', onMac: false), 'Ctrl + Alt + G');
+    });
+
+    test('resolves <mac: ... | other: ...> syntax in resolveDisplayKey', () {
+      const key = '<mac: Mod + Alt + [ | other: Ctrl + Shift + [>';
+      expect(resolveDisplayKey(key, onMac: true), '⌘ + ⌥ + [');
+      expect(resolveDisplayKey(key, onMac: false), 'Ctrl + Shift + [');
+
+      const foldCode = ShortcutDefinition.foldCode;
+      expect(resolveDisplayKey(foldCode.displayKey, onMac: true), '⌘ + ⌥ + [');
+      expect(resolveDisplayKey(foldCode.displayKey, onMac: false), 'Ctrl + Shift + [');
     });
   });
 }


### PR DESCRIPTION
Fix some shortcut definitions to work on (German) mac keyboards.
Also shows the Mac Option key symbol instead of "Alt" in the shortcut dialog.

Fixes #3844 

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
